### PR TITLE
[功能更新]自定义装备发放处,需求是先查询装备初始属性,并回显前端,用户根据前端已有属性进行修改或者不修改,然后发放.

### DIFF
--- a/gms-server/src/main/java/org/gms/controller/EquipController.java
+++ b/gms-server/src/main/java/org/gms/controller/EquipController.java
@@ -1,0 +1,33 @@
+package org.gms.controller;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.gms.constants.api.ApiConstant;
+import org.gms.model.dto.EquipmentInfoReqDTO;
+import org.gms.model.dto.GiveResourceReqDTO;
+import org.gms.model.dto.ResultBody;
+import org.gms.model.dto.SubmitBody;
+import org.gms.service.GiveService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/search")
+public class EquipController {
+    @Autowired
+    private final GiveService giveService;
+
+
+    @Tag(name = "/search/" + ApiConstant.LATEST)
+    @Operation(summary = "查询装备基础属性信息")
+    @PostMapping("/" + ApiConstant.LATEST + "/getEquInitialInfo")
+    public ResultBody<Object> getEquInfoById(@RequestBody SubmitBody<EquipmentInfoReqDTO> submitBody) {
+        return giveService.getEquipmentInfoById(submitBody.getData());
+    }
+}

--- a/gms-server/src/main/java/org/gms/model/dto/EquipmentInfoReqDTO.java
+++ b/gms-server/src/main/java/org/gms/model/dto/EquipmentInfoReqDTO.java
@@ -1,0 +1,35 @@
+package org.gms.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class EquipmentInfoReqDTO {
+//    private Integer worldId;
+//    private Integer playerId;
+//    private String player;
+//    private Byte type;
+    private Integer id;//装备的ID 物品的ID
+//    private Integer quantity;
+//    private Integer rate;
+//    private Short str;
+//    private Short dex;
+//    @JsonProperty("int")
+//    private Short _int;
+//    private Short luk;
+//    private Short hp;
+//    private Short mp;
+//    private Short pAtk;
+//    private Short mAtk;
+//    private Short pDef;
+//    private Short mDef;
+//    private Short acc;
+//    private Short avoid;
+//    private Short hands;
+//    private Short speed;
+//    private Short jump;
+//    private Byte upgradeSlot;
+//    private Long expire;
+}

--- a/gms-server/src/main/java/org/gms/model/dto/EquipmentInfoRtnDTO.java
+++ b/gms-server/src/main/java/org/gms/model/dto/EquipmentInfoRtnDTO.java
@@ -1,0 +1,35 @@
+package org.gms.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class EquipmentInfoRtnDTO {
+    private Integer worldId;
+    private Integer playerId;
+    private String player;
+    private Byte type;
+    private Integer id;
+    private Integer quantity;
+    private Integer rate;
+    private Short str;
+    private Short dex;
+    @JsonProperty("int")
+    private Short _int;
+    private Short luk;
+    private Short hp;
+    private Short mp;
+    private Short pAtk;
+    private Short mAtk;
+    private Short pDef;
+    private Short mDef;
+    private Short acc;
+    private Short avoid;
+    private Short hands;
+    private Short speed;
+    private Short jump;
+    private Byte upgradeSlot;
+    private Long expire;
+}

--- a/gms-server/src/main/java/org/gms/service/GiveService.java
+++ b/gms-server/src/main/java/org/gms/service/GiveService.java
@@ -2,23 +2,30 @@ package org.gms.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.gms.client.Character;
+import org.gms.client.Client;
 import org.gms.client.Stat;
-import org.gms.client.inventory.InventoryType;
-import org.gms.client.inventory.Pet;
+import org.gms.client.inventory.*;
 import org.gms.client.inventory.manipulator.InventoryManipulator;
 import org.gms.constants.inventory.ItemConstants;
 import org.gms.constants.string.ExtendType;
 import org.gms.dao.entity.ExtendValueDO;
+import org.gms.model.dto.EquipmentInfoReqDTO;
+import org.gms.model.dto.EquipmentInfoRtnDTO;
 import org.gms.model.dto.GiveResourceReqDTO;
 import org.gms.exception.BizException;
+import org.gms.model.dto.ResultBody;
+
 import org.gms.net.server.Server;
 import org.gms.server.CashShop;
 import org.gms.server.ItemInformationProvider;
 import org.gms.util.I18nUtil;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+
 import static java.util.concurrent.TimeUnit.DAYS;
+
 
 @Service
 @Slf4j
@@ -407,4 +414,37 @@ public class GiveService {
         chr.message(I18nUtil.getMessage("Give.Fame.Chr", fame));
         log.info(I18nUtil.getLogMessage("Give.Fame.Chr.info1", chr.getId(), chr.getName(), fame));
     }
+
+
+    public ResultBody<Object> getEquipmentInfoById(EquipmentInfoReqDTO data) {
+        ItemInformationProvider ii = ItemInformationProvider.getInstance();
+        Equip equip = null;
+        Item item = ii.getEquipById(data.getId());
+        equip = (Equip) item;
+        EquipmentInfoRtnDTO rtn = new EquipmentInfoRtnDTO();
+
+        rtn.setId(equip.getItemId());
+        rtn.setStr(equip.getStr());
+        rtn.setDex(equip.getDex());
+        rtn.set_int(equip.getInt());
+        rtn.setLuk(equip.getLuk());
+        rtn.setHp(equip.getHp());
+        rtn.setMp(equip.getMp());
+        rtn.setPAtk(equip.getWatk());
+        rtn.setMAtk(equip.getMatk());
+        rtn.setPDef(equip.getWdef());
+        rtn.setMDef(equip.getMdef());
+        rtn.setAcc(equip.getAcc());
+        rtn.setAvoid(equip.getAvoid());
+        rtn.setHands(equip.getHands());
+        rtn.setSpeed(equip.getSpeed());
+        rtn.setJump(equip.getJump());
+        rtn.setUpgradeSlot(equip.getUpgradeSlots());
+        rtn.setExpire(equip.getExpiration());
+
+        return ResultBody.success(rtn);
+
+
+    }
+
 }


### PR DESCRIPTION
代码修改:
新增controller,添加新接口
新增两个DTO,一个用于接受前端传参物品ID,一个用于返回装备装备各种属性
修改GiveService文件,新增getEquipmentInfoById的方法

因个人能力问题(在学了),前端未做配套修改
![e9f40ed5b9a3eb4b7e0a61d61278e2ee](https://github.com/user-attachments/assets/a6b56389-92c9-4c15-9c34-6123df00d38d)
