### PR TITLE
添加停服倒计时功能

### DIFF
--- a/gms-server/pom.xml
+++ b/gms-server/pom.xml
@@ -45,8 +45,8 @@
         <mysql-connector-j.version>8.4.0</mysql-connector-j.version> <!-- MySQL JDBC driver -->
         <junit.version>5.10.2</junit.version> <!-- Unit test -->
         <mockito.version>5.11.0</mockito.version> <!-- Unit test -->
-        <flyway-mysql.version>10.21.0</flyway-mysql.version>
-        <lombok.version>1.18.32</lombok.version>
+        <flyway-mysql.version>9.15.2</flyway-mysql.version>
+        <lombok.version>1.18.30</lombok.version>
         <fastjson2.version>2.0.47</fastjson2.version>
         <mybatis-flex.version>1.8.9</mybatis-flex.version>
         <swagger.version>2.5.0</swagger.version>
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.3.4</version>
+                <version>3.2.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/gms-server/pom.xml
+++ b/gms-server/pom.xml
@@ -45,8 +45,8 @@
         <mysql-connector-j.version>8.4.0</mysql-connector-j.version> <!-- MySQL JDBC driver -->
         <junit.version>5.10.2</junit.version> <!-- Unit test -->
         <mockito.version>5.11.0</mockito.version> <!-- Unit test -->
