### PR TITLE
修复：禁止创建职业群bug，USE_EXP_GAIN_LOG: true报错bug，解决冲突，尝试重新提交

### DIFF
--- a/gms-server/src/main/java/org/gms/client/creator/novice/BeginnerCreator.java
+++ b/gms-server/src/main/java/org/gms/client/creator/novice/BeginnerCreator.java
@@ -44,8 +44,7 @@ public class BeginnerCreator extends CharacterFactory {
     }
 
     public static int createCharacter(Client c, String name, int face, int hair, int skin, int top, int bottom, int shoes, int weapon, int gender) {
-        if (!YamlConfig.config.server.ENABLE_ADVENTURERS) return -3;
-        
+
         int iMapID = MapId.MUSHROOM_TOWN;
         if (YamlConfig.config.server.USE_BEIDOU_BEGINNERMAP)
         {

--- a/gms-server/src/main/java/org/gms/client/creator/novice/LegendCreator.java
+++ b/gms-server/src/main/java/org/gms/client/creator/novice/LegendCreator.java
@@ -24,7 +24,6 @@ import org.gms.client.Job;
 import org.gms.client.creator.CharacterFactory;
 import org.gms.client.creator.CharacterFactoryRecipe;
 import org.gms.client.inventory.InventoryType;
-import org.gms.config.YamlConfig;
 import org.gms.constants.id.ItemId;
 import org.gms.constants.id.MapId;
 
@@ -44,8 +43,7 @@ public class LegendCreator extends CharacterFactory {
     }
 
     public static int createCharacter(Client c, String name, int face, int hair, int skin, int top, int bottom, int shoes, int weapon, int gender) {
-        if (!YamlConfig.config.server.ENABLE_THE_LORD_OF_WAR) return -3;
-        
+
         return createNewCharacter(c, name, face, hair, skin, gender, createRecipe(Job.LEGEND, 1, MapId.ARAN_TUTORIAL_START, top, bottom, shoes, weapon));
     }
 }

--- a/gms-server/src/main/java/org/gms/client/creator/novice/NoblesseCreator.java
+++ b/gms-server/src/main/java/org/gms/client/creator/novice/NoblesseCreator.java
@@ -24,7 +24,6 @@ import org.gms.client.Job;
 import org.gms.client.creator.CharacterFactory;
 import org.gms.client.creator.CharacterFactoryRecipe;
 import org.gms.client.inventory.InventoryType;
-import org.gms.config.YamlConfig;
 import org.gms.constants.id.ItemId;
 import org.gms.constants.id.MapId;
 
@@ -44,8 +43,7 @@ public class NoblesseCreator extends CharacterFactory {
     }
 
     public static int createCharacter(Client c, String name, int face, int hair, int skin, int top, int bottom, int shoes, int weapon, int gender) {
-        if (!YamlConfig.config.server.ENABLE_KNIGHTS_OF_CYGNUS) return -3;
-        
+
         return createNewCharacter(c, name, face, hair, skin, gender, createRecipe(Job.NOBLESSE, 1, MapId.STARTING_MAP_NOBLESSE, top, bottom, shoes, weapon));
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/handlers/login/CreateCharHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/handlers/login/CreateCharHandler.java
@@ -119,7 +119,7 @@ public final class CreateCharHandler extends AbstractPacketHandler {
             String message = I18nUtil.getMessage("CreateCharHandler.handlePacket.serverNotice.disableJob", jobname);
             c.sendPacket(PacketCreator.serverNotice(1,message));    //由于未找到不弹窗结束客户端请求等待，所以先发出未知错误的提示，再发送弹窗提示，这样不会被未知错误窗口挡住
             c.sendPacket(PacketCreator.getLoginFailed(1));       //断开客户端请求，避免客户端假死
-        } else {
+        } else if(status != 0) {
             c.sendPacket(PacketCreator.deleteCharResponse(0, 9));       //发送未知错误的弹窗提示
         }
     }

--- a/gms-server/src/main/java/org/gms/net/server/handlers/login/CreateCharHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/handlers/login/CreateCharHandler.java
@@ -26,9 +26,11 @@ import org.gms.client.Client;
 import org.gms.client.creator.novice.BeginnerCreator;
 import org.gms.client.creator.novice.LegendCreator;
 import org.gms.client.creator.novice.NoblesseCreator;
+import org.gms.config.YamlConfig;
 import org.gms.constants.inventory.ItemConstants;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
+import org.gms.util.I18nUtil;
 import org.gms.util.PacketCreator;
 
 @Slf4j
@@ -92,24 +94,33 @@ public final class CreateCharHandler extends AbstractPacketHandler {
         }
 
         int status;
+        /**
+         * 创建角色职业
+         * 将禁止创建指定职业群的判断挪到此处进行统一判断，并且向客户端发出禁止创建的提示信息
+         */
         switch (job) {
-        case 0: // Knights of Cygnus
-            status = NoblesseCreator.createCharacter(c, name, face, hair + hairColor, skinColor, top, bottom, shoes, weapon, gender);
-            break;
-        case 1: // Adventurer
-            status = BeginnerCreator.createCharacter(c, name, face, hair + hairColor, skinColor, top, bottom, shoes, weapon, gender);
-            break;
-        case 2: // Aran
-            status = LegendCreator.createCharacter(c, name, face, hair + hairColor, skinColor, top, bottom, shoes, weapon, gender);
-            break;
-        default:
-            c.sendPacket(PacketCreator.deleteCharResponse(0, 9));
-            return;
+            case 0: // Knights of Cygnus #天鹅骑士团
+                //先判断是否禁止创建该职业，再进行角色创建
+                status = !YamlConfig.config.server.ENABLE_KNIGHTS_OF_CYGNUS ? -3 : NoblesseCreator.createCharacter(c, name, face, hair + hairColor, skinColor, top, bottom, shoes, weapon, gender);
+                break;
+            case 1: // Adventurer #冒险家
+                status = !YamlConfig.config.server.ENABLE_ADVENTURERS ? -3 : BeginnerCreator.createCharacter(c, name, face, hair + hairColor, skinColor, top, bottom, shoes, weapon, gender);
+                break;
+            case 2: // Aran #战神
+                status = !YamlConfig.config.server.ENABLE_THE_LORD_OF_WAR ? -3 : LegendCreator.createCharacter(c, name, face, hair + hairColor, skinColor, top, bottom, shoes, weapon, gender);
+                break;
+            default:
+                c.sendPacket(PacketCreator.deleteCharResponse(0, 9));
+                return;
         }
 
-        // 修复校验失败时，不发包，导致客户端假死的问题
         if (status != 0) {
-            c.sendPacket(PacketCreator.deleteCharResponse(0, 9));
+            c.sendPacket(PacketCreator.deleteCharResponse(0, 9));       //发送未知错误的弹窗提示
+            if(status == -3) {
+                String jobname = I18nUtil.getMessage("CreateCharHandler.handlePacket.job." + job );
+                String message = I18nUtil.getMessage("CreateCharHandler.handlePacket.serverNotice.disableJob", jobname);
+                c.sendPacket(PacketCreator.serverNotice(0,message));    //由于未找到不弹窗结束客户端请求等待，所以先发出未知错误的提示，再发送弹窗提示，这样不会被未知错误窗口挡住
+            }
         }
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/handlers/login/CreateCharHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/handlers/login/CreateCharHandler.java
@@ -114,13 +114,13 @@ public final class CreateCharHandler extends AbstractPacketHandler {
                 return;
         }
 
-        if (status != 0) {
+        if(status == -3) {
+            String jobname = I18nUtil.getMessage("CreateCharHandler.handlePacket.job." + job );
+            String message = I18nUtil.getMessage("CreateCharHandler.handlePacket.serverNotice.disableJob", jobname);
+            c.sendPacket(PacketCreator.serverNotice(1,message));    //由于未找到不弹窗结束客户端请求等待，所以先发出未知错误的提示，再发送弹窗提示，这样不会被未知错误窗口挡住
+            c.sendPacket(PacketCreator.getLoginFailed(1));       //断开客户端请求，避免客户端假死
+        } else {
             c.sendPacket(PacketCreator.deleteCharResponse(0, 9));       //发送未知错误的弹窗提示
-            if(status == -3) {
-                String jobname = I18nUtil.getMessage("CreateCharHandler.handlePacket.job." + job );
-                String message = I18nUtil.getMessage("CreateCharHandler.handlePacket.serverNotice.disableJob", jobname);
-                c.sendPacket(PacketCreator.serverNotice(0,message));    //由于未找到不弹窗结束客户端请求等待，所以先发出未知错误的提示，再发送弹窗提示，这样不会被未知错误窗口挡住
-            }
         }
     }
 }

