### PR TITLE
web管理端,背包管理部分,后端变量命名统一化,由type都统一为inventoryType

### DIFF
--- a/gms-server/src/main/java/org/gms/model/dto/InventoryTypeRtnDTO.java
+++ b/gms-server/src/main/java/org/gms/model/dto/InventoryTypeRtnDTO.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class InventoryTypeRtnDTO {
-    private Byte type;
+    private Byte inventoryType;
     private String name;
 }

--- a/gms-server/src/main/java/org/gms/service/InventoryService.java
+++ b/gms-server/src/main/java/org/gms/service/InventoryService.java
@@ -41,7 +41,7 @@ public class InventoryService {
     public List<InventoryTypeRtnDTO> getInventoryTypeList() {
         List<InventoryTypeRtnDTO> list = new ArrayList<>();
         for (InventoryType value : InventoryType.values()) {
-            list.add(InventoryTypeRtnDTO.builder().type(value.getType()).name(value.getName()).build());
+            list.add(InventoryTypeRtnDTO.builder().inventoryType(value.getType()).name(value.getName()).build());
         }
         return list;
     }

--- a/gms-ui/src/store/modules/inventory/type.ts
+++ b/gms-ui/src/store/modules/inventory/type.ts
@@ -1,5 +1,5 @@
 export interface InventoryTypeState {
-  type: number;
+  inventoryType: number;
   name: string;
 }
 

--- a/gms-ui/src/views/game/inventory/index.vue
+++ b/gms-ui/src/views/game/inventory/index.vue
@@ -10,7 +10,7 @@
       >
         <a-tab-pane
           v-for="data in typeList"
-          :key="data.type"
+          :key="data.inventoryType"
           :title="data.name"
         >
           <inventory-list :current-type="currentType" />


### PR DESCRIPTION
仅仅修改了,分类查询返回以及前端展示,前端根据类型二次拉取数据部分未修改
![16b73e96f97fbed078664d6d5af7fc1b](https://github.com/user-attachments/assets/381498bf-ffb4-4c96-8cfa-7d743d944f39)

![image](https://github.com/user-attachments/assets/d4dad5f8-03fb-4b04-b52b-eaa1b780248d)