-        <flyway-mysql.version>9.15.2</flyway-mysql.version>
-        <lombok.version>1.18.30</lombok.version>
+        <flyway-mysql.version>10.21.0</flyway-mysql.version>
+        <lombok.version>1.18.32</lombok.version>
         <fastjson2.version>2.0.47</fastjson2.version>
         <mybatis-flex.version>1.8.9</mybatis-flex.version>
         <swagger.version>2.5.0</swagger.version>
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.2.3</version>
+                <version>3.3.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/gms-server/src/main/java/org/gms/client/command/commands/gm6/ShutdownCommand.java
+++ b/gms-server/src/main/java/org/gms/client/command/commands/gm6/ShutdownCommand.java
@@ -64,13 +64,13 @@ public class ShutdownCommand extends Command {
 
             String strTime = "";
             if (days > 0) {
-                strTime += days + I18nUtil.getMessage("ShutdownCommand.message3");
+                strTime += I18nUtil.getMessage("ShutdownCommand.message3", days);
             }
             if (hours > 0) {
-                strTime += hours + I18nUtil.getMessage("ShutdownCommand.message4");
+                strTime += I18nUtil.getMessage("ShutdownCommand.message4", hours);
             }
-            strTime += minutes + I18nUtil.getMessage("ShutdownCommand.message5");
-            strTime += seconds + I18nUtil.getMessage("ShutdownCommand.message6");
+            strTime += I18nUtil.getMessage("ShutdownCommand.message5", minutes);
+            strTime += I18nUtil.getMessage("ShutdownCommand.message6", seconds);
 
             for (World w : Server.getInstance().getWorlds()) {
                 for (Character chr : w.getPlayerStorage().getAllCharacters()) {

--- a/gms-server/src/main/java/org/gms/controller/ServerController.java
+++ b/gms-server/src/main/java/org/gms/controller/ServerController.java
@@ -1,20 +1,21 @@
 package org.gms.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.gms.constants.api.ApiConstant;
 import org.gms.constants.net.ServerConstants;
 import org.gms.model.dto.ChannelListRtnDTO;
-import org.gms.net.server.Server;
 import org.gms.model.dto.ResultBody;
+import org.gms.model.dto.ServerShutdownDTO;
+import org.gms.model.dto.SubmitBody;
+import org.gms.net.server.Server;
 import org.gms.service.ServerService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ApplicationContext;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -40,6 +41,19 @@ public class ServerController {
     @GetMapping("/" + ApiConstant.LATEST + "/stopServer")
     public ResultBody<Object> stopServer() {
         Server.getInstance().shutdownInternal(false);
+        return ResultBody.success();
+    }
+
+    @Tag(name = "/server/" + ApiConstant.LATEST)
+    @Operation(summary = "自定义停止服务")
+    @PostMapping("/" + ApiConstant.LATEST + "/stopServerWithMsgAndInternal")
+    public ResultBody<Object> stopServerWithMsgAndInternal(
+            @Parameter(
+                    name = "data", in = ParameterIn.DEFAULT, required = true,
+                    description = "停服请求参数：包含停服自定义消息，停服倒计时(单位：分钟)"
+            )
+            @RequestBody SubmitBody<ServerShutdownDTO> request) {
+        Server.getInstance().shutdownWithMsgAndInternal(request.getData());
         return ResultBody.success();
     }
 

--- a/gms-server/src/main/java/org/gms/model/dto/ServerShutdownDTO.java
+++ b/gms-server/src/main/java/org/gms/model/dto/ServerShutdownDTO.java
@@ -1,0 +1,20 @@
+package org.gms.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "关服请求参数")
+public class ServerShutdownDTO {
+
+    @Schema(name = "minutes", example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            description = "多少分钟关闭，如果输入小于等于0的数字，则会默认1分钟关闭")
+    private int minutes;
+
+    @Schema(name = "shutdownMsg", example = "服务器将马上停止，请抓紧时间下线",
+            requiredMode = Schema.RequiredMode.AUTO,
+            description = "关服消息，如果不输入或者输入null，则会使用系统默认的停服通知消息")
+    private String shutdownMsg;
+
+}

--- a/gms-server/src/main/java/org/gms/model/dto/ServerShutdownDTO.java
+++ b/gms-server/src/main/java/org/gms/model/dto/ServerShutdownDTO.java
@@ -17,4 +17,19 @@ public class ServerShutdownDTO {
             description = "关服消息，如果不输入或者输入null，则会使用系统默认的停服通知消息")
     private String shutdownMsg;
 
+    @Schema(name = "showServerMsg", example = "true",
+            requiredMode = Schema.RequiredMode.AUTO,
+            description = "是否使用顶部黄色服务器通知，服务重启之后可以重置提示消息。")
+    private Boolean showServerMsg = false;
+
+    @Schema(name = "showCenterMsg", example = "true",
+            requiredMode = Schema.RequiredMode.AUTO,
+            description = "是否使用中央屏幕提示消息。")
+    private Boolean showCenterMsg = false;
+
+    @Schema(name = "showChatMsg", example = "true",
+            requiredMode = Schema.RequiredMode.AUTO,
+            description = "是否使用聊天框给玩家发送蓝色GM消息")
+    private Boolean showChatMsg = false;
+
 }

--- a/gms-server/src/main/java/org/gms/net/server/Server.java
+++ b/gms-server/src/main/java/org/gms/net/server/Server.java
@@ -1661,7 +1661,7 @@ public class Server {
 
         int time = 60000;
 
-        if(serverShutdownDTO.getMinutes() > 0) {
+        if (serverShutdownDTO.getMinutes() > 0) {
             time *= serverShutdownDTO.getMinutes();
         }
 
@@ -1685,19 +1685,26 @@ public class Server {
 
             String shutDownMsg = I18nUtil.getMessage("ShutdownCommand.message7", strTime);
 
-            if(serverShutdownDTO.getShutdownMsg() != null) {
+            if (serverShutdownDTO.getShutdownMsg() != null) {
                 shutDownMsg = serverShutdownDTO.getShutdownMsg();
             }
 
             for (World w : Server.getInstance().getWorlds()) {
                 for (Character chr : w.getPlayerStorage().getAllCharacters()) {
-                    // 屏幕中央提示消息 (火红玫瑰)
-                    chr.startMapEffect(shutDownMsg, 5121009);
+                    if (serverShutdownDTO.getShowCenterMsg()) {
+                        // 屏幕中央提示消息 (火红玫瑰)
+                        chr.startMapEffect(shutDownMsg, 5121009);
+                    }
                 }
-                // 添加滚动消息到顶部，因为是固定时间停服，所以短暂的通知部分玩家可能看不到。
-                w.setServerMessage(shutDownMsg);
-                // 玩家聊天框蓝色GM消息
-                w.broadcastPacket(PacketCreator.serverNotice(6, shutDownMsg));
+                if (serverShutdownDTO.getShowServerMsg()) {
+                    // 添加滚动消息到顶部，因为是固定时间停服，所以短暂的通知部分玩家可能看不到。
+                    w.setServerMessage(shutDownMsg);
+                }
+                if (serverShutdownDTO.getShowChatMsg()) {
+                    // 玩家聊天框蓝色GM消息
+                    w.broadcastPacket(PacketCreator.serverNotice(6, shutDownMsg));
+                }
+
             }
         }
         TimerManager.getInstance().schedule(Server.getInstance().shutdown(false), time);

--- a/gms-server/src/main/java/org/gms/net/server/Server.java
+++ b/gms-server/src/main/java/org/gms/net/server/Server.java
@@ -32,6 +32,7 @@ import org.gms.client.inventory.ItemFactory;
 import org.gms.config.GameConfig;
 import org.gms.dao.entity.CharactersDO;
 import org.gms.dao.entity.PlayernpcsFieldDO;
+import org.gms.model.dto.ServerShutdownDTO;
 import org.gms.property.ServiceProperty;
 import org.gms.util.*;
 import org.gms.model.pojo.NewYearCardRecord;
@@ -1655,4 +1656,52 @@ public class Server {
         nextTime = System.currentTimeMillis() + 86400000 * (base + ran);
         return true;
     }
+
+    public synchronized void shutdownWithMsgAndInternal(ServerShutdownDTO serverShutdownDTO) {
+
+        int time = 60000;
+
+        if(serverShutdownDTO.getMinutes() > 0) {
+            time *= serverShutdownDTO.getMinutes();
+        }
+
+        if (time > 1) {
+
+            int seconds = (time / (int) SECONDS.toMillis(1)) % 60;
+            int minutes = (time / (int) MINUTES.toMillis(1)) % 60;
+            int hours = (time / (int) HOURS.toMillis(1)) % 24;
+            int days = (time / (int) DAYS.toMillis(1));
+
+            String strTime = "";
+            if (days > 0) {
+                strTime += I18nUtil.getMessage("ShutdownCommand.message3", days);
+            }
+            if (hours > 0) {
+                strTime += I18nUtil.getMessage("ShutdownCommand.message4", hours);
+            }
+            strTime += I18nUtil.getMessage("ShutdownCommand.message5", minutes);
+            strTime += I18nUtil.getMessage("ShutdownCommand.message6", seconds);
+
+
+            String shutDownMsg = I18nUtil.getMessage("ShutdownCommand.message7", strTime);
+
+            if(serverShutdownDTO.getShutdownMsg() != null) {
+                shutDownMsg = serverShutdownDTO.getShutdownMsg();
+            }
+
+            for (World w : Server.getInstance().getWorlds()) {
+                for (Character chr : w.getPlayerStorage().getAllCharacters()) {
+                    // 屏幕中央提示消息 (火红玫瑰)
+                    chr.startMapEffect(shutDownMsg, 5121009);
+                }
+                // 添加滚动消息到顶部，因为是固定时间停服，所以短暂的通知部分玩家可能看不到。
+                w.setServerMessage(shutDownMsg);
+                // 玩家聊天框蓝色GM消息
+                w.broadcastPacket(PacketCreator.serverNotice(6, shutDownMsg));
+            }
+        }
+        TimerManager.getInstance().schedule(Server.getInstance().shutdown(false), time);
+    }
+
+
 }


### PR DESCRIPTION
需求 #262

1. 修复服务端正常退出时，spring bean destroy顺序错误导致的报错问题。
2. 添加服务端自定义消息和重启倒计时 API
3. 修复GM停服命令消息打印