### PR TITLE
新增：帮助脚本里新增【爆率一览】用于查看当前地图怪物种类和爆率

### DIFF
--- a/gms-server/scripts-zh-CN/BeiDouSpecial/当前地图掉落.js
+++ b/gms-server/scripts-zh-CN/BeiDouSpecial/当前地图掉落.js
@@ -93,9 +93,9 @@ function levelShowDropList(mobId) {
         let dropall = MonsterInformationProvider.getInstance().retrieveDrop(mobId);										 //根据怪物ID获取掉落物品列表
         let CountItems = dropall.size();																																  //取掉落物品总数量
         let mobName = !mob.getName() || mob.getName() == 'MISSINGNO' ? `#o${mobId}#` : mob.getName();
-        mobName = `${getMobImage(mobId)}\r\n[ #e#b${mobName}#k#n ] `;
+        mobName = `[ #e#b${mobName}#k#n ] `;
         if(CountItems <= 0) {
-            msgtext = `${mobName} 没有掉落。`;
+            msgtext = `${getMobImage(mobId)}\r\n${mobName} 没有掉落。`;
         } else {
             msgtext = `${getMobImage(mobId)}\r\n${mobName} 物品掉落列表一览\r\n\r\n`;
             // 遍历 table 对象的键，并设置其值为键名的长度

--- a/gms-server/scripts-zh-CN/BeiDouSpecial/当前地图掉落.js
+++ b/gms-server/scripts-zh-CN/BeiDouSpecial/当前地图掉落.js
@@ -1,0 +1,142 @@
+/**
+ * 功能：展示当前地图存活的怪物种类以及物品爆率
+ * 作者：Magical-H (https://github.com/Magical-H)
+ * 版本：1.0
+ * 日期：2024-12-02
+ */
+var MonsterInformationProvider;
+var ItemInformationProvider;
+var QuestInfo;
+
+var MapObj;                 //地图对象
+var List_Mob_All;           //所有怪物列表
+var List_Mob_Boss;          //BOSS列表
+var List_Mob;               //普通怪物列表
+var namelength = 0;
+
+function start(){
+    if(MapObj == null) {    //首次打开进行初始化。
+        MonsterInformationProvider = Java.type('org.gms.server.life.MonsterInformationProvider');       //导入 怪物信息 类
+        ItemInformationProvider = Java.type('org.gms.server.ItemInformationProvider');                  //导入 物品信息 类
+        QuestInfo = Java.type('org.gms.server.quest.Quest');                                            //导入 任务 类
+        MapObj = cm.getMap();
+        List_Mob_All = MapObj.getAllMonsters(); //获取当前地图存活的怪物数量，由于未找到获取当前地图固定怪物列表方法，故用此方法代替。
+        //将怪物种类去重并按照Boss和普通怪物区分开
+        [List_Mob, List_Mob_Boss] = Object.values(List_Mob_All.reduce((acc, mob) => (acc.ids.has(mob.getId()) || (acc.ids.add(mob.getId()), mob.isBoss() ? acc.bosses : acc.mobs).push(mob), acc), { ids: new Set(), mobs: [], bosses: [] })).slice(-2);
+    }
+    levelmain();
+}
+
+function leveldispose() {
+    cm.dispose();
+}
+
+/**
+ * 当部分cm.sendLevel方法没有指定下一个跳转方法时会自动跳入null，也就是这里。
+ */
+function levelnull() {
+    cm.dispose();
+}
+
+/**
+ * 这里是第一层对话框，用于展示当前地图存活的怪物种类。
+ */
+function levelmain() {
+    if(List_Mob_All.length == 0) {
+        cm.sendOkLevel('dispose', '当前地图没有存活的怪物，请等待怪物刷新后再进行查询。', 2);
+    } else {
+        var Msg_Select = '当前地图怪物列表一览，点击可查看掉落列表：\r\n\r\n'; //怪物选择展示消息
+        if(List_Mob_Boss.length > 0) {
+            Msg_Select += `#e#rBOSS#k#n：${List_Mob_Boss.length} 种\r\n`;
+            Msg_Select += getSelecttext(List_Mob_Boss);
+            Msg_Select += '#d' + '\r\n'.padStart(28,'——') + '#k';
+        }
+        if(List_Mob.length > 0) {
+            Msg_Select += `普通怪物：${List_Mob.length} 种\r\n`;
+            Msg_Select += getSelecttext(List_Mob);
+        }
+        cm.sendNextSelectLevel('ShowDropList', Msg_Select,2);
+    }
+}
+
+/**
+ * 格式化输出当前地图存在的怪物列表选项。
+ * @param moblist
+ * @returns {string}
+ */
+function getSelecttext(moblist) {
+    let size = moblist.reduce((max, obj) => Math.max(max, obj.getName().length), 0);  //取最长怪物名称长度
+    namelength = namelength > size ? namelength : size;
+    return moblist.map(obj => {
+        let id = obj.getId();
+        let name = obj.getName().padEnd(namelength,'\t');
+        return `#L${id}#${getMobImage(id)}\r\n#b${name}#k\t${obj.isBoss() ? '[ #r#eBOSS#k#n ]' : ''}\t[ Lv.${obj.getLevel()} ]#l`
+    }).join('\r\n') + '\r\n\r\n';
+}
+
+/**
+ * 格式化输出指定怪物的掉落物品列表
+ * @param mobId
+ */
+function levelShowDropList(mobId) {
+    const mob = List_Mob_All.find(mob => mob.getId() == mobId);     //根据怪物ID获取已缓存的怪物对象
+    const table = {
+        '物品名称' : 0,
+        '基础掉率' : 0,
+        '你的掉率' : 0,
+    }
+    let msgtext = `当前查询的怪物ID [ ${mobId} ] 不存在。`;
+
+    if(mob != null) {
+        let player = cm.getPlayer();
+        let dropall = MonsterInformationProvider.getInstance().retrieveDrop(mobId);                     //根据怪物ID获取掉落物品列表
+        let CountItems = dropall.size;                                                                  //取掉落物品总数量
+        let mobName = `[ #e#b${mob.getName()}#k#n ] `;
+        if(CountItems === 0) {
+            msgtext = `${mobName} 没有掉落。`;
+        } else {
+            msgtext = `${getMobImage(mobId)}\r\n${mobName} 物品掉落列表一览\r\n\r\n`;
+            // 遍历 table 对象的键，并设置其值为键名的长度
+            Object.keys(table).forEach(key => {table[key] = Math.max(table[key],key.length)});
+            let dropitemlist = {};
+            dropall.filter(drop => drop.itemId > 0).forEach((drop, index) => {
+                let itemName = ItemInformationProvider.getInstance().getName(drop.itemId);
+                if (itemName != null) {
+                    let itemChance = (drop.chance / 10000).toFixed(4);
+                    // 更新 table 中对应的键值以记录最大长度
+                    table['物品名称'] = Math.max(table['物品名称'], itemName.length);
+                    table['基础掉率'] = Math.max(table['基础掉率'], itemChance.length / 2);
+                    table['你的掉率'] = Math.max(table['你的掉率'], itemChance.length / 2);
+                    // 确保 itemName 在结果对象中是唯一的键
+                    // 如果 itemName 可能重复，可以添加索引或其它唯一标识
+                    dropitemlist[drop.itemId] = {name : itemName , chance : itemChance , questid : drop.questid};
+                }
+            });
+            // 确保所有值都是偶数
+            Object.keys(table).forEach(key => table[key] = Math.ceil(table[key] / 2) * 2);
+            msgtext += '#b' + Object.entries(table).map(([key,val]) => `${key.padEnd(val,'\t')}`).join('\t') + '#k\r\n';
+            msgtext += Object.entries(dropitemlist).map(([itemId, { name, chance ,questid}]) => {
+                    let msg = `#L${itemId}##v${itemId}#\r\n#b#e${name.padEnd(table['物品名称'] + countAllSymbols(name), '\t')}#k#n\t`;
+                    msg += `${(chance + '%').padEnd(table['基础掉率'], '\t')}\t#d${(chance * player.getDropRate() * player.getFamilyDrop() + '%').padEnd(table['你的掉率'], '\t')}#k\r\n`;
+                    msg += questid > 0 ? '#r[任务道具]#k '+QuestInfo.getInstance(questid).getName()+'\r\n' : '';
+                    msg += '#l';
+                    return msg;
+                }
+            ).join('\r\n');
+        }
+    }
+    cm.sendLastLevel('main',msgtext,2); //这里会出现上一项+确定的对话框，如果点击确定则会进入到levelnull的方法里，估计是源码里没做判断。
+}
+
+/**
+ * 提取字符串里的符号数量
+ * @param str
+ * @returns {*|number}
+ */
+function countAllSymbols(str) {
+    return Math.ceil(str.match(/[^\u4e00-\u9fff]/g)?.length / 2) || 0;
+}
+
+function getMobImage(id){
+    return `#fMob/${id}.img/stand/0#`;
+}

--- a/gms-server/scripts-zh-CN/BeiDouSpecial/当前地图掉落.js
+++ b/gms-server/scripts-zh-CN/BeiDouSpecial/当前地图掉落.js
@@ -8,17 +8,17 @@ var MonsterInformationProvider;
 var ItemInformationProvider;
 var QuestInfo;
 
-var MapObj;                 //地图对象
-var List_Mob_All;           //所有怪物列表
-var List_Mob_Boss;          //BOSS列表
-var List_Mob;               //普通怪物列表
+var MapObj;								 //地图对象
+var List_Mob_All;				   //所有怪物列表
+var List_Mob_Boss;				  //BOSS列表
+var List_Mob;						   //普通怪物列表
 var namelength = 0;
 
 function start(){
-    if(MapObj == null) {    //首次打开进行初始化。
-        MonsterInformationProvider = Java.type('org.gms.server.life.MonsterInformationProvider');       //导入 怪物信息 类
-        ItemInformationProvider = Java.type('org.gms.server.ItemInformationProvider');                  //导入 物品信息 类
-        QuestInfo = Java.type('org.gms.server.quest.Quest');                                            //导入 任务 类
+    if(MapObj == null) {		//首次打开进行初始化。
+        MonsterInformationProvider = Java.type('org.gms.server.life.MonsterInformationProvider');		   //导入 怪物信息 类
+        ItemInformationProvider = Java.type('org.gms.server.ItemInformationProvider');								  //导入 物品信息 类
+        QuestInfo = Java.type('org.gms.server.quest.Quest');																						//导入 任务 类
         MapObj = cm.getMap();
         List_Mob_All = MapObj.getAllMonsters(); //获取当前地图存活的怪物数量，由于未找到获取当前地图固定怪物列表方法，故用此方法代替。
         //将怪物种类去重并按照Boss和普通怪物区分开
@@ -69,7 +69,8 @@ function getSelecttext(moblist) {
     namelength = namelength > size ? namelength : size;
     return moblist.map(obj => {
         let id = obj.getId();
-        let name = obj.getName().padEnd(namelength,'\t');
+        let name = !obj.getName() || obj.getName() == 'MISSINGNO' ? `#o${id}#` : obj.getName();
+        name = name.padEnd(namelength,'\t');
         return `#L${id}#${getMobImage(id)}\r\n#b${name}#k\t${obj.isBoss() ? '[ #r#eBOSS#k#n ]' : ''}\t[ Lv.${obj.getLevel()} ]#l`
     }).join('\r\n') + '\r\n\r\n';
 }
@@ -79,7 +80,7 @@ function getSelecttext(moblist) {
  * @param mobId
  */
 function levelShowDropList(mobId) {
-    const mob = List_Mob_All.find(mob => mob.getId() == mobId);     //根据怪物ID获取已缓存的怪物对象
+    const mob = List_Mob_All.find(mob => mob.getId() == mobId);		 //根据怪物ID获取已缓存的怪物对象
     const table = {
         '物品名称' : 0,
         '基础掉率' : 0,
@@ -89,10 +90,11 @@ function levelShowDropList(mobId) {
 
     if(mob != null) {
         let player = cm.getPlayer();
-        let dropall = MonsterInformationProvider.getInstance().retrieveDrop(mobId);                     //根据怪物ID获取掉落物品列表
-        let CountItems = dropall.size;                                                                  //取掉落物品总数量
-        let mobName = `[ #e#b${mob.getName()}#k#n ] `;
-        if(CountItems === 0) {
+        let dropall = MonsterInformationProvider.getInstance().retrieveDrop(mobId);										 //根据怪物ID获取掉落物品列表
+        let CountItems = dropall.size();																																  //取掉落物品总数量
+        let mobName = !mob.getName() || mob.getName() == 'MISSINGNO' ? `#o${mobId}#` : mob.getName();
+        mobName = `${getMobImage(mobId)}\r\n[ #e#b${mobName}#k#n ] `;
+        if(CountItems <= 0) {
             msgtext = `${mobName} 没有掉落。`;
         } else {
             msgtext = `${getMobImage(mobId)}\r\n${mobName} 物品掉落列表一览\r\n\r\n`;

--- a/gms-server/scripts-zh-CN/npc/9900001.js
+++ b/gms-server/scripts-zh-CN/npc/9900001.js
@@ -47,7 +47,7 @@ function action(mode, type, selection) {
         text += "当前信用券：" + cm.getPlayer().getCashShop().getCash(4) + "\r\n";
         text += " \r\n\r\n";
         text += "#L0#新人福利#l \t #L1#每日签到#l \t #L2#在线奖励#l\r\n";
-        text += "#L3#传送自由#l\r\n";
+        text += "#L3#传送自由#l \t #L4#爆率一览#l\r\n";
         if (cm.getPlayer().isGM()) {
             text += "\r\n\r\n";
             text += "\t\t\t\t#r=====以下内容仅GM可见=====\r\n";
@@ -78,6 +78,9 @@ function doSelect(selection) {
         case 3:
             cm.getPlayer().saveLocation("FREE_MARKET");
             cm.warp(910000000, "out00");
+            break;
+        case 4:
+            openNpc("当前地图掉落");
             break;
         // GM功能
         case 61:

--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -9007,7 +9007,7 @@ public class Character extends AbstractCharacterObject {
                 if (pendantExp < 3) {
                     pendantExp++;
                     //用于准确提示装备1小时内还是装备经过几小时
-                    message(I18nUtil.getMessage(pendantExp <= 2 ? "Character.equipPendantOfSpirit.message1" : "Character.equipPendantOfSpirit.message2", pendantExp, pendantExp * 10));
+                    message(I18nUtil.getMessage(pendantExp <= 2 ? "Character.equipPendantOfSpirit.message1" : "Character.equipPendantOfSpirit.message2", pendantExp == 3 : 2 ? pendantExp, pendantExp * 10));
                 } else {
                     pendantOfSpirit.cancel(false);
                 }


### PR DESCRIPTION
新增：帮助脚本里新增【爆率一览】用于查看当前地图怪物种类和爆率
优化：精灵吊坠使用2小时后的文本将正确显示为：经过了2小时。


https://github.com/user-attachments/assets/30a0b86a-0867-459f-bc25-7781c1d9d0c6

![image](https://github.com/user-attachments/assets/6931e4ac-4959-4863-9174-fe216e11cc4b)
![image](https://github.com/user-attachments/assets/df674e49-b19b-411a-b228-1e5f26c9cea7)
![image](https://github.com/user-attachments/assets/4a0a118b-21d4-467c-856e-d98d97a6f974)
![image](https://github.com/user-attachments/assets/ab0ae5c0-622b-48fb-909f-cb7f2bf6fc76)
![image](https://github.com/user-attachments/assets/b3c39a3f-7709-4ecf-b539-53edc81bf7e2)
![image](https://github.com/user-attachments/assets/15acc825-0f08-468a-aca1-d1a7de5d40cf)
