### PR TITLE
增加进入南港时的title显示、明珠港5个npc对话内容修改及汉化

### DIFF
--- a/gms-server/scripts-zh-CN/map/onUserEnter/go2000000.js
+++ b/gms-server/scripts-zh-CN/map/onUserEnter/go2000000.js
@@ -1,0 +1,25 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+function start(ms) {
+    ms.mapEffect("maplemap/enter/2000000");
+}

--- a/gms-server/scripts-zh-CN/npc/1002002.js
+++ b/gms-server/scripts-zh-CN/npc/1002002.js
@@ -27,7 +27,7 @@
 var status = 0;
 
 function start() {
-    cm.sendSimple("你听说过位于立石港附近，能够欣赏到壮观海景的海滩#b弗洛里娜海滩#k吗？我可以带你去那里，只需#b1500金币#k，或者如果你有#b弗洛里娜海滩VIP门票#k的话，那就可以免费进入。\r\n#L0##b 我支付1500金币。#l\r\n#L1# 我有弗洛里娜海滩VIP门票。#l\r\n#L2# 什么是弗洛里娜海滩VIP门票？#l");
+    cm.sendSimple("你听说过位于立石港附近，能够欣赏到壮观海景的海滩#b黄金海滩#k吗？我可以带你去那里，只需#b1500金币#k，或者如果你有#b黄金海滩VIP门票#k的话，那就可以免费进入。\r\n#L0##b 我支付1500金币。#l\r\n#L1# 我有黄金海滩VIP门票。#l\r\n#L2# 什么是黄金海滩VIP门票？#l");
 }
 
 function action(mode, type, selection) {
@@ -48,9 +48,9 @@ function action(mode, type, selection) {
     }
     if (status == 1) {
         if (selection == 1) {
-            cm.sendYesNo("所以你有一张#b弗洛里娜海滩VIP门票#k吗？你可以随时用它前往弗洛里娜海滩。好的，但要注意可能会遇到一些怪物。好的，你现在想前往弗洛里娜海滩吗？");
+            cm.sendYesNo("所以你有一张#b黄金海滩VIP门票#k吗？你可以随时用它前往黄金海滩。好的，但要注意可能会遇到一些怪物。好的，你现在想前往黄金海滩吗？");
         } else if (selection == 2) {
-            cm.sendNext("你一定对#b弗洛里纳海滩的VIP门票#k很感兴趣。哈哈，这很可以理解。弗洛里纳海滩的VIP门票是一种物品，只要你拥有它，就可以免费前往弗洛里纳海滩。这是一种非常稀有的物品，甚至我们也不得不购买，但不幸的是，我在几周前在我珍贵的暑假期间丢失了我的。");
+            cm.sendNext("你一定对#b黄金海滩的VIP门票#k很感兴趣。哈哈，这很可以理解。黄金海滩的VIP门票是一种物品，只要你拥有它，就可以免费前往黄金海滩。这是一种非常稀有的物品，甚至我们也不得不购买，但不幸的是，我在几周前在我珍贵的暑假期间丢失了我的。");
         }
     } else if (status == 2) {
         if (type != 1 && selection != 0) {
@@ -60,7 +60,7 @@ function action(mode, type, selection) {
             if (cm.getMeso() < 1500 && selection == 0) {
                 cm.sendNext("我觉得你缺少冒险币。有很多方法可以赚钱，比如...卖掉你的盔甲...打败怪物...做任务...你知道我在说什么。");
             } else if (!cm.haveItem(4031134) && selection != 0) {
-                cm.sendNext("嗯，你的 #bVIP通行证#k 到弗洛里纳海滩到底在哪里？你确定你有吗？请再检查一遍。");
+                cm.sendNext("嗯，你的 #bVIP通行证#k 到黄金海滩到底在哪里？你确定你有吗？请再检查一遍。");
             } else {
                 if (selection == 0) {
                     cm.gainMeso(-1500);

--- a/gms-server/scripts-zh-CN/npc/1002006.js
+++ b/gms-server/scripts-zh-CN/npc/1002006.js
@@ -20,6 +20,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 function start() {
-    cm.sendNext("Hi, I'm #b#p1002006##k. Nice to meet you.")
+    cm.sendNext("嗨, 我是 #b#p1002006##k 见到你很高兴。")
     cm.dispose();
 }

--- a/gms-server/scripts-zh-CN/npc/1002007.js
+++ b/gms-server/scripts-zh-CN/npc/1002007.js
@@ -43,7 +43,7 @@ function action(mode, type, selection) {
             }
             selStr += "选择您的目的地，因为费用将因地点而异。#b";
             for (var i = 0; i < maps.length; i++) {
-                selStr += "\r\n#L" + i + "##m" + maps[i] + "# (" + (cm.getJobId() == 0 ? cost[i] / 10 : cost[i]) + " mesos)#l";
+                selStr += "\r\n#L" + i + "##m" + maps[i] + "# (" + (cm.getJobId() == 0 ? cost[i] / 10 : cost[i]) + " 金币)#l";
             }
             cm.sendSimple(selStr);
         } else if (status == 2) {

--- a/gms-server/scripts-zh-CN/npc/9000001.js
+++ b/gms-server/scripts-zh-CN/npc/9000001.js
@@ -27,7 +27,7 @@
 var status = 0;
 
 function start() {
-    cm.sendNext("嘿，我是#bJean#k。我在等我的哥哥#bPaul#k。他现在应该已经到了…");
+    cm.sendNext("嘿，我是#b#p9000001##k。我在等我的哥哥#b保罗#k。他现在应该已经到了…");
 }
 
 function action(mode, type, selection) {

--- a/gms-server/scripts-zh-CN/npc/9000021.js
+++ b/gms-server/scripts-zh-CN/npc/9000021.js
@@ -51,7 +51,7 @@ function action(mode, type, selection) {
         } else if (status == 1) {
             cm.sendNext("这些比赛涉及#b连续的boss战#k，其中一些部分之间有一些休息点。这将需要一些策略时间和足够的物资在手，因为它们不是普通的战斗。");
         } else if (status == 2) {
-            cm.sendAcceptDecline("If you feel you are powerful enough, you can join others like you at where we are hosting the contests of power. ... So, what is your decision? Will you come to where the contests are being held right now?");
+            cm.sendAcceptDecline("如果你觉得自己足够强大，你可以像其他人一样在我们举办权力竞赛的地方加入。...那么，你的决定是什么？您现在进入举行比赛的地方吗？");
         } else if (status == 3) {
             cm.sendOk("非常好。记住，在那里你可以组建一个团队，或者独自进行战斗，这取决于你。祝你好运！");
         } else if (status == 4) {


### PR DESCRIPTION
增加进入南港时的title，go2000000
明珠港出租车1002007，mesos	替换为	金币
明珠港npc佩森1002002，弗洛里纳海滩	替换为	黄金海滩
吉夫1002006，对话汉化(没有任务等其他功能)
江9000001，对话里的名字改为中文
佳佳9000021对话第三页是英文，汉化