### PR TITLE
修复：进入地图获取怪物状态因xml节点属性不存在导致的NPE.

### DIFF
--- a/gms-server/src/main/java/org/gms/provider/wz/XMLDomMapleData.java
+++ b/gms-server/src/main/java/org/gms/provider/wz/XMLDomMapleData.java
@@ -210,9 +210,11 @@ public class XMLDomMapleData implements Data {
 
     /**
      * 获取指定节点属性值
+     *
      * @return
      */
     public synchronized String getAttributeValue(String name) {
-        return node.getAttributes().getNamedItem(name).getNodeValue();
+        Node namedItem = node.getAttributes().getNamedItem(name);
+        return namedItem == null ? null : namedItem.getNodeValue();
     }
 }

--- a/gms-server/src/main/java/org/gms/server/life/LifeFactory.java
+++ b/gms-server/src/main/java/org/gms/server/life/LifeFactory.java
@@ -245,14 +245,22 @@ public class LifeFactory {
         }
         Data fly = monsterData.getChildByPath("fly/0");
         Data stand = monsterData.getChildByPath("stand/0");
+
+        Data typeData = null;
         if (fly != null) {
             stats.setMovetype(1);   //设定怪物类型为：fly
-            stats.setImgwidth(Integer.parseInt(fly.getAttributeValue("width")));
-            stats.setImgheight(Integer.parseInt(fly.getAttributeValue("height")));
+            typeData = fly;
         } else if (stand != null) {
             stats.setMovetype(0);   //设定怪物类型为：stand
-            stats.setImgwidth(Integer.parseInt(stand.getAttributeValue("width")));
-            stats.setImgheight(Integer.parseInt(stand.getAttributeValue("height")));
+            typeData = stand;
+        }
+        if (typeData != null) {
+            String width = typeData.getAttributeValue("width");
+            String height = typeData.getAttributeValue("height");
+            if (width != null && height != null) {
+                stats.setImgwidth(Integer.parseInt(width));
+                stats.setImgheight(Integer.parseInt(height));
+            }
         }
         return new Pair<>(stats, attackInfos);
     }


### PR DESCRIPTION
see #256 This pull request includes improvements to error handling and code readability in the `gms-server` project. The most important changes include adding null checks for node attributes and refactoring the monster stats retrieval logic to handle missing data more gracefully.

Error handling improvements:

* [`gms-server/src/main/java/org/gms/provider/wz/XMLDomMapleData.java`](diffhunk://#diff-5134d731719bfc59ab749504b83c4cb91b0c206ee06b06745df6cdc49791f555R213-R218): Added null check for the named item in the `getAttributeValue` method to prevent potential `NullPointerException`.

Code readability improvements:

* [`gms-server/src/main/java/org/gms/server/life/LifeFactory.java`](diffhunk://#diff-cd145eccbd7b387fd8122cc389a754d43eef0618031a4ab899fd60f550206d65R248-R263): Refactored the `getMonsterStats` method to handle `width` and `height` attributes more gracefully by introducing a `typeData` variable and checking for null values before parsing.  