### PR TITLE
新增：调整野外Boss刷新速率配置；优化：改名成功删除所有改名卡；汉化：部分说明

### DIFF
--- a/gms-server/scripts-zh-CN/portal/timeQuest.js
+++ b/gms-server/scripts-zh-CN/portal/timeQuest.js
@@ -44,13 +44,13 @@ function enter(pi) {
         pi.warp(270040100, "out00");
     } else {
         if (map > 200) {
-            pi.playerMessage(5, "As the time starts to flow oddly, you are transported back to a safe lane.");
+            pi.playerMessage(5, "随着时间开始变得异常流动，你被传送回到了一个安全的空间。");
             pi.warp(270030000, "in00");
         } else if (map > 100) {
-            pi.playerMessage(5, "As the time starts to flow oddly, you are transported back to a safe lane.");
+            pi.playerMessage(5, "随着时间开始变得异常流动，你被传送回到了一个安全的空间。");
             pi.warp(270020000, "in00");
         } else {
-            pi.playerMessage(5, "As the time starts to flow oddly, you are transported back to a safe lane.");
+            pi.playerMessage(5, "随着时间开始变得异常流动，你被传送回到了一个安全的空间。");
             pi.warp(270010000, "in00");
         }
     }

--- a/gms-server/src/main/java/org/gms/property/ServerProperty.java
+++ b/gms-server/src/main/java/org/gms/property/ServerProperty.java
@@ -318,4 +318,8 @@ public class ServerProperty {
     public boolean CHANGE_CHANNEL_FORCE_RETURN;
     public int MOB_RESPAWN_RATE;
     public short ITEM_SLOT_MAX;
+
+    //BOSS相关配置
+    public float BOSS_RESPAWN_MOBTIME_RATE;  //BOSS刷新时间速率，浮点值只能在>0 到 <=1 之间
+
 }

