### PR TITLE
Add healthcheck to MySQL service in docker-compose

### DIFF
--- a/gms-server/docker/docker-compose.yml
+++ b/gms-server/docker/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./docker-db-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "uroot", "proot"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/gms-server/docker/docker-compose.yml
+++ b/gms-server/docker/docker-compose.yml
@@ -1,11 +1,13 @@
 version: '3'
 services:
   maplestory:
+    container_name: beidou-client
     build:
       context: ../../
       dockerfile: ./gms-server/docker/Dockerfile
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       # Web
       - "8686:8686"
@@ -21,6 +23,7 @@ services:
       - ./application.yml:/opt/server/application.yml
 
   db:
+    container_name: database
     image: mysql:8.4.0
     environment:
       MYSQL_ROOT_PASSWORD: "root"
@@ -28,3 +31,8 @@ services:
       - "3306:3306"
     volumes:
       - ./docker-db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 10

--- a/gms-server/docker/docker-compose.yml
+++ b/gms-server/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   maplestory:
-    container_name: beidou-client
+    container_name: beidou-server
     build:
       context: ../../
       dockerfile: ./gms-server/docker/Dockerfile
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./docker-db-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "uroot", "proot"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
- Added a healthcheck to the 'db' service to ensure that the MySQL database is fully operational before starting dependent services.
- Configured the healthcheck to use 'mysqladmin ping' for testing the readiness of the database.
- Set the healthcheck interval to 10 seconds, with a timeout of 5 seconds, and allowed up to 5 retries.
- This change ensures that the 'maplestory' service will only start after the MySQL service is confirmed to be healthy, preventing potential startup issues.