--- a/gms-server/src/main/resources/db/migration/V1.4.3__create_characterexplogs.sql
+++ b/gms-server/src/main/resources/db/migration/V1.4.3__create_characterexplogs.sql
@@ -1,0 +1,35 @@
+/*
+ Navicat Premium Data Transfer
+
+ Source Server         : windows-server
+ Source Server Type    : MySQL
+ Source Server Version : 80030
+ Source Host           : 192.168.3.5:3307
+ Source Schema         : beidou
+
+ Target Server Type    : MySQL
+ Target Server Version : 80030
+ File Encoding         : 65001
+
+ Date: 21/09/2024 17:32:51
+*/
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ----------------------------
+-- Table structure for characterexplogs
+-- ----------------------------
+DROP TABLE IF EXISTS `characterexplogs`;
+CREATE TABLE `characterexplogs`  (
+  `id` bigint(0) NOT NULL AUTO_INCREMENT,
+  `world_exp_rate` int(0) NULL DEFAULT NULL,
+  `exp_coupon` int(0) NULL DEFAULT NULL,
+  `gained_exp` bigint(0) NULL DEFAULT NULL,
+  `current_exp` bigint(0) NULL DEFAULT NULL,
+  `exp_gain_time` timestamp(0) NULL DEFAULT NULL,
+  `charid` int(0) NULL DEFAULT NULL,
+  PRIMARY KEY (`id`) USING BTREE
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/gms-server/src/main/resources/i18n/message_en_US.properties
+++ b/gms-server/src/main/resources/i18n/message_en_US.properties
@@ -913,7 +913,7 @@ CharacterFactory.message1 = has created a new character with IGN
 
 ##############################
 # JobName Convert
-##############################//
+##############################
 
 job.name.0 = Beginner
 job.name.100 = Warrior
@@ -997,3 +997,11 @@ job.name.2215 = EVAN7
 job.name.2216 = EVAN8
 job.name.2217 = EVAN9
 job.name.2218 = EVAN10
+
+##############################
+# CreateCharHandler
+##############################
+CreateCharHandler.handlePacket.job.0 = Knights of Cygnus
+CreateCharHandler.handlePacket.job.1 = Adventurer
+CreateCharHandler.handlePacket.job.2 = Aran
+CreateCharHandler.handlePacket.serverNotice.disableJob = The current occupational group [{0}] is not yet enabled. \r\nPlease select another occupational group.

--- a/gms-server/src/main/resources/i18n/message_zh_CN.properties
+++ b/gms-server/src/main/resources/i18n/message_zh_CN.properties
@@ -911,8 +911,7 @@ CharacterFactory.message1 = -账号 创建了新角色,游戏名：
 
 ##############################
 # Job名称转换
-##############################//
-
+##############################
 job.name.0 = 新手
 job.name.100 = 战士
 job.name.110 = 剑客
@@ -997,3 +996,10 @@ job.name.2217 = 龙神9
 job.name.2218 = 龙神10
 
 
+##############################
+# CreateCharHandler
+##############################
+CreateCharHandler.handlePacket.job.0 = 冒险骑士团
+CreateCharHandler.handlePacket.job.1 = 冒险家
+CreateCharHandler.handlePacket.job.2 = 战神
+CreateCharHandler.handlePacket.serverNotice.disableJob = 当前职业群 [{0}] 暂未启用！\r\n请选择其他职业群。


### PR DESCRIPTION
修复：新增不允许创建某一职业时进行弹窗提示，同时修复客户端假死的bug。
修复：允许创建冒险家职业的开关判断逻辑弄反的bug。
优化：将开关判断统一挪动到CreateCharHandler.java里进行判断，提示内容支持i18n

修复：application.yml 配置键 USE_EXP_GAIN_LOG: true 时，后台报错：java.sql.BatchUpdateException: Table 'beidou.characterexplogs' doesn't exist