--- a/gms-server/src/main/java/org/gms/server/maps/MapFactory.java
+++ b/gms-server/src/main/java/org/gms/server/maps/MapFactory.java
@@ -115,12 +115,16 @@ public class MapFactory {
         AbstractLoadedLife myLife = loadLife(id, type, cy, f, fh, rx0, rx1, x, y, hide);
         if (myLife instanceof Monster monster) {
             int mobRespawnRate = YamlConfig.config.server.MOB_RESPAWN_RATE;
-            if (mobRespawnRate < 1) {
+            float mobTimeRate = YamlConfig.config.server.BOSS_RESPAWN_MOBTIME_RATE;
+            mobTimeRate = (mobTimeRate <= 0 || mobTimeRate > 1) ? 1 : mobTimeRate;  //将值限定在0~1之间的范围
+            if (mobRespawnRate < 1) {   //如果读入的值小于1，或者怪物为boss，则设定生怪倍率为1
                 mobRespawnRate = 1;
             }
             if (monster.isBoss()) {
                 mobRespawnRate = 1;
+                mobTime *= mobTimeRate;
             }
+
             for (int i = 0; i < mobRespawnRate; i++) {
                 if (mobTime == -1) { //does not respawn, force spawn once
                     map.spawnMonster(monster);

--- a/gms-server/src/main/java/org/gms/service/NameChangeService.java
+++ b/gms-server/src/main/java/org/gms/service/NameChangeService.java
@@ -6,19 +6,24 @@ import lombok.extern.slf4j.Slf4j;
 import org.gms.client.Character;
 import org.gms.config.YamlConfig;
 import org.gms.dao.entity.CharactersDO;
+import org.gms.dao.entity.InventoryitemsDO;
 import org.gms.dao.entity.NamechangesDO;
 import org.gms.dao.entity.RingsDO;
 import org.gms.dao.mapper.CharactersMapper;
+import org.gms.dao.mapper.InventoryitemsMapper;
 import org.gms.dao.mapper.NamechangesMapper;
 import org.gms.dao.mapper.RingsMapper;
 import org.gms.manager.ServerManager;
 import org.gms.util.I18nUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.gms.constants.id.ItemId;
 
 import java.sql.Timestamp;
 import java.util.List;
 
+import static org.gms.dao.entity.table.InventoryequipmentDOTableDef.INVENTORYEQUIPMENT_D_O;
+import static org.gms.dao.entity.table.InventoryitemsDOTableDef.INVENTORYITEMS_D_O;
 import static org.gms.dao.entity.table.NamechangesDOTableDef.NAMECHANGES_D_O;
 import static org.gms.dao.entity.table.RingsDOTableDef.RINGS_D_O;
 
@@ -29,6 +34,7 @@ public class NameChangeService {
     private final NamechangesMapper namechangesMapper;
     private final CharactersMapper charactersMapper;
     private final RingsMapper ringsMapper;
+    private final InventoryitemsMapper inventoryitemsmapper;
 
     public void applyAllNameChange() {
         List<NamechangesDO> namechangesDOList = getAllNameChanges();
@@ -42,7 +48,7 @@ public class NameChangeService {
         });
     }
 
-    public void applyNameChange(int characterId, String characterName) {
+    public void applyNameChange(int characterId, String characterName) {//下线时检测是否需要更换昵称并应用
         List<NamechangesDO> namechangesDOList = namechangesMapper.selectListByQuery(QueryWrapper.create()
                 .where(NAMECHANGES_D_O.COMPLETION_TIME.isNull()).and(NAMECHANGES_D_O.CHARACTERID.eq(characterId)));
         if (!namechangesDOList.isEmpty()) {
@@ -70,10 +76,13 @@ public class NameChangeService {
      * @param data 改名对象
      */
     @Transactional(rollbackFor = Exception.class)
-    public void doNameChange(NamechangesDO data) {
+    public void doNameChange(NamechangesDO data) {//应用昵称更改
+        int accountid = charactersMapper.selectOneById(data.getCharacterid()).getAccountid();
         charactersMapper.update(CharactersDO.builder().id(data.getCharacterid()).name(data.getNewer()).build());
         ringsMapper.updateByQuery(RingsDO.builder().partnername(data.getNewer()).build(), QueryWrapper.create().where(RINGS_D_O.PARTNERNAME.eq(data.getOlder())));
         namechangesMapper.update(NamechangesDO.builder().id(data.getId()).completionTime(new Timestamp(System.currentTimeMillis())).build());
+        //似乎没有修复使用改名卡撤销已修改名称的功能，当双击改名卡并确认撤销改名，客户端直接闪退报38错误，顾在此处一刀切，直接删除角色背包和账户商城里所有改名卡
+        inventoryitemsmapper.deleteByQuery(QueryWrapper.create().where(INVENTORYITEMS_D_O.ITEMID.eq(ItemId.NAME_CHANGE)).and(INVENTORYITEMS_D_O.CHARACTERID.eq(data.getCharacterid()).or(INVENTORYITEMS_D_O.ACCOUNTID.eq(accountid))));
         log.info(I18nUtil.getLogMessage("CharacterService.doNameChange.info1"), data.getOlder(), data.getNewer());
     }
 

--- a/gms-server/src/main/resources/application.yml
+++ b/gms-server/src/main/resources/application.yml
@@ -247,19 +247,19 @@ gms:
     USE_DEBUG_SHOW_INFO_EQPEXP: false   #在cmd上打印所有装备经验增益信息。
     USE_DEBUG_SHOW_RCVD_PACKET: false   #在cmd上打印所有接收到的数据包ID。
     USE_DEBUG_SHOW_RCVD_MVLIFE: false   #在cmd上打印所有接收到的移动生命内容。
-    USE_DEBUG_SHOW_PACKET: false
+    USE_DEBUG_SHOW_PACKET: false				#在cmd上打印所有接收到的数据包内容
     USE_SUPPLY_RATE_COUPONS: true       #允许通过现金商店出售速率优惠券。
     USE_IP_VALIDATION: false             #在登录时启用IP检查。
     USE_CHARACTER_ACCOUNT_CHECK: false  #在登录时启用单角色-账户检查。这可能是资源密集型的。
     NO_PASSWORD: false                  #跳过密码验证直接凭账号登录，必须先开启debug模式
 
     USE_MAXRANGE: true                  #将从地图上的所有事件发送和接收数据包，而不仅仅是视图范围内的那些。.
-    USE_MAXRANGE_ECHO_OF_HERO: true
-    USE_MTS: false
+    USE_MAXRANGE_ECHO_OF_HERO: true			#使用英雄的最大范围回响技能
+    USE_MTS: false											#开关拍卖行，true=进入拍卖行，false=打开NPC
     USE_CPQ: true                       #Renders the CPQ available or not.
     USE_AUTOHIDE_GM: true              #开启后GM上线自动隐身. Thanks to Steven Deblois (steven1152).
     USE_FIXED_RATIO_HPMP_UPDATE: false   #Enables the HeavenMS-builtin HPMP update based on the current pool to max pool ratio.
-    USE_FAMILY_SYSTEM: true
+    USE_FAMILY_SYSTEM: true							#[机翻]使用家庭系统；[推测]开启家族系统
     USE_DUEY: true                     # 是否开启快递
     USE_RANDOMIZE_HPMP_GAIN: true       #在升级时启用MaxHP/MaxMP增益和INT对MaxMP增益的随机化。
     USE_STORAGE_ITEM_SORT: true         #启用存储“整理物品”功能。
@@ -402,7 +402,7 @@ gms:
     #角色配置
     USE_ADD_SLOTS_BY_LEVEL: false    #每20级增加槽位。
     USE_ADD_RATES_BY_LEVEL: false    #每20级增加速率。
-    USE_STACK_COUPON_RATES: false   #多个优惠券效果叠加在一起。
+    USE_STACK_COUPON_RATES: false   #多个倍率券效果叠加在一起。
     USE_PERFECT_PITCH: false         #对于30级或以上的玩家，每次升级授予1个完美音高。
     USE_LEVEL_UP_PROTECT: true       #升级保护，避免连续升级
 
@@ -499,9 +499,9 @@ gms:
     MINIMUM_GM_LEVEL_TO_DROP: 4
     
     #创建角色
-    ENABLE_ADVENTURERS: true             #允许创建冒险家
-    ENABLE_KNIGHTS_OF_CYGNUS: false       #允许创建骑士团
-    ENABLE_THE_LORD_OF_WAR: false         #允许创建战神
+    ENABLE_ADVENTURERS: true             #是否允许创建冒险家，true=允许，false=禁止
+    ENABLE_KNIGHTS_OF_CYGNUS: false       #是否允许创建骑士团，true=允许，false=禁止
+    ENABLE_THE_LORD_OF_WAR: false         #是否允许创建战神，true=允许，false=禁止
 
     #应搜索js覆盖脚本的任何NPC ID（如果它们已经有wz条目，否则它们会被忽略）。
     NPCS_SCRIPTABLE:
@@ -512,5 +512,7 @@ gms:
     CHANGE_CHANNEL_FORCE_RETURN: false
     # 怪物生成倍率
     MOB_RESPAWN_RATE: 1
+    # BOSS刷新时间速率，浮点值只能在>0 到 <=1 之间
+    BOSS_RESPAWN_MOBTIME_RATE : 1
     # 消耗栏和其他栏的物品最大堆叠，-1保持默认，以wz的最大堆叠为准。
     ITEM_SLOT_MAX: -1


### PR DESCRIPTION
新增：加入一个配置用于缩短野外BOSS刷新时间，支持浮点数: (>0 && <=1)。
优化：改名卡在应用改名后似乎没有撤销改名的功能，当双击改名卡并确认撤销改名，客户端直接闪退报38错误。因此在改名成功后直接删除账户商城和角色背包里的所有改名卡。
汉化：汉化了配置里的部分说明，以及时间神殿一个传送脚本的提示