### PR TITLE
优化：查看地图掉落脚本增加防止客户端展示超过一定尺寸的图片导致假死。

### DIFF
--- a/gms-server/scripts-zh-CN/BeiDouSpecial/当前地图掉落.js
+++ b/gms-server/scripts-zh-CN/BeiDouSpecial/当前地图掉落.js
@@ -50,7 +50,7 @@ function levelmain() {
         if(List_Mob_Boss.length > 0) {
             Msg_Select += `#e#rBOSS#k#n：${List_Mob_Boss.length} 种\r\n`;
             Msg_Select += getSelecttext(List_Mob_Boss);
-            Msg_Select += '#d' + '\r\n'.padStart(28,'——') + '#k';
+            if(List_Mob.length > 0) Msg_Select += '#d' + '\r\n'.padStart(28,'——') + '#k';
         }
         if(List_Mob.length > 0) {
             Msg_Select += `普通怪物：${List_Mob.length} 种\r\n`;
@@ -151,6 +151,8 @@ function getMobImage(mob){
         type = type[mob.getStats().getMovetype() + 1];    //-1=未知类型，0=陆地类型，1=飞天类型
     if(type == null) {
         return `#fUI/UIWindow.img/Maker/randomRecipe#`;     //没有怪物图片时显示一个问号。
+    } else if (mob.getStats().getImgwidth() > 160 && mob.getStats().getImgheight() > 250) { //如果图片超过指定范围会造成客户端假死，因此这里需要替换成别的图片或者干脆不要。
+        return `#fMap/Obj/Tdungeon.img/mushCatle/npc/0/0#\r\n(形象过大，不能展示)`;
     } else {
         //当前怪物ID最多7位数，不足7位数则需要在前面补0
         return `#fMob/${mob.getId().toString().padStart(7, '0')}.img/${type}/0#`;

--- a/gms-server/src/main/java/org/gms/provider/Data.java
+++ b/gms-server/src/main/java/org/gms/provider/Data.java
@@ -32,4 +32,5 @@ public interface Data extends DataEntity, Iterable<Data> {
     List<Data> getChildren();
     Data getChildByPath(String path);
     Object getData();
+    String getAttributeValue(String name);
 }

--- a/gms-server/src/main/java/org/gms/provider/wz/XMLDomMapleData.java
+++ b/gms-server/src/main/java/org/gms/provider/wz/XMLDomMapleData.java
@@ -207,4 +207,12 @@ public class XMLDomMapleData implements Data {
     public synchronized Iterator<Data> iterator() {
         return getChildren().iterator();
     }
+
+    /**
+     * 获取指定节点属性值
+     * @return
+     */
+    public synchronized String getAttributeValue(String name) {
+        return node.getAttributes().getNamedItem(name).getNodeValue();
+    }
 }

--- a/gms-server/src/main/java/org/gms/server/life/LifeFactory.java
+++ b/gms-server/src/main/java/org/gms/server/life/LifeFactory.java
@@ -243,10 +243,16 @@ public class LifeFactory {
                 stats.setFixedStance(origin.getX() < 1 ? 5 : 4);    // fixed left/right
             }
         }
-        if (monsterData.getChildByPath("fly") != null) {
+        Data fly = monsterData.getChildByPath("fly/0");
+        Data stand = monsterData.getChildByPath("stand/0");
+        if (fly != null) {
             stats.setMovetype(1);   //设定怪物类型为：fly
-        } else if (monsterData.getChildByPath("stand") != null) {
+            stats.setImgwidth(Integer.parseInt(fly.getAttributeValue("width")));
+            stats.setImgheight(Integer.parseInt(fly.getAttributeValue("height")));
+        } else if (stand != null) {
             stats.setMovetype(0);   //设定怪物类型为：stand
+            stats.setImgwidth(Integer.parseInt(stand.getAttributeValue("width")));
+            stats.setImgheight(Integer.parseInt(stand.getAttributeValue("height")));
         }
         return new Pair<>(stats, attackInfos);
     }

--- a/gms-server/src/main/java/org/gms/server/life/MonsterStats.java
+++ b/gms-server/src/main/java/org/gms/server/life/MonsterStats.java
@@ -55,6 +55,8 @@ public class MonsterStats {
     public int fixedStance = 0;
     public boolean friendly;
     public int movetype = -1;    //怪物类型，-1=未知，0=stand（陆地），1=fly（飞天）
+    public int imgwidth = 0;     //第一帧图片宽度
+    public int imgheight = 0;    //第一帧图片高度
 
     public void setChange(boolean change) {
         this.changeable = change;
@@ -358,6 +360,38 @@ public class MonsterStats {
      */
     public void setMovetype(int movetype) {
         this.movetype = movetype;
+    }
+
+    /**
+     * 设置第一帧图片的宽度
+     * @param imgwidth
+     */
+    public void setImgwidth(int imgwidth) {
+        this.imgwidth = imgwidth;
+    }
+
+    /**
+     * 设置第一帧图片的高度
+     * @param imgheight
+     */
+    public void setImgheight(int imgheight) {
+        this.imgheight = imgheight;
+    }
+
+    /**
+     * 取第一帧图片的宽度
+     * @return
+     */
+    public int getImgwidth() {
+        return this.imgwidth;
+    }
+
+    /**
+     * 取第一帧图片的高度
+     * @return
+     */
+    public int getImgheight() {
+        return this.imgheight;
     }
 
     public MonsterStats copy() {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/eb432dab-0cd7-40c9-8fe9-b51e3d3dda70)
