### PR TITLE
优化控制台，新增功能，修复部分bug

### DIFF
--- a/gms-server/scripts-zh-CN/event/2xEvent.js
+++ b/gms-server/scripts-zh-CN/event/2xEvent.js
@@ -25,6 +25,29 @@
  -- Author --------------------------------------------------------------------------------------
  Twdtwd
  **/
+/*
+    该文件是OdinMS Maple Story服务器的一部分
+    版权所有 (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+                   Matthias Butz <matze@odinms.de>
+                   Jan Christian Meyer <vimes@odinms.de>
+
+    该程序是自由软件：你可以根据自由软件基金会发布的GNU Affero通用公共许可协议第三版重新分发和/或修改它。
+    你不得在任何其他版本的GNU Affero通用公共许可协议下使用、修改或分发此程序。
+
+    该程序是基于它可以是有用的前提下发的，
+    但是没有任何形式的担保；甚至没有默示的保证
+    商业性或者适用于特定目的。有关详细信息，请参阅
+    GNU Affero通用公共许可协议。
+
+    你应该已经收到了一份GNU Affero通用公共许可协议的副本，
+    如果没有，请参见<http://www.gnu.org/licenses/>。
+*/
+/**
+ -- Odin JavaScript --------------------------------------------------------------------------------
+ 2倍经验活动脚本
+ -- 作者 --------------------------------------------------------------------------------------
+ Twdtwd
+ **/
 
 var timer1;
 var timer2;
@@ -33,11 +56,11 @@ var timer4;
 
 function init() {
     /*
-        if(em.getChannelServer().getId() == 1) { // Only run on channel 1.
-        // AEST
-        timer1 = em.scheduleAtTimestamp("start", 1428220800000);
-        timer2 = em.scheduleAtTimestamp("stop", 1428228000000);
-        // EDT
+        if(em.getChannelServer().getId() == 1) { // 仅在频道1运行。
+        // 澳大利亚东部标准时间(AEST)
+        timer1 = em.scheduleAtTimestamp("start", 1428220800000); // 在给定的时间戳启动活动
+        timer2 = em.scheduleAtTimestamp("stop", 1428228000000); // 在给定的时间戳停止活动
+        // 美国东部夏令时(EDT)
         timer1 = em.scheduleAtTimestamp("start", 1428271200000);
         timer2 = em.scheduleAtTimestamp("stop", 1428278400000);
     }
@@ -46,66 +69,138 @@ function init() {
 
 function cancelSchedule() {
     if (timer1 != null) {
-        timer1.cancel(true);
+        timer1.cancel(true); // 取消定时器1
     }
     if (timer2 != null) {
-        timer2.cancel(true);
+        timer2.cancel(true); // 取消定时器2
     }
     if (timer3 != null) {
-        timer3.cancel(true);
+        timer3.cancel(true); // 取消定时器3
     }
     if (timer4 != null) {
-        timer4.cancel(true);
+        timer4.cancel(true); // 取消定时器4
     }
 }
-
+/**
+ * 开始双倍经验活动
+ */
 function start() {
     const Server = Java.type('org.gms.net.server.Server');
     const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    var world = Server.getInstance().getWorld(em.getChannelServer().getWorld());
-    world.setExpRate(8);
-    // world.broadcastPacket(PacketCreator.serverNotice(6, "The Bunny Onslaught Survival Scanner (BOSS) has detected an Easter Bunny onslaught soon! The GM team has activated the Emergency XP Pool (EXP) that doubles experience gained for the next two hours!"));
-    world.broadcastPacket(PacketCreator.serverNotice(6, "兔子猛攻生存扫描仪（BOSS）已检测到复活节兔子即将发动猛攻！GM团队已激活紧急经验池（EXP），在接下来的 2 小时内，玩家获得的经验将翻倍！"));
+    let world = Server.getInstance().getWorld(em.getChannelServer().getWorld());
+    let ExpRate = world.getExpRate();   //获取当前经验倍率
+    world.setExpRate(ExpRate * 2); // 将经验倍率调整为双倍经验
+    world.broadcastPacket(PacketCreator.serverNotice(6, "BOSS扫描器检测到即将到来的复活节兔子袭击！GM团队已激活紧急经验池，在接下来的两小时内获得的经验值将翻倍！"));
 }
-
+/**
+ * 结束双倍经验活动
+ */
 function stop() {
     const Server = Java.type('org.gms.net.server.Server');
     const PacketCreator = Java.type('org.gms.util.PacketCreator');
     var world = Server.getInstance().getWorld(em.getChannelServer().getWorld());
-    world.setExpRate(4);
-    // world.broadcastPacket(PacketCreator.serverNotice(6, "Unfortunately the Emergency XP Pool (EXP) has run out of juice for now and needs to recharge causing the EXP rate to go back to normal."));
-    world.broadcastPacket(PacketCreator.serverNotice(6, "紧急经验池（EXP）目前能量已经耗尽，需要重新充能，经验倍率恢复正常。"));
+    world.setExpRate(4); // 将经验值恢复到原来的4倍（正常情况下）
+    world.broadcastPacket(PacketCreator.serverNotice(6, "很遗憾，紧急经验池(EXP)能量已耗尽需要重新充能，经验倍率已恢复正常。"));
 }
 
-// ---------- FILLER FUNCTIONS ----------
+// ---------- 预留函数(空实现) ----------
 
+/**
+ * 清理函数
+ */
 function dispose() {}
 
+/**
+ * 设置副本
+ * @param {Object} eim 副本实例
+ * @param {number} leaderid 队长ID
+ */
 function setup(eim, leaderid) {}
 
+/**
+ * 获取怪物价值
+ * @param {Object} eim 副本实例
+ * @param {number} mobid 怪物ID
+ * @return {number} 总是返回0
+ */
 function monsterValue(eim, mobid) {return 0;}
 
+/**
+ * 解散队伍
+ * @param {Object} eim 副本实例
+ * @param {Object} player 玩家对象
+ */
 function disbandParty(eim, player) {}
 
+/**
+ * 玩家断开连接
+ * @param {Object} eim 副本实例
+ * @param {Object} player 玩家对象
+ */
 function playerDisconnected(eim, player) {}
 
+/**
+ * 玩家进入副本
+ * @param {Object} eim 副本实例
+ * @param {Object} player 玩家对象
+ */
 function playerEntry(eim, player) {}
 
+/**
+ * 怪物被击杀
+ * @param {Object} mob 怪物对象
+ * @param {Object} eim 副本实例
+ */
 function monsterKilled(mob, eim) {}
 
+/**
+ * 副本超时
+ * @param {Object} eim 副本实例
+ */
 function scheduledTimeout(eim) {}
 
+/**
+ * 副本设置完成后
+ * @param {Object} eim 副本实例
+ */
 function afterSetup(eim) {}
 
+/**
+ * 队长变更
+ * @param {Object} eim 副本实例
+ * @param {Object} leader 新队长对象
+ */
 function changedLeader(eim, leader) {}
 
+/**
+ * 玩家退出副本
+ * @param {Object} eim 副本实例
+ * @param {Object} player 玩家对象
+ */
 function playerExit(eim, player) {}
 
+/**
+ * 玩家离开队伍
+ * @param {Object} eim 副本实例
+ * @param {Object} player 玩家对象
+ */
 function leftParty(eim, player) {}
 
+/**
+ * 清理副本任务
+ * @param {Object} eim 副本实例
+ */
 function clearPQ(eim) {}
 
+/**
+ * 所有怪物被击杀
+ * @param {Object} eim 副本实例
+ */
 function allMonstersDead(eim) {}
 
+/**
+ * 玩家取消注册
+ * @param {Object} eim 副本实例
+ * @param {Object} player 玩家对象
+ */
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/3rdJob_mount.js
+++ b/gms-server/scripts-zh-CN/event/3rdJob_mount.js
@@ -49,7 +49,7 @@ function checkHogHealth(eim) {
         var oldHp = eim.getIntProperty("whog_hp");
 
         if (oldHp - hp > 1000) {    // or 800, if using mobHP / eventTime
-            eim.dropMessage(6, "Please protect the pig from the aliens!");  // thanks Vcoc
+            eim.dropMessage(6, "小心！外星人想抓走猪猪去烤乳猪！快挡住它们！");  // thanks Vcoc
         }
         eim.setIntProperty("whog_hp", hp);
     }

--- a/gms-server/scripts-zh-CN/event/4jship.js
+++ b/gms-server/scripts-zh-CN/event/4jship.js
@@ -66,9 +66,9 @@ function playerCanLeave(eim) {
 function playerSurvived(eim) {
     if (eim.getLeader().isAlive()) {
         eim.setIntProperty("canLeave", 2);
-        eim.dropMessage(5, "Kyrin: You have passed the test. Now for the closing part... Are you able reach the exit over there?");
+        eim.dropMessage(5, "凯琳：试炼通过。最终考验——你能抵达那边的出口吗？");
     } else {
-        eim.dropMessage(5, "Kyrin: You have failed the test. Aww, don't have such a sad face, just try it again later, ok?");
+        eim.dropMessage(5, "凯琳：考验失败啦~别哭丧着脸嘛，休息会儿再试试？");
     }
 }
 

--- a/gms-server/scripts-zh-CN/event/4jsuper.js
+++ b/gms-server/scripts-zh-CN/event/4jsuper.js
@@ -66,9 +66,9 @@ function playerCanLeave(eim) {
 function playerSurvived(eim) {
     if (eim.getLeader().isAlive()) {
         eim.setIntProperty("canLeave", 2);
-        eim.dropMessage(5, "Kyrin: You have passed the test. Now for the closing part... Are you able reach the exit over there?");
+        eim.dropMessage(5, "凯琳：试炼通过。最终考验——你能抵达那边的出口吗？");
     } else {
-        eim.dropMessage(5, "Kyrin: You have failed the test. Aww, don't have such a sad face, just try it again later, ok?");
+        eim.dropMessage(5, "凯琳：考验失败啦~别哭丧着脸嘛，休息会儿再试试？");
     }
 }
 

--- a/gms-server/scripts-zh-CN/event/AmoriaPQ.js
+++ b/gms-server/scripts-zh-CN/event/AmoriaPQ.js
@@ -70,9 +70,9 @@ function setEventRequirements() {
         reqStr += minLevel;
     }
 
-    reqStr += "\r\n    At least 1 of both genders";
+    reqStr += "\r\n    至少一男一女";
     if (onlyMarriedPlayers) {
-        reqStr += "\r\n    All married";
+        reqStr += "\r\n    都结婚了";
     }
 
     reqStr += "\r\n   时间限制: ";

--- a/gms-server/scripts-zh-CN/event/AmoriaPQ.js
+++ b/gms-server/scripts-zh-CN/event/AmoriaPQ.js
@@ -41,6 +41,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/AreaBossBamboo.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossBamboo.js
@@ -1,37 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 800020120;
+var BossID = 6090002;
+var BossName = "青竹武士";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 100) + 600), 50);
+var BossNotice= "青岚自氤氲雾气笼罩的断垣残壁间，骤然现形！";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Bamboo Warrior Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
- Ronan - based on xQuasar's King Clang spawner
-
+ ThreeStep - based on xQuasar's King Clang spawner
  **/
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -41,20 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var mapObj = em.getChannelServer().getMapFactory().getMap(800020120);   // original mapid was 251010101
-    var mobObj = LifeFactory.getMonster(6090002);
-
-    if (mapObj.getMonsterById(6090002) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
+    
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const Point = Java.type('java.awt.Point');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    mapObj.spawnMonsterOnGroundBelow(mobObj, new Point(560, 50));
-    mapObj.broadcastMessage(PacketCreator.serverNotice(6, "From amongst the ruins shrouded by the mists, Bamboo Warrior appears."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -88,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossCentipede.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossCentipede.js
@@ -1,37 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 251010102;
+var BossID = 5220004;
+var BossName = "巨型蜈蚣";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 100) + 600), 50);
+var BossNotice= "从药圃生瘴处破雾而出，千足划空如戈戟森然‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Centipede Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
- Ronan - based on xQuasar's King Clang spawner
-
+ ThreeStep - based on xQuasar's King Clang spawner
  **/
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -41,21 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var herbGarden = em.getChannelServer().getMapFactory().getMap(251010102);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (herbGarden.getMonsterById(5220004) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    const Point = Java.type('java.awt.Point');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-
-    var gcent = LifeFactory.getMonster(5220004);
-    herbGarden.spawnMonsterOnGroundBelow(gcent, new Point(560, 50));
-    herbGarden.broadcastMessage(PacketCreator.serverNotice(6, "From the mists surrounding the herb garden, the gargantuous Giant Centipede appears."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -89,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossDeo.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossDeo.js
@@ -1,37 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 260010201;
+var BossID = 3220001;
+var BossName = "大宇";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(645, 275);
+var BossNotice= "自沙暴中缓缓显形，黄沙如时光之纱寸寸剥落‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Deo Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -41,21 +62,27 @@ function cancelSchedule() {
 }
 
 function start() {
-    var royalCatthusDesert = em.getChannelServer().getMapFactory().getMap(260010201);
-
-    if (royalCatthusDesert.getMonsterById(3220001) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    const Point = Java.type('java.awt.Point');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-
-    var deo = LifeFactory.getMonster(3220001);
-    royalCatthusDesert.spawnMonsterOnGroundBelow(deo, new Point(645, 275));
-    royalCatthusDesert.broadcastMessage(PacketCreator.serverNotice(6, "Deo slowly appeared out of the sand dust."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -89,4 +116,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossDoor1.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossDoor1.js
@@ -1,35 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 677000003;
+var BossID = 9400610;
+var BossName = "黑暗独角兽";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 100) + 400), 0);
+var BossNotice= "安度西亚斯‌撕裂天幕降临，其独角兽形躯体由失传的《格里高利圣咏》手稿羊皮纸折叠而成，每根毛发都是凝固的管风琴音管‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Door boss Spawner (based on xQuasar's King Clang spawner)
+ Zeno Spawner
+ -- Edited by --------------------------------------------------------------------------------------
+ ThreeStep - based on xQuasar's King Clang spawner
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -39,26 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var bossMobid = 9400610;
-    var bossMapid = 677000003;
-    var bossMsg = "Amdusias has appeared!";
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    var map = em.getChannelServer().getMapFactory().getMap(bossMapid);
-    if (map.getMonsterById(bossMobid) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const Point = Java.type('java.awt.Point');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-
-    var boss = LifeFactory.getMonster(bossMobid);
-    var bossPos = new Point(467, 0);
-    map.spawnMonsterOnGroundBelow(boss, bossPos);
-    map.broadcastMessage(PacketCreator.serverNotice(6, bossMsg));
-
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -92,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossDoor2.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossDoor2.js
@@ -1,35 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 677000005;
+var BossID = 9400609;
+var BossName = "印第安老斑鸠";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 100) + 300), 80);
+var BossNotice= "安杜拉斯刺穿次元壁的刹那，所有乌鸦的瞳孔骤缩为刀锋状，战场遗迹的锈铁自动熔铸成其黄铜巨剑‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Door boss Spawner (based on xQuasar's King Clang spawner)
+ Zeno Spawner
+ -- Edited by --------------------------------------------------------------------------------------
+ ThreeStep - based on xQuasar's King Clang spawner
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -39,26 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var bossMobid = 9400609;
-    var bossMapid = 677000005;
-    var bossMsg = "Andras has appeared!";
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    var map = em.getChannelServer().getMapFactory().getMap(bossMapid);
-    if (map.getMonsterById(bossMobid) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    const Point = Java.type('java.awt.Point');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-
-    var boss = LifeFactory.getMonster(bossMobid);
-    var bossPos = new Point(201, 80);
-    map.spawnMonsterOnGroundBelow(boss, bossPos);
-    map.broadcastMessage(PacketCreator.serverNotice(6, bossMsg));
-
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -92,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossDoor3.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossDoor3.js
@@ -1,35 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 677000009;
+var BossID = 9400613;
+var BossName = "沃勒福";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 100) + 300), -841);
+var BossNotice= "出现的瞬间，月光在它蛇鳞状的皮毛上折射出千重幻影，所有目睹者的视网膜上同时烙下旋转的倒五芒星‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Door boss Spawner (based on xQuasar's King Clang spawner)
+ Zeno Spawner
+ -- Edited by --------------------------------------------------------------------------------------
+ ThreeStep - based on xQuasar's King Clang spawner
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -39,26 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var bossMobid = 9400613;
-    var bossMapid = 677000009;
-    var bossMsg = "Valefor has appeared!";
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    var map = em.getChannelServer().getMapFactory().getMap(bossMapid);
-    if (map.getMonsterById(bossMobid) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    const Point = Java.type('java.awt.Point');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-
-    var boss = LifeFactory.getMonster(bossMobid);
-    var bossPos = new Point(251, -841);
-    map.spawnMonsterOnGroundBelow(boss, bossPos);
-    map.broadcastMessage(PacketCreator.serverNotice(6, bossMsg));
-
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -92,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossDoor4.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossDoor4.js
@@ -1,35 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 677000012;
+var BossID = 9400633;
+var BossName = "牛魔王";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(842, 0);
+var BossNotice= "玛巴斯现世之时，黄金狮鬃在硫磺风暴中燃烧成几何光轮，其足印所踏之处自动浮现精密齿轮构成的所罗门封印‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Door boss Spawner (based on xQuasar's King Clang spawner)
+ Zeno Spawner
+ -- Edited by --------------------------------------------------------------------------------------
+ ThreeStep - based on xQuasar's King Clang spawner
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -39,26 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var bossMobid = 9400633;
-    var bossMapid = 677000012;
-    var bossMsg = "Astaroth has appeared!";
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    var map = em.getChannelServer().getMapFactory().getMap(bossMapid);
-    if (map.getMonsterById(bossMobid) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    const Point = Java.type('java.awt.Point');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-
-    var boss = LifeFactory.getMonster(bossMobid);
-    var bossPos = new Point(842, 0);
-    map.spawnMonsterOnGroundBelow(boss, bossPos);
-    map.broadcastMessage(PacketCreator.serverNotice(6, bossMsg));
-
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -92,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossDoor5.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossDoor5.js
@@ -1,35 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 677000001;
+var BossID = 9400612;
+var BossName = "牛魔王";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(461, 61);
+var BossNotice= "玛巴斯现世之时，黄金狮鬃在硫磺风暴中燃烧成几何光轮，其足印所踏之处自动浮现精密齿轮构成的所罗门封印‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Door boss Spawner (based on xQuasar's King Clang spawner)
+ Zeno Spawner
+ -- Edited by --------------------------------------------------------------------------------------
+ ThreeStep - based on xQuasar's King Clang spawner
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -39,26 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var bossMobid = 9400612;
-    var bossMapid = 677000001;
-    var bossMsg = "Marbas has appeared!";
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    var map = em.getChannelServer().getMapFactory().getMap(bossMapid);
-    if (map.getMonsterById(bossMobid) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    const Point = Java.type('java.awt.Point');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-
-    var boss = LifeFactory.getMonster(bossMobid);
-    var bossPos = new Point(461, 61);
-    map.spawnMonsterOnGroundBelow(boss, bossPos);
-    map.broadcastMessage(PacketCreator.serverNotice(6, bossMsg));
-
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -92,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossDoor6.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossDoor6.js
@@ -1,35 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 677000007;
+var BossID = 9400611;
+var BossName = "雪之猫女";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 100) + 100), 50);
+var BossNotice= "克罗塞尔降临之际，硫磺火雨在它蝠翼的阴影中凝成悬浮的赤红结晶，方圆十里的电子设备同时爆出幽蓝电弧‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Door boss Spawner (based on xQuasar's King Clang spawner)
+ Zeno Spawner
+ -- Edited by --------------------------------------------------------------------------------------
+ ThreeStep - based on xQuasar's King Clang spawner
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -39,26 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var bossMobid = 9400611;
-    var bossMapid = 677000007;
-    var bossMsg = "Crocell has appeared!";
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    var map = em.getChannelServer().getMapFactory().getMap(bossMapid);
-    if (map.getMonsterById(bossMobid) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    const Point = Java.type('java.awt.Point');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-
-    var boss = LifeFactory.getMonster(bossMobid);
-    var bossPos = new Point(171, 50);
-    map.spawnMonsterOnGroundBelow(boss, bossPos);
-    map.broadcastMessage(PacketCreator.serverNotice(6, bossMsg));
-
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -92,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossDyle.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossDyle.js
@@ -1,38 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 107000300;
+var BossID = 6220000;
+var BossName = "多尔";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(90, 119);
+var BossNotice= "破开沼泽浮出时，腐殖质的气味与沼气在它嶙峋的背甲上凝结成绿色雾霭‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Dyle Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -42,19 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var dangeroudCroko1 = em.getChannelServer().getMapFactory().getMap(107000300);
-    if (dangeroudCroko1.getMonsterById(6220000) != null) {
-        setupTask = em.schedule("start", 3 * 60 * 60 * 1000);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
+
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(90, 119);
-    dangeroudCroko1.spawnMonsterOnGroundBelow(LifeFactory.getMonster(6220000), spawnpoint);
-    dangeroudCroko1.broadcastMessage(PacketCreator.serverNotice(6, "The huge crocodile Dyle has come out from the swamp."));
-    setupTask = em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -88,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossEliza1.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossEliza1.js
@@ -1,40 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 200010300;
+var BossID = 8220000;
+var BossName = "艾利杰";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(208, 83);
+var BossNotice= "降临之时，黑色旋风如巨蟒盘绕，将天光绞碎成纷扬的鸦羽‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Eliza1 Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
-var setupTask;
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -44,21 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var eliza = LifeFactory.getMonster(8220000);
-    var stairwayToTheSky2 = em.getChannelServer().getMapFactory().getMap(200010300);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (stairwayToTheSky2.getMonsterById(8220000) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(208, 83);
-    stairwayToTheSky2.spawnMonsterOnGroundBelow(eliza, spawnpoint);
-    stairwayToTheSky2.broadcastMessage(PacketCreator.serverNotice(6, "Eliza has appeared with a black whirlwind."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -92,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossFaust2.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossFaust2.js
@@ -1,38 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 100040106;
+var BossID = 5220002;
+var BossName = "浮士德";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(478, 278);
+var BossNotice= "自靛蓝雾霭中显形时，整片天空呈现出光谱折射的奇异蓝调，仿佛歌德手稿里未完成的魔法阵正在现世具象化‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Faust2 Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -42,22 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var theForestOfEvil2 = em.getChannelServer().getMapFactory().getMap(100040106);
-    var faust2 = LifeFactory.getMonster(5220002);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (theForestOfEvil2.getMonsterById(5220002) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(474, 278);
-    theForestOfEvil2.spawnMonsterOnGroundBelow(faust2, spawnpoint);
-
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    theForestOfEvil2.broadcastMessage(PacketCreator.serverNotice(6, "Faust appeared amidst the blue fog."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -91,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossKimera.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossKimera.js
@@ -1,38 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 261030000;
+var BossID = 8220002;
+var BossName = "吉米拉";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 900) - 900), 180);
+var BossNotice= "自地底幽暗中现身的刹那，眼瞳里跃动的碎光如未淬火的星屑‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Chimera/Kimera Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -42,25 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var labSecretBasementPath = em.getChannelServer().getMapFactory().getMap(261030000);
-    var chimera = LifeFactory.getMonster(8220002);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (labSecretBasementPath.getMonsterById(8220002) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    var posX;
-    var posY = 180;
-    posX = (Math.floor(Math.random() * 900) - 900);
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(posX, posY);
-    labSecretBasementPath.spawnMonsterOnGroundBelow(chimera, spawnpoint);
-
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    labSecretBasementPath.broadcastMessage(PacketCreator.serverNotice(6, "Kimera has appeared out of the darkness of the underground with a glitter in her eyes."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -94,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossKingClang.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossKingClang.js
@@ -1,41 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 110040000;
+var BossID = 5220001;
+var BossName = "巨居蟹";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 2400) - 1600), 140);
+var BossNotice= "出现在海岸线上，一顶形似螺壳的奇异头巾随潮水起伏，其螺旋纹路在夕照下泛着妖异的磷光‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- King Clang Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
-var hotSand;
-
 function init() {
-    hotSand = em.getChannelServer().getMapFactory().getMap(110040000);
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -45,23 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    if (hotSand.getMonsterById(5220001) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
+
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var kingClang = LifeFactory.getMonster(5220001);
-    var posX;
-    var posY = 140;
-    posX = Math.floor((Math.random() * 2400) - 1600);
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(posX, posY);
-    hotSand.spawnMonsterOnGroundBelow(kingClang, spawnpoint);
-
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    hotSand.broadcastMessage(PacketCreator.serverNotice(6, "A strange turban shell has appeared on the beach."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -95,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossKingSageCat.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossKingSageCat.js
@@ -1,38 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 250010504;
+var BossID = 7220002;
+var BossName = "妖怪禅师";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 1300) - 500), 540);
+var BossNotice= "的出现使幽魅之气愈发浓稠，野猫的泣鸣如锈蚀的刀片划破凝滞的夜雾‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- King Sage Cat Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -42,24 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var goblinForest2 = em.getChannelServer().getMapFactory().getMap(250010504);
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var kingSageCat = LifeFactory.getMonster(7220002);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (goblinForest2.getMonsterById(7220002) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
-    var posX;
-    var posY = 540;
-    posX = Math.floor((Math.random() * 1300) - 500);
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(posX, posY);
-    goblinForest2.spawnMonsterOnGroundBelow(kingSageCat, spawnpoint);
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    goblinForest2.broadcastMessage(PacketCreator.serverNotice(6, "The ghostly air around here has become stronger. The unpleasant sound of a cat crying can be heard."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -93,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossLeviathan.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossLeviathan.js
@@ -1,38 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 240040401;
+var BossID = 8220003;
+var BossName = "大海兽";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 600) - 300), 1125);
+var BossNotice= "昂首而起的刹那，裹挟着冰晶的寒风如远古战吼般撕裂云层‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Leviathan Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -42,24 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var leviathansCanyon = em.getChannelServer().getMapFactory().getMap(240040401);
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var leviathan = LifeFactory.getMonster(8220003);
-    if (leviathansCanyon.getMonsterById(8220003) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
+
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    var posX;
-    var posY = 1125;
-    posX = Math.floor((Math.random() * 600) - 300);
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(posX, posY);
-    leviathansCanyon.spawnMonsterOnGroundBelow(leviathan, spawnpoint);
-
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    leviathansCanyon.broadcastMessage(PacketCreator.serverNotice(6, "Leviathan emerges from the canyon and the cold icy wind blows."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -93,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossMano.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossMano.js
@@ -1,37 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 104000400;
+var BossID = 2220000;
+var BossName = "红蜗牛王";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(279, -496);
+var BossNotice= "玛诺的身影伴随着凉风乍起时悄然显现，落叶在她脚边打着旋儿静止";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Mano Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -41,21 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var thicketAroundTheBeach3 = em.getChannelServer().getMapFactory().getMap(104000400);
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var mano = LifeFactory.getMonster(2220000);
-    if (thicketAroundTheBeach3.getMonsterById(2220000) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
+
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(279, -496);
-    thicketAroundTheBeach3.spawnMonsterOnGroundBelow(mano, spawnpoint);
-
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    thicketAroundTheBeach3.broadcastMessage(PacketCreator.serverNotice(6, "A cool breeze was felt when Mano appeared."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -89,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossNineTailedFox.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossNineTailedFox.js
@@ -1,38 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 222010310;
+var BossID = 7220001;
+var BossName = "九尾狐";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 1300) - 800), 33);
+var BossNotice= "伴随着一声悠长的狐啸划破夜色，那老狐的气息如雾霭般在林间弥散‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Nine Tailed Fox (Old Fox) Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -42,23 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var moonRidge = em.getChannelServer().getMapFactory().getMap(222010310);
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var nineTailedFox = LifeFactory.getMonster(7220001);
-    if (moonRidge.getMonsterById(7220001) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
+
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
-    var posX;
-    var posY = 33;
-    posX = Math.floor((Math.random() * 1300) - 800);
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(posX, posY);
-    moonRidge.spawnMonsterOnGroundBelow(nineTailedFox, spawnpoint);
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    moonRidge.broadcastMessage(PacketCreator.serverNotice(6, "As the moon light dims, a long fox cry can be heard and the presence of the old fox can be felt"));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -92,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossSeruf.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossSeruf.js
@@ -1,39 +1,58 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc> 
-					   Matthias Butz <matze@odinms.de>
-					   Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 230020100;
+var BossID = 4220001;
+var BossName = "歇尔夫";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 2300) - 1500), 520);
+var BossNotice= "，一枚泛着诡异磷光的贝壳悄然浮现在幽暗的海藻林中，其螺旋纹路在流动的藻须间若隐若现‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Seruf Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -43,25 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var theSeaweedTower = em.getChannelServer().getMapFactory().getMap(230020100);
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var seruf = LifeFactory.getMonster(4220001);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (theSeaweedTower.getMonsterById(4220001) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    var posX;
-    var posY = 520;
-    posX = Math.floor((Math.random() * 2300) - 1500);
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(posX, posY);
-    theSeaweedTower.spawnMonsterOnGroundBelow(seruf, spawnpoint);
-
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    theSeaweedTower.broadcastMessage(PacketCreator.serverNotice(6, "A strange shell has appeared from a grove of seaweed"));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -95,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossSnackBar.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossSnackBar.js
@@ -1,37 +1,60 @@
 /*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 105090310;
+var BossID = 8220009;
+var BossName = "小吃店";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+var setPos = [[-626, -604], [735, -600]];
+var rndPos = setPos[Math.floor(Math.random() * setPos.length)];
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(rndPos[0], rndPos[1]);
+var BossNotice= "正缓缓在幽僻的荒郊野径旁支起招牌，蒸腾的热气在空荡的山路上显得格外扎眼。‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Snack Bar Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
- Ronan - based on xQuasar's King Clang spawner
-
+ ThreeStep - based on xQuasar's King Clang spawner
  **/
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -41,24 +64,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var snackBarMap = em.getChannelServer().getMapFactory().getMap(105090310);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (snackBarMap.getMonsterById(8220008) != null || snackBarMap.getMonsterById(8220009) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    var setPos = [[-626, -604], [735, -600]];
-    var rndPos = setPos[Math.floor(Math.random() * setPos.length)];
-
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    const Point = Java.type('java.awt.Point');
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-
-    var snackBar = LifeFactory.getMonster(8220008);
-    snackBarMap.spawnMonsterOnGroundBelow(snackBar, new Point(rndPos[0], rndPos[1]));
-    snackBarMap.broadcastMessage(PacketCreator.serverNotice(6, "Slowly, a suspicious food stand opens up on a strangely remote place."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------

--- a/gms-server/scripts-zh-CN/event/AreaBossStumpy.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossStumpy.js
@@ -1,8 +1,8 @@
 /*
 	This file is part of the OdinMS Maple Story Server
     Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+					   Matthias Butz <matze@odinms.de>
+					   Jan Christian Meyer <vimes@odinms.de>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as
@@ -19,20 +19,40 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 101030404;
+var BossID = 3220000;
+var BossName = "树妖王";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 800) + 400), 1280);
+var BossNotice= "伴着沉闷的撞击声现身于石山之间，余音在山谷中回荡‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Stumpy Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -42,25 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var eastRockyMountain5 = em.getChannelServer().getMapFactory().getMap(101030404);
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var stumpy = LifeFactory.getMonster(3220000);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (eastRockyMountain5.getMonsterById(3220000) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    var posX;
-    var posY = 1280;
-    posX = Math.floor((Math.random() * 800) + 400);
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(posX, posY);
-    eastRockyMountain5.spawnMonsterOnGroundBelow(stumpy, spawnpoint);
-
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    eastRockyMountain5.broadcastMessage(PacketCreator.serverNotice(6, "Stumpy has appeared with a stumping sound that rings the Stone Mountain."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------

--- a/gms-server/scripts-zh-CN/event/AreaBossTaeRoon.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossTaeRoon.js
@@ -1,8 +1,8 @@
 /*
 	This file is part of the OdinMS Maple Story Server
     Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+					   Matthias Butz <matze@odinms.de>
+					   Jan Christian Meyer <vimes@odinms.de>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as
@@ -19,20 +19,40 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 250010304;
+var BossID = 7220000;
+var BossName = "肯德熊";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 700) - 800), 390);
+var BossNotice= "伴着一声柔和的哨音翩然而至‌";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Tae Roon Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -42,25 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var territoryOfWanderingBear = em.getChannelServer().getMapFactory().getMap(250010304);
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var taeRoon = LifeFactory.getMonster(7220000);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (territoryOfWanderingBear.getMonsterById(7220000) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    var posX;
-    var posY = 390;
-    posX = Math.floor((Math.random() * 700) - 800);
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(posX, posY);
-    territoryOfWanderingBear.spawnMonsterOnGroundBelow(taeRoon, spawnpoint);
-
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    territoryOfWanderingBear.broadcastMessage(PacketCreator.serverNotice(6, "Tae Roon has appeared with a soft whistling sound."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------

--- a/gms-server/scripts-zh-CN/event/AreaBossTimer1.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossTimer1.js
@@ -1,8 +1,8 @@
 /*
 	This file is part of the OdinMS Maple Story Server
     Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+					   Matthias Butz <matze@odinms.de>
+					   Jan Christian Meyer <vimes@odinms.de>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as
@@ -19,19 +19,40 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 220050000;
+var BossID = 5220003;
+var BossName = "提莫";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 1400) - 1000), 1030);
+var BossNotice= "嘀嗒...嘀嗒...！时间精灵提莫在轻声提醒。";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Timer1 Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -41,25 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var whirlpoolOfTime = em.getChannelServer().getMapFactory().getMap(220050100);
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var timer1 = LifeFactory.getMonster(5220003);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (whirlpoolOfTime.getMonsterById(5220003) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    var posX;
-    var posY = 1030;
-    posX = Math.floor((Math.random() * 770) - 770);
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(posX, posY);
-    whirlpoolOfTime.spawnMonsterOnGroundBelow(timer1, spawnpoint);
-
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    whirlpoolOfTime.broadcastMessage(PacketCreator.serverNotice(6, "Tick-Tock Tick-Tock! Timer makes it's presence known."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------
@@ -93,4 +117,3 @@ function clearPQ(eim) {}
 function allMonstersDead(eim) {}
 
 function playerUnregistered(eim, player) {}
-

--- a/gms-server/scripts-zh-CN/event/AreaBossTimer2.js
+++ b/gms-server/scripts-zh-CN/event/AreaBossTimer2.js
@@ -1,8 +1,8 @@
 /*
 	This file is part of the OdinMS Maple Story Server
     Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+					   Matthias Butz <matze@odinms.de>
+					   Jan Christian Meyer <vimes@odinms.de>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as
@@ -19,20 +19,40 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+const Point = Java.type('java.awt.Point');
+const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+const LoggerFactory = Java.type('org.slf4j.LoggerFactory');
+var log = null;
+var channel = null;
+var isinit = false;
+
+var MapID = 220050100;
+var BossID = 5220003;
+var BossName = "提莫";
+/**刷新时间，分钟;  Generation time in minutes*/
+var BossTime = 180;
+/**指定Boss刷新的XY坐标位置; Specify the XY coordinate position for Boss refresh*/
+var point = new Point(Math.floor((Math.random() * 770) - 770), 1030);
+var BossNotice= "嘀嗒...嘀嗒...！时间精灵提莫在轻声提醒。";
+
+const methodName = "start";     //指定当前事件刷新Boss的函数，无需改动
 /**
  -- Odin JavaScript --------------------------------------------------------------------------------
- Timer2 Spawner
+ Zeno Spawner
  -- Edited by --------------------------------------------------------------------------------------
  ThreeStep - based on xQuasar's King Clang spawner
-
  **/
-
 function init() {
+    channel = em.getChannelServer().getId();
+    log = LoggerFactory.getLogger(em.getName());
+  
     scheduleNew();
 }
 
 function scheduleNew() {
-    setupTask = em.schedule("start", 0);    //spawns upon server start. Each 3 hours an server event checks if boss exists, if not spawns it instantly.
+    setupTask = em.schedule(methodName, 0);    //服务器启动时生成。每指定时间，服务器事件会检查boss是否存在，如果不存在，会立即生成boss。
 }
 
 function cancelSchedule() {
@@ -42,25 +62,28 @@ function cancelSchedule() {
 }
 
 function start() {
-    var lostTime1 = em.getChannelServer().getMapFactory().getMap(220050000);
-    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    var timer2 = LifeFactory.getMonster(5220003);
+    var graysPrairie = em.getChannelServer().getMapFactory().getMap(MapID);
+    var Timer = em.getBossTime(BossTime * 60 * 1000);  //转为毫秒并加载时间倍率修正
 
-    if (lostTime1.getMonsterById(5220003) != null) {
-        em.schedule("start", 3 * 60 * 60 * 1000);
+    if (graysPrairie.getMonsterById(BossID) != null) {
+        em.schedule(methodName, Timer);
         return;
     }
+    const BossObj = LifeFactory.getMonster(BossID);
+    BossName = BossObj.getName() || BossName;
+    try {
+        graysPrairie.spawnMonsterOnGroundBelow(BossObj, point);
+        if(isinit) {
+            log.info(`[事件脚本-野外BOSS] ${em.getName()} 已在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID})，检测间隔：${Timer / 60 / 1000} 分钟`);
+        } else {
+            isinit = true;
+        }
+    } catch (e) {
+        console.error(`[事件脚本-野外BOSS] ${em.getName()} 在频道 ${channel} 的 ${graysPrairie.getMapName()}(${MapID}) ${point.x} , ${point.y}) 生成 ${BossName}(${BossID}) 时出错`,e);
+    }
+    graysPrairie.broadcastMessage(PacketCreator.serverNotice(6, `[野外BOSS] ${BossName}  ${BossNotice}`));     //聊天框输出当前地图范围的Boss登场消息
 
-    var posX;
-    var posY = 1030;
-    posX = Math.floor((Math.random() * 1400) - 1000);
-    const Point = Java.type('java.awt.Point');
-    const spawnpoint = new Point(posX, posY);
-    lostTime1.spawnMonsterOnGroundBelow(timer2, spawnpoint);
-
-    const PacketCreator = Java.type('org.gms.util.PacketCreator');
-    lostTime1.broadcastMessage(PacketCreator.serverNotice(6, "Tick-Tock Tick-Tock! Timer makes it's presence known."));
-    em.schedule("start", 3 * 60 * 60 * 1000);
+    em.schedule(methodName, Timer);
 }
 
 // ---------- FILLER FUNCTIONS ----------

--- a/gms-server/scripts-zh-CN/event/BalrogBattle.js
+++ b/gms-server/scripts-zh-CN/event/BalrogBattle.js
@@ -45,6 +45,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/BalrogBattle_Easy.js
+++ b/gms-server/scripts-zh-CN/event/BalrogBattle_Easy.js
@@ -45,6 +45,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/Boats.js
+++ b/gms-server/scripts-zh-CN/event/Boats.js
@@ -20,14 +20,13 @@
 const PacketCreator = Java.type('org.gms.util.PacketCreator');  //获取封包数据实例
 
 function init() {
-    console.log("当前函数名:", getCurrentFunctionName());
-    // 初始化函数，用于设置时间和获取地图实例。
+    // 初始化函数，用于修正交通工具旅行时间和获取地图实例。
     closeTime = em.getTransportationTime(closeTime);
     beginTime = em.getTransportationTime(beginTime);
     rideTime = em.getTransportationTime(rideTime);
     invasionStartTime = em.getTransportationTime(invasionStartTime);
     invasionDelayTime = em.getTransportationTime(invasionDelayTime);
-    console.log(closeTime/1000,beginTime/1000,rideTime/1000,invasionStartTime/1000,invasionDelayTime/1000);
+
     // 获取地图实例
     Orbis_btf = em.getChannelServer().getMapFactory().getMap(200000112);    //候船室<开往魔法密林>
     Ellinia_btf = em.getChannelServer().getMapFactory().getMap(101000301);  //候船室<开往天空之城>
@@ -48,7 +47,6 @@ function init() {
 }
 
 function scheduleNew() {
-    console.log("scheduleNew");
     // 设置属性，并安排关闭入口和起飞的任务
     em.setProperty("docked", "true");
     em.setProperty("entry", "true");
@@ -57,8 +55,6 @@ function scheduleNew() {
     // 安排关闭入口和起飞的时间点
     em.schedule("stopentry", closeTime);
     em.schedule("takeoff", beginTime);
-    // setClock(Ellinia_docked,closeTime);
-    // setClock(Orbis_docked,closeTime);
 }
 
 function stopentry() {
@@ -69,8 +65,6 @@ function stopentry() {
 }
 
 function takeoff() {
-    console.log("takeoff");
-
     // 玩家被传送至船上，广播船只离开的消息
     Orbis_btf.warpEveryone(Boat_to_Ellinia.getId());
     Ellinia_btf.warpEveryone(Boat_to_Orbis.getId());
@@ -87,15 +81,9 @@ function takeoff() {
 
     // 安排到达目的地的时间点
     em.schedule("arrived", rideTime);
-    // em.startInstance(1,);
-    // eim.startEventTimer(rideTime);  // 启动事件计时器
-    // setClock(Boat_to_Ellinia,rideTime);
-    // setClock(Boat_to_Orbis,rideTime);
 }
 
 function arrived() {
-    console.log("arrived");
-    // end();
     // 玩家到达目的地后被传送至对应站点或码头
     Boat_to_Orbis.warpEveryone(Orbis_Station.getId(), 0);
     Orbis_Boat_Cabin.warpEveryone(Orbis_Station.getId(), 0);
@@ -116,7 +104,6 @@ function arrived() {
 }
 
 function approach() {
-    console.log("approach");
     // 处理蝙蝠魔船只接近的情况
     if (Math.floor(Math.random() * 10) < 10) {
         em.setProperty("haveBalrog", "true");
@@ -134,7 +121,6 @@ function approach() {
 }
 
 function invasion() {
-    console.log("invasion");
     // 生成偶遇蝙蝠魔
     const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
 
@@ -152,165 +138,35 @@ function invasion() {
 /**
  * 取消预定的事件/任务调度
  */
-function cancelSchedule() {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
-
-function setClock(MapObj,Time) {
-    console.log("setClock",MapObj,Time);
-    const players = MapObj.getCharacters(); //获取当前地图的所有角色
-    console.log(players);
-    if (players.length > 0){
-        players.map(player => { //遍历角色
-            player.sendPacket(PacketCreator.getClock(Time));    //发送创建倒计时封包
-        });
-    }
-}
+function cancelSchedule() {}
 
 // ---------- 辅助函数 ----------
+function dispose() {}
 
-/**
- * 释放/清理资源
- */
-function dispose() {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function setup(eim, leaderid) {}
 
-/**
- * 初始化副本实例（Event Instance Management）
- * @param {Object} eim - 副本实例对象
- * @param {number} leaderid - 队伍领袖ID
- */
-function setup(level, lobbyid) {
-    console.log("当前函数名:", getCurrentFunctionName());
-    var eim = em.newInstance("Boats_takeoff");
-    var Maplist = [Boat_to_Ellinia,Boat_to_Orbis,Orbis_Boat_Cabin,Ellinia_Boat_Cabin];
-    Maplist.map(obj => eim.getInstanceMap(obj.getId()).resetPQ(1));
-    eim.startEventTimer(rideTime);  // 启动事件计时器
-    return eim;
-}
-
-/**
- * 获取指定怪物的数值（经验/掉落等）
- * @param {Object} eim - 副本实例对象
- * @param {number} mobid - 怪物ID
- * @return {number} 怪物数值
- */
 function monsterValue(eim, mobid) {return 0;}
 
-/**
- * 解散队伍
- * @param {Object} eim - 副本实例对象
- * @param {Object} player - 玩家对象
- */
-function disbandParty(eim, player) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function disbandParty(eim, player) {}
 
-/**
- * 玩家断开连接处理
- * @param {Object} eim - 副本实例对象
- * @param {Object} player - 玩家对象
- */
-function playerDisconnected(eim, player) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function playerDisconnected(eim, player) {}
 
-/**
- * 玩家进入副本处理
- * @param {Object} eim - 副本实例对象
- * @param {Object} player - 玩家对象
- */
-function playerEntry(eim, player) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function playerEntry(eim, player) {}
 
-/**
- * 怪物被击杀处理
- * @param {Object} mob - 怪物对象
- * @param {Object} eim - 副本实例对象
- */
-function monsterKilled(mob, eim) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function monsterKilled(mob, eim) {}
 
-/**
- * 预定超时触发
- * @param {Object} eim - 副本实例对象
- */
-function scheduledTimeout(eim) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function scheduledTimeout(eim) {}
 
-/**
- * 副本设置完成后执行
- * @param {Object} eim - 副本实例对象
- */
-function afterSetup(eim) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function afterSetup(eim) {}
 
-/**
- * 队伍领袖变更处理
- * @param {Object} eim - 副本实例对象
- * @param {Object} leader - 新领袖对象
- */
-function changedLeader(eim, leader) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function changedLeader(eim, leader) {}
 
-/**
- * 玩家退出副本处理
- * @param {Object} eim - 副本实例对象
- * @param {Object} player - 玩家对象
- */
-function playerExit(eim, player) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function playerExit(eim, player) {}
 
-/**
- * 玩家离开队伍处理
- * @param {Object} eim - 副本实例对象
- * @param {Object} player - 玩家对象
- */
-function leftParty(eim, player) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function leftParty(eim, player) {}
 
-/**
- * 清理副本任务（Party Quest）
- * @param {Object} eim - 副本实例对象
- */
-function clearPQ(eim) {
-    console.log("当前函数名:", getCurrentFunctionName());
-    eim.stopEventTimer();
-    eim.setEventCleared();
-}
+function clearPQ(eim) {}
 
-/**
- * 所有怪物被击杀处理
- * @param {Object} eim - 副本实例对象
- */
-function allMonstersDead(eim) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
+function allMonstersDead(eim) {}
 
-/**
- * 玩家注销/取消注册处理
- * @param {Object} eim - 副本实例对象
- * @param {Object} player - 玩家对象
- */
-function playerUnregistered(eim, player) {
-    console.log("当前函数名:", getCurrentFunctionName());
-}
-function end(eim) {
-    eim.dispose();
-}
-function getCurrentFunctionName() {
-    const stack = new Error().stack;
-    const stackLines = stack.split('\n');
-    // 不同浏览器/环境格式不同，可能需要调整
-    const callerLine = stackLines[2]; // 通常是调用者的行
-    const functionName = callerLine.match(/at (.*?) /)?.[1] || 'anonymous';
-    return functionName;
-}
+function playerUnregistered(eim, player) {}

--- a/gms-server/scripts-zh-CN/event/Boats.js
+++ b/gms-server/scripts-zh-CN/event/Boats.js
@@ -1,32 +1,33 @@
 // 渡轮相关地图变量
-var Orbis_btf; // 候船室<开往魔法密林>
-var Boat_to_Orbis; // 开往天空之城
-var Orbis_Boat_Cabin; // 船仓<开往天空之城>
-var Orbis_docked; // 码头<开往魔法密林>
+/** 候船室<开往魔法密林> */var Orbis_btf;
+/** 开往天空之城的船 */var Boat_to_Orbis;
+/** 船仓<开往天空之城> */var Orbis_Boat_Cabin;
+/** 码头<开往魔法密林> */var Orbis_docked;
+/** 候船室<开往天空之城> */var Ellinia_btf;
+/** 开往魔法密林的船 */var Boat_to_Ellinia;
+/** 船仓<开往魔法密林> */var Ellinia_Boat_Cabin;
+/** 魔法密林码头 */var Ellinia_docked;
+/** 天空之城售票处 */var Orbis_Station;
 
-var Ellinia_btf; // 候船室<开往天空之城>
-var Boat_to_Ellinia; // 开往魔法密林
-var Ellinia_Boat_Cabin; // 船仓<开往魔法密林>
-var Ellinia_docked; // 魔法密林码头
+// 时间设置（以毫秒为单位），以下变量会被getTransportationTime()函数改变时间倍率而重新赋值
+/** 关闭登船入口的时间 (4分钟) */ var closeTime = 4 * 60 * 1000;
+/** 船只启航前的准备时间 (5分钟) */ var beginTime = 5 * 60 * 1000;
+/** 到达目的地所需的时间 (10分钟) */ var rideTime = 10 * 60 * 1000;
+/** 蝙蝠魔船只接近的时间 (3分钟) */ var invasionStartTime = 3 * 60 * 1000;
+/** 蝙蝠魔船只接近的时间延迟 (1分钟) */ var invasionDelayTime = 1 * 60 * 1000;
+/** 生成蝙蝠魔的时间延迟 (5秒) */ var invasionDelay = 5 * 1000;
 
-var Orbis_Station; // 天空之城售票处
-
-// 时间设置（以毫秒为单位）
-var closeTime = 4 * 60 * 1000; // 关闭登船入口的时间
-var beginTime = 5 * 60 * 1000; // 船只启航前的准备时间
-var rideTime = 10 * 60 * 1000; // 到达目的地所需的时间
-var invasionStartTime = 3 * 60 * 1000; // 蝙蝠魔船只接近的时间
-var invasionDelayTime = 1 * 60 * 1000; // 蝙蝠魔船只接近的时间延迟
-var invasionDelay = 5 * 1000; // 生成蝙蝠魔的时间延迟
+const PacketCreator = Java.type('org.gms.util.PacketCreator');  //获取封包数据实例
 
 function init() {
+    console.log("当前函数名:", getCurrentFunctionName());
     // 初始化函数，用于设置时间和获取地图实例。
     closeTime = em.getTransportationTime(closeTime);
     beginTime = em.getTransportationTime(beginTime);
     rideTime = em.getTransportationTime(rideTime);
     invasionStartTime = em.getTransportationTime(invasionStartTime);
     invasionDelayTime = em.getTransportationTime(invasionDelayTime);
-
+    console.log(closeTime/1000,beginTime/1000,rideTime/1000,invasionStartTime/1000,invasionDelayTime/1000);
     // 获取地图实例
     Orbis_btf = em.getChannelServer().getMapFactory().getMap(200000112);    //候船室<开往魔法密林>
     Ellinia_btf = em.getChannelServer().getMapFactory().getMap(101000301);  //候船室<开往天空之城>
@@ -47,6 +48,7 @@ function init() {
 }
 
 function scheduleNew() {
+    console.log("scheduleNew");
     // 设置属性，并安排关闭入口和起飞的任务
     em.setProperty("docked", "true");
     em.setProperty("entry", "true");
@@ -55,6 +57,8 @@ function scheduleNew() {
     // 安排关闭入口和起飞的时间点
     em.schedule("stopentry", closeTime);
     em.schedule("takeoff", beginTime);
+    // setClock(Ellinia_docked,closeTime);
+    // setClock(Orbis_docked,closeTime);
 }
 
 function stopentry() {
@@ -65,6 +69,8 @@ function stopentry() {
 }
 
 function takeoff() {
+    console.log("takeoff");
+
     // 玩家被传送至船上，广播船只离开的消息
     Orbis_btf.warpEveryone(Boat_to_Ellinia.getId());
     Ellinia_btf.warpEveryone(Boat_to_Orbis.getId());
@@ -81,9 +87,15 @@ function takeoff() {
 
     // 安排到达目的地的时间点
     em.schedule("arrived", rideTime);
+    // em.startInstance(1,);
+    // eim.startEventTimer(rideTime);  // 启动事件计时器
+    // setClock(Boat_to_Ellinia,rideTime);
+    // setClock(Boat_to_Orbis,rideTime);
 }
 
 function arrived() {
+    console.log("arrived");
+    // end();
     // 玩家到达目的地后被传送至对应站点或码头
     Boat_to_Orbis.warpEveryone(Orbis_Station.getId(), 0);
     Orbis_Boat_Cabin.warpEveryone(Orbis_Station.getId(), 0);
@@ -104,6 +116,7 @@ function arrived() {
 }
 
 function approach() {
+    console.log("approach");
     // 处理蝙蝠魔船只接近的情况
     if (Math.floor(Math.random() * 10) < 10) {
         em.setProperty("haveBalrog", "true");
@@ -121,6 +134,7 @@ function approach() {
 }
 
 function invasion() {
+    console.log("invasion");
     // 生成偶遇蝙蝠魔
     const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
 
@@ -135,35 +149,168 @@ function invasion() {
     map2.spawnMonsterOnGroundBelow(LifeFactory.getMonster(8150000), pos2);
 }
 
-function cancelSchedule() {}
+/**
+ * 取消预定的事件/任务调度
+ */
+function cancelSchedule() {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
+
+function setClock(MapObj,Time) {
+    console.log("setClock",MapObj,Time);
+    const players = MapObj.getCharacters(); //获取当前地图的所有角色
+    console.log(players);
+    if (players.length > 0){
+        players.map(player => { //遍历角色
+            player.sendPacket(PacketCreator.getClock(Time));    //发送创建倒计时封包
+        });
+    }
+}
 
 // ---------- 辅助函数 ----------
-function dispose() {}
 
-function setup(eim, leaderid) {}
+/**
+ * 释放/清理资源
+ */
+function dispose() {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
+/**
+ * 初始化副本实例（Event Instance Management）
+ * @param {Object} eim - 副本实例对象
+ * @param {number} leaderid - 队伍领袖ID
+ */
+function setup(level, lobbyid) {
+    console.log("当前函数名:", getCurrentFunctionName());
+    var eim = em.newInstance("Boats_takeoff");
+    var Maplist = [Boat_to_Ellinia,Boat_to_Orbis,Orbis_Boat_Cabin,Ellinia_Boat_Cabin];
+    Maplist.map(obj => eim.getInstanceMap(obj.getId()).resetPQ(1));
+    eim.startEventTimer(rideTime);  // 启动事件计时器
+    return eim;
+}
+
+/**
+ * 获取指定怪物的数值（经验/掉落等）
+ * @param {Object} eim - 副本实例对象
+ * @param {number} mobid - 怪物ID
+ * @return {number} 怪物数值
+ */
 function monsterValue(eim, mobid) {return 0;}
 
-function disbandParty(eim, player) {}
+/**
+ * 解散队伍
+ * @param {Object} eim - 副本实例对象
+ * @param {Object} player - 玩家对象
+ */
+function disbandParty(eim, player) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
-function playerDisconnected(eim, player) {}
+/**
+ * 玩家断开连接处理
+ * @param {Object} eim - 副本实例对象
+ * @param {Object} player - 玩家对象
+ */
+function playerDisconnected(eim, player) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
-function playerEntry(eim, player) {}
+/**
+ * 玩家进入副本处理
+ * @param {Object} eim - 副本实例对象
+ * @param {Object} player - 玩家对象
+ */
+function playerEntry(eim, player) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
-function monsterKilled(mob, eim) {}
+/**
+ * 怪物被击杀处理
+ * @param {Object} mob - 怪物对象
+ * @param {Object} eim - 副本实例对象
+ */
+function monsterKilled(mob, eim) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
-function scheduledTimeout(eim) {}
+/**
+ * 预定超时触发
+ * @param {Object} eim - 副本实例对象
+ */
+function scheduledTimeout(eim) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
-function afterSetup(eim) {}
+/**
+ * 副本设置完成后执行
+ * @param {Object} eim - 副本实例对象
+ */
+function afterSetup(eim) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
-function changedLeader(eim, leader) {}
+/**
+ * 队伍领袖变更处理
+ * @param {Object} eim - 副本实例对象
+ * @param {Object} leader - 新领袖对象
+ */
+function changedLeader(eim, leader) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
-function playerExit(eim, player) {}
+/**
+ * 玩家退出副本处理
+ * @param {Object} eim - 副本实例对象
+ * @param {Object} player - 玩家对象
+ */
+function playerExit(eim, player) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
-function leftParty(eim, player) {}
+/**
+ * 玩家离开队伍处理
+ * @param {Object} eim - 副本实例对象
+ * @param {Object} player - 玩家对象
+ */
+function leftParty(eim, player) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
-function clearPQ(eim) {}
+/**
+ * 清理副本任务（Party Quest）
+ * @param {Object} eim - 副本实例对象
+ */
+function clearPQ(eim) {
+    console.log("当前函数名:", getCurrentFunctionName());
+    eim.stopEventTimer();
+    eim.setEventCleared();
+}
 
-function allMonstersDead(eim) {}
+/**
+ * 所有怪物被击杀处理
+ * @param {Object} eim - 副本实例对象
+ */
+function allMonstersDead(eim) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
 
-function playerUnregistered(eim, player) {}
+/**
+ * 玩家注销/取消注册处理
+ * @param {Object} eim - 副本实例对象
+ * @param {Object} player - 玩家对象
+ */
+function playerUnregistered(eim, player) {
+    console.log("当前函数名:", getCurrentFunctionName());
+}
+function end(eim) {
+    eim.dispose();
+}
+function getCurrentFunctionName() {
+    const stack = new Error().stack;
+    const stackLines = stack.split('\n');
+    // 不同浏览器/环境格式不同，可能需要调整
+    const callerLine = stackLines[2]; // 通常是调用者的行
+    const functionName = callerLine.match(/at (.*?) /)?.[1] || 'anonymous';
+    return functionName;
+}

--- a/gms-server/scripts-zh-CN/event/BossRushPQ.js
+++ b/gms-server/scripts-zh-CN/event/BossRushPQ.js
@@ -38,6 +38,12 @@ var eventTime = 5;     //5 minutes
 
 const maxLobbies = 7;
 
+const GameConfig = Java.type('org.gms.config.GameConfig');
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/CWKPQ.js
+++ b/gms-server/scripts-zh-CN/event/CWKPQ.js
@@ -231,7 +231,7 @@ function setup(channel) {
 }
 
 function playerEntry(eim, player) {
-    eim.dropMessage(5, "[Expedition] " + player.getName() + " has entered the map.");
+    eim.dropMessage(5, "[远征队] " + player.getName() + " 已进入地图。");
     var map = eim.getMapInstance(610030100 + (eim.getIntProperty("current_instance") * 100));
     player.changeMap(map, map.getPortal(0));
 }
@@ -241,7 +241,7 @@ function spawnGuardians(eim) {
     if (map.countPlayers() <= 0) {
         return;
     }
-    map.broadcastStringMessage(5, "The Master Guardians have detected you.");
+    map.broadcastStringMessage(5, eim.getMonster(9400594).getName() + " 已发现了你！");
     for (var i = 0; i < 20; i++) { //spawn 20 guardians
         var mob = eim.getMonster(9400594);
         eim.registerMonster(mob);
@@ -255,14 +255,7 @@ function scheduledTimeout(eim) {
 
 function changedMap(eim, player, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
-        if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
-            eim.unregisterPlayer(player);
-            eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-            end(eim);
-        } else {
-            eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-            eim.unregisterPlayer(player);
-        }
+        partyPlayersCheck(eim, player);
     } else {
         switch (mapid) {
             case 610030200:
@@ -310,25 +303,11 @@ function changedLeader(eim, leader) {}
 function playerDead(eim, player) {}
 
 function playerRevive(eim, player) {
-    if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-        end(eim);
-    } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-        eim.unregisterPlayer(player);
-    }
+    partyPlayersCheck(eim, player);
 }
 
 function playerDisconnected(eim, player) {
-    if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-        end(eim);
-    } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-        eim.unregisterPlayer(player);
-    }
+    partyPlayersCheck(eim, player);
 }
 
 function leftParty(eim, player) {}
@@ -370,3 +349,21 @@ function allMonstersDead(eim) {}
 function cancelSchedule() {}
 
 function dispose(eim) {}
+/**
+ * 检测队伍人数是否满足最低人数要求
+ * @param {ExpeditionInstanceManager} eim - 远征副本实例管理器
+ * @param {Player} player - 触发事件的玩家对象
+ * @returns {void}
+ */
+function partyPlayersCheck(eim, player) {
+    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
+        eim.unregisterPlayer(player);
+        eim.dropMessage(5, "[远征队] 队长已退出远征或者队伍人数不足最低要求，无法继续。");
+        end(eim);
+        return false;
+    } else {
+        eim.dropMessage(5, "[远征队] " + player.getName() + " 已离开副本。");
+        eim.unregisterPlayer(player);
+        return true;
+    }
+}

--- a/gms-server/scripts-zh-CN/event/CWKPQ.js
+++ b/gms-server/scripts-zh-CN/event/CWKPQ.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/CafePQ_1.js
+++ b/gms-server/scripts-zh-CN/event/CafePQ_1.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/CafePQ_2.js
+++ b/gms-server/scripts-zh-CN/event/CafePQ_2.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/CafePQ_3.js
+++ b/gms-server/scripts-zh-CN/event/CafePQ_3.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/CafePQ_4.js
+++ b/gms-server/scripts-zh-CN/event/CafePQ_4.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/CafePQ_5.js
+++ b/gms-server/scripts-zh-CN/event/CafePQ_5.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/CafePQ_6.js
+++ b/gms-server/scripts-zh-CN/event/CafePQ_6.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/DelliBattle.js
+++ b/gms-server/scripts-zh-CN/event/DelliBattle.js
@@ -37,6 +37,12 @@ var eventTime = 6;     // 6 minutes
 
 const maxLobbies = 7;
 
+const GameConfig = Java.type('org.gms.config.GameConfig');
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/ElementalBattle.js
+++ b/gms-server/scripts-zh-CN/event/ElementalBattle.js
@@ -40,6 +40,10 @@ const maxLobbies = 7;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/EllinPQ.js
+++ b/gms-server/scripts-zh-CN/event/EllinPQ.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/ElnathPQ.js
+++ b/gms-server/scripts-zh-CN/event/ElnathPQ.js
@@ -37,6 +37,12 @@ var eventTime = 10;     // 10 minutes
 
 const maxLobbies = 1;
 
+const GameConfig = Java.type('org.gms.config.GameConfig');
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/GuildQuest.js
+++ b/gms-server/scripts-zh-CN/event/GuildQuest.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 
 function init() {
     setEventRequirements();

--- a/gms-server/scripts-zh-CN/event/HenesysPQ.js
+++ b/gms-server/scripts-zh-CN/event/HenesysPQ.js
@@ -160,7 +160,7 @@ function scheduledTimeout(eim) {
 }
 
 function bunnyDefeated(eim) {
-    eim.dropMessage(5, "Due to your failure to protect the Moon Bunny, you have been transported to the Exile Map.");
+    eim.dropMessage(5, "因未能守护月兔，你已被传送至流放之地！");
     end(eim);
 }
 

--- a/gms-server/scripts-zh-CN/event/HenesysPQ.js
+++ b/gms-server/scripts-zh-CN/event/HenesysPQ.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/HenesysPQ.js
+++ b/gms-server/scripts-zh-CN/event/HenesysPQ.js
@@ -44,6 +44,8 @@ if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果
     minLevel = 1 , maxLevel = 999;
 }
 
+const PacketCreator = Java.type('org.gms.util.PacketCreator');
+
 function init() {
     setEventRequirements();
 }
@@ -160,7 +162,7 @@ function scheduledTimeout(eim) {
 }
 
 function bunnyDefeated(eim) {
-    eim.dropMessage(5, "因未能守护月兔，你已被传送至流放之地！");
+    eim.dropMessage(5, "因未能保护好玉兔月妙导致其重伤，你已被传送至流放之地！");
     end(eim);
 }
 
@@ -264,9 +266,7 @@ function friendlyItemDrop(eim, mob) {
     if (mob.getId() == 9300061) {
         var cakes = eim.getIntProperty("bunnyCake") + 1;
         eim.setIntProperty("bunnyCake", cakes);
-
-        const PacketCreator = Java.type('org.gms.util.PacketCreator');
-        mob.getMap().broadcastMessage(PacketCreator.serverNotice(6, "The Moon Bunny made rice cake number " + cakes + "."));
+        mob.getMap().broadcastMessage(PacketCreator.serverNotice(6, `玉兔月妙成功捣出了第 ${cakes} 份年糕！`));
     }
 }
 
@@ -274,9 +274,10 @@ function friendlyDamaged(eim, mob) {
     if (mob.getId() == 9300061) {
         var bunnyDamage = eim.getIntProperty("bunnyDamaged") + 1;
         if (bunnyDamage > 5) {
-            const PacketCreator = Java.type('org.gms.util.PacketCreator');
-            broadcastMessage(PacketCreator.serverNotice(6, "The Moon Bunny is feeling sick. Please protect it so it can make delicious rice cakes."));
+            mob.getMap().broadcastMessage(PacketCreator.serverNotice(5, "玉兔月妙受到了伤害，请保护好它，这样它才能继续做出美味的年糕！"));
             eim.setIntProperty("bunnyDamaged", 0);
+        } else {
+            eim.setIntProperty("bunnyDamaged", bunnyDamage);
         }
     }
 }

--- a/gms-server/scripts-zh-CN/event/HolidayPQ_1.js
+++ b/gms-server/scripts-zh-CN/event/HolidayPQ_1.js
@@ -370,7 +370,7 @@ function snowmanSnackFake(eim) {
         eim.setIntProperty("snowmanStep", step - 1);
     }
 
-    eim.dropMessage(5, "The snowman absorbed a Fake Snow Vigor!");
+    eim.dropMessage(5, "雪人吸收了假的雪之精气!");
 }
 
 

--- a/gms-server/scripts-zh-CN/event/HolidayPQ_1.js
+++ b/gms-server/scripts-zh-CN/event/HolidayPQ_1.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/HolidayPQ_2.js
+++ b/gms-server/scripts-zh-CN/event/HolidayPQ_2.js
@@ -370,7 +370,7 @@ function snowmanSnackFake(eim) {
         eim.setIntProperty("snowmanStep", step - 1);
     }
 
-    eim.dropMessage(5, "The snowman absorbed a Fake Snow Vigor!");
+    eim.dropMessage(5, "雪人吸收了假的雪之精气!");
 }
 
 

--- a/gms-server/scripts-zh-CN/event/HolidayPQ_2.js
+++ b/gms-server/scripts-zh-CN/event/HolidayPQ_2.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/HolidayPQ_3.js
+++ b/gms-server/scripts-zh-CN/event/HolidayPQ_3.js
@@ -370,7 +370,7 @@ function snowmanSnackFake(eim) {
         eim.setIntProperty("snowmanStep", step - 1);
     }
 
-    eim.dropMessage(5, "The snowman absorbed a Fake Snow Vigor!");
+    eim.dropMessage(5, "雪人吸收了假的雪之精气!");
 }
 
 

--- a/gms-server/scripts-zh-CN/event/HolidayPQ_3.js
+++ b/gms-server/scripts-zh-CN/event/HolidayPQ_3.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/HorntailBattle.js
+++ b/gms-server/scripts-zh-CN/event/HorntailBattle.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/HorntailBattle.js
+++ b/gms-server/scripts-zh-CN/event/HorntailBattle.js
@@ -127,7 +127,7 @@ function setup(channel) {
 }
 
 function playerEntry(eim, player) {
-    eim.dropMessage(5, "[Expedition] " + player.getName() + " has entered the map.");
+    eim.dropMessage(5, "[远征队] " + player.getName() + " 已进入地图。");
     var map = eim.getMapInstance(entryMap);
     player.changeMap(map, map.getPortal(0));
 }
@@ -138,14 +138,7 @@ function scheduledTimeout(eim) {
 
 function changedMap(eim, player, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
-        if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-            eim.unregisterPlayer(player);
-            eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-            end(eim);
-        } else {
-            eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-            eim.unregisterPlayer(player);
-        }
+        partyPlayersCheck(eim, player);
     }
 }
 
@@ -154,25 +147,11 @@ function changedLeader(eim, leader) {}
 function playerDead(eim, player) {}
 
 function playerRevive(eim, player) {
-    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-        end(eim);
-    } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-        eim.unregisterPlayer(player);
-    }
+    partyPlayersCheck(eim, player);
 }
 
 function playerDisconnected(eim, player) {
-    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-        end(eim);
-    } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-        eim.unregisterPlayer(player);
-    }
+    partyPlayersCheck(eim, player);
 }
 
 function leftParty(eim, player) {}
@@ -237,3 +216,21 @@ function allMonstersDead(eim) {}
 function cancelSchedule() {}
 
 function dispose(eim) {}
+/**
+ * 检测队伍人数是否满足最低人数要求
+ * @param {ExpeditionInstanceManager} eim - 远征副本实例管理器
+ * @param {Player} player - 触发事件的玩家对象
+ * @returns {void}
+ */
+function partyPlayersCheck(eim, player) {
+    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
+        eim.unregisterPlayer(player);
+        eim.dropMessage(5, "[远征队] 队长已退出远征或者队伍人数不足最低要求，无法继续。");
+        end(eim);
+        return false;
+    } else {
+        eim.dropMessage(5, "[远征队] " + player.getName() + " 已离开副本。");
+        eim.unregisterPlayer(player);
+        return true;
+    }
+}

--- a/gms-server/scripts-zh-CN/event/HorntailPQ.js
+++ b/gms-server/scripts-zh-CN/event/HorntailPQ.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 
 function init() {
     setEventRequirements();

--- a/gms-server/scripts-zh-CN/event/KerningPQ.js
+++ b/gms-server/scripts-zh-CN/event/KerningPQ.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/LatanicaBattle.js
+++ b/gms-server/scripts-zh-CN/event/LatanicaBattle.js
@@ -38,6 +38,12 @@ var eventTime = 10;     // 10 minutes
 
 const maxLobbies = 1;
 
+const GameConfig = Java.type('org.gms.config.GameConfig');
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/LudiMazePQ.js
+++ b/gms-server/scripts-zh-CN/event/LudiMazePQ.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/LudiPQ.js
+++ b/gms-server/scripts-zh-CN/event/LudiPQ.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 
 function init() {
     setEventRequirements();

--- a/gms-server/scripts-zh-CN/event/MK_PrimeMinister.js
+++ b/gms-server/scripts-zh-CN/event/MK_PrimeMinister.js
@@ -10,9 +10,37 @@ var minMapId = 106021600;
 var maxMapId = 106021600;
 
 var mobId = 3300008; //Prime Minister
+const GameConfig = Java.type('org.gms.config.GameConfig');
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
 
-function init() {}
+function init() {
+    setEventRequirements();
+}
+function setEventRequirements() {
+    var reqStr = "";
 
+    reqStr += "\r\n   组队人数: ";
+    if (maxPlayers - minPlayers >= 1) {
+        reqStr += minPlayers + " ~ " + maxPlayers;
+    } else {
+        reqStr += minPlayers;
+    }
+
+    reqStr += "\r\n   等级要求: ";
+    if (maxLevel - minLevel >= 1) {
+        reqStr += minLevel + " ~ " + maxLevel;
+    } else {
+        reqStr += minLevel;
+    }
+
+    reqStr += "\r\n   时间限制: ";
+    reqStr += eventTime + " 分钟";
+
+    em.setProperty("party", reqStr);
+}
 function getEligibleParty(party) {      //selects, from the given party, the team that is allowed to attempt this event
     var eligible = [];
     var hasLeader = false;

--- a/gms-server/scripts-zh-CN/event/MK_PrimeMinister2.js
+++ b/gms-server/scripts-zh-CN/event/MK_PrimeMinister2.js
@@ -10,9 +10,37 @@ var minMapId = 106021601;
 var maxMapId = 106021601;
 
 var mobId = 3300008; //Prime Minister
+const GameConfig = Java.type('org.gms.config.GameConfig');
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
 
-function init() {}
+function init() {
+    setEventRequirements();
+}
+function setEventRequirements() {
+    var reqStr = "";
 
+    reqStr += "\r\n   组队人数: ";
+    if (maxPlayers - minPlayers >= 1) {
+        reqStr += minPlayers + " ~ " + maxPlayers;
+    } else {
+        reqStr += minPlayers;
+    }
+
+    reqStr += "\r\n   等级要求: ";
+    if (maxLevel - minLevel >= 1) {
+        reqStr += minLevel + " ~ " + maxLevel;
+    } else {
+        reqStr += minLevel;
+    }
+
+    reqStr += "\r\n   时间限制: ";
+    reqStr += eventTime + " 分钟";
+
+    em.setProperty("party", reqStr);
+}
 function getEligibleParty(party) {      //selects, from the given party, the team that is allowed to attempt this event
     var eligible = [];
     var hasLeader = false;

--- a/gms-server/scripts-zh-CN/event/MagatiaPQ_A.js
+++ b/gms-server/scripts-zh-CN/event/MagatiaPQ_A.js
@@ -318,9 +318,9 @@ function yuleteAction(eim) {
     if (eim.getIntProperty("yuleteTalked") == 1) {
         eim.setIntProperty("yuletePassed", 1);
 
-        eim.dropMessage(5, "Yulete: Ugh, you guys disgust me. All I desired was to make this nation the greatest alchemy powerhouse of the entire world. If they won't accept this, I will make it true by myself, at any costs!!!");
+        eim.dropMessage(5, "犹泰：呃...你们真让我作呕。我想要的不过是让这个国家成为全世界最伟大的炼金术强国。如果他们不接受，我不惜一切代价也要独自实现这个目标！！！");
     } else {
-        eim.dropMessage(5, "Yulete: Hahaha... Did you really think I was going to be so disprepared knowing that the Magatia societies' dogs would be coming in my pursuit after my actions? Fools!");
+        eim.dropMessage(5, "犹泰：哈哈哈...你们真以为我会毫无准备，不知道玛加提亚协会的走狗们会来追捕我吗？愚蠢！");
     }
     eim.setIntProperty("yuleteTalked", -1);
 

--- a/gms-server/scripts-zh-CN/event/MagatiaPQ_A.js
+++ b/gms-server/scripts-zh-CN/event/MagatiaPQ_A.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/MagatiaPQ_Z.js
+++ b/gms-server/scripts-zh-CN/event/MagatiaPQ_Z.js
@@ -318,10 +318,11 @@ function yuleteAction(eim) {
     if (eim.getIntProperty("yuleteTalked") == 1) {
         eim.setIntProperty("yuletePassed", 1);
 
-        eim.dropMessage(5, "Yulete: Ugh, you guys disgust me. All I desired was to make this nation the greatest alchemy powerhouse of the entire world. If they won't accept this, I will make it true by myself, at any costs!!!");
+        eim.dropMessage(5, "犹泰：呃...你们真让我作呕。我想要的不过是让这个国家成为全世界最伟大的炼金术强国。如果他们不接受，我不惜一切代价也要独自实现这个目标！！！");
     } else {
-        eim.dropMessage(5, "Yulete: Hahaha... Did you really think I was going to be so disprepared knowing that the Magatia societies' dogs would be coming in my pursuit after my actions? Fools!");
+        eim.dropMessage(5, "犹泰：哈哈哈...你们真以为我会毫无准备，不知道玛加提亚协会的走狗们会来追捕我吗？愚蠢！");
     }
+
     eim.setIntProperty("yuleteTalked", -1);
 
     var mapobj = eim.getMapInstance(926100203);

--- a/gms-server/scripts-zh-CN/event/MagatiaPQ_Z.js
+++ b/gms-server/scripts-zh-CN/event/MagatiaPQ_Z.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/OrbisPQ.js
+++ b/gms-server/scripts-zh-CN/event/OrbisPQ.js
@@ -195,7 +195,7 @@ function playerEntry(eim, player) {
     var map = eim.getMapInstance(entryMap);
     player.changeMap(map, map.getPortal(0));
 
-    var texttt = "Hi, my name is Eak, the Chamberlain of the Goddess. Don't be alarmed; you won't be able to see me right now. Back when the Goddess turned into a block of stone, I simultaneously lost my own power. If you gather up the power of the Magic Cloud of Orbis, however, then I'll be able to recover my body and re-transform back to my original self. Please collect #b20#k Magic Clouds and bring them back to me. Right now, you'll only see me as a tiny, flickering light.";
+    var texttt = "你好，我是女神的内侍官#e#b帮佣易克#n#k。\r\n别紧张，你现在还看不到我。\r\n当女神石化时，我也同时失去了力量，所以现在你只能看到我微弱的闪光。\r\n如果你能收集到魔法云的力量，我就能恢复形体变回原样。\r\n请帮我收集 #b#e20#n#k 朵 #b#e#v4001063##t4001063##k#n 带回来。";
     player.getAbstractPlayerInteraction().npcTalk(2013001, texttt);
 }
 

--- a/gms-server/scripts-zh-CN/event/OrbisPQ.js
+++ b/gms-server/scripts-zh-CN/event/OrbisPQ.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/PapulatusBattle.js
+++ b/gms-server/scripts-zh-CN/event/PapulatusBattle.js
@@ -38,6 +38,12 @@ var eventTime = 45;     // 45 minutes
 
 const maxLobbies = 1;
 
+const GameConfig = Java.type('org.gms.config.GameConfig');
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/PinkBeanBattle.js
+++ b/gms-server/scripts-zh-CN/event/PinkBeanBattle.js
@@ -96,7 +96,7 @@ function setEventRewards(eim) {
 }
 
 function afterSetup(eim) {
-    eim.dropMessage(5, "The first wave will start within 15 seconds, prepare yourselves.");
+    eim.dropMessage(5, "第一波攻击将在15秒后开始，请做好准备。");
     eim.schedule("startWave", 15 * 1000);
 }
 
@@ -128,7 +128,7 @@ function setup(channel) {
 }
 
 function playerEntry(eim, player) {
-    eim.dropMessage(5, "[Expedition] " + player.getName() + " has entered the map.");
+    eim.dropMessage(5, "[远征队] " + player.getName() + " 已进入地图。");
     var map = eim.getMapInstance(entryMap);
     player.changeMap(map, map.getPortal(0));
 }
@@ -141,10 +141,10 @@ function changedMap(eim, player, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
         if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
             eim.unregisterPlayer(player);
-            eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
+            eim.dropMessage(5, "[远征队] 队长已退出远征队或队伍人数不足最低要求，无法继续。");
             end(eim);
         } else {
-            eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the expedition.");
+            eim.dropMessage(5, "[远征队] " + player.getName() + " 已离开远征队。");
             eim.unregisterPlayer(player);
         }
     }
@@ -159,12 +159,12 @@ function playerDead(eim, player) {
     eim.setIntProperty("fallenPlayers", count);
 
     if (count == 5) {
-        eim.dropMessage(5, "[Expedition] Too many players have fallen, Pink Bean is now deemed undefeatable; the expedition is over.");
+        eim.dropMessage(5, "[远征队] 太多队员阵亡，品克缤现在被视为不可战胜，远征结束。");
         end(eim);
     } else if (count == 4) {
-        eim.dropMessage(5, "[Expedition] Pink Bean is growing stronger than ever, last stand mode everyone!");
+        eim.dropMessage(5, "[远征队] 品克缤变得比以往更强大，大家进入背水一战模式！");
     } else if (count == 3) {
-        eim.dropMessage(5, "[Expedition] Casualty count is starting to get out of control. Battle with care.");
+        eim.dropMessage(5, "[远征队] 伤亡人数开始失控，请小心战斗。");
     }
 }
 
@@ -181,10 +181,10 @@ function monsterRevive(eim, mob) {
 function playerDisconnected(eim, player) {
     if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
         eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
+        eim.dropMessage(5, "[远征队] 队长已退出远征队或队伍人数不足最低要求，无法继续。");
         end(eim);
     } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the expedition.");
+        eim.dropMessage(5, "[远征队] " + player.getName() + " 已离开远征队。");
         eim.unregisterPlayer(player);
     }
 }
@@ -272,12 +272,12 @@ function monsterKilled(mob, eim) {
                 mapObj.spawnItemDrop(dropper, dropper, itemObj, reactObj.getPosition(), true, true);
 
 
-                eim.dropMessage(6, "With the last of its guardians fallen, Pink Bean loses its invulnerability. The real fight starts now!");
+                eim.dropMessage(6, "随着最后的守护者倒下，品克缤失去了无敌状态。真正的战斗现在开始！");
             } else {
                 stage++;
                 eim.setIntProperty("stage", stage);
 
-                eim.dropMessage(5, "The next wave will start within 15 seconds, prepare yourselves.");
+                eim.dropMessage(5, "下一波攻击将在15秒后开始，请做好准备。");
                 eim.schedule("startWave", 15 * 1000);
             }
         }

--- a/gms-server/scripts-zh-CN/event/PinkBeanBattle.js
+++ b/gms-server/scripts-zh-CN/event/PinkBeanBattle.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/PiratePQ.js
+++ b/gms-server/scripts-zh-CN/event/PiratePQ.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 
 function init() {
     setEventRequirements();

--- a/gms-server/scripts-zh-CN/event/PiratePQ.js
+++ b/gms-server/scripts-zh-CN/event/PiratePQ.js
@@ -368,7 +368,7 @@ function monsterKilled(mob, eim) {
     var map = mob.getMap();
 
     if (isLordPirate(mob)) {  // lord pirate defeated, spawn the little fella!
-        map.broadcastStringMessage(5, "As Lord Pirate dies, Wu Yang is released!");
+        map.broadcastStringMessage(5, "随着海盗领主死亡，无恙被释放了！");
         eim.spawnNpc(2094001, new java.awt.Point(777, 140), mob.getMap());
     }
 

--- a/gms-server/scripts-zh-CN/event/RescueGaga.js
+++ b/gms-server/scripts-zh-CN/event/RescueGaga.js
@@ -119,7 +119,7 @@ function playerEntry(eim, player) {
 
     const PacketCreator = Java.type('org.gms.util.PacketCreator');
     player.sendPacket(PacketCreator.showEffect("event/space/start"));
-    player.startMapEffect("Please rescue Gaga within the time limit.", 5120027);
+    player.startMapEffect("请在时限内解救嘎嘎。", 5120027);
 }
 
 function scheduledTimeout(eim) {

--- a/gms-server/scripts-zh-CN/event/RescueGaga.js
+++ b/gms-server/scripts-zh-CN/event/RescueGaga.js
@@ -19,6 +19,10 @@ const maxLobbies = 20;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/ScargaBattle.js
+++ b/gms-server/scripts-zh-CN/event/ScargaBattle.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/ScargaBattle.js
+++ b/gms-server/scripts-zh-CN/event/ScargaBattle.js
@@ -113,7 +113,7 @@ function setup(channel) {
 }
 
 function playerEntry(eim, player) {
-    eim.dropMessage(5, "[Expedition] " + player.getName() + " has entered the map.");
+    eim.dropMessage(5, "[远征队] " + player.getName() + " 已进入地图。");
     var map = eim.getMapInstance(entryMap);
     player.changeMap(map, map.getPortal(0));
 }
@@ -124,14 +124,7 @@ function scheduledTimeout(eim) {
 
 function changedMap(eim, player, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
-        if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-            eim.unregisterPlayer(player);
-            eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-            end(eim);
-        } else {
-            eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-            eim.unregisterPlayer(player);
-        }
+        partyPlayersCheck(eim, player);
     }
 }
 
@@ -140,25 +133,11 @@ function changedLeader(eim, leader) {}
 function playerDead(eim, player) {}
 
 function playerRevive(eim, player) {
-    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-        end(eim);
-    } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-        eim.unregisterPlayer(player);
-    }
+    partyPlayersCheck(eim, player);
 }
 
 function playerDisconnected(eim, player) {
-    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-        end(eim);
-    } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-        eim.unregisterPlayer(player);
-    }
+    partyPlayersCheck(eim, player);
 }
 
 function leftParty(eim, player) {}
@@ -215,3 +194,21 @@ function allMonstersDead(eim) {}
 function cancelSchedule() {}
 
 function dispose(eim) {}
+/**
+ * 检测队伍人数是否满足最低人数要求
+ * @param {ExpeditionInstanceManager} eim - 远征副本实例管理器
+ * @param {Player} player - 触发事件的玩家对象
+ * @returns {void}
+ */
+function partyPlayersCheck(eim, player) {
+    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
+        eim.unregisterPlayer(player);
+        eim.dropMessage(5, "[远征队] 队长已退出远征或者队伍人数不足最低要求，无法继续。");
+        end(eim);
+        return false;
+    } else {
+        eim.dropMessage(5, "[远征队] " + player.getName() + " 已离开副本。");
+        eim.unregisterPlayer(player);
+        return true;
+    }
+}

--- a/gms-server/scripts-zh-CN/event/ShowaBattle.js
+++ b/gms-server/scripts-zh-CN/event/ShowaBattle.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 
 function init() {
     setEventRequirements();

--- a/gms-server/scripts-zh-CN/event/ShowaBattle.js
+++ b/gms-server/scripts-zh-CN/event/ShowaBattle.js
@@ -121,7 +121,7 @@ function respawnStages(eim) {
 }
 
 function playerEntry(eim, player) {
-    eim.dropMessage(5, "[Expedition] " + player.getName() + " has entered the map.");
+    eim.dropMessage(5, "[远征队] " + player.getName() + " 已进入地图。");
     var map = eim.getMapInstance(entryMap);
     player.changeMap(map, map.getPortal(0));
 }
@@ -132,14 +132,7 @@ function scheduledTimeout(eim) {
 
 function changedMap(eim, player, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
-        if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-            eim.unregisterPlayer(player);
-            eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-            end(eim);
-        } else {
-            eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-            eim.unregisterPlayer(player);
-        }
+        partyPlayersCheck(eim, player);
     }
 }
 
@@ -150,26 +143,13 @@ function playerDead(eim, player) {
 }
 
 function playerRevive(eim, player) {
-    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-        end(eim);
-    } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-        eim.unregisterPlayer(player);
-    }
+    partyPlayersCheck(eim, player);
 }
 
 function playerDisconnected(eim, player) {
-    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-        end(eim);
-    } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-        eim.unregisterPlayer(player);
-    }
+    partyPlayersCheck(eim, player);
 }
+
 
 function leftParty(eim, player) {}
 
@@ -207,7 +187,7 @@ function clearPQ(eim) {
     if (eim.getIntProperty("playerDied") == 0) {
         var mob = eim.getMonster(9400114);
         eim.getMapInstance(801040101).spawnMonsterOnGroundBelow(mob, new java.awt.Point(500, -50));
-        eim.dropMessage(5, "Konpei: The Boss has been defeated with no casualties, well done! We found a suspicious machine inside, we're moving it out.");
+        eim.dropMessage(5, "康培：Boss已被击败且无人员伤亡，干得漂亮！我们在里面发现了一台可疑的机器，正在将它移出。");
     }
 }
 
@@ -227,3 +207,21 @@ function allMonstersDead(eim) {}
 function cancelSchedule() {}
 
 function dispose(eim) {}
+/**
+ * 检测队伍人数是否满足最低人数要求
+ * @param {ExpeditionInstanceManager} eim - 远征副本实例管理器
+ * @param {Player} player - 触发事件的玩家对象
+ * @returns {void}
+ */
+function partyPlayersCheck(eim, player) {
+    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
+        eim.unregisterPlayer(player);
+        eim.dropMessage(5, "[远征队] 队长已退出远征或者队伍人数不足最低要求，无法继续。");
+        end(eim);
+        return false;
+    } else {
+        eim.dropMessage(5, "[远征队] " + player.getName() + " 已离开副本。");
+        eim.unregisterPlayer(player);
+        return true;
+    }
+}

--- a/gms-server/scripts-zh-CN/event/TD_Battle1.js
+++ b/gms-server/scripts-zh-CN/event/TD_Battle1.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/TD_Battle2.js
+++ b/gms-server/scripts-zh-CN/event/TD_Battle2.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/TD_Battle3.js
+++ b/gms-server/scripts-zh-CN/event/TD_Battle3.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/TD_Battle4.js
+++ b/gms-server/scripts-zh-CN/event/TD_Battle4.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }

--- a/gms-server/scripts-zh-CN/event/TD_Battle5.js
+++ b/gms-server/scripts-zh-CN/event/TD_Battle5.js
@@ -42,6 +42,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 
 function init() {
     setEventRequirements();

--- a/gms-server/scripts-zh-CN/event/TreasurePQ.js
+++ b/gms-server/scripts-zh-CN/event/TreasurePQ.js
@@ -41,6 +41,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 
 function init() {
     setEventRequirements();

--- a/gms-server/scripts-zh-CN/event/WeddingCathedral.js
+++ b/gms-server/scripts-zh-CN/event/WeddingCathedral.js
@@ -122,7 +122,7 @@ function playerEntry(eim, player) {
 
 function stopBlessings(eim) {
     var mapobj = eim.getMapInstance(entryMap + 10);
-    mapobj.dropMessage(6, "Wedding Assistant: Alright people, our couple are preparing their vows to each other right now.");
+    mapobj.dropMessage(6, "[婚礼助手] 各位宾客，新人正在准备彼此的誓言。");
 
     eim.setIntProperty("weddingStage", 2);
 }
@@ -177,7 +177,7 @@ function scheduledTimeout(eim) {
             chr.changeMap(entryMap + 10, "we00");
         }
 
-        mapobj.dropMessage(6, "Wedding Assistant: The couple are heading to the altar, hurry hurry talk to me to arrange your seat.");
+        mapobj.dropMessage(6, "[婚礼助手] 新人正走向圣坛，请尽快与我交谈安排您的座位。");
 
         eim.setIntProperty("weddingStage", 1);
         eim.schedule("showStartMsg", startMsgTime * 60 * 1000);

--- a/gms-server/scripts-zh-CN/event/WeddingChapel.js
+++ b/gms-server/scripts-zh-CN/event/WeddingChapel.js
@@ -53,19 +53,19 @@ function getMaxLobbies() {
 }
 
 function setEventExclusives(eim) {
-    var itemSet = [4031217, 4000313];    // golden key, golden maple leaf
+    var itemSet = [4031217, 4000313];    //金钥匙，金枫叶
     eim.setExclusiveItems(itemSet);
 }
 
 function setEventRewards(eim) {
     var itemSet, itemQty, evLevel, expStages;
 
-    evLevel = 1;    //Rewards at clear PQ
+    evLevel = 1;    //清晰PQ奖励
     itemSet = [];
     itemQty = [];
     eim.setEventRewards(evLevel, itemSet, itemQty);
 
-    expStages = [];    //bonus exp given on CLEAR stage signal
+    expStages = [];    //CLEAR舞台信号提供额外体验
     eim.setEventClearStageExp(expStages);
 }
 
@@ -81,7 +81,7 @@ function spawnCakeBoss(eim) {
 function setup(level, lobbyid) {
     var eim = em.newMarriage("Wedding" + lobbyid);
     eim.setProperty("weddingId", "0");
-    eim.setProperty("weddingStage", "0");   // 0: gathering time, 1: wedding time, 2: ready to fulfill the wedding, 3: just married
+    eim.setProperty("weddingStage", "0");   //0:聚会时间，1:婚礼时间，2:准备完成婚礼，3:刚刚结婚
     eim.setProperty("guestBlessings", "0");
     eim.setProperty("isPremium", "1");
     eim.setProperty("canJoin", "1");
@@ -122,7 +122,7 @@ function playerEntry(eim, player) {
 
 function stopBlessings(eim) {
     var mapobj = eim.getMapInstance(entryMap + 10);
-    mapobj.dropMessage(6, "Wedding Assistant: Alright people, our couple are preparing their vows to each other right now.");
+    mapobj.dropMessage(6, "[婚礼助手] 各位宾客请注意，新人正在互相准备誓言。");
 
     eim.setIntProperty("weddingStage", 2);
 }
@@ -178,7 +178,7 @@ function scheduledTimeout(eim) {
             chr.changeMap(entryMap + 10, "we00");
         }
 
-        mapobj.dropMessage(6, "Wedding Assistant: The couple are heading to the altar, hurry hurry talk to me to arrange your seat.");
+        mapobj.dropMessage(6, "[婚礼助手] 新人即将走向圣坛，请尽快与我交谈安排座位。");
 
         eim.setIntProperty("weddingStage", 1);
         eim.schedule("showStartMsg", startMsgTime * 60 * 1000);
@@ -223,7 +223,7 @@ function changedLeader(eim, leader) {}
 
 function playerDead(eim, player) {}
 
-function playerRevive(eim, player) { // player presses ok on the death pop up.
+function playerRevive(eim, player) { // 玩家在死亡弹出窗口上按ok。
     if (isMarrying(eim, player)) {
         eim.unregisterPlayer(player);
         end(eim);

--- a/gms-server/scripts-zh-CN/event/WuGongPQ.js
+++ b/gms-server/scripts-zh-CN/event/WuGongPQ.js
@@ -385,8 +385,8 @@ function monsterKilled(mob, eim) {
             var mapObj = mob.getMap();
             var dropper = eim.getPlayers().get(0);
             mapObj.spawnItemDropList(BossDropList,mob,dropper,mob.getPosition());
+            clearPQ(eim);
         }
-        clearPQ(eim);
     } catch (err) {
         console.error(err);
     } // PQ not started yet

--- a/gms-server/scripts-zh-CN/event/WuGongPQ.js
+++ b/gms-server/scripts-zh-CN/event/WuGongPQ.js
@@ -23,8 +23,10 @@ var BossDropCount = [5];                 // 掉落最大数量
 var BossDropChance = [0.4];                // 掉率
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
-minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  // 如果解除远征队人数限制，则最低人数改为1人
-
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
 /**
  * 初始化事件，设置事件要求。
  */

--- a/gms-server/scripts-zh-CN/event/YaoSengPQ.js
+++ b/gms-server/scripts-zh-CN/event/YaoSengPQ.js
@@ -384,8 +384,8 @@ function monsterKilled(mob, eim) {
             var mapObj = mob.getMap();
             var dropper = eim.getPlayers().get(0);
             mapObj.spawnItemDropList(BossDropList,mob,dropper,mob.getPosition());
+            clearPQ(eim);
         }
-        clearPQ(eim);
     } catch (err) {
         console.error(err);
     } // PQ not started yet

--- a/gms-server/scripts-zh-CN/event/YaoSengPQ.js
+++ b/gms-server/scripts-zh-CN/event/YaoSengPQ.js
@@ -23,8 +23,10 @@ var BossDropCount = [5];                 // 掉落最大数量
 var BossDropChance = [0.4];                // 掉率
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
-minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  // 如果解除远征队人数限制，则最低人数改为1人
-
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
 /**
  * 初始化事件，设置事件要求。
  */

--- a/gms-server/scripts-zh-CN/event/ZakumBattle.js
+++ b/gms-server/scripts-zh-CN/event/ZakumBattle.js
@@ -40,6 +40,10 @@ const maxLobbies = 1;
 
 const GameConfig = Java.type('org.gms.config.GameConfig');
 minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
+
 
 function init() {
     setEventRequirements();

--- a/gms-server/scripts-zh-CN/event/ZakumBattle.js
+++ b/gms-server/scripts-zh-CN/event/ZakumBattle.js
@@ -115,9 +115,21 @@ function setup(channel) {
     return eim;
 }
 
+/**
+ * 处理玩家进入远征副本事件 - 当玩家进入远征副本时触发
+ * @param {ExpeditionInstanceManager} eim - 远征副本实例管理器
+ * @param {Player} player - 进入副本的玩家对象
+ * @returns {void}
+ * @description 当玩家进入副本时发送系统消息，并将玩家传送到副本入口地图
+ */
 function playerEntry(eim, player) {
-    eim.dropMessage(5, "[Expedition] " + player.getName() + " has entered the map.");
+    // 发送玩家进入副本的系统提示消息
+    eim.dropMessage(5, "[远征队] " + player.getName() + " 已进入副本地图。");
+
+    // 获取副本入口地图实例
     var map = eim.getMapInstance(entryMap);
+
+    // 将玩家传送到入口地图的第一个传送点
     player.changeMap(map, map.getPortal(0));
 }
 
@@ -125,16 +137,19 @@ function scheduledTimeout(eim) {
     end(eim);
 }
 
+/**
+ * 处理玩家切换地图事件 - 当玩家在远征副本中切换地图时触发
+ * @param {ExpeditionInstanceManager} eim - 远征副本实例管理器
+ * @param {Player} player - 触发事件的玩家对象
+ * @param {number} mapid - 玩家切换到的地图ID
+ * @returns {void}
+ * @description 当玩家切换到副本允许范围外的地图时，执行玩家移除逻辑
+ */
 function changedMap(eim, player, mapid) {
+    // 检查地图ID是否超出副本允许范围
     if (mapid < minMapId || mapid > maxMapId) {
-        if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-            eim.unregisterPlayer(player);
-            eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-            end(eim);
-        } else {
-            eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-            eim.unregisterPlayer(player);
-        }
+        // 检查是否因玩家退出导致队伍不满足最低人数要求
+        partyPlayersCheck(eim, player);
     }
 }
 
@@ -142,26 +157,24 @@ function changedLeader(eim, leader) {}
 
 function playerDead(eim, player) {}
 
+/**
+ * 处理玩家复活事件 - 当玩家在远征副本中复活时触发
+ * @param {ExpeditionInstanceManager} eim - 远征副本实例管理器
+ * @param {Player} player - 触发事件的玩家对象
+ * @returns {void}
+ */
 function playerRevive(eim, player) {
-    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-        end(eim);
-    } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-        eim.unregisterPlayer(player);
-    }
+    partyPlayersCheck(eim, player);
 }
 
+/**
+ * 处理玩家断线事件 - 当玩家在远征副本中断开连接时触发
+ * @param {ExpeditionInstanceManager} eim - 远征副本实例管理器
+ * @param {Player} player - 触发事件的玩家对象
+ * @returns {void}
+ */
 function playerDisconnected(eim, player) {
-    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        eim.dropMessage(5, "[Expedition] Either the leader has quit the expedition or there is no longer the minimum number of members required to continue it.");
-        end(eim);
-    } else {
-        eim.dropMessage(5, "[Expedition] " + player.getName() + " has left the instance.");
-        eim.unregisterPlayer(player);
-    }
+    partyPlayersCheck(eim, player);
 }
 
 function leftParty(eim, player) {}
@@ -227,5 +240,23 @@ function updateGateState(newState) {    // thanks Conrad for noticing missing ga
 function dispose(eim) {
     if (!eim.isEventCleared()) {
         updateGateState(0);
+    }
+}
+/**
+ * 检测队伍人数是否满足最低人数要求
+ * @param {ExpeditionInstanceManager} eim - 远征副本实例管理器
+ * @param {Player} player - 触发事件的玩家对象
+ * @returns {void}
+ */
+function partyPlayersCheck(eim, player) {
+    if (eim.isExpeditionTeamLackingNow(true, minPlayers, player)) {
+        eim.unregisterPlayer(player);
+        eim.dropMessage(5, "[远征队] 队长已退出远征或者队伍人数不足最低要求，无法继续。");
+        end(eim);
+        return false;
+    } else {
+        eim.dropMessage(5, "[远征队] " + player.getName() + " 已离开副本。");
+        eim.unregisterPlayer(player);
+        return true;
     }
 }

--- a/gms-server/scripts-zh-CN/event/ZakumPQ.js
+++ b/gms-server/scripts-zh-CN/event/ZakumPQ.js
@@ -42,8 +42,10 @@ const maxLobbies = 1;
 
 // 从游戏配置获取是否启用单人远征队设置
 const GameConfig = Java.type('org.gms.config.GameConfig');
-minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;
-
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果解除远征队等级限制，则最低1级，最高999级。
+    minLevel = 1 , maxLevel = 999;
+}
 /**
  * 初始化事件，设置事件要求
  */

--- a/gms-server/scripts-zh-CN/event/ZakumPQ.js
+++ b/gms-server/scripts-zh-CN/event/ZakumPQ.js
@@ -23,73 +23,91 @@
  * @event: Zakum PQ
  */
 
+/** 是否为远征队(Party Quest)模式 */
 var isPq = true;
+/** minPlayers - 队伍最小人数 , maxPlayers - 队伍最大人数 */
 var minPlayers = 6, maxPlayers = 6;
+/** minLevel - 最低等级限制 , maxLevel - 最高等级限制 */
 var minLevel = 50, maxLevel = 255;
-var entryMap = 280010000;
-var exitMap = 211042300;
-var recruitMap = 211042300;
-var clearMap = 211042300;
-
-var minMapId = 280010000;
-var maxMapId = 280011006;
-
-var eventTime = 30;     // 30 minutes
-
+/** entryMap - 入口地图ID , exitMap - 退出地图ID */
+var entryMap = 280010000, exitMap = 211042300;
+/** recruitMap - 招募地图ID , clearMap - 清除地图ID */
+var recruitMap = 211042300, clearMap = 211042300;
+/** minMapId - 最小地图ID , maxMapId - 最大地图ID */
+var minMapId = 280010000, maxMapId = 280011006;
+/** eventTime - 事件时间限制(分钟) */
+var eventTime = 30;
+/** maxLobbies - 最大大厅数量 */
 const maxLobbies = 1;
 
+// 从游戏配置获取是否启用单人远征队设置
 const GameConfig = Java.type('org.gms.config.GameConfig');
-minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;  //如果解除远征队人数限制，则最低人数改为1人
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;
 
+/**
+ * 初始化事件，设置事件要求
+ */
 function init() {
     setEventRequirements();
 }
 
+/**
+ * 获取最大大厅数量
+ * @returns {number} 最大大厅数
+ */
 function getMaxLobbies() {
     return maxLobbies;
 }
 
+/**
+ * 设置事件参与要求并更新到事件管理器
+ */
 function setEventRequirements() {
     var reqStr = "";
 
+    // 组队人数要求
     reqStr += "\r\n   组队人数: ";
-    if (maxPlayers - minPlayers >= 1) {
-        reqStr += minPlayers + " ~ " + maxPlayers;
-    } else {
-        reqStr += minPlayers;
-    }
+    reqStr += maxPlayers - minPlayers >= 1 ? minPlayers + " ~ " + maxPlayers : minPlayers;
 
+    // 等级要求
     reqStr += "\r\n   等级要求: ";
-    if (maxLevel - minLevel >= 1) {
-        reqStr += minLevel + " ~ " + maxLevel;
-    } else {
-        reqStr += minLevel;
-    }
+    reqStr += maxLevel - minLevel >= 1 ? minLevel + " ~ " + maxLevel : minLevel;
 
-    reqStr += "\r\n   时间限制: ";
-    reqStr += eventTime + " 分钟";
+    // 时间限制
+    reqStr += "\r\n   时间限制: " + eventTime + " 分钟";
 
     em.setProperty("party", reqStr);
 }
 
+/**
+ * 设置事件专属物品
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ */
 function setEventExclusives(eim) {
     var itemSet = [4001015, 4001016, 4001018];
     eim.setExclusiveItems(itemSet);
 }
 
+/**
+ * 设置事件奖励
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ */
 function setEventRewards(eim) {
-    var itemSet, itemQty, evLevel, expStages;
-
-    evLevel = 1;    //Rewards at clear PQ
+    var evLevel = 1;    // 清除PQ时的奖励等级
     itemSet = [];
     itemQty = [];
-    eim.setEventRewards(evLevel, itemSet, itemQty);
+    eim.setEventRewards(evLevel, itemSet, itemQty);  // 空物品奖励
 
-    expStages = [];    //bonus exp given on CLEAR stage signal
-    eim.setEventClearStageExp(expStages);
+    expStages = [];
+    eim.setEventClearStageExp(expStages);         // 空经验奖励
 }
 
-function getEligibleParty(party) {      //selects, from the given party, the team that is allowed to attempt this event
+/**
+ * 从队伍中筛选符合条件的成员
+ * @param {Party} party - 玩家队伍
+ * @returns {PartyCharacter[]} 符合条件的队伍成员数组
+ */
+function getEligibleParty(party) {
     var eligible = [];
     var hasLeader = false;
 
@@ -98,27 +116,31 @@ function getEligibleParty(party) {      //selects, from the given party, the tea
 
         for (var i = 0; i < party.size(); i++) {
             var ch = partyList[i];
-
+            // 检查玩家是否在招募地图且等级符合要求
             if (ch.getMapId() == recruitMap && ch.getLevel() >= minLevel && ch.getLevel() <= maxLevel) {
-                if (ch.isLeader()) {
-                    hasLeader = true;
-                }
+                if (ch.isLeader()) hasLeader = true;
                 eligible.push(ch);
             }
         }
     }
-
+    // 必须有队长且人数符合要求
     if (!(hasLeader && eligible.length >= minPlayers && eligible.length <= maxPlayers)) {
         eligible = [];
     }
     return Java.to(eligible, Java.type('org.gms.net.server.world.PartyCharacter[]'));
 }
 
+/**
+ * 设置事件实例
+ * @param {number} level - 事件等级
+ * @param {number} lobbyid - 大厅ID
+ * @returns {EventInstanceManager} 创建的事件实例管理器
+ */
 function setup(level, lobbyid) {
     var eim = em.newInstance("PreZakum" + lobbyid);
     eim.setProperty("level", level);
     eim.setProperty("gotDocuments", 0);
-
+    // 重置所有PQ地图
     eim.getInstanceMap(280010000).resetPQ(level);
     eim.getInstanceMap(280010010).resetPQ(level);
     eim.getInstanceMap(280010011).resetPQ(level);
@@ -152,116 +174,168 @@ function setup(level, lobbyid) {
 
     respawnStages(eim);
 
-    eim.startEventTimer(eventTime * 60000);
-    setEventRewards(eim);
-    setEventExclusives(eim);
-
+    eim.startEventTimer(eventTime * 60000);  // 启动事件计时器
+    setEventRewards(eim);                   // 设置奖励
+    setEventExclusives(eim);                // 设置专属物品
     return eim;
 }
 
+// 空函数 - 事件设置后执行
 function afterSetup(eim) {}
 
+// 空函数 - 重生阶段
 function respawnStages(eim) {}
 
+/**
+ * 玩家进入事件处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ * @param {Player} player - 玩家对象
+ */
 function playerEntry(eim, player) {
     var map = eim.getMapInstance(entryMap);
     player.changeMap(map, map.getPortal(0));
 }
 
+/**
+ * 事件超时处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ */
 function scheduledTimeout(eim) {
     end(eim);
 }
 
+// 空函数 - 玩家取消注册
 function playerUnregistered(eim, player) {}
 
+/**
+ * 玩家退出事件处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ * @param {Player} player - 玩家对象
+ */
 function playerExit(eim, player) {
     eim.unregisterPlayer(player);
     player.changeMap(exitMap, 0);
 }
 
+/**
+ * 玩家离开事件处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ * @param {Player} player - 玩家对象
+ */
 function playerLeft(eim, player) {
-    if (!eim.isEventCleared()) {
-        playerExit(eim, player);
-    }
+    if (!eim.isEventCleared()) playerExit(eim, player);
 }
 
+/**
+ * 玩家切换地图处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ * @param {Player} player - 玩家对象
+ * @param {number} mapid - 地图ID
+ */
 function changedMap(eim, player, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
-        if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
-            eim.unregisterPlayer(player);
-            end(eim);
-        } else {
-            eim.unregisterPlayer(player);
-        }
+        eim.unregisterPlayer(player);
+        if (eim.isEventTeamLackingNow(true, minPlayers, player)) end(eim);
     }
 }
 
+/**
+ * 队长变更处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ * @param {Player} leader - 新队长对象
+ */
 function changedLeader(eim, leader) {
     var mapid = leader.getMapId();
-    if (!eim.isEventCleared() && (mapid < minMapId || mapid > maxMapId)) {
-        end(eim);
-    }
+    if (!eim.isEventCleared() && (mapid < minMapId || mapid > maxMapId)) end(eim);
 }
 
+// 空函数 - 玩家死亡处理
 function playerDead(eim, player) {}
 
-function playerRevive(eim, player) { // player presses ok on the death pop up.
-    if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        end(eim);
-    } else {
-        eim.unregisterPlayer(player);
-    }
+/**
+ * 玩家复活处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ * @param {Player} player - 玩家对象
+ */
+function playerRevive(eim, player) {
+    eim.unregisterPlayer(player);
+    if (eim.isEventTeamLackingNow(true, minPlayers, player)) end(eim);
 }
 
+/**
+ * 玩家断线处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ * @param {Player} player - 玩家对象
+ */
 function playerDisconnected(eim, player) {
-    if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
-        eim.unregisterPlayer(player);
-        end(eim);
-    } else {
-        eim.unregisterPlayer(player);
-    }
+    eim.unregisterPlayer(player);
+    if (eim.isEventTeamLackingNow(true, minPlayers, player)) end(eim);
 }
 
+/**
+ * 玩家离开队伍处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ * @param {Player} player - 玩家对象
+ */
 function leftParty(eim, player) {
-    if (eim.isEventTeamLackingNow(false, minPlayers, player)) {
-        end(eim);
-    } else {
-        playerLeft(eim, player);
-    }
+    if (eim.isEventTeamLackingNow(false, minPlayers, player)) end(eim);
+    else playerLeft(eim, player);
 }
 
+/**
+ * 解散队伍处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ */
 function disbandParty(eim) {
-    if (!eim.isEventCleared()) {
-        end(eim);
-    }
+    if (!eim.isEventCleared()) end(eim);
 }
 
+/**
+ * 获取怪物价值
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ * @param {number} mobId - 怪物ID
+ * @returns {number} 怪物价值(固定为1)
+ */
 function monsterValue(eim, mobId) {
     return 1;
 }
 
+/**
+ * 结束事件处理
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ */
 function end(eim) {
     var party = eim.getPlayers();
-    for (var i = 0; i < party.size(); i++) {
-        playerExit(eim, party.get(i));
-    }
+    for (var i = 0; i < party.size(); i++) playerExit(eim, party.get(i));
     eim.dispose();
 }
 
+/**
+ * 给予随机事件奖励
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ * @param {Player} player - 玩家对象
+ */
 function giveRandomEventReward(eim, player) {
     eim.giveEventReward(player);
 }
 
+/**
+ * 清除PQ状态
+ * @param {EventInstanceManager} eim - 事件实例管理器
+ */
 function clearPQ(eim) {
     eim.stopEventTimer();
     eim.setEventCleared();
 }
 
+// 空函数 - 怪物被击杀处理
 function monsterKilled(mob, eim) {}
 
+// 空函数 - 所有怪物死亡处理
 function allMonstersDead(eim) {}
 
+// 空函数 - 取消计划
 function cancelSchedule() {}
 
+// 空函数 - 释放资源
 function dispose(eim) {}

--- a/gms-server/scripts-zh-CN/map/onUserEnter/677000001.js
+++ b/gms-server/scripts-zh-CN/map/onUserEnter/677000001.js
@@ -12,6 +12,8 @@ function start(ms) {
     }
 
     const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    map.spawnMonsterOnGroundBelow(LifeFactory.getMonster(mobId), pos);
-    player.message(mobName + " has appeared!");
+    const mobobj = LifeFactory.getMonster(mobId);
+    mobName = mobobj.getName() || mobName;
+    map.spawnMonsterOnGroundBelow(mobobj, pos);
+    player.message(mobName + " 已现身！");
 }

--- a/gms-server/scripts-zh-CN/map/onUserEnter/677000003.js
+++ b/gms-server/scripts-zh-CN/map/onUserEnter/677000003.js
@@ -12,6 +12,8 @@ function start(ms) {
     }
 
     const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    map.spawnMonsterOnGroundBelow(LifeFactory.getMonster(mobId), pos);
-    player.message(mobName + " has appeared!");
+    const mobobj = LifeFactory.getMonster(mobId);
+    mobName = mobobj.getName() || mobName;
+    map.spawnMonsterOnGroundBelow(mobobj, pos);
+    player.message(mobName + " 已现身！");
 }

--- a/gms-server/scripts-zh-CN/map/onUserEnter/677000005.js
+++ b/gms-server/scripts-zh-CN/map/onUserEnter/677000005.js
@@ -12,6 +12,8 @@ function start(ms) {
     }
 
     const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    map.spawnMonsterOnGroundBelow(LifeFactory.getMonster(mobId), pos);
-    player.message(mobName + " has appeared!");
+    const mobobj = LifeFactory.getMonster(mobId);
+    mobName = mobobj.getName() || mobName;
+    map.spawnMonsterOnGroundBelow(mobobj, pos);
+    player.message(mobName + " 已现身！");
 }

--- a/gms-server/scripts-zh-CN/map/onUserEnter/677000007.js
+++ b/gms-server/scripts-zh-CN/map/onUserEnter/677000007.js
@@ -12,6 +12,8 @@ function start(ms) {
     }
 
     const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    map.spawnMonsterOnGroundBelow(LifeFactory.getMonster(mobId), pos);
-    player.message(mobName + " has appeared!");
+    const mobobj = LifeFactory.getMonster(mobId);
+    mobName = mobobj.getName() || mobName;
+    map.spawnMonsterOnGroundBelow(mobobj, pos);
+    player.message(mobName + " 已现身！");
 }

--- a/gms-server/scripts-zh-CN/map/onUserEnter/677000009.js
+++ b/gms-server/scripts-zh-CN/map/onUserEnter/677000009.js
@@ -12,6 +12,8 @@ function start(ms) {
     }
 
     const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    map.spawnMonsterOnGroundBelow(LifeFactory.getMonster(mobId), pos);
-    player.message(mobName + " has appeared!");
+    const mobobj = LifeFactory.getMonster(mobId);
+    mobName = mobobj.getName() || mobName;
+    map.spawnMonsterOnGroundBelow(mobobj, pos);
+    player.message(mobName + " 已现身！");
 }

--- a/gms-server/scripts-zh-CN/map/onUserEnter/677000012.js
+++ b/gms-server/scripts-zh-CN/map/onUserEnter/677000012.js
@@ -12,6 +12,8 @@ function start(ms) {
     }
 
     const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
-    map.spawnMonsterOnGroundBelow(LifeFactory.getMonster(mobId), pos);
-    player.message(mobName + " has appeared!");
+    const mobobj = LifeFactory.getMonster(mobId);
+    mobName = mobobj.getName() || mobName;
+    map.spawnMonsterOnGroundBelow(mobobj, pos);
+    player.message(mobName + " 已现身！");
 }

--- a/gms-server/scripts-zh-CN/map/onUserEnter/dojang_Msg.js
+++ b/gms-server/scripts-zh-CN/map/onUserEnter/dojang_Msg.js
@@ -24,17 +24,20 @@
 	Map(s):	Mu Lung Dojo Entrance
 	Desc:   Sends the entrance message or the taunt message from that dojo guy
 */
-var messages = Array("Your courage for challenging the Mu Lung Dojo is commendable!", "If you want to taste the bitterness of defeat, come on in!", "I will make you thoroughly regret challenging the Mu Lung Dojo! Hurry up!");
+var messages = [
+    "勇闯武陵道场，阁下好胆识！",
+    "想尝尝败北的滋味？尽管放马过来！",
+    "定让你后悔挑战武陵道场！速来受死！"
+];
 
 function start(ms) {
-    if (ms.getPlayer().getMap().getId() == 925020000) {
-        if (ms.getPlayer().getMap().findClosestPlayerSpawnpoint(ms.getPlayer().getPosition()).getId() == 0) {
+    if (ms.getPlayer().getMap().getId() === 925020000) {
+        if (ms.getPlayer().getMap().findClosestPlayerSpawnpoint(ms.getPlayer().getPosition()).getId() === 0) {
             ms.getPlayer().startMapEffect(messages[(Math.random() * messages.length) | 0], 5120024);
         }
-
         ms.resetDojoEnergy();
     } else {
-        ms.getPlayer().resetEnteredScript(); //in case the person dcs in here we set it at dojang_tuto portal
-        ms.getPlayer().startMapEffect("Ha! Let's see what you got! I won't let you leave unless you defeat me first!", 5120024);
+        ms.getPlayer().resetEnteredScript(); // 玩家进入道场试炼时执行的脚本// 防止断线重连时卡关，在道场传送门处重置状态
+        ms.getPlayer().startMapEffect("哼！让我看看你有几斤几两！不打败我就别想离开！", 5120024);// 启动全屏特效并显示BOSS挑衅台词
     }
 }

--- a/gms-server/scripts-zh-CN/portal/Depart_ToKerning.js
+++ b/gms-server/scripts-zh-CN/portal/Depart_ToKerning.js
@@ -1,7 +1,7 @@
 function enter(pi) {
     var em = pi.getEventManager("KerningTrain");
     if (!em.startInstance(pi.getPlayer())) {
-        pi.message("The passenger wagon is already full. Try again a bit later.");
+        pi.message("本次班车已满客，请等候下一班。");
         return false;
     }
 

--- a/gms-server/scripts-zh-CN/portal/Depart_goFoward0.js
+++ b/gms-server/scripts-zh-CN/portal/Depart_goFoward0.js
@@ -23,7 +23,7 @@ function enter(pi) {
             pi.warp(mapid + 10, "right00");
             return true;
         }
-        pi.getPlayer().dropMessage(5, "You cannot access this area.");
+        pi.getPlayer().dropMessage(5, "您无法进入该区域");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/Depart_goFoward1.js
+++ b/gms-server/scripts-zh-CN/portal/Depart_goFoward1.js
@@ -23,7 +23,7 @@ function enter(pi) {
             pi.warp(mapid + 10, "right01");
             return true;
         }
-        pi.getPlayer().dropMessage(5, "You cannot access this area.");
+        pi.getPlayer().dropMessage(5, "你无法进入该区域。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/MD_drakeroom.js
+++ b/gms-server/scripts-zh-CN/portal/MD_drakeroom.js
@@ -37,7 +37,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -49,7 +49,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_error.js
+++ b/gms-server/scripts-zh-CN/portal/MD_error.js
@@ -39,7 +39,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -51,7 +51,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_golem.js
+++ b/gms-server/scripts-zh-CN/portal/MD_golem.js
@@ -39,7 +39,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -51,7 +51,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_high.js
+++ b/gms-server/scripts-zh-CN/portal/MD_high.js
@@ -39,7 +39,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -51,7 +51,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_mushroom.js
+++ b/gms-server/scripts-zh-CN/portal/MD_mushroom.js
@@ -39,7 +39,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -51,7 +51,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_pig.js
+++ b/gms-server/scripts-zh-CN/portal/MD_pig.js
@@ -39,7 +39,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -51,7 +51,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_protect.js
+++ b/gms-server/scripts-zh-CN/portal/MD_protect.js
@@ -37,7 +37,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -49,7 +49,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_rabbit.js
+++ b/gms-server/scripts-zh-CN/portal/MD_rabbit.js
@@ -37,7 +37,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -49,7 +49,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_remember.js
+++ b/gms-server/scripts-zh-CN/portal/MD_remember.js
@@ -37,7 +37,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -49,7 +49,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_roundTable.js
+++ b/gms-server/scripts-zh-CN/portal/MD_roundTable.js
@@ -37,7 +37,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -49,7 +49,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_sand.js
+++ b/gms-server/scripts-zh-CN/portal/MD_sand.js
@@ -37,7 +37,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -49,7 +49,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/MD_treasure.js
+++ b/gms-server/scripts-zh-CN/portal/MD_treasure.js
@@ -37,7 +37,7 @@ function enter(pi) {
                     }
                 }
             } else {
-                pi.playerMessage(5, "Only solo or party leaders are supposed to enter the Mini-Dungeon.");
+                pi.playerMessage(5, "只有单人玩家或队伍队长才能进入迷你地下城");
                 return false;
             }
         } else {
@@ -49,7 +49,7 @@ function enter(pi) {
                 }
             }
         }
-        pi.playerMessage(5, "All of the Mini-Dungeons are in use right now, please try again later.");
+        pi.playerMessage(5, "当前所有迷你地下城都在使用中，请稍后再试");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/Populatus00.js
+++ b/gms-server/scripts-zh-CN/portal/Populatus00.js
@@ -27,20 +27,20 @@ function enter(pi) {
         var em = pi.getEventManager("PapulatusBattle");
 
         if (pi.getParty() == null) {
-            pi.playerMessage(5, "You are currently not in a party, create one to attempt the boss.");
+            pi.playerMessage(5, "你当前未加入队伍，请创建队伍后再挑战BOSS。");
             return false;
         } else if (!pi.isLeader()) {
-            pi.playerMessage(5, "Your party leader must enter the portal to start the battle.");
+            pi.playerMessage(5, "你的队伍队长必须进入传送门才能开始战斗。");
             return false;
         } else {
             var eli = em.getEligibleParty(pi.getParty());
             if (eli.size() > 0) {
                 if (!em.startInstance(pi.getParty(), pi.getPlayer().getMap(), 1)) {
-                    pi.playerMessage(5, "The battle against the boss has already begun, so you may not enter this place yet.");
+                    pi.playerMessage(5, "你的队伍队长必须进入传送门才能开始战斗。");
                     return false;
                 }
             } else {  //this should never appear
-                pi.playerMessage(5, "You cannot start this battle yet, because either your party is not in the range size, some of your party members are not eligible to attempt it or they are not in this map. If you're having trouble finding party members, try Party Search.");
+                pi.playerMessage(5, "你暂时无法开始这场战斗，可能是因为队伍人数不符合要求、部分队员未满足挑战条件或不在当前地图。若组队遇到困难，请尝试使用队伍搜索功能。");
                 return false;
             }
 

--- a/gms-server/scripts-zh-CN/portal/TD_Boss_enter.js
+++ b/gms-server/scripts-zh-CN/portal/TD_Boss_enter.js
@@ -4,25 +4,25 @@ function enter(pi) {
     var stage = ((Math.floor(pi.getMapId() / 100)) % 10) - 1;
     var em = pi.getEventManager("TD_Battle" + stage);
     if (em == null) {
-        pi.playerMessage(5, "TD Battle " + stage + " encountered an unexpected error and is currently unavailable.");
+        pi.playerMessage(5, "TD战场第" + stage + "阶段发生意外错误，当前不可用。");
         return false;
     }
 
     if (pi.getParty() == null) {
-        pi.playerMessage(5, "You are currently not in a party, create one to attempt the boss.");
+        pi.playerMessage(5, "您当前未加入队伍，请创建队伍来挑战首领。");
         return false;
     } else if (!pi.isLeader()) {
-        pi.playerMessage(5, "Your party leader must enter the portal to start the battle.");
+        pi.playerMessage(5, "必须由队长进入传送门才能开始战斗。");
         return false;
     } else {
         var eli = em.getEligibleParty(pi.getParty());
         if (eli.size() > 0) {
             if (!em.startInstance(pi.getParty(), pi.getPlayer().getMap(), 1)) {
-                pi.playerMessage(5, "The battle against the boss has already begun, so you may not enter this place yet.");
+                pi.playerMessage(5, "首领战斗已经开始，您暂时无法进入该区域。");
                 return false;
             }
         } else {
-            pi.playerMessage(5, "Your party must consist of at least 2 players to attempt the boss.");
+            pi.playerMessage(5, "您的队伍至少需要2名成员才能挑战首领。");
             return false;
         }
 

--- a/gms-server/scripts-zh-CN/portal/TD_MC_first.js
+++ b/gms-server/scripts-zh-CN/portal/TD_MC_first.js
@@ -15,6 +15,6 @@ function enter(pi) {
         pi.warp(106020000, 0);
         return true;
     }
-    pi.playerMessage(5, "A strange force is blocking you from entering.");
+    pi.playerMessage(5, "一股神秘力量阻挡了你的进入");
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/TD_neo_inTree.js
+++ b/gms-server/scripts-zh-CN/portal/TD_neo_inTree.js
@@ -1,7 +1,7 @@
 function enter(pi) {
     var nex = pi.getEventManager("GuardianNex");
     if (nex == null) {
-        pi.message("Guardian Nex challenge encountered an error and is unavailable.");
+        pi.message("守护者布索 特挑战系统发生错误，当前不可用");  // 保留原意同时符合中文语序‌:ml-citation{ref="1,8" data="citationList"}
         return false;
     }
 
@@ -11,12 +11,12 @@ function enter(pi) {
     for (var i = 0; i < quests.length; i++) {
         if (pi.isQuestActive(quests[i])) {
             if (pi.getQuestProgressInt(quests[i], mobs[i]) != 0) {
-                pi.message("You already faced Nex. Complete your mission.");
+                pi.message("你已挑战过布索，请先完成当前任务");
                 return false;
             }
 
             if (!nex.startInstance(i, pi.getPlayer())) {
-                pi.message("Someone is already challenging Nex. Wait for them to finish before you enter.");
+                pi.message("布索 正在被挑战，请等待其他玩家完成挑战");
                 return false;
             } else {
                 pi.playPortalSound();
@@ -25,6 +25,6 @@ function enter(pi) {
         }
     }
 
-    pi.message("A mysterious force won't let you in.");
+    pi.message("一股神秘的力量阻止你进入。");
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/captinsg00.js
+++ b/gms-server/scripts-zh-CN/portal/captinsg00.js
@@ -2,26 +2,26 @@
 
 function enter(pi) {
     if (!pi.haveItem(4000381)) {
-        pi.playerMessage(5, "You do not have White Essence.");
+        pi.playerMessage(5, "你尚未持有白色精华。");
         return false;
     } else {
         var em = pi.getEventManager("LatanicaBattle");
 
         if (pi.getParty() == null) {
-            pi.playerMessage(5, "You are currently not in a party, create one to attempt the boss.");
+            pi.playerMessage(5, "你当前未加入队伍，请创建队伍后再挑战BOSS。");
             return false;
         } else if (!pi.isLeader()) {
-            pi.playerMessage(5, "Your party leader must enter the portal to start the battle.");
+            pi.playerMessage(5, "你的队伍队长必须进入传送门才能开始战斗。");
             return false;
         } else {
             var eli = em.getEligibleParty(pi.getParty());
             if (eli.size() > 0) {
                 if (!em.startInstance(pi.getParty(), pi.getPlayer().getMap(), 1)) {
-                    pi.playerMessage(5, "The battle against the boss has already begun, so you may not enter this place yet.");
+                    pi.playerMessage(5, "你的队伍队长必须进入传送门才能开始战斗。");
                     return false;
                 }
             } else {  //this should never appear
-                pi.playerMessage(5, "You cannot start this battle yet, because either your party is not in the range size, some of your party members are not eligible to attempt it or they are not in this map. If you're having trouble finding party members, try Party Search.");
+                pi.playerMessage(5, "你暂时无法开始这场战斗，可能是因为队伍人数不符合要求、部分队员未满足挑战条件或不在当前地图。若组队遇到困难，请尝试使用队伍搜索功能。");
                 return false;
             }
 

--- a/gms-server/scripts-zh-CN/portal/curseforest.js
+++ b/gms-server/scripts-zh-CN/portal/curseforest.js
@@ -1,16 +1,21 @@
 function enter(pi) {
+    // 任务状态检测
     if (pi.isQuestStarted(2224) || pi.isQuestStarted(2226) || pi.isQuestCompleted(2227)) {
         var hourDay = pi.getHourOfDay();
+
+        // 时间限制检测（0-7点或17-24点）
         if (!((hourDay >= 0 && hourDay < 7) || hourDay >= 17)) {
-            pi.getPlayer().dropMessage(5, "You cannot access this area right now.");
+            pi.getPlayer().dropMessage(5, "当前时段禁止进入该区域");  // 时间限制提示
             return false;
         } else {
+            // 传送逻辑
             pi.playPortalSound();
             pi.warp(pi.isQuestCompleted(2227) ? 910100001 : 910100000, "out00");
             return true;
         }
     }
 
-    pi.getPlayer().dropMessage(5, "You cannot access this area.");
+    // 默认拒绝提示
+    pi.getPlayer().dropMessage(5, "尚未满足进入条件");  // 任务限制提示‌
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/davy_next0.js
+++ b/gms-server/scripts-zh-CN/portal/davy_next0.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(925100100, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/davy_next1.js
+++ b/gms-server/scripts-zh-CN/portal/davy_next1.js
@@ -6,11 +6,11 @@ function enter(pi) {
             pi.warp(925100200, 0); //next
             return true;
         } else {
-            pi.playerMessage(5, "The portal is not opened yet.");
+            pi.playerMessage(5, "传送门尚未开启。");
             return false;
         }
     } catch (e) {
-        pi.playerMessage(5, "Error: " + e);
+        pi.playerMessage(5, "传送门故障，请联系管理员处理");
     }
 
     return false;

--- a/gms-server/scripts-zh-CN/portal/davy_next2.js
+++ b/gms-server/scripts-zh-CN/portal/davy_next2.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(925100300, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/davy_next3.js
+++ b/gms-server/scripts-zh-CN/portal/davy_next3.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(925100400, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/davy_next4.js
+++ b/gms-server/scripts-zh-CN/portal/davy_next4.js
@@ -29,7 +29,7 @@ function enter(pi) {
         pi.warp(925100500, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/dojang_next.js
+++ b/gms-server/scripts-zh-CN/portal/dojang_next.js
@@ -47,19 +47,19 @@ function enter(pi) {
                                 var chr = pIter.next();
 
                                 for (var j = i; j >= 0; j--) {
-                                    chr.message("You received " + chr.addDojoPointsByMap(mapId - 100 * j) + " training points. Your total training points score is now " + chr.getDojoPoints() + ".");
+                                    chr.message("你获得了" + chr.addDojoPointsByMap(mapId - 100 * j) + "修炼点数。当前总修炼点数为：" + chr.getDojoPoints() + "。");
                                 }
 
                                 chr.changeMap(restMapId, 0);
                             }
                         }
                     } else {
-                        pi.getPlayer().message("You received " + pi.getPlayer().addDojoPointsByMap(pi.getMapId()) + " training points. Your total training points score is now " + pi.getPlayer().getDojoPoints() + ".");
+                        pi.getPlayer().message("你获得了" + pi.getPlayer().addDojoPointsByMap(pi.getMapId()) + "修炼点数。当前总修炼点数为：" + pi.getPlayer().getDojoPoints() + "。");
                         pi.playPortalSound();
                         pi.warp(pi.getPlayer().getMap().getId() + 100, 0);
                     }
                 } else {
-                    pi.getPlayer().message("You received " + pi.getPlayer().addDojoPointsByMap(pi.getMapId()) + " training points. Your total training points score is now " + pi.getPlayer().getDojoPoints() + ".");
+                    pi.getPlayer().message("你获得了" + pi.getPlayer().addDojoPointsByMap(pi.getMapId()) + "修炼点数。当前总修炼点数为：" + pi.getPlayer().getDojoPoints() + "。");
                     pi.playPortalSound();
                     pi.warp(pi.getPlayer().getMap().getId() + 100, 0);
                 }
@@ -70,7 +70,7 @@ function enter(pi) {
             }
             return true;
         } else {
-            pi.getPlayer().message("The door is not open yet.");
+            pi.getPlayer().message("传送门尚未开启。");
             return false;
         }
     } else {

--- a/gms-server/scripts-zh-CN/portal/dojang_tuto.js
+++ b/gms-server/scripts-zh-CN/portal/dojang_tuto.js
@@ -36,7 +36,7 @@ function enter(pi) {
         pi.warp(925020001, 0);
         return true;
     } else {
-        pi.getPlayer().message("So Gong: Haha! You're going to run away like a coward? I won't let you get away that easily!");
+        pi.getPlayer().message("萧公：哈哈！你想像个懦夫一样逃跑吗？我不会让你这么容易逃掉的！");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/dojang_up.js
+++ b/gms-server/scripts-zh-CN/portal/dojang_up.js
@@ -38,7 +38,7 @@ function enter(pi) {
                 pi.getPlayer().setVanquisherKills(pi.getPlayer().getVanquisherKills() + 1);
             }
         } else {
-            pi.getPlayer().message("There are still some monsters remaining.");
+            pi.getPlayer().message("当前区域仍有怪物未清除。");
         }
         pi.enableActions();
         return true;

--- a/gms-server/scripts-zh-CN/portal/dragonNest.js
+++ b/gms-server/scripts-zh-CN/portal/dragonNest.js
@@ -27,14 +27,14 @@ function enter(pi) {
     } else if (pi.isQuestStarted(100203) || pi.getPlayer().haveItem(4001094)) {
         var em = pi.getEventManager("NineSpirit");
         if (!em.startInstance(pi.getPlayer())) {
-            pi.message("There is currently someone in this map, come back later.");
+            pi.message("当前地图已有其他玩家，请稍后再试");
             return false;
         } else {
             pi.playPortalSound();
             return true;
         }
     } else {
-        pi.message("A strange force is blocking you from entering.");
+        pi.message("一股神秘力量阻挡了你的进入");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/elevator.js
+++ b/gms-server/scripts-zh-CN/portal/elevator.js
@@ -2,18 +2,18 @@ function enter(pi) {
     try {
         var elevator = pi.getEventManager("Elevator");
         if (elevator == null) {
-            pi.getPlayer().dropMessage(5, "The elevator is under maintenance.");
+            pi.getPlayer().dropMessage(5, "电梯正在维修中");
         } else if (elevator.getProperty(pi.getMapId() == 222020100 ? ("goingUp") : ("goingDown")) === "false") {
             pi.playPortalSound();
             pi.warp(pi.getMapId() == 222020100 ? 222020110 : 222020210, 0);
             return true;
         } else if (elevator.getProperty(pi.getMapId() == 222020100 ? ("goingUp") : ("goingDown")) === "true") {
-            pi.getPlayer().dropMessage(5, "The elevator is currently moving.");
+            pi.getPlayer().dropMessage(5, "电梯正在移动中");
         } else {
-            pi.getPlayer().dropMessage(5, "Dafuq is happening?!");
+            pi.getPlayer().dropMessage(5, "电梯系统有异常，请联系管理员处理。");
         }
     } catch (e) {
-        pi.getPlayer().dropMessage(5, "Error: " + e);
+        pi.getPlayer().dropMessage(5, "系统错误：" + e);
     }
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/end_cow.js
+++ b/gms-server/scripts-zh-CN/portal/end_cow.js
@@ -11,7 +11,7 @@ function enter(pi) {
             pi.warp(120000103);
             return true;
         } else {
-            pi.getPlayer().dropMessage(5, "Your milk jug is not full...");
+            pi.getPlayer().dropMessage(5, "牛奶罐还未装满...");
             return false;
         }
     } else {

--- a/gms-server/scripts-zh-CN/portal/enterBackStreet.js
+++ b/gms-server/scripts-zh-CN/portal/enterBackStreet.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(925040000, 0);
         return true;
     } else {
-        pi.message("You don't have permission to access this area.");
+        pi.message("你无权访问该区域。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/enterDisguise0.js
+++ b/gms-server/scripts-zh-CN/portal/enterDisguise0.js
@@ -31,7 +31,7 @@ function enter(pi) {
             pi.playPortalSound();
             pi.warp(130010000, "east00");
         } else {
-            pi.getPlayer().dropMessage(5, "Due to the lock down you can not enter without a permit.");
+            pi.getPlayer().dropMessage(5, "当前区域封锁中，需持有通行证方可进入！");
             return false;
         }
     } else {

--- a/gms-server/scripts-zh-CN/portal/enterDisguise1.js
+++ b/gms-server/scripts-zh-CN/portal/enterDisguise1.js
@@ -28,12 +28,12 @@ function enter(pi) {
     if (pi.isQuestStarted(20301) || pi.isQuestStarted(20302) || pi.isQuestStarted(20303) || pi.isQuestStarted(20304) || pi.isQuestStarted(20305)) {
         var map = pi.getClient().getChannelServer().getMapFactory().getMap(108010600 + (10 * jobtype));
         if (map.countPlayers() > 0) {
-            pi.message("Someone else is already searching the area.");
+            pi.message("已有其他玩家正在该区域搜寻。");
             return false;
         }
 
         if (pi.haveItem(4032101 + jobtype, 1)) {
-            pi.message("You have already challenged the Master of Disguise, report your success to the Chief Knight.");
+            pi.message("你已挑战过变身术士，请向骑士团长报告你的成功。");
             return false;
         }
 

--- a/gms-server/scripts-zh-CN/portal/enterDisguise2.js
+++ b/gms-server/scripts-zh-CN/portal/enterDisguise2.js
@@ -28,12 +28,12 @@ function enter(pi) {
     if (pi.isQuestStarted(20301) || pi.isQuestStarted(20302) || pi.isQuestStarted(20303) || pi.isQuestStarted(20304) || pi.isQuestStarted(20305)) {
         var map = pi.getClient().getChannelServer().getMapFactory().getMap(108010600 + (10 * jobtype));
         if (map.countPlayers() > 0) {
-            pi.message("Someone else is already searching the area.");
+            pi.message("已有其他玩家正在该区域搜索。");
             return false;
         }
 
         if (pi.haveItem(4032101 + jobtype, 1)) {
-            pi.message("You have already challenged the Master of Disguise, report your success to the Chief Knight.");
+            pi.message("你已挑战过变身术士，请向骑士长报告你的成功。" );
             return false;
         }
 

--- a/gms-server/scripts-zh-CN/portal/enterDisguise3.js
+++ b/gms-server/scripts-zh-CN/portal/enterDisguise3.js
@@ -28,12 +28,12 @@ function enter(pi) {
     if (pi.isQuestStarted(20301) || pi.isQuestStarted(20302) || pi.isQuestStarted(20303) || pi.isQuestStarted(20304) || pi.isQuestStarted(20305)) {
         var map = pi.getClient().getChannelServer().getMapFactory().getMap(108010600 + (10 * jobtype));
         if (map.countPlayers() > 0) {
-            pi.message("Someone else is already searching the area.");
+            pi.message("已有其他玩家正在该区域搜索。");
             return false;
         }
 
         if (pi.haveItem(4032101 + jobtype, 1)) {
-            pi.message("You have already challenged the Master of Disguise, report your success to the Chief Knight.");
+            pi.message("你已挑战过变身术士，请向骑士长报告你的成功。" );
             return false;
         }
 

--- a/gms-server/scripts-zh-CN/portal/enterDisguise4.js
+++ b/gms-server/scripts-zh-CN/portal/enterDisguise4.js
@@ -28,12 +28,12 @@ function enter(pi) {
     if (pi.isQuestStarted(20301) || pi.isQuestStarted(20302) || pi.isQuestStarted(20303) || pi.isQuestStarted(20304) || pi.isQuestStarted(20305)) {
         var map = pi.getClient().getChannelServer().getMapFactory().getMap(108010600 + (10 * jobtype));
         if (map.countPlayers() > 0) {
-            pi.message("Someone else is already searching the area.");
+            pi.message("已有其他玩家正在该区域搜索。");
             return false;
         }
 
         if (pi.haveItem(4032101 + jobtype, 1)) {
-            pi.message("You have already challenged the Master of Disguise, report your success to the Chief Knight.");
+            pi.message("你已挑战过变身术士，请向骑士长报告你的成功。" );
             return false;
         }
 

--- a/gms-server/scripts-zh-CN/portal/enterDisguise5.js
+++ b/gms-server/scripts-zh-CN/portal/enterDisguise5.js
@@ -28,12 +28,12 @@ function enter(pi) {
     if (pi.isQuestStarted(20301) || pi.isQuestStarted(20302) || pi.isQuestStarted(20303) || pi.isQuestStarted(20304) || pi.isQuestStarted(20305)) {
         var map = pi.getClient().getChannelServer().getMapFactory().getMap(108010600 + (10 * jobtype));
         if (map.countPlayers() > 0) {
-            pi.message("Someone else is already searching the area.");
+            pi.message("已有其他玩家正在该区域搜索。");
             return false;
         }
 
         if (pi.haveItem(4032101 + jobtype, 1)) {
-            pi.message("You have already challenged the Master of Disguise, report your success to the Chief Knight.");
+            pi.message("你已挑战过变身术士，请向骑士长报告你的成功。");
             return false;
         }
 

--- a/gms-server/scripts-zh-CN/portal/enterDollWay.js
+++ b/gms-server/scripts-zh-CN/portal/enterDollWay.js
@@ -8,7 +8,7 @@ function enter(pi) {
         pi.warp(910510100, 0);
         return true;
     } else {
-        pi.message("An ominous power prevents you from passing here.");
+        pi.message("一股不祥的力量阻止你通过此处。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/enterGym.js
+++ b/gms-server/scripts-zh-CN/portal/enterGym.js
@@ -12,7 +12,7 @@ function enter(pi) {
         pi.warp(914010200, 1);
         return true;
     } else {
-        pi.playerMessage(5, "You will be allowed to enter the Penguin Training Ground only if you are receiving a lesson from Puo.");
+        pi.playerMessage(5, "只有正在接受小企企普奥的修炼指导时，才能进入企鹅训练场。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/enterMCave.js
+++ b/gms-server/scripts-zh-CN/portal/enterMCave.js
@@ -1,5 +1,5 @@
 function enter(pi) {
-    if (pi.isQuestStarted(21201)) { // Second Job
+    if (pi.isQuestStarted(21201)) { // 二转
         for (var i = 108000700; i < 108000709; i++) {
             if (pi.getPlayerCount(i) > 0 && pi.getPlayerCount(i + 10) > 0) {
                 continue;
@@ -10,11 +10,11 @@ function enter(pi) {
             pi.setQuestProgress(21202, 21203, 0);
             return true;
         }
-        pi.message("The mirror is blank due to many players recalling their memories. Please wait and try again.");
+        pi.message("由于太多玩家正在回忆，镜子暂时空白。请稍后再试。");
         return false;
-    } else if (pi.isQuestStarted(21302) && !pi.isQuestCompleted(21303)) { // Third Job
+    } else if (pi.isQuestStarted(21302) && !pi.isQuestCompleted(21303)) { // 三转
         if (pi.getPlayerCount(108010701) > 0 || pi.getPlayerCount(108010702) > 0) {
-            pi.message("The mirror is blank due to many players recalling their memories. Please wait and try again.");
+            pi.message("由于太多玩家正在回忆，镜子暂时空白。请稍后再试。");
             return false;
         } else {
             var map = pi.getClient().getChannelServer().getMapFactory().getMap(108010702);
@@ -26,7 +26,7 @@ function enter(pi) {
             return true;
         }
     } else {
-        pi.message("You have already passed your test, there is no need to access the mirror again.");
+        pi.message("你已经通过测试，无需再次使用镜子。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/enterNepenthes.js
+++ b/gms-server/scripts-zh-CN/portal/enterNepenthes.js
@@ -15,7 +15,7 @@ function enter(pi) {
             pi.warp(920030000, 2);
             return true;
         } else {
-            pi.message("Someone is already challenging the area.");
+            pi.message("该区域已被其他玩家挑战中。");
             return false;
         }
     } else {

--- a/gms-server/scripts-zh-CN/portal/enterPort.js
+++ b/gms-server/scripts-zh-CN/portal/enterPort.js
@@ -23,7 +23,7 @@
 function enter(pi) {
     if (pi.isQuestStarted(21301) && pi.getQuestProgressInt(21301, 9001013) == 0) {
         if (pi.getPlayerCount(108010700) != 0) {
-            pi.message("The portal is blocked from the other side. I wonder if someone is already fighting the Thief Crow?");
+            pi.message("传送门被另一侧封锁了，莫非有人在讨伐小偷乌鸦？");
             return false;
         } else {
             var map = pi.getClient().getChannelServer().getMapFactory().getMap(108010700);

--- a/gms-server/scripts-zh-CN/portal/enterRider.js
+++ b/gms-server/scripts-zh-CN/portal/enterRider.js
@@ -2,12 +2,12 @@ function enter(pi) {
     if (pi.isQuestStarted(21610) && pi.haveItem(4001193, 1) == 0) {
         var em = pi.getEventManager("Aran_2ndmount");
         if (em == null) {
-            pi.message("Sorry, but the 2nd mount quest (Scadur) is closed.");
+            pi.message("抱歉，第二坐骑(斯卡德)任务目前不可用。");
             return false;
         } else {
             var em = pi.getEventManager("Aran_2ndmount");
             if (!em.startInstance(pi.getPlayer())) {
-                pi.message("There is currently someone in this map, come back later.");
+                pi.message("当前地图有其他玩家，请稍后再试。");
                 return false;
             } else {
                 pi.playPortalSound();
@@ -15,7 +15,7 @@ function enter(pi) {
             }
         }
     } else {
-        pi.playerMessage(5, "Only attendants of the 2nd Wolf Riding quest may enter this field.");
+        pi.playerMessage(5, "只有参加第二骑狼任务的玩家才能进入此场地。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/enterWitch.js
+++ b/gms-server/scripts-zh-CN/portal/enterWitch.js
@@ -16,7 +16,7 @@ function enter(pi) {
 
 
     } else {
-        pi.playerMessage(5, "I shouldn't go here.. it's creepy!");
+        pi.playerMessage(5, "这里阴森森的...还是别进去了！");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/enter_earth00.js
+++ b/gms-server/scripts-zh-CN/portal/enter_earth00.js
@@ -1,6 +1,6 @@
 function enter(pi) {
     if (!pi.haveItem(4031890)) {
-        pi.getPlayer().dropMessage(6, "You need a warp card to activate this portal.");
+        pi.getPlayer().dropMessage(6, "需要霍夫卡才能激活此传送门。");
         return false;
     }
 

--- a/gms-server/scripts-zh-CN/portal/enter_earth01.js
+++ b/gms-server/scripts-zh-CN/portal/enter_earth01.js
@@ -1,6 +1,6 @@
 function enter(pi) {
     if (!pi.haveItem(4031890)) {
-        pi.getPlayer().dropMessage(6, "You need a warp card to activate this portal.");
+        pi.getPlayer().dropMessage(6, "需要霍夫卡才能激活此传送门。");
         return false;
     }
 

--- a/gms-server/scripts-zh-CN/portal/evanFarmCT.js
+++ b/gms-server/scripts-zh-CN/portal/evanFarmCT.js
@@ -3,7 +3,7 @@ function enter(pi) {
         pi.playPortalSound();
         pi.warp(100030310, 0);
     } else {
-        pi.playerMessage(5, "Cannot enter the Lush Forest without a reason.");
+        pi.playerMessage(5, "未满足条件，无法进入茂密森林！");
     }
     return true;
 }

--- a/gms-server/scripts-zh-CN/portal/evanGarden1.js
+++ b/gms-server/scripts-zh-CN/portal/evanGarden1.js
@@ -3,7 +3,7 @@ function enter(pi) {
         pi.playPortalSound();
         pi.warp(100030103, "west00");
     } else {
-        pi.playerMessage(5, "You cannot go to the Back Yard without a reason");
+        pi.playerMessage(5, "后院区域需完成任务后方可进入！");
     }
     return true;
 }  

--- a/gms-server/scripts-zh-CN/portal/exit_puppeteer.js
+++ b/gms-server/scripts-zh-CN/portal/exit_puppeteer.js
@@ -1,6 +1,6 @@
 function enter(pi) {
     if (pi.getMap().countMonster(9300285) > 0) {
-        pi.getPlayer().message("Defeat the Puppeteer before leaving.");
+        pi.getPlayer().message("请在离开前击败傀儡师。");
         return false;
     } else {
         var eim = pi.getEventInstance();

--- a/gms-server/scripts-zh-CN/portal/female00.js
+++ b/gms-server/scripts-zh-CN/portal/female00.js
@@ -29,7 +29,7 @@ function enter(pi) {
         pi.warp(670010200, 4);
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "You cannot proceed past here.");
+        pi.getPlayer().dropMessage(5, "女生无法从这里继续前进。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/gendergo.js
+++ b/gms-server/scripts-zh-CN/portal/gendergo.js
@@ -6,7 +6,7 @@ function enter(pi) {
             pi.warp(map.getId(), "female01");
             return true;
         } else {
-            pi.message("This portal leads to the girls' area, try the portal at the other side.");
+            pi.message("此传送门通向女生区域，请使用另一侧的男生传送门");
             return false;
         }
     } else {
@@ -15,7 +15,7 @@ function enter(pi) {
             pi.warp(map.getId(), "male01");
             return true;
         } else {
-            pi.message("This portal leads to the boys' area, try the portal at the other side.");
+            pi.message("此传送门通向男生区域，请使用另一侧的女生传送门");
             return false;
         }
     }

--- a/gms-server/scripts-zh-CN/portal/ghostgate_open.js
+++ b/gms-server/scripts-zh-CN/portal/ghostgate_open.js
@@ -32,7 +32,7 @@ function enter(pi) {
         pi.warp(990000800, 0);
         return true;
     } else {
-        pi.playerMessage(5, "This way forward is not open yet.");
+        pi.playerMessage(5, "前方的道路尚未开放。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/glpqEnter.js
+++ b/gms-server/scripts-zh-CN/portal/glpqEnter.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(610030020, "out00");
         return true;
     } else {
-        pi.playerMessage(5, "The giant gate of iron will not budge no matter what, however there is a visible key-shaped socket.");
+        pi.playerMessage(5, "※ 巨大的铁门纹丝不动，但可以看到一个明显的钥匙孔。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal0.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal0.js
@@ -1,6 +1,6 @@
 function enter(pi) {
     if (pi.getEventInstance().getIntProperty("glpq1") == 0) {
-        pi.getEventInstance().dropMessage(5, "This path is currently blocked.");
+        pi.getEventInstance().dropMessage(5, "※ 当前路径已被封锁！");
         return false;
 
     } else {

--- a/gms-server/scripts-zh-CN/portal/glpqPortal00.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal00.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(610030510, 0);
         return true;
     } else {
-        pi.playerMessage(5, "Only warriors may enter this portal.");
+        pi.playerMessage(5, "※ 仅限战士职业进入该传送门！");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal01.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal01.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(610030540, 0);
         return true;
     } else {
-        pi.playerMessage(5, "Only bowmen may enter this portal.");
+        pi.playerMessage(5, "只有弓箭手才能进入此传送门。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal02.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal02.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(610030521, 0);
         return true;
     } else {
-        pi.playerMessage(5, "Only mages may enter this portal.");
+        pi.playerMessage(5, "※ 仅限魔法师职业进入该传送门！");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal03.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal03.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(610030530, 0);
         return true;
     } else {
-        pi.playerMessage(5, "Only thieves may enter this portal.");
+        pi.playerMessage(5, "※ 仅限飞侠职业进入该传送门！");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal04.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal04.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(610030550, 0);
         return true;
     } else {
-        pi.playerMessage(5, "Only pirates may enter this portal.");
+        pi.playerMessage(5, "※ 仅限海盗职业进入该传送门！")
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal1.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal1.js
@@ -6,7 +6,7 @@ function enter(pi) {
             pi.warp(610030300, 0);
             return true;
         } else {
-            pi.playerMessage(5, "The portal has not been activated yet!");
+            pi.playerMessage(5, "传送门尚未激活！");
             return false;
         }
     }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal2.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal2.js
@@ -6,25 +6,23 @@ function enter(pi) {
 
         if (eim.getIntProperty("glpq3") < 5 || eim.getIntProperty("glpq3_p") < 5) {
             if (eim.getIntProperty("glpq3_p") == 5) {
-                pi.mapMessage(6, "Not all Sigils have been activated yet. Make sure they have all been activated to proceed to the next stage.");
+                pi.mapMessage(6, "尚未激活所有封印石！请确保全部激活后再进入下一阶段。");
             } else {
                 eim.setIntProperty("glpq3_p", eim.getIntProperty("glpq3_p") + 1);
 
                 if (eim.getIntProperty("glpq3") == 5 && eim.getIntProperty("glpq3_p") == 5) {
-                    pi.mapMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                    pi.mapMessage(6, "【圣石安特利昂】已开启传送门！请继续前进！");
 
                     eim.showClearEffect(610030300, "3pt", 2);
                     eim.giveEventPlayersStageReward(3);
                 } else {
-                    pi.mapMessage(6, "An adventurer has passed through! " + (5 - eim.getIntProperty("glpq3_p")) + " to go.");
+                    pi.mapMessage(6, "一位冒险者已通过！还需" + (5 - eim.getIntProperty("glpq3_p")) + "人。");
                 }
             }
         } else {
-            pi.getPlayer().dropMessage(6, "The portal at the bottom has already been opened! Proceed there!");
+            pi.getPlayer().dropMessage(6, "底部传送门已经开启！请从该处继续前进！");
         }
-
         return true;
     }
-
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal3.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal3.js
@@ -2,7 +2,7 @@ function enter(pi) {
     var eim = pi.getEventInstance();
     if (eim != null) {
         if (eim.getIntProperty("glpq3") < 5 || eim.getIntProperty("glpq3_p") < 5) {
-            pi.playerMessage(5, "The portal is not opened yet.");
+            pi.playerMessage(5, "传送门尚未开启。");
             return false;
         } else {
             pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/glpqPortal4.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal4.js
@@ -2,7 +2,7 @@ function enter(pi) {
     var eim = pi.getEventInstance();
     if (eim != null) {
         if (eim.getIntProperty("glpq4") < 5) {
-            pi.playerMessage(5, "The portal is not opened yet.");
+            pi.playerMessage(5, "传送门尚未开启。");
             return false;
         } else {
             pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/glpqPortal5.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal5.js
@@ -2,7 +2,7 @@ function enter(pi) {
     var eim = pi.getEventInstance();
     if (eim != null) {
         if (eim.getIntProperty("glpq5") < 5) {
-            pi.playerMessage(5, "The portal is not opened yet.");
+            pi.playerMessage(5, "传送门尚未开启。");
             return false;
         } else {
             pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/glpqPortal6.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal6.js
@@ -2,7 +2,7 @@ function enter(pi) {
     var eim = pi.getEventInstance();
     if (eim != null) {
         if (eim.getIntProperty("glpq6") < 3) {
-            pi.playerMessage(5, "The portal is not opened yet.");
+            pi.playerMessage(5, "传送门尚未开启。");
             return false;
         } else {
             pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/glpqPortalDummy.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortalDummy.js
@@ -7,7 +7,7 @@ function enter(pi) {
         var eim = pi.getEventInstance();
         eim.setIntProperty("glpq1", 1);
 
-        pi.getEventInstance().dropMessage(5, "A strange force starts being emitted from the portal apparatus, showing a hidden path once blocked now open.");
+        pi.getEventInstance().dropMessage(5, "传送装置开始散发出奇异能量，原先被封锁的隐藏路径现在开启了。");
         pi.playPortalSound();
         pi.warp(610030100, 0);
 
@@ -16,6 +16,6 @@ function enter(pi) {
         return true;
     }
 
-    pi.getEventInstance().dropMessage(5, "The portal apparatus is malfunctional, due to the last transportation. The finding another way through.");
+    pi.getEventInstance().dropMessage(5, "由于上次传送的影响，传送装置出现故障。请寻找其他路径通过。");
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/guildwaitingenter.js
+++ b/gms-server/scripts-zh-CN/portal/guildwaitingenter.js
@@ -37,7 +37,7 @@ function enter(pi) {
         pi.warp(990000100, 0);
         return true;
     } else { //cannot proceed while allies can still enter
-        pi.playerMessage(5, "The portal will open in about " + timeLeft + " seconds.");
+        pi.playerMessage(5, "传送门将在约" + timeLeft + "秒后开启！")
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/guyfawkes0_esc.js
+++ b/gms-server/scripts-zh-CN/portal/guyfawkes0_esc.js
@@ -23,7 +23,7 @@ function enter(pi) {
         pi.warp(674030200, 0);
         return true;
     } else {
-        pi.message("The tunnel is currently blocked.");
+        pi.message("通道目前被堵塞无法通行");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/halloween_Omni1.js
+++ b/gms-server/scripts-zh-CN/portal/halloween_Omni1.js
@@ -20,6 +20,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 function enter(pi) {
-    pi.playerMessage(5, "It seems to be locked.");
+    pi.playerMessage(5, "这个似乎被锁住了。");
     return true;
 }

--- a/gms-server/scripts-zh-CN/portal/hontale_BR.js
+++ b/gms-server/scripts-zh-CN/portal/hontale_BR.js
@@ -26,7 +26,7 @@ function enter(pi) {
             pi.warp(240060100, 0);
             return true;
         } else {
-            pi.getPlayer().dropMessage(6, "Horntail\'s Seal is Blocking this Door.");
+            pi.getPlayer().dropMessage(6, "【暗黑龙王】的封印阻挡着这扇门！");
             return false;
         }
     } else if (pi.getPlayer().getMapId() == 240060100) {
@@ -35,7 +35,7 @@ function enter(pi) {
             pi.warp(240060200, 0);
             return true;
         } else {
-            pi.getPlayer().dropMessage(6, "Horntail\'s Seal is Blocking this Door.");
+            pi.getPlayer().dropMessage(6, "【暗黑龙王】的封印阻挡着这扇门！");
             return false;
         }
     }

--- a/gms-server/scripts-zh-CN/portal/hontale_Bopen.js
+++ b/gms-server/scripts-zh-CN/portal/hontale_Bopen.js
@@ -39,7 +39,7 @@ function enter(pi) {
         avail = eim.getProperty("1stageclear");
         if (avail == null) {
             // do nothing; send message to player
-            pi.getPlayer().dropMessage(6, "Horntail\'s Seal is Blocking this Door.");
+            pi.getPlayer().dropMessage(6, "【暗黑龙王】的封印阻挡着这扇门！");
             return false;
         } else {
             pi.playPortalSound();
@@ -55,7 +55,7 @@ function enter(pi) {
         avail = eim.getProperty("2stageclear");
         if (avail == null) {
             // do nothing; send message to player
-            pi.getPlayer().dropMessage(6, "Horntail\'s Seal is Blocking this Door.");
+            pi.getPlayer().dropMessage(6, "【暗黑龙王】的封印阻挡着这扇门！");
             return false;
         } else {
             pi.playPortalSound();
@@ -71,7 +71,7 @@ function enter(pi) {
         avail = eim.getProperty("3stageclear");
         if (avail == null) {
             // do nothing; send message to player
-            pi.getPlayer().dropMessage(6, "Horntail\'s Seal is Blocking this Door.");
+            pi.getPlayer().dropMessage(6, "【暗黑龙王】的封印阻挡着这扇门！");
             return false;
         } else {
             pi.playPortalSound();
@@ -87,7 +87,7 @@ function enter(pi) {
         avail = eim.getProperty("4stageclear");
         if (avail == null) {
             // do nothing; send message to player
-            pi.getPlayer().dropMessage(6, "Horntail\'s Seal is Blocking this Door.");
+            pi.getPlayer().dropMessage(6, "【暗黑龙王】的封印阻挡着这扇门！");
             return false;
         } else {
             pi.playPortalSound();
@@ -104,13 +104,13 @@ function enter(pi) {
         if (avail == null) {
             if (pi.haveItem(4001092) && pi.isEventLeader()) {
                 eim.showClearEffect();
-                pi.getPlayer().dropMessage(6, "The leader's key break the seal for a flash...");
+                pi.getPlayer().dropMessage(6, "队长的红色钥匙瞬间打破了封印...");
                 pi.playPortalSound();
                 pi.getPlayer().changeMap(target, targetPortal);
                 eim.setIntProperty("5stageclear", 1);
                 return true;
             } else {
-                pi.getPlayer().dropMessage(6, "Horntail\'s Seal is blocking this door. Only the leader with the key can lift this seal.");
+                pi.getPlayer().dropMessage(6, "【暗黑龙王】的封印阻挡着入口！需队长持有钥匙方可解除。");
                 return false;
             }
         } else {

--- a/gms-server/scripts-zh-CN/portal/hontale_BtoB1.js
+++ b/gms-server/scripts-zh-CN/portal/hontale_BtoB1.js
@@ -1,36 +1,10 @@
-/*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-/*
-@Author Jvlaple
-*/
-
 function enter(pi) {
     if (pi.getMap().countPlayers() == 1) {
-        pi.getPlayer().dropMessage(6, "As the last player on this map, you are compelled to wait for the incoming keys.");
+        pi.getPlayer().dropMessage(6, "当前地图仅剩你一人，请等待其他玩家携带钥匙进入。");
         return false;
     } else {
         if (pi.haveItem(4001087)) {
-            pi.getPlayer().dropMessage(6, "You cannot pass to the next map holding the 1st Crystal Key in your inventory.");
+            pi.getPlayer().dropMessage(6, "背包中持有【第一个迷宫的水晶钥匙】时无法进入下一地图！");
             return false;
         }
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/hontale_C.js
+++ b/gms-server/scripts-zh-CN/portal/hontale_C.js
@@ -36,7 +36,7 @@ function enter(pi) {
         } else if (theWay == 3) {
             target = 240050310; //dark
         } else {
-            pi.playerMessage(5, "Hit the Lightbulb to determine your fate!");
+            pi.playerMessage(5, "点击灯泡揭开你的命运！");
             return false;
         }
 
@@ -44,7 +44,7 @@ function enter(pi) {
         eim.warpEventTeam(target);
         return true;
     } else {
-        pi.playerMessage(6, "You are not the party leader. Only the party leader may proceed through this portal.");
+        pi.playerMessage(6, "您不是队伍队长，只有队长可以通过此传送门。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jail_out.js
+++ b/gms-server/scripts-zh-CN/portal/jail_out.js
@@ -16,7 +16,7 @@ function enter(pi) {
         var minutes = (Math.floor(jailedTime / (1000 * 60)) % 60);
         var hours = (Math.floor(jailedTime / (1000 * 60 * 60)) % 24);
 
-        pi.playerMessage(5, "You have been caught in bad behaviour by the Maple POLICE. You've got to stay here for " + hours + " hours " + minutes + " minutes " + seconds + " seconds yet.");
+        pi.playerMessage(5, "你因违规行为被【北斗警长】抓获。还需在此反省" + hours + "小时" + minutes + "分钟" + seconds + "秒。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr1_out.js
+++ b/gms-server/scripts-zh-CN/portal/jnr1_out.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926110100, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr1_pt00.js
+++ b/gms-server/scripts-zh-CN/portal/jnr1_pt00.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926110001, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr2_out.js
+++ b/gms-server/scripts-zh-CN/portal/jnr2_out.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926110200, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr3_in0.js
+++ b/gms-server/scripts-zh-CN/portal/jnr3_in0.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926110201, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The door is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr3_in1.js
+++ b/gms-server/scripts-zh-CN/portal/jnr3_in1.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926110202, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The door is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr3_out.js
+++ b/gms-server/scripts-zh-CN/portal/jnr3_out.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926110203, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The door is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr4_r1.js
+++ b/gms-server/scripts-zh-CN/portal/jnr4_r1.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(926110301 + reg, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "This room is already being explored.");
+        pi.playerMessage(5, "该房间正在被探索中。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr4_r2.js
+++ b/gms-server/scripts-zh-CN/portal/jnr4_r2.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(926110301 + reg, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "This room is already being explored.");
+        pi.playerMessage(5, "该房间正在被探索中。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr4_r3.js
+++ b/gms-server/scripts-zh-CN/portal/jnr4_r3.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(926110301 + reg, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "This room is already being explored.");
+        pi.playerMessage(5, "该房间正在被探索中。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr4_r4.js
+++ b/gms-server/scripts-zh-CN/portal/jnr4_r4.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(926110301 + reg, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "This room is already being explored.");
+        pi.playerMessage(5, "该房间正在被探索中。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr6_out.js
+++ b/gms-server/scripts-zh-CN/portal/jnr6_out.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926110300, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr_201_0.js
+++ b/gms-server/scripts-zh-CN/portal/jnr_201_0.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926110200, 1);
         return true;
     } else {
-        pi.playerMessage(5, "The door is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/jnr_202.js
+++ b/gms-server/scripts-zh-CN/portal/jnr_202.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926110200, 2);
         return true;
     } else {
-        pi.playerMessage(5, "The door is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/kinggate2_open.js
+++ b/gms-server/scripts-zh-CN/portal/kinggate2_open.js
@@ -35,7 +35,7 @@ function enter(pi) {
         }
         return true;
     } else {
-        pi.playerMessage(5, "This crack appears to be blocked off by the door nearby.");
+        pi.playerMessage(5, "这条裂缝似乎被附近的门挡住了。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/kinggate_open.js
+++ b/gms-server/scripts-zh-CN/portal/kinggate_open.js
@@ -35,7 +35,7 @@ function enter(pi) {
         }
         return true;
     } else {
-        pi.playerMessage(5, "This door is closed.");
+        pi.playerMessage(5, "大门已关闭。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/kpq0.js
+++ b/gms-server/scripts-zh-CN/portal/kpq0.js
@@ -32,7 +32,7 @@ function enter(pi) {
         pi.getPlayer().changeMap(target, target.getPortal("st00"));
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "The portal is not opened yet.");
+        pi.getPlayer().dropMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/kpq1.js
+++ b/gms-server/scripts-zh-CN/portal/kpq1.js
@@ -32,7 +32,7 @@ function enter(pi) {
         pi.getPlayer().changeMap(target, target.getPortal("st00"));
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "The portal is not opened yet.");
+        pi.getPlayer().dropMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/kpq2.js
+++ b/gms-server/scripts-zh-CN/portal/kpq2.js
@@ -32,7 +32,7 @@ function enter(pi) {
         pi.getPlayer().changeMap(target, target.getPortal("st00"));
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "The portal is not opened yet.");
+        pi.getPlayer().dropMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/kpq3.js
+++ b/gms-server/scripts-zh-CN/portal/kpq3.js
@@ -33,7 +33,7 @@ function enter(pi) {
         pi.getPlayer().changeMap(target, target.getPortal("st00"));
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "The portal is not opened yet.");
+        pi.getPlayer().dropMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/kpq4.js
+++ b/gms-server/scripts-zh-CN/portal/kpq4.js
@@ -32,7 +32,7 @@ function enter(pi) {
         pi.getPlayer().changeMap(target, target.getPortal("st00"));
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "The portal is not opened yet.");
+        pi.getPlayer().dropMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/lpq0.js
+++ b/gms-server/scripts-zh-CN/portal/lpq0.js
@@ -31,7 +31,7 @@ function enter(pi) {
     var targetPortal = target.getPortal("st00");
     var avail = eim.getProperty("1stageclear");
     if (avail == null) {
-        pi.getPlayer().dropMessage(5, "Some seal is blocking this door.");
+        pi.getPlayer().dropMessage(5, "某种封印阻挡着这扇门，暂时无法进入。");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/lpq1.js
+++ b/gms-server/scripts-zh-CN/portal/lpq1.js
@@ -32,7 +32,7 @@ function enter(pi) {
     var targetPortal = target.getPortal("st00");
     var avail = eim.getProperty("2stageclear");
     if (avail == null) {
-        pi.getPlayer().dropMessage(5, "Some seal is blocking this door.");
+        pi.getPlayer().dropMessage(5, "某种封印阻挡着这扇门，暂时无法进入。");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/lpq2.js
+++ b/gms-server/scripts-zh-CN/portal/lpq2.js
@@ -33,7 +33,7 @@ function enter(pi) {
     var avail = eim.getProperty("3stageclear");
     if (avail == null) {
         // can't go thru eh?
-        pi.getPlayer().dropMessage(5, "Some seal is blocking this door.");
+        pi.getPlayer().dropMessage(5, "某种封印阻挡着这扇门，暂时无法进入。");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/lpq3.js
+++ b/gms-server/scripts-zh-CN/portal/lpq3.js
@@ -33,7 +33,7 @@ function enter(pi) {
     var avail = eim.getProperty("4stageclear");
     if (avail == null) {
         // can't go thru eh?
-        pi.getPlayer().dropMessage(5, "Some seal is blocking this door.");
+        pi.getPlayer().dropMessage(5, "某种封印阻挡着这扇门，暂时无法进入。");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/lpq4.js
+++ b/gms-server/scripts-zh-CN/portal/lpq4.js
@@ -33,7 +33,7 @@ function enter(pi) {
     var avail = eim.getProperty("5stageclear");
     if (avail == null) {
         // can't go thru eh?
-        pi.getPlayer().dropMessage(5, "Some seal is blocking this door.");
+        pi.getPlayer().dropMessage(5, "某种封印阻挡着这扇门，暂时无法进入。");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/lpq5.js
+++ b/gms-server/scripts-zh-CN/portal/lpq5.js
@@ -33,7 +33,7 @@ function enter(pi) {
     var avail = eim.getProperty("5stageclear");
     if (avail == null) {
         // can't go thru eh?
-        pi.getPlayer().dropMessage(5, "Some seal is blocking this door.");
+        pi.getPlayer().dropMessage(5, "某种封印阻挡着这扇门，暂时无法进入。");
         return false;
     } else {
         if (eim.getProperty("6stageclear") == null) {

--- a/gms-server/scripts-zh-CN/portal/lpq7.js
+++ b/gms-server/scripts-zh-CN/portal/lpq7.js
@@ -33,7 +33,7 @@ function enter(pi) {
     var avail = eim.getProperty("8stageclear");
     if (avail == null) {
         // can't go thru eh?
-        pi.getPlayer().dropMessage(5, "Some seal is blocking this door.");
+        pi.getPlayer().dropMessage(5, "某种封印阻挡着这扇门，暂时无法进入。");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/magatia_dark0.js
+++ b/gms-server/scripts-zh-CN/portal/magatia_dark0.js
@@ -25,7 +25,7 @@ function enter(pi) {
         pi.warp(926130000, "out00");
         return true;
     } else {
-        pi.playerMessage(5, "This pipe seems too dark to venture inside.");
+        pi.playerMessage(5, "这个管道太黑了，不敢贸然进入...");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/male00.js
+++ b/gms-server/scripts-zh-CN/portal/male00.js
@@ -29,7 +29,7 @@ function enter(pi) {
         pi.warp(670010200, 3);
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "You cannot proceed past here.");
+        pi.getPlayer().dropMessage(5, "你无法从这里过去，请你的男队友试试看。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/metalgate_open.js
+++ b/gms-server/scripts-zh-CN/portal/metalgate_open.js
@@ -32,6 +32,6 @@ function enter(pi) {
         pi.warp(990000431, 0);
         return true;
     }
-    pi.playerMessage(5, "This way forward is not open yet.");
+    pi.playerMessage(5, "前方的道路尚未开放。");
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/minar_elli.js
+++ b/gms-server/scripts-zh-CN/portal/minar_elli.js
@@ -21,7 +21,7 @@
 */
 function enter(pi) {
     if (!pi.haveItem(4031346)) {
-        pi.getPlayer().dropMessage(6, "You need a magic seed to use this portal.");
+        pi.getPlayer().dropMessage(6, "需要【魔法种子】才能启动时空门。");
         return false;
     }
     if (pi.getPlayer().getMapId() == 240010100) {

--- a/gms-server/scripts-zh-CN/portal/move_elin.js
+++ b/gms-server/scripts-zh-CN/portal/move_elin.js
@@ -22,6 +22,6 @@
 function enter(pi) {
     pi.playPortalSound();
     pi.warp(300000100, "out00");
-    pi.playerMessage(5, "Now passing the Time Gate.");
+    pi.playerMessage(5, "正在穿越时空之门。");
     return true;
 }

--- a/gms-server/scripts-zh-CN/portal/outMagiclib.js
+++ b/gms-server/scripts-zh-CN/portal/outMagiclib.js
@@ -1,6 +1,6 @@
 function enter(pi) {
     if (pi.getMap().countMonster(2220100) > 0) {
-        pi.getPlayer().message("Cannot leave until all Blue Mushrooms have been defeated.");
+        pi.getPlayer().message("必须清除所有蓝蘑菇后才能离开副本");
         return false;
     } else {
         var eim = pi.getEventInstance();

--- a/gms-server/scripts-zh-CN/portal/outPerrion_1.js
+++ b/gms-server/scripts-zh-CN/portal/outPerrion_1.js
@@ -1,5 +1,5 @@
 function enter(pi) {
-    pi.message("You found a shortcut to the start of the underground temple.");
+    pi.message("你发现了通往地下神殿入口的捷径");
     pi.playPortalSound();
     pi.warp(105100000, 2);
     return true;

--- a/gms-server/scripts-zh-CN/portal/outRider.js
+++ b/gms-server/scripts-zh-CN/portal/outRider.js
@@ -5,7 +5,7 @@ function enter(pi) {
         pi.warp(211050000, 4);
         return true;
     } else {
-        pi.playerMessage(5, "Free a slot on your inventory before receiving the couse clear's token.");
+        pi.playerMessage(5, "请在背包中的其它栏目预留至少1个空位以领取通关奖励");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/outtestWolf.js
+++ b/gms-server/scripts-zh-CN/portal/outtestWolf.js
@@ -6,11 +6,11 @@ function enter(pi) {
             pi.warp(140010210, 0);
             return true;
         } else {
-            pi.playerMessage(5, "Free a slot on your inventory before receiving the couse clear's token.");
+            pi.playerMessage(5, "请在背包中的其它栏目预留至少1个空位以领取通关奖励");
             return false;
         }
     } else {
-        pi.playerMessage(5, "Defeat all wolves before exiting the stage.");
+        pi.playerMessage(5, "离场前需消灭所有狼群");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/party3_gardenin.js
+++ b/gms-server/scripts-zh-CN/portal/party3_gardenin.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.getEventInstance().warpEventTeam(920010100);
         return true;
     } else {
-        pi.playerMessage(5, "Please get the leader in this portal, make sure you have the Root of Life.");
+        pi.playerMessage(5, "请让队长进入此传送门，并确保持有生命草。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/party3_jail1.js
+++ b/gms-server/scripts-zh-CN/portal/party3_jail1.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(920010910, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The storage is currently inaccessible, as the powers of the Pixies remains active within the tower.");
+        pi.playerMessage(5, "当前无法使用仓库，因为精灵的力量仍在塔内生效。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/party3_jail2.js
+++ b/gms-server/scripts-zh-CN/portal/party3_jail2.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(920010920, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The storage is currently inaccessible, as the powers of the Pixies remains active within the tower.");
+        pi.playerMessage(5, "当前无法使用仓库，因为精灵的力量仍在塔内生效。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/party3_jail3.js
+++ b/gms-server/scripts-zh-CN/portal/party3_jail3.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(920010930, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The storage is currently inaccessible, as the powers of the Pixies remains active within the tower.");
+        pi.playerMessage(5, "当前无法使用仓库，因为精灵的力量仍在塔内生效。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/party3_jailin.js
+++ b/gms-server/scripts-zh-CN/portal/party3_jailin.js
@@ -35,7 +35,7 @@ function enterLeverSequence(pi) {
             map.broadcastMessage(PacketCreator.showEffect("quest/party/wrong_kor"));
             map.broadcastMessage(PacketCreator.playSound("Party1/Failed"));
 
-            pi.playerMessage(5, "The right combination of levers is needed to pass. " + countMiss + " lever(s) are misplaced.");
+            pi.playerMessage(5, "需要通过正确的拉杆组合才能继续前进。当前有 " + countMiss + " 个拉杆位置错误。");
             return false;
         }
 
@@ -54,7 +54,7 @@ function enterNoMobs(pi) {
     var mobcount = map.countMonster(9300044);
 
     if (mobcount > 0) {
-        pi.playerMessage(5, "Please use the levers to defeat all the threats before you proceed.");
+        pi.playerMessage(5, "请先使用控制杆清除所有威胁再继续前进");
         return false;
     } else {
         pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/party3_room8.js
+++ b/gms-server/scripts-zh-CN/portal/party3_room8.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(920011000, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The storage is currently inaccessible, as the powers of the Pixies remains active within the tower.");
+        pi.playerMessage(5, "当前无法使用仓库，因为精灵的力量仍在塔内生效。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/party6_out.js
+++ b/gms-server/scripts-zh-CN/portal/party6_out.js
@@ -7,11 +7,11 @@ function enter(pi) {
             eim.warpEventTeam(930000800);
             return true;
         } else {
-            pi.playerMessage(5, "Wait for the leader to pass through the portal.");
+            pi.playerMessage(5, "请等待队长先通过传送门");
             return false;
         }
     } else {
-        pi.playerMessage(5, "Please eliminate the Poison Golem.");
+        pi.playerMessage(5, "请先消灭剧毒魔像");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/party6_stage.js
+++ b/gms-server/scripts-zh-CN/portal/party6_stage.js
@@ -11,13 +11,13 @@ function enter(pi) {
                 pi.warp(930000200, 0);
                 return true;
             } else {
-                pi.playerMessage(5, "Eliminate all the monsters.");
+                pi.playerMessage(5, "请消灭所有怪物。");
                 return false;
             }
             break;
         case 930000200:
             if (pi.getMap().getReactorByName("spine") != null && pi.getMap().getReactorByName("spine").getState() < 4) {
-                pi.playerMessage(5, "The spine blocks the way.");
+                pi.playerMessage(5, "尖刺障碍物阻挡了道路。");
                 return false;
             } else {
                 pi.playPortalSound();
@@ -27,7 +27,7 @@ function enter(pi) {
             break;
 
         default:
-            pi.playerMessage(5, "This portal leads to an unbound path.");
+            pi.playerMessage(5, "该传送门通往未绑定的路径。");
             return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/party6_stage800.js
+++ b/gms-server/scripts-zh-CN/portal/party6_stage800.js
@@ -8,7 +8,7 @@ function enter(pi) {
     var spring = pi.getMap().getReactorById(3008000);  // thanks Chloek3, seth1 for noticing fragments not being awarded properly
     if (spring != null && spring.getState() > 0) {
         if (!pi.canHold(4001198, 1)) {
-            pi.playerMessage(5, "Check for a free space on your ETC inventory before entering this portal.");
+            pi.playerMessage(5, "进入传送门前请给背包的 其它栏 空出至少1个空格子。");
             return false;
         }
 

--- a/gms-server/scripts-zh-CN/portal/q2073.js
+++ b/gms-server/scripts-zh-CN/portal/q2073.js
@@ -29,7 +29,7 @@ function enter(pi) {
         pi.warp(900000000, 0);
         return true;
     } else {
-        pi.message("Private property. This place can only be entered when running an errand from Camila.");
+        pi.message("私人领地：仅接受卡米拉的任务委托时方可进入");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/q3366in.js
+++ b/gms-server/scripts-zh-CN/portal/q3366in.js
@@ -23,7 +23,7 @@ function enter(pi) {
         pi.warp(926130101, 0);
         return true;
     } else {
-        pi.message("You don't have permission to access this room.");
+        pi.message("你没有权限进入此房间");
         return false;
     }
 

--- a/gms-server/scripts-zh-CN/portal/q3367in.js
+++ b/gms-server/scripts-zh-CN/portal/q3367in.js
@@ -30,7 +30,7 @@ function enter(pi) {
         pi.warp(926130102, 0);
         return true;
     } else {
-        pi.message("You don't have permission to access this room.");
+        pi.message("你没有权限进入此房间");
         return false;
     }
 

--- a/gms-server/scripts-zh-CN/portal/q3368in.js
+++ b/gms-server/scripts-zh-CN/portal/q3368in.js
@@ -23,7 +23,7 @@ function enter(pi) {
         pi.warp(926130103, 0);
         return true;
     } else {
-        pi.message("You don't have permission to access this room.");
+        pi.message("你没有权限进入此房间");
         return false;
     }
 

--- a/gms-server/scripts-zh-CN/portal/raid_rest.js
+++ b/gms-server/scripts-zh-CN/portal/raid_rest.js
@@ -28,7 +28,7 @@ function enter(pi) {
     var evLevel = ((pi.getMapId() - 1) % 5) + 1;
 
     if (pi.getPlayer().getEventInstance().isEventLeader(pi.getPlayer()) && pi.getPlayer().getEventInstance().getPlayerCount() > 1) {
-        pi.message("Being the party leader, you cannot leave before your teammates leave first or you pass leadership.");
+        pi.message("作为队长，你必须在队友全部离开或移交队长权限后才能退出副本。");
         return false;
     }
 
@@ -37,7 +37,7 @@ function enter(pi) {
         pi.warp(970030000);
         return true;
     } else {
-        pi.message("Make a room available on all EQUIP, USE, SET-UP and ETC inventory to claim an instance prize.");
+        pi.message("请确保背包的 装备、消耗、设置、其它 位均有至少1个空格子，才能领取副本奖励。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/raid_stage.js
+++ b/gms-server/scripts-zh-CN/portal/raid_stage.js
@@ -38,7 +38,7 @@ function enter(pi) {
         pi.warp(nextStage);
         return true;
     } else {
-        pi.getPlayer().dropMessage(6, "Defeat all monsters before proceeding to the next stage.");
+        pi.getPlayer().dropMessage(6, "击败所有怪物后才能进入下一阶段");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rankDeveloperRoom.js
+++ b/gms-server/scripts-zh-CN/portal/rankDeveloperRoom.js
@@ -2,7 +2,7 @@ function enter(pi) {
     if (pi.getPlayer().getMapId() != 777777777) {
         const Server = Java.type('org.gms.net.server.Server');
         if (!Server.getInstance().canEnterDeveloperRoom()) {
-            pi.message("The next room is currently unavailable.");
+            pi.message("这个房间你无法进入");
             return false;
         }
 

--- a/gms-server/scripts-zh-CN/portal/rienCaveEnter.js
+++ b/gms-server/scripts-zh-CN/portal/rienCaveEnter.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(140030000, 1);
         return true;
     } else {
-        pi.playerMessage(5, "Something seems to be blocking this portal!");
+        pi.playerMessage(5, "传送门的作用似乎被某种力量封印了！");
         return false;
     }
 

--- a/gms-server/scripts-zh-CN/portal/rienTutor1.js
+++ b/gms-server/scripts-zh-CN/portal/rienTutor1.js
@@ -24,7 +24,7 @@
 */
 function enter(pi) {
     if (!pi.isQuestCompleted(21010)) {
-        pi.message("You must complete the quest before proceeding to the next map.");
+        pi.message("请先完成当前任务才能进入下一张地图。");
         return false;
     }
     pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/rienTutor2.js
+++ b/gms-server/scripts-zh-CN/portal/rienTutor2.js
@@ -24,7 +24,7 @@
 */
 function enter(pi) {
     if (!pi.isQuestCompleted(21011)) {
-        pi.message("You must complete the quest before proceeding to the next map..");
+        pi.message("你必须完成任务后才能进入下一张地图。");
         return false;
     }
     pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/rienTutor3.js
+++ b/gms-server/scripts-zh-CN/portal/rienTutor3.js
@@ -24,7 +24,7 @@
 */
 function enter(pi) {
     if (!pi.isQuestCompleted(21012)) {
-        pi.message("You must complete the quest before proceeding to the next map..");
+        pi.message("你必须完成任务后才能进入下一张地图。");
         return false;
     }
     pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/rienTutor4.js
+++ b/gms-server/scripts-zh-CN/portal/rienTutor4.js
@@ -24,7 +24,7 @@
 */
 function enter(pi) {
     if (!pi.isQuestCompleted(21013)) {
-        pi.message("You must complete the quest before proceeding to the next map..");
+        pi.message("你必须完成任务后才能进入下一张地图。");
         return false;
     }
     pi.playPortalSound();

--- a/gms-server/scripts-zh-CN/portal/rnj1_out.js
+++ b/gms-server/scripts-zh-CN/portal/rnj1_out.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926100100, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj1_pt00.js
+++ b/gms-server/scripts-zh-CN/portal/rnj1_pt00.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926100001, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj2_out.js
+++ b/gms-server/scripts-zh-CN/portal/rnj2_out.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926100200, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj3_in0.js
+++ b/gms-server/scripts-zh-CN/portal/rnj3_in0.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926100201, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The door is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj3_in1.js
+++ b/gms-server/scripts-zh-CN/portal/rnj3_in1.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926100202, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The door is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj3_out.js
+++ b/gms-server/scripts-zh-CN/portal/rnj3_out.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926100203, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "The door is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj4_r1.js
+++ b/gms-server/scripts-zh-CN/portal/rnj4_r1.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(926100301 + reg, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "This room is already being explored.");
+        pi.playerMessage(5, "该房间正在被探索中。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj4_r2.js
+++ b/gms-server/scripts-zh-CN/portal/rnj4_r2.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(926100301 + reg, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "This room is already being explored.");
+        pi.playerMessage(5, "该房间正在被探索中。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj4_r3.js
+++ b/gms-server/scripts-zh-CN/portal/rnj4_r3.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(926100301 + reg, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "This room is already being explored.");
+        pi.playerMessage(5, "该房间正在被探索中。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj4_r4.js
+++ b/gms-server/scripts-zh-CN/portal/rnj4_r4.js
@@ -11,7 +11,7 @@ function enter(pi) {
         pi.warp(926100301 + reg, 0); //next
         return true;
     } else {
-        pi.playerMessage(5, "This room is already being explored.");
+        pi.playerMessage(5, "该房间正在被探索中。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj6_out.js
+++ b/gms-server/scripts-zh-CN/portal/rnj6_out.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926100300, 0);
         return true;
     } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj_201_0.js
+++ b/gms-server/scripts-zh-CN/portal/rnj_201_0.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926100200, 1);
         return true;
     } else {
-        pi.playerMessage(5, "The door is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/rnj_202.js
+++ b/gms-server/scripts-zh-CN/portal/rnj_202.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(926100200, 2);
         return true;
     } else {
-        pi.playerMessage(5, "The door is not opened yet.");
+        pi.playerMessage(5, "传送门尚未开启。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/s4berserk.js
+++ b/gms-server/scripts-zh-CN/portal/s4berserk.js
@@ -34,11 +34,11 @@ function enter(pi) {
 
             return true;
         } else {
-            pi.getPlayer().message("Some other player is currently inside.");
+            pi.getPlayer().message("当前有其他玩家正在地图内。");
             return false;
         }
     } else {
-        pi.getPlayer().message("A mysterious force won't let you in.");
+        pi.getPlayer().message("一股神秘的力量阻止你进入。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/s4berserk_move.js
+++ b/gms-server/scripts-zh-CN/portal/s4berserk_move.js
@@ -25,6 +25,6 @@ function enter(pi) {
         pi.warp(910500200, "out00");
         return true;
     }
-    pi.getPlayer().dropMessage(5, "You must defeat all the monsters first.");
+    pi.getPlayer().dropMessage(5, "你需要先清除所有怪物。");
     return true;
 }

--- a/gms-server/scripts-zh-CN/portal/s4firehawk.js
+++ b/gms-server/scripts-zh-CN/portal/s4firehawk.js
@@ -32,11 +32,11 @@ function enter(pi) {
 
             return true;
         } else {
-            pi.getPlayer().message("Some other player is currently inside.");
+            pi.getPlayer().message("当前有其他玩家正在地图内。");
             return false;
         }
     } else {
-        pi.getPlayer().message("A mysterious force won't let you in.");
+        pi.getPlayer().message("一股神秘的力量阻止你进入。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/s4hitman.js
+++ b/gms-server/scripts-zh-CN/portal/s4hitman.js
@@ -32,11 +32,11 @@ function enter(pi) {
 
             return true;
         } else {
-            pi.getPlayer().message("Some other player is currently inside.");
+            pi.getPlayer().message("当前有其他玩家正在地图内。");
             return false;
         }
     }
 
-    pi.getPlayer().message("A mysterious force won't let you in.");
+    pi.getPlayer().message("一股神秘的力量阻止你进入。");
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/s4iceeagle.js
+++ b/gms-server/scripts-zh-CN/portal/s4iceeagle.js
@@ -32,11 +32,11 @@ function enter(pi) {
 
             return true;
         } else {
-            pi.getPlayer().message("Some other player is currently inside.");
+            pi.getPlayer().message("当前有其他玩家正在地图内。");
             return false;
         }
     } else {
-        pi.getPlayer().message("A mysterious force won't let you in.");
+        pi.getPlayer().message("一股神秘的力量阻止你进入。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/s4mind_end.js
+++ b/gms-server/scripts-zh-CN/portal/s4mind_end.js
@@ -19,7 +19,7 @@
 */
 function enter(pi) {
     if (!pi.getEventInstance().isEventCleared()) {
-        pi.message("You have to clear this mission before entering this portal.");
+        pi.message("请先完成当前任务才能进入此传送门。");
         return false;
     } else {
         if (pi.isQuestStarted(6410)) {

--- a/gms-server/scripts-zh-CN/portal/s4nest.js
+++ b/gms-server/scripts-zh-CN/portal/s4nest.js
@@ -32,11 +32,11 @@ function enter(pi) {
 
             return true;
         } else {
-            pi.getPlayer().message("Some other player is currently inside.");
+            pi.getPlayer().message("当前有其他玩家正在地图内。");
             return false;
         }
     }
 
-    pi.getPlayer().message("A mysterious force won't let you in.");
+    pi.getPlayer().message("一股神秘的力量阻止你进入。");
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/s4resur_enter.js
+++ b/gms-server/scripts-zh-CN/portal/s4resur_enter.js
@@ -30,6 +30,6 @@ function enter(pi) {
         return true;
     }
 
-    pi.getPlayer().message("A mysterious force won't let you in.");
+    pi.getPlayer().message("一股神秘的力量阻止你进入。");
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/s4resur_out.js
+++ b/gms-server/scripts-zh-CN/portal/s4resur_out.js
@@ -32,7 +32,7 @@ function enter(pi) {
 
             return true;
         } else {
-            pi.getPlayer().message("Make room on your ETC to receive the quest item.");
+            pi.getPlayer().message("请先确保背包的[其它栏]至少有1个空格子可以接收任务物品");
             return false;
         }
     } else {

--- a/gms-server/scripts-zh-CN/portal/s4resurrection.js
+++ b/gms-server/scripts-zh-CN/portal/s4resurrection.js
@@ -32,11 +32,11 @@ function enter(pi) {
 
             return true;
         } else {
-            pi.getPlayer().message("Some other player is currently inside.");
+            pi.getPlayer().message("当前有其他玩家正在地图内。");
             return false;
         }
     }
 
-    pi.getPlayer().message("A mysterious force won't let you in.");
+    pi.getPlayer().message("一股神秘的力量阻止你进入。");
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/s4rush.js
+++ b/gms-server/scripts-zh-CN/portal/s4rush.js
@@ -29,7 +29,7 @@ function enter(pi) {
         pi.warp(910500100, 0);
         return true;
     } else {
-        pi.getPlayer().message("A mysterious force won't let you in.");
+        pi.getPlayer().message("一股神秘的力量阻止你进入。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/s4ship_out.js
+++ b/gms-server/scripts-zh-CN/portal/s4ship_out.js
@@ -18,17 +18,21 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 function enter(pi) {
-    var exit = pi.getEventInstance().getIntProperty("canLeave");
-    if (exit == 0) {
-        pi.message("You have to wait one minute before you can leave this place.");
-        return false;
-    } else if (exit == 2) {
-        pi.playPortalSound();
-        pi.warp(912010200);
-        return true;
-    } else {
-        pi.playPortalSound();
-        pi.warp(120000101);
-        return true;
+    const exitStatus = pi.getEventInstance().getIntProperty("canLeave");
+
+    switch(exitStatus) {
+        case 0: // 限制离开状态
+            pi.message("请等待1分钟后再尝试离开该区域");
+            return false;
+
+        case 2: // 特殊传送条件
+            pi.playPortalSound();
+            pi.warp(912010200); // 传送到特殊地图
+            return true;
+
+        default: // 常规传送
+            pi.playPortalSound();
+            pi.warp(120000101); // 返回主城
+            return true;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/s4super_out.js
+++ b/gms-server/scripts-zh-CN/portal/s4super_out.js
@@ -18,17 +18,21 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 function enter(pi) {
-    var exit = pi.getEventInstance().getIntProperty("canLeave");
-    if (exit == 0) {
-        pi.message("You have to wait one minute before you can leave this place.");
-        return false;
-    } else if (exit == 2) {
-        pi.playPortalSound();
-        pi.warp(912010200);
-        return true;
-    } else {
-        pi.playPortalSound();
-        pi.warp(120000101);
-        return true;
+    const exitStatus = pi.getEventInstance().getIntProperty("canLeave");
+
+    switch(exitStatus) {
+        case 0: // 限制离开状态
+            pi.message("请等待1分钟后再尝试离开该区域");
+            return false;
+
+        case 2: // 特殊传送条件
+            pi.playPortalSound();
+            pi.warp(912010200); // 传送到特殊地图
+            return true;
+
+        default: // 常规传送
+            pi.playPortalSound();
+            pi.warp(120000101); // 返回主城
+            return true;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/s4tornado_enter.js
+++ b/gms-server/scripts-zh-CN/portal/s4tornado_enter.js
@@ -32,7 +32,7 @@ function enter(pi) {
 
             return true;
         } else {
-            pi.getPlayer().message("Some other player is currently inside.");
+            pi.getPlayer().message("当前有其他玩家正在地图内。");
             return false;
         }
     }

--- a/gms-server/scripts-zh-CN/portal/secretgate1_open.js
+++ b/gms-server/scripts-zh-CN/portal/secretgate1_open.js
@@ -31,7 +31,7 @@ function enter(pi) {
         pi.warp(990000611, 1);
         return true;
     } else {
-        pi.playerMessage(5, "This door is closed.");
+        pi.playerMessage(5, "大门已关闭。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/secretgate2_open.js
+++ b/gms-server/scripts-zh-CN/portal/secretgate2_open.js
@@ -30,7 +30,7 @@ function enter(pi) {
         pi.warp(990000631, 1);
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "This door is closed.");
+        pi.getPlayer().dropMessage(5, "大门已关闭。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/secretgate3_open.js
+++ b/gms-server/scripts-zh-CN/portal/secretgate3_open.js
@@ -30,7 +30,7 @@ function enter(pi) {
         pi.warp(990000641, 1);
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "This door is closed.");
+        pi.getPlayer().dropMessage(5, "大门已关闭。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/skyrom.js
+++ b/gms-server/scripts-zh-CN/portal/skyrom.js
@@ -25,7 +25,7 @@ function enter(pi) {
             pi.warp(926000010, 0);
             return true;
         } else {
-            pi.message("Someone is already trying this map.");
+            pi.message("当前地图已有其他玩家正在挑战，请稍后再试。");
             return false;
         }
     } else {

--- a/gms-server/scripts-zh-CN/portal/speargate_open.js
+++ b/gms-server/scripts-zh-CN/portal/speargate_open.js
@@ -31,7 +31,7 @@ function enter(pi) {
         pi.warp(990000401, 0);
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "This way forward is not open yet.");
+        pi.getPlayer().dropMessage(5, "前方的道路尚未开放。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/statuegate_open.js
+++ b/gms-server/scripts-zh-CN/portal/statuegate_open.js
@@ -30,7 +30,7 @@ function enter(pi) {
         pi.warp(990000301, 0);
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "The gate is closed.");
+        pi.getPlayer().dropMessage(5, "大门已关闭。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/stonegate_open.js
+++ b/gms-server/scripts-zh-CN/portal/stonegate_open.js
@@ -29,7 +29,7 @@ function enter(pi) {
         pi.warp(990000430, 0);
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "The door is still blocked.");
+        pi.getPlayer().dropMessage(5, "入口仍处于封锁状态");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/tristanEnter.js
+++ b/gms-server/scripts-zh-CN/portal/tristanEnter.js
@@ -4,7 +4,7 @@ function enter(pi) {
         pi.warp(105100101, "in00");
         return true;
     } else {
-        pi.message("A mysterious force won't let you in.");
+        pi.message("一股神秘的力量阻止你进入。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/tutorHelper.js
+++ b/gms-server/scripts-zh-CN/portal/tutorHelper.js
@@ -1,31 +1,12 @@
-/*
-	This file is part of the OdinMS Maple Story Server
-    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as
-    published by the Free Software Foundation version 3 as published by
-    the Free Software Foundation. You may not use, modify or distribute
-    this program under any other version of the GNU Affero General Public
-    License.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-/*
- * @author kevintjuh93
+/**
+ * 骑士团-女皇之路（MapID：130030001）
+ * 触发召唤NPC利林跟随
+ * @param pi
+ * @returns {boolean}
  */
 function enter(pi) {
-    pi.spawnGuide();
-    pi.talkGuide("Welcome to Maple World! I'm Mimo. I'm in charge of guiding you until you reach Lv. 10 and become a Knight-In-Training. Double-click for further information!");
-    pi.blockPortal();
-    return true;
+    pi.spawnGuide();// 生成（召唤）新手引导NPC
+    pi.talkGuide("欢迎来到北斗世界！我是利琳。我会负责引导你，直到你达到10级并成为见习骑士。双击我获取更多信息！");// 让引导NPC对玩家发送消息
+    pi.blockPortal();// 阻止玩家通过传送门（防止玩家提前离开新手引导区域）
+    return true;// 返回 `true`，表示事件执行成功
 }

--- a/gms-server/scripts-zh-CN/portal/tutorquest.js
+++ b/gms-server/scripts-zh-CN/portal/tutorquest.js
@@ -1,36 +1,48 @@
 function enter(pi) {
-    if (pi.getPlayer().getMapId() == 130030001) {
-        if (pi.isQuestStarted(20010)) {
-            pi.playPortalSound();
-            pi.warp(130030002, 0);
-            return true;
-        } else {
-            pi.message("Please click on the NPC first to receive a quest.");
-        }
-    } else if (pi.getPlayer().getMapId() == 130030002) {
-        if (pi.isQuestCompleted(20011)) {
-            pi.playPortalSound();
-            pi.warp(130030003, 0);
-            return true;
-        } else {
-            pi.message("Please complete the required quest before proceeding.");
-        }
-    } else if (pi.getPlayer().getMapId() == 130030003) {
-        if (pi.isQuestCompleted(20012)) {
-            pi.playPortalSound();
-            pi.warp(130030004, 0);
-            return true;
-        } else {
-            pi.message("Please complete the required quest before proceeding.");
-        }
-    } else if (pi.getPlayer().getMapId() == 130030004) {
-        if (pi.isQuestCompleted(20013)) {
-            pi.playPortalSound();
-            pi.warp(130030005, 0);
-            return true;
-        } else {
-            pi.message("Please complete the required quest before proceeding.");
-        }
+    const player = pi.getPlayer();
+    const currentMap = player.getMapId();
+
+    // 根据不同地图ID进行传送判断
+    switch(currentMap) {
+        case 130030001: // 新手起始地图
+            if (pi.isQuestStarted(20010)) {
+                pi.playPortalSound();
+                pi.warp(130030002, 0); // 传送到下一地图
+                return true;
+            } else {
+                pi.message("请先与NPC对话接取任务");
+            }
+            break;
+
+        case 130030002: // 初级任务地图
+            if (pi.isQuestCompleted(20011)) {
+                pi.playPortalSound();
+                pi.warp(130030003, 0);
+                return true;
+            } else {
+                pi.message("请先完成当前任务再继续前进");
+            }
+            break;
+
+        case 130030003: // 中级任务地图
+            if (pi.isQuestCompleted(20012)) {
+                pi.playPortalSound();
+                pi.warp(130030004, 0);
+                return true;
+            } else {
+                pi.message("请先通过本关试炼任务");
+            }
+            break;
+
+        case 130030004: // 高级任务地图
+            if (pi.isQuestCompleted(20013)) {
+                pi.playPortalSound();
+                pi.warp(130030005, 0);
+                return true;
+            } else {
+                pi.message("需完成最终试炼才能进入圣地");
+            }
+            break;
     }
 
     return false;

--- a/gms-server/scripts-zh-CN/portal/under30gate.js
+++ b/gms-server/scripts-zh-CN/portal/under30gate.js
@@ -33,7 +33,7 @@ function enter(pi) {
         pi.warp(990000640, 1);
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "You cannot proceed past this point.");
+        pi.getPlayer().dropMessage(5, "你无法通过此处。");
         return false;
     }
 }

--- a/gms-server/scripts-zh-CN/portal/watergate_open.js
+++ b/gms-server/scripts-zh-CN/portal/watergate_open.js
@@ -31,7 +31,7 @@ function enter(pi) {
         pi.warp(990000600, 1);
         return true;
     } else {
-        pi.getPlayer().dropMessage(5, "This way forward is not open yet.");
+        pi.getPlayer().dropMessage(5, "前方的道路尚未开放。");
     }
     return false;
 }

--- a/gms-server/scripts-zh-CN/quest/21015.js
+++ b/gms-server/scripts-zh-CN/quest/21015.js
@@ -17,11 +17,11 @@ function start(mode, type, selection) {
 	qm.sendYesNo("体力就是战力！英雄的基础就是体力！ ... 您没听过这些话吗？当然要先做#b基础体力锻炼#k ... 啊！ 您丧失记忆所以什么都忘了。不知道也没关系。那么现在就进入基础体力锻炼吧！");
     } else if (status == 3) {
         if (mode == 0) {
-            qm.sendNext("What are you so hesitant about? You're a hero! You gotta strike while the iron is hot! Come on, let's do this!");
+            qm.sendNext("你还犹豫什么？你可是英雄啊！机不可失，时不再来！来吧，我们上！");
             qm.dispose();
         } else {
             qm.forceStartQuest();
-            qm.sendNext("The population of Rien may be mostly Penguins, but even this island has monsters. You'll find #o0100131#s if you go to #b#m140020000##k, located on the right side of the town. Please defeat #r10 of those #o0100131#s#k. I'm sure you'll have no trouble defeating the #o0100131#s that even the slowest penguins here can defeat.", 1);
+            qm.sendNext("虽然里恩岛的居民大多是企鹅，但这座岛上也有怪物。如果你前往位于城镇右侧的#b#m140020000##k，你会发现#o0100131#s。请击败#r10只#o0100131#s#k。我相信这对你来说轻而易举，毕竟就连这里最菜的企鹅都能打败它们。", 1);
         }
     } else if (status == 4) {
         qm.showInfo("Effect/OnUserEff.img/guideEffect/aranTutorial/tutorialArrow3");

--- a/gms-server/scripts-zh-CN/quest/21017.js
+++ b/gms-server/scripts-zh-CN/quest/21017.js
@@ -12,7 +12,7 @@ function start(mode, type, selection) {
     if (status == 0) {
         qm.sendNext("“看来你现在已经热身了。这时候严格的训练真的能帮助你打下坚实的基础。我们开始基础训练吧，好吗？”", 8);
     } else if (status == 1) {
-        qm.sendNextPrev("这次去#b#m140020200##k打败一些 #r#o0100133#s#k。我想大约#r20#k就行了。继续前进……嗯？你有什么想说的吗？?", 8);
+        qm.sendNextPrev("这次去#b#m140020200##k打败一些 #r#o0100133##k。我想大约#r20#k就行了。继续前进……嗯？你有什么想说的吗？?", 8);
     } else if (status == 2) {
         qm.sendNextPrev("“数字不是越来越大了吗”?", 2);
     } else if (status == 3) {
@@ -32,7 +32,7 @@ function start(mode, type, selection) {
             qm.sendNext("#b(“你接受了，想着如果让她继续说下去，你可能最终要处理999个这样的请求。”)#k", 2);
         }
     } else if (status == 7) {
-        qm.sendNextPrev("请继续击杀20个 #o0100133#s.", 8);
+        qm.sendNextPrev("请继续击杀20个 #r#o0100133##.", 8);
     } else if (status == 8) {
         qm.showInfo("Effect/OnUserEff.img/guideEffect/aranTutorial/tutorialArrow3");
         qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/21018.js
+++ b/gms-server/scripts-zh-CN/quest/21018.js
@@ -10,16 +10,16 @@ function start(mode, type, selection) {
         status++;
     }
     if (status == 0) {
-        qm.sendNext("现在，你将接受一个测试，以确定你是否合格。你要做的就是挑战这个岛上最强大的怪物，#o0100134#s。大约#r50#k只就可以了，但是...");
+        qm.sendNext("来，让我测试一下，你至今为止的基础体力训练结果。测试方法很简单。这座岛上有一种最强悍凶猛的怪兽，#o0100134#。大约#r50#k只就可以了，但是...");
     } else if (status == 1) {
-        qm.sendAcceptDecline("“我们不能让你消灭所有#o0100134#s，因为它们数量不多。消灭5个怎么样？你是来训练的，不是来破坏生态系统的。”");
+        qm.sendAcceptDecline("不过#o0100134#的数量本来就不多，杀掉那么多恐怕不利生态平衡的保持，你消灭5只就差不多了。你看，这训练与自然环境之间是多么滴和谐啊！真是完美啊……");
     } else if (status == 2) {
         if (mode == 0 && type == 15) {
-            qm.sendNext("“哦，五只还不够吗？如果你觉得需要进一步训练，请随意多杀几只。如果你杀掉全部，我只能忍痛不看，因为他们是为了一个好的目的而被牺牲的……”");
+            qm.sendNext("哦，五只还不够吗？如果你觉得需要进一步训练，请随意多杀几只。如果你杀掉全部，我也只能忍痛装作看不见，毕竟它们是为了你而被牺牲的……");
             qm.dispose();
         } else {
             qm.forceStartQuest();
-            qm.sendNext("#o0100134#s 可以在岛屿的更深处找到。继续向左走，直到到达#b#m140010200##k，并击败#r5 #o0100134#s#k.");
+            qm.sendNext("#o0100134#在岛的较深处。村子左边的路一直走，就能看到#b#m140010200##k，请去那里消灭#r5只#o0100134#s#k。");
         }
     } else if (status == 3) {
         qm.showInfo("Effect/OnUserEff.img/guideEffect/aranTutorial/tutorialArrow1");

--- a/gms-server/scripts-zh-CN/quest/21703.js
+++ b/gms-server/scripts-zh-CN/quest/21703.js
@@ -48,27 +48,27 @@ function end(mode, type, selection) {
         status++;
     } else {
         if (status == 2) {
-            qm.sendNext("Are you reluctant to leave your instructor? *Sniff sniff* I'm so moved, but you can't stop here. You are destined for bigger and better things!");
+            qm.sendNext("你是不舍得离开我这个老头子吗？*抽泣* 我真的很感动，但你不能在这里停下脚步。你注定要成就更伟大的事业！");
             qm.dispose();
             return;
         }
         status--;
     }
     if (status == 0) {
-        qm.sendNext("Ah, you've come back after defeating all 30 #o9300343#s. I knew you had it in you... Even though you have no memories and few abilities, I could see that you were different! How? Because you're carrying around a Polearm, obviously!");
+        qm.sendNext("这么快就打倒了30只#o9300343#……我这老头子果然没有看错。虽然你失去了曾经的记忆，失去了曾经的能力，但你仍然是个英雄！只要手上的长矛还在！");
     } else if (status == 1) {
-        qm.sendNextPrev("#b(Is he pulling your leg?)#k'", 2);
+        qm.sendNextPrev("#b(这么说是为了安慰我吗？)#k", 2);
     } else if (status == 2) {
-        qm.sendYesNo("I have nothing more to teach you, as you've surpassed my level of skill. Go now! Don't look back! This old man is happy to have served as your instructor.");
+        qm.sendYesNo("我已经没什么可继续教你的了。你已经超越了我这个老头子。你可以下山了……唉，没什么好忧郁的。我这老头子能够有机会指导你，已经很满足了。");
     } else if (status == 3) {
         if (qm.isQuestStarted(21703)) {
             qm.forceCompleteQuest();
             qm.teachSkill(21000000, qm.getPlayer().getSkillLevel(21000000), 10, -1);   // Combo Ability Skill
             qm.gainExp(2800);
         }
-        qm.sendNext("(You remembered the #bCombo Ability#k skill! You were skeptical of the training at first, since the old man suffers from Alzheimer's and all, but boy, was it effective!)", 2);
+        qm.sendNext("(我想起了技能#b连击能力#k！ 我还想跟着有点痴呆的老头子训练有没有效果呢，没想到真的有效！)", 2);
     } else if (status == 4) {
-        qm.sendPrev("Now report back to #p1201000#. I know she'll be ecstatic when she sees the progress you've made!");
+        qm.sendPrev("现在你回去找#p1201000#吧。她看到你的进步会很高兴的！");
     } else if (status == 5) {
         qm.dispose();
     }

--- a/gms-server/scripts-zh-CN/quest/30000.js
+++ b/gms-server/scripts-zh-CN/quest/30000.js
@@ -97,7 +97,7 @@ function end(mode, type, selection)
 	    if (status == 0)
 	    {
 			//第一层对话
-            qm.sendOk("看来你已经见过小睡了，欢迎来到北斗，这是给你的启动资金，希望对您的冒险有所帮助\r\n\r\n#fUI/CashShop.img/CSDiscount/bonus# 金币: 1000000");
+            qm.sendOk("看来你已经见过小睡了，欢迎来到北斗，这是给你的启动资金，希望对您的冒险有所帮助\r\n\r\n#fUI/CashShop.img/CSDiscount/bonus# 金币: 100000");
             qm.gainMeso(100000);			
 			qm.forceCompleteQuest();
             qm.dispose();			

--- a/gms-server/scripts-zh-CN/reactor/1029000.js
+++ b/gms-server/scripts-zh-CN/reactor/1029000.js
@@ -2,6 +2,6 @@ function act() {
     if (rm.isAllReactorState(1029000, 0x04)) { // 0x04 appears to be the destroyed state
         rm.killMonster(3230300);
         rm.killMonster(3230301);
-        rm.playerMessage(6, "Once the rock crumbled, Jr. Boogie was in great pain and disappeared.");
+        rm.playerMessage(6, "幼魔精灵痛苦哀嚎，身形逐渐消散！");
     }    
 }

--- a/gms-server/scripts-zh-CN/reactor/2001016.js
+++ b/gms-server/scripts-zh-CN/reactor/2001016.js
@@ -28,5 +28,5 @@ function act() {
     rm.getMap().killAllMonsters();
     rm.getMap().allowSummonState(false);
     rm.spawnMonster(9300039, 260, 490);
-    rm.mapMessage(5, "As the air on the tower outskirts starts to become more dense, Papa Pixie appears.");
+    rm.mapMessage(5, "塔楼外围空气骤凝，远古精灵现身！");
 }

--- a/gms-server/scripts-zh-CN/reactor/2006000.js
+++ b/gms-server/scripts-zh-CN/reactor/2006000.js
@@ -26,6 +26,6 @@
   */
 
 function act() {
-    rm.mapMessage(5, "As the light flickers, someone appears out of the light.");
+    rm.mapMessage(5, "光影闪烁间，有人自光芒中现身！");
     rm.spawnNpc(2013001);
 }

--- a/gms-server/scripts-zh-CN/reactor/2110000.js
+++ b/gms-server/scripts-zh-CN/reactor/2110000.js
@@ -26,6 +26,6 @@
 */
 
 function act() {
-    rm.playerMessage(5, "An unknown force has moved you to the starting point.");
+    rm.playerMessage(5, "未知力量将你传送至起始点！");
     rm.warp(280010000, 0);
 }

--- a/gms-server/scripts-zh-CN/reactor/2111000.js
+++ b/gms-server/scripts-zh-CN/reactor/2111000.js
@@ -26,6 +26,6 @@
 */
 
 function act() {
-    rm.playerMessage(5, "Oh noes! Monsters in the chest!");
+    rm.playerMessage(5, "【危险警报】宝箱中潜伏着怪物！");
     rm.spawnMonster(9300004, 3);
 }

--- a/gms-server/scripts-zh-CN/reactor/2111001.js
+++ b/gms-server/scripts-zh-CN/reactor/2111001.js
@@ -30,5 +30,5 @@ function act() {
         rm.spawnMonster(i);
     }
     rm.createMapMonitor(280030000, "ps00");
-    rm.mapMessage(5, "Zakum is summoned by the force of Eye of Fire.");
+    rm.mapMessage(5, "【炎魔苏醒】火焰之眼的力量正在召唤扎昆！");
 }

--- a/gms-server/scripts-zh-CN/reactor/2200000.js
+++ b/gms-server/scripts-zh-CN/reactor/2200000.js
@@ -26,6 +26,6 @@
 */
 
 function act() {
-    rm.playerMessage(5, "Gotcha! Try again next time!");
+    rm.playerMessage(5, "差一点就成功了！下次再挑战吧！");
     rm.warp(221023200);
 }

--- a/gms-server/scripts-zh-CN/reactor/2200001.js
+++ b/gms-server/scripts-zh-CN/reactor/2200001.js
@@ -27,6 +27,6 @@
 */
 
 function act() {
-    rm.playerMessage(5, "You have found a secret factory!");
+    rm.playerMessage(5, "你已发现隐藏的机械工厂！");
     rm.warp(Math.random() < .5 ? 922000020 : 922000021, 0);
 }

--- a/gms-server/scripts-zh-CN/reactor/2200002.js
+++ b/gms-server/scripts-zh-CN/reactor/2200002.js
@@ -25,6 +25,6 @@
  */
 
 function act() {
-    rm.mapMessage(5, "An unknown force has warped you into a trap.");
+    rm.mapMessage(5, "未知力量将你卷入致命陷阱！");
     rm.warpMap(922010201);
 }

--- a/gms-server/scripts-zh-CN/reactor/2201002.js
+++ b/gms-server/scripts-zh-CN/reactor/2201002.js
@@ -25,6 +25,6 @@
  */
 
 function act() {
-    rm.mapMessage(5, "Rombard has been summoned somewhere in the map.");
+    rm.mapMessage(5, "战甲吹泡泡鱼正在地图某处苏醒...");
     rm.spawnMonster(9300010, 1, -211);
 }

--- a/gms-server/scripts-zh-CN/reactor/2201003.js
+++ b/gms-server/scripts-zh-CN/reactor/2201003.js
@@ -27,10 +27,10 @@
 
 function act() {
     if (rm.getPlayer().getMapId() == 922010900) {
-        rm.mapMessage(5, "Alishar has been summoned.");
+        rm.mapMessage(5, "黑暗术士阿利沙乐已被召唤至祭坛！");
         rm.spawnMonster(9300012, 941, 184);
     } else if (rm.getPlayer().getMapId() == 922010700) {
-        rm.mapMessage(5, "Rombard has been summoned somewhere in the map.");
+        rm.mapMessage(5, "战甲吹泡泡鱼正在地图某处苏醒...");
         rm.spawnMonster(9300010, 1, -211);
     }
 }

--- a/gms-server/scripts-zh-CN/reactor/2201004.js
+++ b/gms-server/scripts-zh-CN/reactor/2201004.js
@@ -20,7 +20,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 function act() {
-    rm.mapMessage(5, "The dimensional hole has been filled by the <Piece of Cracked Dimension>.");
+    rm.mapMessage(5, "次元裂隙已被<破碎的维度碎片>填补！");
     rm.changeMusic("Bgm09/TimeAttack");
     rm.spawnMonster(8500000, -410, -400);
     rm.createMapMonitor(220080001, "in00");

--- a/gms-server/scripts-zh-CN/reactor/2221000.js
+++ b/gms-server/scripts-zh-CN/reactor/2221000.js
@@ -28,5 +28,5 @@
 
 function act() {
     rm.spawnMonster(7130400);
-    rm.mapMessage(5, "Here comes Yellow King Goblin!");
+    rm.mapMessage(5, "黄色鬼怪破土而出！");
 }

--- a/gms-server/scripts-zh-CN/reactor/2221001.js
+++ b/gms-server/scripts-zh-CN/reactor/2221001.js
@@ -28,5 +28,5 @@
 
 function act() {
     rm.spawnMonster(7130401);
-    rm.mapMessage(5, "Here comes Blue King Goblin!");
+    rm.mapMessage(5, "蓝色鬼怪破土而出！");
 }

--- a/gms-server/scripts-zh-CN/reactor/2221002.js
+++ b/gms-server/scripts-zh-CN/reactor/2221002.js
@@ -28,5 +28,5 @@
 
 function act() {
     rm.spawnMonster(7130402, -340, 100);
-    rm.mapMessage(5, "Here comes Green King Goblin!");
+    rm.mapMessage(5, "绿色鬼怪破土而出！");
 }

--- a/gms-server/scripts-zh-CN/reactor/2401000.js
+++ b/gms-server/scripts-zh-CN/reactor/2401000.js
@@ -32,5 +32,5 @@ function act() {
         var eim = rm.getEventInstance();
         eim.restartEventTimer(60 * 60000);
     }
-    rm.mapMessage(6, "From the depths of his cave, here comes Horntail!");
+    rm.mapMessage(6, "洞穴深处传来震天咆哮，暗黑龙王破岩而出！")
 }

--- a/gms-server/scripts-zh-CN/reactor/2406000.js
+++ b/gms-server/scripts-zh-CN/reactor/2406000.js
@@ -5,7 +5,7 @@ Dragon nest
 function sendToHeaven() {
     rm.spawnNpc(2081008);
     rm.startQuest(100203);
-    rm.mapMessage(6, "In a flicker of light the egg has matured and cracked, thus born a radiant baby dragon.");
+    rm.mapMessage(6, "光芒闪烁间，龙蛋破壳而出，一只璀璨的幼龙降临世间！");
 }
 
 function touch() {

--- a/gms-server/scripts-zh-CN/reactor/2408002.js
+++ b/gms-server/scripts-zh-CN/reactor/2408002.js
@@ -34,7 +34,7 @@ function act() {
     var vvpOrig = 4001088;
     var vvpStage = -1;
     eim.showClearEffect(false, vvpMap);
-    rm.mapMessage(6, "The key has been teleported somewhere...");
+    rm.mapMessage(6, "神秘钥匙已被传送至未知领域...");
     switch (vvpMap) {
         case 240050101 : {
             vvpKey = vvpOrig;
@@ -69,7 +69,7 @@ function act() {
     var theWomanfred = womanfred.getReactorByName("keyDrop1");
     var dropper = eim.getPlayers().get(0);
     womanfred.spawnItemDrop(theWomanfred, dropper, tehWomanfred, theWomanfred.getPosition(), true, true);
-    eim.getMapInstance(240050100).dropMessage(6, "A bright flash of light, then a key suddenly appears somewhere in the map.");
+    eim.getMapInstance(240050100).dropMessage(6, "强光闪过，一把神秘钥匙随机出现在地图某处！");
 }
 	
 	

--- a/gms-server/scripts-zh-CN/reactor/2408003.js
+++ b/gms-server/scripts-zh-CN/reactor/2408003.js
@@ -33,7 +33,7 @@ function touch() {
         rm.getPlayer().getEventInstance().setProperty("canEnter", "false");
     }
     rm.spawnFakeMonster(8800000);
-    rm.mapMessage(6, "A gigantic creature is approaching from the deep cave.");
+    rm.mapMessage(6, "深渊洞穴中，庞然巨物正逼近而来！");
     //rm.createMapMonitor(rm.getPlayer().getMap().getId(),"ps00");
     switch (rm.getPlayer().getMap().getId()) {
         case 240060000:

--- a/gms-server/scripts-zh-CN/reactor/2516000.js
+++ b/gms-server/scripts-zh-CN/reactor/2516000.js
@@ -25,6 +25,6 @@
  */
 
 function act() {
-    rm.mapMessage(5, "As Lord Pirate dies, Wu Yang is released!");
+    rm.mapMessage(5, "海盗领主已被击杀，无恙被释放了");
     rm.spawnNpc(2094001);
 }

--- a/gms-server/scripts-zh-CN/reactor/3001000.js
+++ b/gms-server/scripts-zh-CN/reactor/3001000.js
@@ -1,4 +1,4 @@
 function act() {
-    rm.playerMessage(5, "Poison Golem has been spawned.");
+    rm.playerMessage(5, "毒液石头人已苏醒！");
     rm.spawnMonster(9300180, 1);
 }

--- a/gms-server/scripts-zh-CN/reactor/5411000.js
+++ b/gms-server/scripts-zh-CN/reactor/5411000.js
@@ -23,5 +23,5 @@ function act() {
     rm.changeMusic("Bgm09/TimeAttack");
     rm.spawnMonster(9420513, -146, 225);
     rm.getEventInstance().setIntProperty("boss", 1);
-    rm.mapMessage(5, "As you wish, here comes Capt Latanica.");
+    rm.mapMessage(5, "如您所愿，幽灵船长即将登场！");
 }

--- a/gms-server/scripts-zh-CN/reactor/6109000.js
+++ b/gms-server/scripts-zh-CN/reactor/6109000.js
@@ -4,20 +4,20 @@ function act() {
         var mapId = rm.getMap().getId();
 
         if (mapId == 610030200) {
-            eim.dropMessage(6, "The Warrior Sigil has been activated!");
+            eim.dropMessage(6, "战士印记已激活！");
             eim.setIntProperty("glpq2", eim.getIntProperty("glpq2") + 1);
             if (eim.getIntProperty("glpq2") == 5) { //all 5 done
-                eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
                 eim.showClearEffect(mapId, "2pt", 2);
                 eim.giveEventPlayersStageReward(2);
             }
         } else if (mapId == 610030300) {
-            eim.dropMessage(6, "The Warrior Sigil has been activated! You hear gears turning! The Menhir Defense System is active! Run!");
+            eim.dropMessage(6, "战士印记已激活！ 机关运转声响起！巨石防御系统启动！快逃！");
             eim.setIntProperty("glpq3", eim.getIntProperty("glpq3") + 1);
             rm.getMap().moveEnvironment("menhir0", 1);
             if (eim.getIntProperty("glpq3") == 5 && eim.getIntProperty("glpq3_p") == 5) {
-                eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
                 eim.showClearEffect(mapId, "3pt", 2);
                 eim.giveEventPlayersStageReward(3);

--- a/gms-server/scripts-zh-CN/reactor/6109001.js
+++ b/gms-server/scripts-zh-CN/reactor/6109001.js
@@ -4,21 +4,21 @@ function act() {
         var mapId = rm.getMap().getId();
 
         if (mapId == 610030200) {
-            eim.dropMessage(6, "The Archer Sigil has been activated!");
+            eim.dropMessage(6, "射手印记已激活！");
             eim.setIntProperty("glpq2", eim.getIntProperty("glpq2") + 1);
             if (eim.getIntProperty("glpq2") == 5) { //all 5 done
-                eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
                 eim.showClearEffect(mapId, "2pt", 2);
                 eim.giveEventPlayersStageReward(2);
             }
         } else if (mapId == 610030300) {
-            eim.dropMessage(6, "The Archer Sigil has been activated! You hear gears turning! The Menhir Defense System is active! Run!");
+            eim.dropMessage(6, "射手印记已激活！ 机关运转声响起！巨石防御系统启动！快逃！");
             eim.setIntProperty("glpq3", eim.getIntProperty("glpq3") + 1);
             rm.getMap().moveEnvironment("menhir1", 1);
             rm.getMap().moveEnvironment("menhir2", 1);
             if (eim.getIntProperty("glpq3") == 5 && eim.getIntProperty("glpq3_p") == 5) {
-                eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
                 eim.showClearEffect(mapId, "3pt", 2);
                 eim.giveEventPlayersStageReward(3);

--- a/gms-server/scripts-zh-CN/reactor/6109002.js
+++ b/gms-server/scripts-zh-CN/reactor/6109002.js
@@ -4,20 +4,20 @@ function act() {
         var mapId = rm.getMap().getId();
 
         if (mapId == 610030200) {
-            eim.dropMessage(6, "The Mage Sigil has been activated!");
+            eim.dropMessage(6, "魔法师印记已激活！");
             eim.setIntProperty("glpq2", eim.getIntProperty("glpq2") + 1);
             if (eim.getIntProperty("glpq2") == 5) { //all 5 done
-                eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
                 eim.showClearEffect(mapId, "2pt", 2);
                 eim.giveEventPlayersStageReward(2);
             }
         } else if (mapId == 610030300) {
-            eim.dropMessage(6, "The Mage Sigil has been activated! You hear gears turning! The Menhir Defense System is active! Run!");
+            eim.dropMessage(6, "魔法师印记已激活！ 机关运转声响起！巨石防御系统启动！快逃！");
             eim.setIntProperty("glpq3", eim.getIntProperty("glpq3") + 1);
             rm.getMap().moveEnvironment("menhir3", 1);
             if (eim.getIntProperty("glpq3") == 5 && eim.getIntProperty("glpq3_p") == 5) {
-                eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
                 eim.showClearEffect(mapId, "3pt", 2);
                 eim.giveEventPlayersStageReward(3);

--- a/gms-server/scripts-zh-CN/reactor/6109003.js
+++ b/gms-server/scripts-zh-CN/reactor/6109003.js
@@ -4,20 +4,20 @@ function act() {
         var mapId = rm.getMap().getId();
 
         if (mapId == 610030200) {
-            eim.dropMessage(6, "The Thief Sigil has been activated!");
+            eim.dropMessage(6, "盗贼印记已激活！");
             eim.setIntProperty("glpq2", eim.getIntProperty("glpq2") + 1);
             if (eim.getIntProperty("glpq2") == 5) { //all 5 done
-                eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
                 eim.showClearEffect(mapId, "2pt", 2);
                 eim.giveEventPlayersStageReward(2);
             }
         } else if (mapId == 610030300) {
-            eim.dropMessage(6, "The Thief Sigil has been activated! You hear gears turning! The Menhir Defense System is active! Run!");
+            eim.dropMessage(6, "盗贼印记已激活！ 机关运转声响起！巨石防御系统启动！快逃！");
             eim.setIntProperty("glpq3", eim.getIntProperty("glpq3") + 1);
             rm.getMap().moveEnvironment("menhir4", 1);
             if (eim.getIntProperty("glpq3") == 5 && eim.getIntProperty("glpq3_p") == 5) {
-                rm.mapMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                rm.mapMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
                 eim.showClearEffect(mapId, "3pt", 2);
                 eim.giveEventPlayersStageReward(3);

--- a/gms-server/scripts-zh-CN/reactor/6109004.js
+++ b/gms-server/scripts-zh-CN/reactor/6109004.js
@@ -4,20 +4,20 @@ function act() {
         var mapId = rm.getMap().getId();
 
         if (mapId == 610030200) {
-            eim.dropMessage(6, "The Pirate Sigil has been activated!");
+            eim.dropMessage(6, "海盗印记已激活！");
             eim.setIntProperty("glpq2", eim.getIntProperty("glpq2") + 1);
             if (eim.getIntProperty("glpq2") == 5) { //all 5 done
-                eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
                 eim.showClearEffect(mapId, "2pt", 2);
                 eim.giveEventPlayersStageReward(2);
             }
         } else if (mapId == 610030300) {
-            eim.dropMessage(6, "The Pirate Sigil has been activated! You hear gears turning! The Menhir Defense System is active! Run!");
+            eim.dropMessage(6, "海盗印记已激活！ 机关运转声响起！巨石防御系统启动！快逃！");
             eim.setIntProperty("glpq3", eim.getIntProperty("glpq3") + 1);
             rm.getMap().moveEnvironment("menhir5", 1);
             if (eim.getIntProperty("glpq3") == 5 && eim.getIntProperty("glpq3_p") == 5) {
-                eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+                eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
                 eim.showClearEffect(mapId, "3pt", 2);
                 eim.giveEventPlayersStageReward(3);

--- a/gms-server/scripts-zh-CN/reactor/6109005.js
+++ b/gms-server/scripts-zh-CN/reactor/6109005.js
@@ -1,10 +1,10 @@
 function act() {
     var eim = rm.getEventInstance();
     if (eim != null) {
-        eim.dropMessage(6, "A weapon has been restored to the Relic of Mastery!");
+        eim.dropMessage(6, "一件武器已归还至宗师圣器！");
         eim.setIntProperty("glpq5", eim.getIntProperty("glpq5") + 1);
         if (eim.getIntProperty("glpq5") == 5) { //all 5 done
-            eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+            eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
             eim.showClearEffect(610030500, "5pt", 2);
             eim.giveEventPlayersStageReward(5);

--- a/gms-server/scripts-zh-CN/reactor/6109006.js
+++ b/gms-server/scripts-zh-CN/reactor/6109006.js
@@ -1,10 +1,10 @@
 function act() {
     var eim = rm.getEventInstance();
     if (eim != null) {
-        eim.dropMessage(6, "A weapon has been restored to the Relic of Mastery!");
+        eim.dropMessage(6, "一件武器已归还至宗师圣器！");
         eim.setIntProperty("glpq5", eim.getIntProperty("glpq5") + 1);
         if (eim.getIntProperty("glpq5") == 5) { //all 5 done
-            eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+            eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
             eim.showClearEffect(610030500, "5pt", 2);
             eim.giveEventPlayersStageReward(5);

--- a/gms-server/scripts-zh-CN/reactor/6109007.js
+++ b/gms-server/scripts-zh-CN/reactor/6109007.js
@@ -1,10 +1,10 @@
 function act() {
     var eim = rm.getEventInstance();
     if (eim != null) {
-        eim.dropMessage(6, "A weapon has been restored to the Relic of Mastery!");
+        eim.dropMessage(6, "一件武器已归还至宗师圣器！");
         eim.setIntProperty("glpq5", eim.getIntProperty("glpq5") + 1);
         if (eim.getIntProperty("glpq5") == 5) { //all 5 done
-            eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+            eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
             eim.showClearEffect(610030500, "5pt", 2);
             eim.giveEventPlayersStageReward(5);

--- a/gms-server/scripts-zh-CN/reactor/6109008.js
+++ b/gms-server/scripts-zh-CN/reactor/6109008.js
@@ -1,10 +1,10 @@
 function act() {
     var eim = rm.getEventInstance();
     if (eim != null) {
-        eim.dropMessage(6, "A weapon has been restored to the Relic of Mastery!");
+        eim.dropMessage(6, "一件武器已归还至宗师圣器！");
         eim.setIntProperty("glpq5", eim.getIntProperty("glpq5") + 1);
         if (eim.getIntProperty("glpq5") == 5) { //all 5 done
-            eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+            eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
             eim.showClearEffect(610030500, "5pt", 2);
             eim.giveEventPlayersStageReward(5);

--- a/gms-server/scripts-zh-CN/reactor/6109009.js
+++ b/gms-server/scripts-zh-CN/reactor/6109009.js
@@ -1,10 +1,10 @@
 function act() {
     var eim = rm.getEventInstance();
     if (eim != null) {
-        eim.dropMessage(6, "A weapon has been restored to the Relic of Mastery!");
+        eim.dropMessage(6, "一件武器已归还至宗师圣器！");
         eim.setIntProperty("glpq5", eim.getIntProperty("glpq5") + 1);
         if (eim.getIntProperty("glpq5") == 5) { //all 5 done
-            eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+            eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
             eim.showClearEffect(610030500, "5pt", 2);
             eim.giveEventPlayersStageReward(5);

--- a/gms-server/scripts-zh-CN/reactor/6109013.js
+++ b/gms-server/scripts-zh-CN/reactor/6109013.js
@@ -1,7 +1,7 @@
 var fid = "glpq_s";
 
 function action() {
-    rm.mapMessage(6, "All stirges have disappeared.");
+    rm.mapMessage(6, "所有吸血蝙蝠已消失！");
     rm.getMap().killAllMonsters(true);
     eim.setIntProperty(fid, 777);
 }

--- a/gms-server/scripts-zh-CN/reactor/6109016.js
+++ b/gms-server/scripts-zh-CN/reactor/6109016.js
@@ -1,10 +1,10 @@
 function act() {
     var eim = rm.getEventInstance();
     if (eim != null) {
-        eim.dropMessage(6, "The Warrior Sigil has been activated!");
+        eim.dropMessage(6, "战士印记已激活！");
         eim.setIntProperty("glpq4", eim.getIntProperty("glpq4") + 1);
         if (eim.getIntProperty("glpq4") == 5) { //all 5 done
-            eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+            eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
             eim.showClearEffect(610030400, "4pt", 2);
             eim.giveEventPlayersStageReward(4);

--- a/gms-server/scripts-zh-CN/reactor/6109017.js
+++ b/gms-server/scripts-zh-CN/reactor/6109017.js
@@ -1,10 +1,10 @@
 function act() {
     var eim = rm.getEventInstance();
     if (eim != null) {
-        eim.dropMessage(6, "The Archer Sigil has been activated!");
+        eim.dropMessage(6, "游侠印记已激活！");
         eim.setIntProperty("glpq4", eim.getIntProperty("glpq4") + 1);
         if (eim.getIntProperty("glpq4") == 5) { //all 5 done
-            eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+            eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
             eim.showClearEffect(610030400, "4pt", 2);
             eim.giveEventPlayersStageReward(4);

--- a/gms-server/scripts-zh-CN/reactor/6109018.js
+++ b/gms-server/scripts-zh-CN/reactor/6109018.js
@@ -1,10 +1,10 @@
 function act() {
     var eim = rm.getEventInstance();
     if (eim != null) {
-        eim.dropMessage(6, "The Mage Sigil has been activated!");
+        eim.dropMessage(6, "魔法师印记已激活！");
         eim.setIntProperty("glpq4", eim.getIntProperty("glpq4") + 1);
         if (eim.getIntProperty("glpq4") == 5) { //all 5 done
-            eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+            eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
             eim.showClearEffect(610030400, "4pt", 2);
             eim.giveEventPlayersStageReward(4);

--- a/gms-server/scripts-zh-CN/reactor/6109019.js
+++ b/gms-server/scripts-zh-CN/reactor/6109019.js
@@ -1,10 +1,10 @@
 function act() {
     var eim = rm.getEventInstance();
     if (eim != null) {
-        eim.dropMessage(6, "The Thief Sigil has been activated!");
+        eim.dropMessage(6, "盗贼印记已激活！");
         eim.setIntProperty("glpq4", eim.getIntProperty("glpq4") + 1);
         if (eim.getIntProperty("glpq4") == 5) { //all 5 done
-            eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+            eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
             eim.showClearEffect(610030400, "4pt", 2);
             eim.giveEventPlayersStageReward(4);

--- a/gms-server/scripts-zh-CN/reactor/6109020.js
+++ b/gms-server/scripts-zh-CN/reactor/6109020.js
@@ -1,10 +1,10 @@
 function act() {
     var eim = rm.getEventInstance();
     if (eim != null) {
-        eim.dropMessage(6, "The Pirate Sigil has been activated!");
+        eim.dropMessage(6, "海盗印记已被激活！");
         eim.setIntProperty("glpq4", eim.getIntProperty("glpq4") + 1);
-        if (eim.getIntProperty("glpq4") == 5) { //all 5 done
-            eim.dropMessage(6, "The Antellion grants you access to the next portal! Proceed!");
+        if (eim.getIntProperty("glpq4") == 5) { //5个全部完成
+            eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
 
             eim.showClearEffect(610030400, "4pt", 2);
             eim.giveEventPlayersStageReward(4);

--- a/gms-server/scripts-zh-CN/reactor/6829000.js
+++ b/gms-server/scripts-zh-CN/reactor/6829000.js
@@ -20,6 +20,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 function act() { //wtf is this?
-    rm.playerMessage(5, "Enjoy Halloween!");
+    rm.playerMessage(5, "万圣狂欢夜！");
     rm.spawnMonster(9400202, 10);
 }

--- a/gms-server/scripts-zh-CN/reactor/8091000.js
+++ b/gms-server/scripts-zh-CN/reactor/8091000.js
@@ -28,5 +28,5 @@
 function act() {
     rm.spawnMonster(9400210, 2);
     rm.spawnMonster(9400209, 2);
-    rm.mapMessage(5, "Some monsters are summoned.");
+    rm.mapMessage(5, "魔物已被召唤");
 }

--- a/gms-server/scripts-zh-CN/reactor/8091001.js
+++ b/gms-server/scripts-zh-CN/reactor/8091001.js
@@ -28,5 +28,5 @@
 function act() {
     rm.spawnMonster(9400211, 2);
     rm.spawnMonster(9400212, 2);
-    rm.mapMessage(5, "Some monsters are summoned.");
+    rm.mapMessage(5, "魔物已被召唤");
 }

--- a/gms-server/scripts-zh-CN/reactor/8091002.js
+++ b/gms-server/scripts-zh-CN/reactor/8091002.js
@@ -28,5 +28,5 @@
 function act() {
     rm.spawnMonster(9400213, 2);
     rm.spawnMonster(9400214, 2);
-    rm.mapMessage(5, "Some monsters are summoned.");
+    rm.mapMessage(5, "魔物已被召唤");
 }

--- a/gms-server/scripts-zh-CN/reactor/8091003.js
+++ b/gms-server/scripts-zh-CN/reactor/8091003.js
@@ -28,5 +28,5 @@
 function act() {
     rm.spawnMonster(9400215, 2);
     rm.spawnMonster(9400216, 2);
-    rm.mapMessage(5, "Some monsters are summoned.");
+    rm.mapMessage(5, "魔物已被召唤");
 }

--- a/gms-server/scripts-zh-CN/reactor/8091004.js
+++ b/gms-server/scripts-zh-CN/reactor/8091004.js
@@ -28,5 +28,5 @@
 function act() {
     rm.spawnMonster(9400217, 2);
     rm.spawnMonster(9400218, 2);
-    rm.mapMessage(5, "Some monsters are summoned.");
+    rm.mapMessage(5, "魔物已被召唤");
 }

--- a/gms-server/scripts-zh-CN/reactor/8098000.js
+++ b/gms-server/scripts-zh-CN/reactor/8098000.js
@@ -34,5 +34,5 @@ function act() {
         rm.spawnMonster(9400209, 6);
         rm.spawnMonster(9400210, 9);
     }
-    rm.mapMessage(5, "Some monsters are summoned.");
+    rm.mapMessage(5, "魔物已被召唤");
 }

--- a/gms-server/scripts-zh-CN/reactor/9108000.js
+++ b/gms-server/scripts-zh-CN/reactor/9108000.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "守护月妙！！！");
+            rm.mapMessage(6, "月妙开始制作美味的年糕，其香味会吸引各种怪物，请务必守护好月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108000.js
+++ b/gms-server/scripts-zh-CN/reactor/9108000.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "Protect the Moon Bunny!!!");
+            rm.mapMessage(6, "守护月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108001.js
+++ b/gms-server/scripts-zh-CN/reactor/9108001.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "守护月妙！！！");
+            rm.mapMessage(6, "月妙开始制作美味的年糕，其香味会吸引各种怪物，请务必守护好月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108001.js
+++ b/gms-server/scripts-zh-CN/reactor/9108001.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "Protect the Moon Bunny!!!");
+            rm.mapMessage(6, "守护月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108002.js
+++ b/gms-server/scripts-zh-CN/reactor/9108002.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "守护月妙！！！");
+            rm.mapMessage(6, "月妙开始制作美味的年糕，其香味会吸引各种怪物，请务必守护好月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108002.js
+++ b/gms-server/scripts-zh-CN/reactor/9108002.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "Protect the Moon Bunny!!!");
+            rm.mapMessage(6, "守护月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108003.js
+++ b/gms-server/scripts-zh-CN/reactor/9108003.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "守护月妙！！！");
+            rm.mapMessage(6, "月妙开始制作美味的年糕，其香味会吸引各种怪物，请务必守护好月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108003.js
+++ b/gms-server/scripts-zh-CN/reactor/9108003.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "Protect the Moon Bunny!!!");
+            rm.mapMessage(6, "守护月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108004.js
+++ b/gms-server/scripts-zh-CN/reactor/9108004.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "守护月妙！！！");
+            rm.mapMessage(6, "月妙开始制作美味的年糕，其香味会吸引各种怪物，请务必守护好月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108004.js
+++ b/gms-server/scripts-zh-CN/reactor/9108004.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "Protect the Moon Bunny!!!");
+            rm.mapMessage(6, "守护月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108005.js
+++ b/gms-server/scripts-zh-CN/reactor/9108005.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "守护月妙！！！");
+            rm.mapMessage(6, "月妙开始制作美味的年糕，其香味会吸引各种怪物，请务必守护好月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9108005.js
+++ b/gms-server/scripts-zh-CN/reactor/9108005.js
@@ -7,7 +7,7 @@ function act() {
         eim.setProperty("stage", newStage);
         react.forceHitReactor(react.getState() + 1);
         if (eim.getProperty("stage") === "6") {
-            rm.mapMessage(6, "Protect the Moon Bunny!!!");
+            rm.mapMessage(6, "守护月妙！！！");
             var map = eim.getMapInstance(rm.getReactor().getMap().getId());
             map.allowSummonState(true);
             map.spawnMonsterOnGroundBelow(9300061, -183, -433);

--- a/gms-server/scripts-zh-CN/reactor/9201001.js
+++ b/gms-server/scripts-zh-CN/reactor/9201001.js
@@ -28,6 +28,6 @@
  */
 
 function act() {
-    rm.mapMessage(5, "A bright flash of light, then someone familiar appears in front of the blocked gate.");
+    rm.mapMessage(5, "强光闪过，熟悉的身影出现在紧闭的门前");
     rm.spawnNpc(9040003);
 }

--- a/gms-server/scripts-zh-CN/reactor/9208000.js
+++ b/gms-server/scripts-zh-CN/reactor/9208000.js
@@ -48,7 +48,7 @@ function act() {
                     eim.setProperty("stage1combo", prevCombo);
                     if (prevCombo.length == (3 * (stage + 3))) { //end of displaying
                         eim.setProperty("stage1status", "active");
-                        rm.mapMessage(5, "The combo has been displayed; Proceed with caution.");
+                        rm.mapMessage(5, "连击效果已触发，请小心前进。");
                         eim.setProperty("stage1guess", "");
                     }
                 }

--- a/gms-server/scripts-zh-CN/reactor/9208001.js
+++ b/gms-server/scripts-zh-CN/reactor/9208001.js
@@ -51,7 +51,7 @@ function act() {
                     eim.setProperty("stage1combo", prevCombo);
                     if (prevCombo.length == (3 * (stage + 3))) { //end of displaying
                         eim.setProperty("stage1status", "active");
-                        rm.mapMessage(5, "The combo has been displayed; Proceed with caution.");
+                        rm.mapMessage(5, "连击效果已触发，请小心前进。");
                         eim.setProperty("stage1guess", "");
                     }
                 }

--- a/gms-server/scripts-zh-CN/reactor/9208002.js
+++ b/gms-server/scripts-zh-CN/reactor/9208002.js
@@ -47,7 +47,7 @@ function act() {
                     eim.setProperty("stage1combo", prevCombo);
                     if (prevCombo.length == (3 * (stage + 3))) { //end of displaying
                         eim.setProperty("stage1status", "active");
-                        rm.mapMessage(5, "The combo has been displayed; Proceed with caution.");
+                        rm.mapMessage(5, "连击效果已触发，请小心前进。");
                         eim.setProperty("stage1guess", "");
                     }
                 }

--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -1971,8 +1971,8 @@ public class Character extends AbstractCharacterObject {
 
                                 this.getMap().pickItemDrop(pickupPacket, mapitem);
                             } else if (ItemId.isNxCard(mapitem.getItemId())) {
-                                // Add NX to account, show effect and make item disappear
-                                int nxGain = mapitem.getItemId() == ItemId.NX_CARD_100 ? 100 : 250;
+                                // Add NX to account, show effect and make item disappear   //添加点券到账户，是否展示捡到点券，并移除物品
+                                int nxGain = (mapitem.getItemId() == ItemId.NX_CARD_100 ? 100 : 250) * mItem.getQuantity(); //使点券支持按数量相乘
                                 this.getCashShop().gainCash(CashShop.NX_CREDIT, nxGain);
 
                                 if (GameConfig.getServerBoolean("use_announce_nx_coupon_loot")) {       //捡到点券是否展示
@@ -2025,14 +2025,14 @@ public class Character extends AbstractCharacterObject {
                         }
                     } else if (ItemId.isNxCard(mapitem.getItemId())) {
                         // Add NX to account, show effect and make item disappear
-                        int nxGain = mapitem.getItemId() == ItemId.NX_CARD_100 ? 100 : 250;
+                        int nxGain = (mapitem.getItemId() == ItemId.NX_CARD_100 ? 100 : 250) * mItem.getQuantity(); //使点券支持按数量相乘
                         this.getCashShop().gainCash(CashShop.NX_CREDIT, nxGain);
 
                         if (GameConfig.getServerBoolean("use_announce_nx_coupon_loot")) {       //捡到点券是否展示
                             showHint(I18nUtil.getMessage("Character.pickupItem.message1", nxGain, this.getCashShop().getCash(CashShop.NX_CREDIT)), 300);
                             //showHint("捡到 #e#b" + nxGain + " NX#k#n (" + this.getCashShop().getCash(CashShop.NX_CREDIT) + " NX)", 300);
                         }
-                    } else if (applyConsumeOnPickup(mItem.getItemId())) {
+                    //} else if (applyConsumeOnPickup(mItem.getItemId())) {//这个不知道干嘛的，空的判断，注释掉。
                     } else if (InventoryManipulator.addFromDrop(client, mItem, true)) {
                         if (mItem.getItemId() == ItemId.ARPQ_SPIRIT_JEWEL) {
                             updateAriantScore();

--- a/gms-server/src/main/java/org/gms/client/command/commands/gm5/DebugCommand.java
+++ b/gms-server/src/main/java/org/gms/client/command/commands/gm5/DebugCommand.java
@@ -26,8 +26,10 @@ package org.gms.client.command.commands.gm5;
 import org.gms.client.Character;
 import org.gms.client.Client;
 import org.gms.client.command.Command;
+import org.gms.client.inventory.Item;
 import org.gms.constants.id.NpcId;
 import org.gms.net.server.Server;
+import org.gms.server.ItemInformationProvider;
 import org.gms.server.TimerManager;
 import org.gms.server.life.Monster;
 import org.gms.server.life.SpawnPoint;
@@ -43,6 +45,7 @@ import java.util.List;
 
 public class DebugCommand extends Command {
     private final static String[] debugTypes = {"monster", "packet", "portal", "spawnpoint", "pos", "map", "mobsp", "event", "areas", "reactors", "servercoupons", "playercoupons", "timer", "marriage", "buff", ""};
+    private final static ItemInformationProvider ii = ItemInformationProvider.getInstance();
 
     {
         setDescription(I18nUtil.getMessage("DebugCommand.message1"));
@@ -73,7 +76,7 @@ public class DebugCommand extends Command {
                 for (MapObject monstermo : monsters) {
                     Monster monster = (Monster) monstermo;
                     Character controller = monster.getController();
-                    player.message(I18nUtil.getMessage("DebugCommand.message4", monster.getId(), controller != null ? I18nUtil.getMessage("DebugCommand.message5", controller.getName(), monster.isControllerHasAggro(), monster.isControllerKnowsAboutAggro()) : "<none>"));
+                    player.message(I18nUtil.getMessage("DebugCommand.message4",monster.getName(), monster.getId(), controller != null ? I18nUtil.getMessage("DebugCommand.message5", controller.getName(), monster.isControllerHasAggro(), monster.isControllerKnowsAboutAggro()) : "<none>"));
                 }
                 break;
 
@@ -100,7 +103,7 @@ public class DebugCommand extends Command {
                 break;
 
             case "pos":
-                player.dropMessage(6, I18nUtil.getMessage("DebugCommand.message10", player.getPosition().getX(), player.getPosition().getY()));
+                player.dropMessage(6, I18nUtil.getMessage("DebugCommand.message10", (int) player.getPosition().getX(), (int) player.getPosition().getY()));
                 break;
 
             case "map":
@@ -141,20 +144,20 @@ public class DebugCommand extends Command {
             case "servercoupons":
             case "coupons":
                 String s = I18nUtil.getMessage("DebugCommand.message18");
-                for (Integer i : Server.getInstance().getActiveCoupons()) {
-                    s += (i + " ");
-                }
-
                 player.dropMessage(6, s);
+                for (Integer i : Server.getInstance().getActiveCoupons()) {
+                    s = ii.getName(i) + "  (" + i + ");";
+                    player.dropMessage(6, s);
+                }
                 break;
 
             case "playercoupons":
-                String st = I18nUtil.getMessage("DebugCommand.message19");
+                s = I18nUtil.getMessage("DebugCommand.message19");
+                player.dropMessage(6, s);
                 for (Integer i : player.getActiveCoupons()) {
-                    st += (i + " ");
+                    s = ii.getName(i) + "  (" + i + ");";
+                    player.dropMessage(6, s);
                 }
-
-                player.dropMessage(6, st);
                 break;
 
             case "timer":
@@ -169,6 +172,8 @@ public class DebugCommand extends Command {
             case "buff":
                 c.getPlayer().debugListAllBuffs();
                 break;
+            default:
+                player.dropMessage(5, I18nUtil.getMessage("DebugCommand.message21"));
         }
     }
 }

--- a/gms-server/src/main/java/org/gms/client/processor/stat/AssignAPProcessor.java
+++ b/gms-server/src/main/java/org/gms/client/processor/stat/AssignAPProcessor.java
@@ -44,434 +44,489 @@ import org.gms.net.packet.InPacket;
 import org.gms.util.PacketCreator;
 import org.gms.util.Randomizer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
- * @author RonanLana - synchronization of AP transaction modules
+ * 处理角色属性点(AP)分配的核心处理器
+ * 主要功能：
+ * 1. AP自动分配 - 根据职业智能分配剩余AP
+ * 2. AP手动分配 - 玩家手动选择分配属性
+ * 3. AP重置 - 允许玩家重新分配属性点
+ * 实现了不同职业的AP分配策略，包括：
+ * - 战士(Warrior)、魔法师(Magician)、弓箭手(Bowman)
+ * - 飞侠(Thief)、海盗(Pirate)等
+ * 同时处理HP/MP的AP分配和重置逻辑
  */
 public class AssignAPProcessor {
 
+    // 配置参数全局变量，减少重复读取
+    /** 使用HeavenMS的属性点自动分配器 */
+    private static boolean useServerAutoAssigner;
+    /** 自动分配属性点到主属性，除非主属性已经达到职业设定最大，才会分配到次属性 */
+    private static boolean useAutoAssignSecondaryCap;
+    /** 强制洗血蓝的点数只能加到血蓝，不能分配到其他属性 */
+    private static boolean useEnforceHpmpSwap;
+    /** 启用HeavenMS的血蓝更新机制，升级、分配属性、转职等按照比例更新血量和蓝量 */
+    private static boolean useFixedRatioHpmpUpdate;
+    /** 获取HP和MP是否随机化，有职业系数加成 */
+    private static boolean useRandomizeHpmpGain;
+    /** 属性点最大值 */
+    private static int maxAp;
+
+    // 重新加载配置方法
+    public static void reloadConfig() {
+        useServerAutoAssigner = GameConfig.getServerBoolean("use_server_auto_assigner");
+        useAutoAssignSecondaryCap = GameConfig.getServerBoolean("use_auto_assign_secondary_cap");
+        useEnforceHpmpSwap = GameConfig.getServerBoolean("use_enforce_hpmp_swap");
+        useFixedRatioHpmpUpdate = GameConfig.getServerBoolean("use_fixed_ratio_hpmp_update");
+        useRandomizeHpmpGain = GameConfig.getServerBoolean("use_randomize_hpmp_gain");
+        maxAp = GameConfig.getServerInt("max_ap");
+    }
+
+    /**
+     * 自动分配角色的剩余AP点
+     * 处理流程：
+     * 1. 检查是否有剩余AP可分配
+     * 2. 锁定客户端防止并发操作
+     * 3. 根据职业类型采用不同的分配策略：
+     *    - 魔法师：主INT副LUK
+     *    - 弓箭手：主DEX副STR
+     *    - 飞侠：主LUK副DEX
+     *    - 战士：主STR副DEX
+     * 4. 考虑装备属性需求优化分配
+     * 5. 应用分配结果并更新角色状态
+     * 6. 解锁客户端
+     *
+     * @param inPacket 客户端输入数据包
+     * @param c 客户端连接对象
+     */
     public static void APAutoAssignAction(InPacket inPacket, Client c) {
-        Character chr = c.getPlayer();
-        if (chr.getRemainingAp() < 1) {
-            return;
+        reloadConfig(); // 重新加载配置
+        Character chr = c.getPlayer(); // 获取当前玩家角色对象
+        if (chr.getRemainingAp() < 1) { // 检查玩家剩余AP是否小于1
+            return; // 如果不足1点AP则直接返回
         }
 
-        Collection<Item> equippedC = chr.getInventory(InventoryType.EQUIPPED).list();
+        Collection<Item> equippedC = chr.getInventory(InventoryType.EQUIPPED).list(); // 获取玩家当前装备的物品列表
 
-        c.lockClient();
+        c.lockClient(); // 锁定客户端，防止并发操作
         try {
-            int[] statGain = new int[4];
-            int[] statUpdate = new int[4];
-            statGain[0] = 0;
-            statGain[1] = 0;
-            statGain[2] = 0;
-            statGain[3] = 0;
+            int[] statGain = new int[4]; // 创建属性增益数组，用于存储STR/DEX/LUK/INT的增益值
+            int[] statUpdate = new int[4]; // 创建属性更新数组，用于存储更新后的属性值
+            statGain[0] = 0; // 初始化力量(STR)增益为0
+            statGain[1] = 0; // 初始化敏捷(DEX)增益为0
+            statGain[2] = 0; // 初始化运气(LUK)增益为0
+            statGain[3] = 0; // 初始化智力(INT)增益为0
 
-            int remainingAp = chr.getRemainingAp();
-            inPacket.skip(8);
+            int remainingAp = chr.getRemainingAp(); // 获取玩家剩余的AP点数
+            inPacket.skip(8); // 跳过数据包的前8个字节
 
-            if (GameConfig.getServerBoolean("use_server_auto_assigner")) {
+            if (useServerAutoAssigner) { // 检查是否使用服务器自动分配器
                 // --------- Ronan Lana's AUTOASSIGNER ---------
-                // This method excels for assigning APs in such a way to cover all equipments AP requirements.
-                byte opt = inPacket.readByte();     // useful for pirate autoassigning
+                // 这个方法的优势在于能够智能分配AP点数以满足所有装备的属性需求
+                byte opt = inPacket.readByte(); // 读取数据包中的选项字节(对海盗职业的自动分配有用)
 
-                int str = 0, dex = 0, luk = 0, int_ = 0;
-                List<Short> eqpStrList = new ArrayList<>();
-                List<Short> eqpDexList = new ArrayList<>();
-                List<Short> eqpLukList = new ArrayList<>();
+                int str = 0, dex = 0, luk = 0, int_ = 0; // 初始化装备属性总和变量
+                List<Short> eqpStrList = new ArrayList<>(); // 创建装备STR值列表
+                List<Short> eqpDexList = new ArrayList<>(); // 创建装备DEX值列表
+                List<Short> eqpLukList = new ArrayList<>(); // 创建装备LUK值列表
 
-                Equip nEquip;
+                Equip nEquip; // 声明装备对象变量
 
-                for (Item item : equippedC) {   //selecting the biggest AP value of each stat from each equipped item.
-                    nEquip = (Equip) item;
-                    if (nEquip.getStr() > 0) {
-                        eqpStrList.add(nEquip.getStr());
+                // 遍历所有已装备的物品，收集属性信息
+                for (Item item : equippedC) {
+                    nEquip = (Equip) item; // 将物品转换为装备对象
+                    if (nEquip.getStr() > 0) { // 检查装备是否有STR加成
+                        eqpStrList.add(nEquip.getStr()); // 将STR值添加到列表中
                     }
-                    str += nEquip.getStr();
+                    str += nEquip.getStr(); // 累加STR总值
 
-                    if (nEquip.getDex() > 0) {
-                        eqpDexList.add(nEquip.getDex());
+                    if (nEquip.getDex() > 0) { // 检查装备是否有DEX加成
+                        eqpDexList.add(nEquip.getDex()); // 将DEX值添加到列表中
                     }
-                    dex += nEquip.getDex();
+                    dex += nEquip.getDex(); // 累加DEX总值
 
-                    if (nEquip.getLuk() > 0) {
-                        eqpLukList.add(nEquip.getLuk());
+                    if (nEquip.getLuk() > 0) { // 检查装备是否有LUK加成
+                        eqpLukList.add(nEquip.getLuk()); // 将LUK值添加到列表中
                     }
-                    luk += nEquip.getLuk();
+                    luk += nEquip.getLuk(); // 累加LUK总值
 
                     //if(nEquip.getInt() > 0) eqpIntList.add(nEquip.getInt()); //not needed...
-                    int_ += nEquip.getInt();
+                    int_ += nEquip.getInt(); // 累加INT总值
                 }
 
-                statUpdate[0] = chr.getStr();
-                statUpdate[1] = chr.getDex();
-                statUpdate[2] = chr.getLuk();
-                statUpdate[3] = chr.getInt();
+                // 获取玩家当前基础属性值
+                statUpdate[0] = chr.getStr(); // 获取当前STR值
+                statUpdate[1] = chr.getDex(); // 获取当前DEX值
+                statUpdate[2] = chr.getLuk(); // 获取当前LUK值
+                statUpdate[3] = chr.getInt(); // 获取当前INT值
 
-                eqpStrList.sort(Collections.reverseOrder());
-                eqpDexList.sort(Collections.reverseOrder());
-                eqpLukList.sort(Collections.reverseOrder());
+                // 对装备属性列表进行降序排序
+                eqpStrList.sort(Collections.reverseOrder()); // STR降序排序
+                eqpDexList.sort(Collections.reverseOrder()); // DEX降序排序
+                eqpLukList.sort(Collections.reverseOrder()); // LUK降序排序
 
-                //Autoassigner looks up the 1st/2nd placed equips for their stats to calculate the optimal upgrade.
-                int eqpStr = getNthHighestStat(eqpStrList, (short) 0) + getNthHighestStat(eqpStrList, (short) 1);
-                int eqpDex = getNthHighestStat(eqpDexList, (short) 0) + getNthHighestStat(eqpDexList, (short) 1);
-                int eqpLuk = getNthHighestStat(eqpLukList, (short) 0) + getNthHighestStat(eqpLukList, (short) 1);
+                // 自动分配器会查看前两件装备的属性来计算最佳升级方案
+                int eqpStr = getNthHighestStat(eqpStrList, (short) 0) + getNthHighestStat(eqpStrList, (short) 1); // 计算前两高STR装备的总和
+                int eqpDex = getNthHighestStat(eqpDexList, (short) 0) + getNthHighestStat(eqpDexList, (short) 1); // 计算前两高DEX装备的总和
+                int eqpLuk = getNthHighestStat(eqpLukList, (short) 0) + getNthHighestStat(eqpLukList, (short) 1); // 计算前两高LUK装备的总和
 
                 //c.getPlayer().message("----------------------------------------");
                 //c.getPlayer().message("SDL: s" + eqpStr + " d" + eqpDex + " l" + eqpLuk + " BASE STATS --> STR: " + chr.getStr() + " DEX: " + chr.getDex() + " INT: " + chr.getInt() + " LUK: " + chr.getLuk());
                 //c.getPlayer().message("SUM EQUIP STATS -> STR: " + str + " DEX: " + dex + " LUK: " + luk + " INT: " + int_);
 
-                Job stance = c.getPlayer().getJobStyle(opt);
-                int prStat = 0, scStat = 0, trStat = 0, temp, tempAp = remainingAp, CAP;
-                if (tempAp < 1) {
-                    return;
+                Job stance = c.getPlayer().getJobStyle(opt); // 根据选项获取玩家的职业类型
+                int prStat = 0, scStat = 0, trStat = 0, temp, tempAp = remainingAp, CAP; // 初始化主属性、副属性、第三属性、临时变量和上限值
+                if (tempAp < 1) { // 检查临时AP是否小于1
+                    return; // 如果不足则返回
                 }
 
-                Stat primary, secondary, tertiary = Stat.LUK;
-                switch (stance) {
-                    case MAGICIAN:
-                        CAP = 165;
-                        scStat = (chr.getLevel() + 3) - (chr.getLuk() + luk - eqpLuk);
-                        if (scStat < 0) {
-                            scStat = 0;
+                Stat primary, secondary, tertiary = Stat.LUK; // 声明主、副、第三属性枚举
+                switch (stance) { // 根据职业类型进行不同的处理
+                    case MAGICIAN -> { // 魔法师职业
+                        CAP = 165; // 设置副属性上限为165
+                        scStat = (chr.getLevel() + 3) - (chr.getLuk() + luk - eqpLuk); // 计算LUK需求
+                        if (scStat < 0) { // 检查计算结果是否为负
+                            scStat = 0; // 如果是则设为0
                         }
-                        scStat = Math.min(scStat, tempAp);
-
-                        if (tempAp > scStat) {
-                            tempAp -= scStat;
+                        scStat = Math.min(scStat, tempAp); // 确保不超过可用AP
+                        if (tempAp > scStat) { // 如果还有剩余AP
+                            tempAp -= scStat; // 扣除已分配的AP
                         } else {
-                            tempAp = 0;
+                            tempAp = 0; // 否则清空剩余AP
                         }
+                        prStat = tempAp; // 将剩余AP全部分配给主属性
+                        int_ = prStat; // 主属性为INT
+                        luk = scStat; // 副属性为LUK
+                        str = 0; // STR不分配
+                        dex = 0; // DEX不分配
 
-                        prStat = tempAp;
-                        int_ = prStat;
-                        luk = scStat;
-                        str = 0;
-                        dex = 0;
 
-                        if (GameConfig.getServerBoolean("use_auto_assign_secondary_cap") && luk + chr.getLuk() > CAP) {
-                            temp = luk + chr.getLuk() - CAP;
-                            scStat -= temp;
-                            prStat += temp;
+                        // 检查并处理副属性超过上限的情况
+                        if (useAutoAssignSecondaryCap && luk + chr.getLuk() > CAP) {
+                            temp = luk + chr.getLuk() - CAP; // 计算超出量
+                            scStat -= temp; // 减少副属性分配
+                            prStat += temp; // 将超出的部分加到主属性
                         }
-
-                        primary = Stat.INT;
-                        secondary = Stat.LUK;
-                        tertiary = Stat.DEX;
-
-                        break;
-
-                    case BOWMAN:
-                        CAP = 125;
-                        scStat = (chr.getLevel() + 5) - (chr.getStr() + str - eqpStr);
-                        if (scStat < 0) {
-                            scStat = 0;
+                        primary = Stat.INT; // 设置主属性为智力
+                        secondary = Stat.LUK; // 设置副属性为运气
+                        tertiary = Stat.DEX; // 设置第三属性为敏捷
+                    }
+                    case BOWMAN -> { // 弓箭手职业
+                        CAP = 125; // 设置副属性上限为125
+                        scStat = (chr.getLevel() + 5) - (chr.getStr() + str - eqpStr); // 计算STR需求
+                        if (scStat < 0) { // 检查计算结果是否为负
+                            scStat = 0; // 如果是则设为0
                         }
-                        scStat = Math.min(scStat, tempAp);
-
-                        if (tempAp > scStat) {
-                            tempAp -= scStat;
+                        scStat = Math.min(scStat, tempAp); // 确保不超过可用AP
+                        if (tempAp > scStat) { // 如果还有剩余AP
+                            tempAp -= scStat; // 扣除已分配的AP
                         } else {
-                            tempAp = 0;
+                            tempAp = 0; // 否则清空剩余AP
                         }
+                        prStat = tempAp; // 将剩余AP全部分配给主属性
+                        dex = prStat; // 主属性为DEX
+                        str = scStat; // 副属性为STR
+                        int_ = 0; // INT不分配
+                        luk = 0; // LUK不分配
 
-                        prStat = tempAp;
-                        dex = prStat;
-                        str = scStat;
-                        int_ = 0;
-                        luk = 0;
 
-                        if (GameConfig.getServerBoolean("use_auto_assign_secondary_cap") && str + chr.getStr() > CAP) {
-                            temp = str + chr.getStr() - CAP;
-                            scStat -= temp;
-                            prStat += temp;
+                        // 检查并处理副属性超过上限的情况
+                        if (useAutoAssignSecondaryCap && str + chr.getStr() > CAP) {
+                            temp = str + chr.getStr() - CAP; // 计算超出量
+                            scStat -= temp; // 减少副属性分配
+                            prStat += temp; // 将超出的部分加到主属性
                         }
-
-                        primary = Stat.DEX;
-                        secondary = Stat.STR;
-
-                        break;
-
-                    case GUNSLINGER:
-                    case CROSSBOWMAN:
-                        CAP = 120;
-                        scStat = chr.getLevel() - (chr.getStr() + str - eqpStr);
-                        if (scStat < 0) {
-                            scStat = 0;
+                        primary = Stat.DEX; // 设置主属性为敏捷
+                        secondary = Stat.STR; // 设置副属性为力量
+                    } // 枪手职业
+                    case GUNSLINGER, CROSSBOWMAN -> { // 弩手职业
+                        CAP = 120; // 设置副属性上限为120
+                        scStat = chr.getLevel() - (chr.getStr() + str - eqpStr); // 计算STR需求
+                        if (scStat < 0) { // 检查计算结果是否为负
+                            scStat = 0; // 如果是则设为0
                         }
-                        scStat = Math.min(scStat, tempAp);
-
-                        if (tempAp > scStat) {
-                            tempAp -= scStat;
+                        scStat = Math.min(scStat, tempAp); // 确保不超过可用AP
+                        if (tempAp > scStat) { // 如果还有剩余AP
+                            tempAp -= scStat; // 扣除已分配的AP
                         } else {
-                            tempAp = 0;
+                            tempAp = 0; // 否则清空剩余AP
                         }
+                        prStat = tempAp; // 将剩余AP全部分配给主属性
+                        dex = prStat; // 主属性为DEX
+                        str = scStat; // 副属性为STR
+                        int_ = 0; // INT不分配
+                        luk = 0; // LUK不分配
 
-                        prStat = tempAp;
-                        dex = prStat;
-                        str = scStat;
-                        int_ = 0;
-                        luk = 0;
 
-                        if (GameConfig.getServerBoolean("use_auto_assign_secondary_cap") && str + chr.getStr() > CAP) {
-                            temp = str + chr.getStr() - CAP;
-                            scStat -= temp;
-                            prStat += temp;
+                        // 检查并处理副属性超过上限的情况
+                        if (useAutoAssignSecondaryCap && str + chr.getStr() > CAP) {
+                            temp = str + chr.getStr() - CAP; // 计算超出量
+                            scStat -= temp; // 减少副属性分配
+                            prStat += temp; // 将超出的部分加到主属性
                         }
-
-                        primary = Stat.DEX;
-                        secondary = Stat.STR;
-
-                        break;
-
-                    case THIEF:
-                        CAP = 160;
-
-                        scStat = 0;
-                        if (chr.getDex() < 80) {
-                            scStat = (2 * chr.getLevel()) - (chr.getDex() + dex - eqpDex);
-                            if (scStat < 0) {
-                                scStat = 0;
+                        primary = Stat.DEX; // 设置主属性为敏捷
+                        secondary = Stat.STR; // 设置副属性为力量
+                    }
+                    case THIEF -> { // 盗贼职业
+                        CAP = 160; // 设置副属性上限为160
+                        scStat = 0; // 初始化副属性分配值
+                        if (chr.getDex() < 80) { // 检查DEX是否低于80
+                            scStat = (2 * chr.getLevel()) - (chr.getDex() + dex - eqpDex); // 计算DEX需求
+                            if (scStat < 0) { // 检查计算结果是否为负
+                                scStat = 0; // 如果是则设为0
                             }
 
-                            scStat = Math.min(80 - chr.getDex(), scStat);
-                            scStat = Math.min(tempAp, scStat);
-                            tempAp -= scStat;
+                            scStat = Math.min(80 - chr.getDex(), scStat); // 确保不超过DEX上限差值
+                            scStat = Math.min(tempAp, scStat); // 确保不超过可用AP
+                            tempAp -= scStat; // 扣除已分配的AP
                         }
-
-                        temp = (chr.getLevel() + 40) - Math.max(80, scStat + chr.getDex() + dex - eqpDex);
-                        if (temp < 0) {
-                            temp = 0;
+                        temp = (chr.getLevel() + 40) - Math.max(80, scStat + chr.getDex() + dex - eqpDex); // 计算额外DEX需求
+                        if (temp < 0) { // 检查计算结果是否为负
+                            temp = 0; // 如果是则设为0
                         }
-                        temp = Math.min(tempAp, temp);
-                        scStat += temp;
-                        tempAp -= temp;
+                        temp = Math.min(tempAp, temp); // 确保不超过可用AP
+                        scStat += temp; // 增加副属性分配
+                        tempAp -= temp; // 扣除已分配的AP
 
-                        // thieves will upgrade STR as well only if a level-based threshold is reached.
-                        if (chr.getStr() >= Math.max(13, (int) (0.4 * chr.getLevel()))) {
-                            if (chr.getStr() < 50) {
-                                trStat = (chr.getLevel() - 10) - (chr.getStr() + str - eqpStr);
-                                if (trStat < 0) {
-                                    trStat = 0;
+
+                        // 盗贼只有在达到基于等级的阈值时才会分配STR
+                        if (chr.getStr() >= Math.max(13, (int) (0.4 * chr.getLevel()))) { // 检查STR是否达到阈值
+                            if (chr.getStr() < 50) { // 检查STR是否低于50
+                                trStat = (chr.getLevel() - 10) - (chr.getStr() + str - eqpStr); // 计算STR需求
+                                if (trStat < 0) { // 检查计算结果是否为负
+                                    trStat = 0; // 如果是则设为0
                                 }
 
-                                trStat = Math.min(50 - chr.getStr(), trStat);
-                                trStat = Math.min(tempAp, trStat);
-                                tempAp -= trStat;
+                                trStat = Math.min(50 - chr.getStr(), trStat); // 确保不超过STR上限差值
+                                trStat = Math.min(tempAp, trStat); // 确保不超过可用AP
+                                tempAp -= trStat; // 扣除已分配的AP
                             }
 
-                            temp = (20 + (chr.getLevel() / 2)) - Math.max(50, trStat + chr.getStr() + str - eqpStr);
-                            if (temp < 0) {
-                                temp = 0;
+                            temp = (20 + (chr.getLevel() / 2)) - Math.max(50, trStat + chr.getStr() + str - eqpStr); // 计算额外STR需求
+                            if (temp < 0) { // 检查计算结果是否为负
+                                temp = 0; // 如果是则设为0
                             }
-                            temp = Math.min(tempAp, temp);
-                            trStat += temp;
-                            tempAp -= temp;
+                            temp = Math.min(tempAp, temp); // 确保不超过可用AP
+                            trStat += temp; // 增加第三属性分配
+                            tempAp -= temp; // 扣除已分配的AP
                         }
+                        prStat = tempAp; // 将剩余AP全部分配给主属性
+                        luk = prStat; // 主属性为LUK
+                        dex = scStat; // 副属性为DEX
+                        str = trStat; // 第三属性为STR
+                        int_ = 0; // INT不分配
 
-                        prStat = tempAp;
-                        luk = prStat;
-                        dex = scStat;
-                        str = trStat;
-                        int_ = 0;
 
-                        if (GameConfig.getServerBoolean("use_auto_assign_secondary_cap") && dex + chr.getDex() > CAP) {
-                            temp = dex + chr.getDex() - CAP;
-                            scStat -= temp;
-                            prStat += temp;
+                        // 检查并处理副属性超过上限的情况
+                        if (useAutoAssignSecondaryCap && dex + chr.getDex() > CAP) {
+                            temp = dex + chr.getDex() - CAP; // 计算超出量
+                            scStat -= temp; // 减少副属性分配
+                            prStat += temp; // 将超出的部分加到主属性
                         }
-                        if (GameConfig.getServerBoolean("use_auto_assign_secondary_cap") && str + chr.getStr() > CAP) {
-                            temp = str + chr.getStr() - CAP;
-                            trStat -= temp;
-                            prStat += temp;
+                        if (useAutoAssignSecondaryCap && str + chr.getStr() > CAP) {
+                            temp = str + chr.getStr() - CAP; // 计算超出量
+                            trStat -= temp; // 减少第三属性分配
+                            prStat += temp; // 将超出的部分加到主属性
                         }
-
-                        primary = Stat.LUK;
-                        secondary = Stat.DEX;
-                        tertiary = Stat.STR;
-
-                        break;
-
-                    case BRAWLER:
-                    default:    //warrior, beginner, ...
-                        CAP = 300;
-
-                        boolean highDex = false;    // thanks lucasziron & Vcoc for finding out DEX autoassigning poorly for STR-based characters
-                        if (chr.getLevel() < 40) {
-                            if (chr.getDex() >= (2 * chr.getLevel()) + 2) {
-                                highDex = true;
+                        primary = Stat.LUK; // 设置主属性为运气
+                        secondary = Stat.DEX; // 设置副属性为敏捷
+                        tertiary = Stat.STR; // 设置第三属性为力量
+                    } // 拳手职业
+                    default -> {    // 战士、新手等默认职业
+                        CAP = 300; // 设置副属性上限为300
+                        boolean highDex = false; // 标记是否高DEX
+                        if (chr.getLevel() < 40) { // 检查等级是否低于40
+                            if (chr.getDex() >= (2 * chr.getLevel()) + 2) { // 检查DEX是否达到阈值
+                                highDex = true; // 标记为高DEX
                             }
                         } else {
-                            if (chr.getDex() >= chr.getLevel() + 42) {
-                                highDex = true;
+                            if (chr.getDex() >= chr.getLevel() + 42) { // 检查DEX是否达到阈值
+                                highDex = true; // 标记为高DEX
                             }
                         }
 
-                        // other classes will start favoring more DEX only if a level-based threshold is reached.
-                        if (!highDex) {
-                            scStat = 0;
-                            if (chr.getDex() < 80) {
-                                scStat = (2 * chr.getLevel()) - (chr.getDex() + dex - eqpDex);
-                                if (scStat < 0) {
-                                    scStat = 0;
+                        // 其他职业只有在达到基于等级的阈值时才会倾向于分配更多DEX
+                        if (!highDex) { // 如果不是高DEX
+                            scStat = 0; // 初始化副属性分配值
+                            if (chr.getDex() < 80) { // 检查DEX是否低于80
+                                scStat = (2 * chr.getLevel()) - (chr.getDex() + dex - eqpDex); // 计算DEX需求
+                                if (scStat < 0) { // 检查计算结果是否为负
+                                    scStat = 0; // 如果是则设为0
                                 }
 
-                                scStat = Math.min(80 - chr.getDex(), scStat);
-                                scStat = Math.min(tempAp, scStat);
-                                tempAp -= scStat;
+                                scStat = Math.min(80 - chr.getDex(), scStat); // 确保不超过DEX上限差值
+                                scStat = Math.min(tempAp, scStat); // 确保不超过可用AP
+                                tempAp -= scStat; // 扣除已分配的AP
                             }
 
-                            temp = (chr.getLevel() + 40) - Math.max(80, scStat + chr.getDex() + dex - eqpDex);
-                            if (temp < 0) {
-                                temp = 0;
+                            temp = (chr.getLevel() + 40) - Math.max(80, scStat + chr.getDex() + dex - eqpDex); // 计算额外DEX需求
+                            if (temp < 0) { // 检查计算结果是否为负
+                                temp = 0; // 如果是则设为0
                             }
-                            temp = Math.min(tempAp, temp);
-                            scStat += temp;
-                            tempAp -= temp;
-                        } else {
-                            scStat = 0;
-                            if (chr.getDex() < 96) {
-                                scStat = (int) (2.4 * chr.getLevel()) - (chr.getDex() + dex - eqpDex);
-                                if (scStat < 0) {
-                                    scStat = 0;
+                            temp = Math.min(tempAp, temp); // 确保不超过可用AP
+                            scStat += temp; // 增加副属性分配
+                            tempAp -= temp; // 扣除已分配的AP
+                        } else { // 如果是高DEX
+                            scStat = 0; // 初始化副属性分配值
+                            if (chr.getDex() < 96) { // 检查DEX是否低于96
+                                scStat = (int) (2.4 * chr.getLevel()) - (chr.getDex() + dex - eqpDex); // 计算DEX需求
+                                if (scStat < 0) { // 检查计算结果是否为负
+                                    scStat = 0; // 如果是则设为0
                                 }
 
-                                scStat = Math.min(96 - chr.getDex(), scStat);
-                                scStat = Math.min(tempAp, scStat);
-                                tempAp -= scStat;
+                                scStat = Math.min(96 - chr.getDex(), scStat); // 确保不超过DEX上限差值
+                                scStat = Math.min(tempAp, scStat); // 确保不超过可用AP
+                                tempAp -= scStat; // 扣除已分配的AP
                             }
 
-                            temp = 96 + (int) (1.2 * (chr.getLevel() - 40)) - Math.max(96, scStat + chr.getDex() + dex - eqpDex);
-                            if (temp < 0) {
-                                temp = 0;
+                            temp = 96 + (int) (1.2 * (chr.getLevel() - 40)) - Math.max(96, scStat + chr.getDex() + dex - eqpDex); // 计算额外DEX需求
+                            if (temp < 0) { // 检查计算结果是否为负
+                                temp = 0; // 如果是则设为0
                             }
-                            temp = Math.min(tempAp, temp);
-                            scStat += temp;
-                            tempAp -= temp;
+                            temp = Math.min(tempAp, temp); // 确保不超过可用AP
+                            scStat += temp; // 增加副属性分配
+                            tempAp -= temp; // 扣除已分配的AP
                         }
+                        prStat = tempAp; // 将剩余AP全部分配给主属性
+                        str = prStat; // 主属性为STR
+                        dex = scStat; // 副属性为DEX
+                        int_ = 0; // INT不分配
+                        luk = 0; // LUK不分配
 
-                        prStat = tempAp;
-                        str = prStat;
-                        dex = scStat;
-                        int_ = 0;
-                        luk = 0;
 
-                        if (GameConfig.getServerBoolean("use_auto_assign_secondary_cap") && dex + chr.getDex() > CAP) {
-                            temp = dex + chr.getDex() - CAP;
-                            scStat -= temp;
-                            prStat += temp;
+                        // 检查并处理副属性超过上限的情况
+                        if (useAutoAssignSecondaryCap && dex + chr.getDex() > CAP) {
+                            temp = dex + chr.getDex() - CAP; // 计算超出量
+                            scStat -= temp; // 减少副属性分配
+                            prStat += temp; // 将超出的部分加到主属性
                         }
-
-                        primary = Stat.STR;
-                        secondary = Stat.DEX;
+                        primary = Stat.STR; // 设置主属性为力量
+                        secondary = Stat.DEX; // 设置副属性为敏捷
+                    }
                 }
 
-                //-------------------------------------------------------------------------------------
+                // 实际执行属性分配
+                int extras = 0; // 初始化剩余AP变量
+                extras = gainStatByType(primary, statGain, prStat + extras, statUpdate); // 分配主属性
+                extras = gainStatByType(secondary, statGain, scStat + extras, statUpdate); // 分配副属性
+                extras = gainStatByType(tertiary, statGain, trStat + extras, statUpdate); // 分配第三属性
 
-                int extras = 0;
-
-                extras = gainStatByType(primary, statGain, prStat + extras, statUpdate);
-                extras = gainStatByType(secondary, statGain, scStat + extras, statUpdate);
-                extras = gainStatByType(tertiary, statGain, trStat + extras, statUpdate);
-
-                if (extras > 0) {    //redistribute surplus in priority order
-                    extras = gainStatByType(primary, statGain, extras, statUpdate);
-                    extras = gainStatByType(secondary, statGain, extras, statUpdate);
-                    extras = gainStatByType(tertiary, statGain, extras, statUpdate);
-                    gainStatByType(getQuaternaryStat(stance), statGain, extras, statUpdate);
+                // 重新分配剩余的AP点数
+                if (extras > 0) {
+                    extras = gainStatByType(primary, statGain, extras, statUpdate); // 优先分配给主属性
+                    extras = gainStatByType(secondary, statGain, extras, statUpdate); // 其次分配给副属性
+                    extras = gainStatByType(tertiary, statGain, extras, statUpdate); // 最后分配给第三属性
+                    gainStatByType(getQuaternaryStat(stance), statGain, extras, statUpdate); // 如果还有剩余，分配给第四属性
                 }
 
+                // 更新玩家属性
                 chr.assignStrDexIntLuk(statGain[0], statGain[1], statGain[3], statGain[2]);
+                // 允许玩家行动
                 c.sendPacket(PacketCreator.enableActions());
 
-                //----------------------------------------------------------------------------------------
-
-                c.sendPacket(PacketCreator.serverNotice(1, "Better AP applications detected:\r\nSTR: +" + statGain[0] + "\r\nDEX: +" + statGain[1] + "\r\nINT: +" + statGain[3] + "\r\nLUK: +" + statGain[2]));
-            } else {
-                if (inPacket.available() < 16) {
-                    AutobanFactory.PACKET_EDIT.alert(chr, "Didn't send full packet for Auto Assign.");
-
-                    c.disconnect(true, false);
+                // 发送分配结果通知给玩家
+                c.sendPacket(PacketCreator.serverNotice(1,
+                        "检测到更优AP分配方案：\r\n力量(STR): +" + statGain[0] +
+                                "\r\n敏捷(DEX): +" + statGain[1] +
+                                "\r\n智力(INT): +" + statGain[3] +
+                                "\r\n运气(LUK): +" + statGain[2]));
+            } else { // 不使用自动分配器的情况
+                if (inPacket.available() < 16) { // 检查数据包是否完整
+                    AutobanFactory.PACKET_EDIT.alert(chr, "Auto Assign数据包不完整"); // 记录异常
+                    c.disconnect(true, false); // 断开客户端连接
                     return;
                 }
 
-                for (int i = 0; i < 2; i++) {
-                    int type = inPacket.readInt();
-                    int tempVal = inPacket.readInt();
-                    if (tempVal < 0 || tempVal > remainingAp) {
-                        return;
+                // 手动分配属性
+                for (int i = 0; i < 2; i++) { // 循环处理两种属性
+                    int type = inPacket.readInt(); // 读取属性类型
+                    int tempVal = inPacket.readInt(); // 读取分配值
+                    if (tempVal < 0 || tempVal > remainingAp) { // 验证分配值是否合法
+                        return; // 不合法则返回
                     }
-
-                    gainStatByType(Stat.getBy5ByteEncoding(type), statGain, tempVal, statUpdate);
+                    gainStatByType(Stat.getBy5ByteEncoding(type), statGain, tempVal, statUpdate); // 分配属性
                 }
 
+                // 更新玩家属性
                 chr.assignStrDexIntLuk(statGain[0], statGain[1], statGain[3], statGain[2]);
+                // 允许玩家行动
                 c.sendPacket(PacketCreator.enableActions());
             }
         } finally {
-            c.unlockClient();
+            c.unlockClient(); // 确保最终解锁客户端
         }
     }
 
     private static int getNthHighestStat(List<Short> statList, short rank) {    // ranks from 0
         return (statList.size() <= rank ? 0 : statList.get(rank));
     }
-
+    /**
+     * 按属性类型增加属性点
+     * 处理流程：
+     * 1. 检查增益值是否有效
+     * 2. 根据属性类型(STR/DEX/INT/LUK)更新对应属性
+     * 3. 确保不超过服务器配置的最大值
+     * 4. 返回未能分配的剩余点数
+     *
+     * @param type 属性类型
+     * @param statGain 各属性增益数组
+     * @param gain 要增加的点数
+     * @param statUpdate 当前属性值数组
+     * @return 未能分配的剩余点数
+     */
     private static int gainStatByType(Stat type, int[] statGain, int gain, int[] statUpdate) {
+        reloadConfig();
         if (gain <= 0) {
             return 0;
         }
 
         int newVal = 0;
         switch (type) {
-        case STR:
-            newVal = statUpdate[0] + gain;
-            if (newVal > GameConfig.getServerInt("max_ap")) {
-                statGain[0] += (gain - (newVal - GameConfig.getServerInt("max_ap")));
-                statUpdate[0] = GameConfig.getServerInt("max_ap");
-            } else {
-                statGain[0] += gain;
-                statUpdate[0] = newVal;
+            case STR -> {
+                newVal = statUpdate[0] + gain;
+                if (newVal > maxAp) {
+                    statGain[0] += (gain - (newVal - maxAp));
+                    statUpdate[0] = maxAp;
+                } else {
+                    statGain[0] += gain;
+                    statUpdate[0] = newVal;
+                }
             }
-            break;
-        case INT:
-            newVal = statUpdate[3] + gain;
-            if (newVal > GameConfig.getServerInt("max_ap")) {
-                statGain[3] += (gain - (newVal - GameConfig.getServerInt("max_ap")));
-                statUpdate[3] = GameConfig.getServerInt("max_ap");
-            } else {
-                statGain[3] += gain;
-                statUpdate[3] = newVal;
+            case INT -> {
+                newVal = statUpdate[3] + gain;
+                if (newVal > maxAp) {
+                    statGain[3] += (gain - (newVal - maxAp));
+                    statUpdate[3] = maxAp;
+                } else {
+                    statGain[3] += gain;
+                    statUpdate[3] = newVal;
+                }
             }
-            break;
-        case LUK:
-            newVal = statUpdate[2] + gain;
-            if (newVal > GameConfig.getServerInt("max_ap")) {
-                statGain[2] += (gain - (newVal - GameConfig.getServerInt("max_ap")));
-                statUpdate[2] = GameConfig.getServerInt("max_ap");
-            } else {
-                statGain[2] += gain;
-                statUpdate[2] = newVal;
+            case LUK -> {
+                newVal = statUpdate[2] + gain;
+                if (newVal > maxAp) {
+                    statGain[2] += (gain - (newVal - maxAp));
+                    statUpdate[2] = maxAp;
+                } else {
+                    statGain[2] += gain;
+                    statUpdate[2] = newVal;
+                }
             }
-            break;
-        case DEX:
-            newVal = statUpdate[1] + gain;
-            if (newVal > GameConfig.getServerInt("max_ap")) {
-                statGain[1] += (gain - (newVal - GameConfig.getServerInt("max_ap")));
-                statUpdate[1] = GameConfig.getServerInt("max_ap");
-            } else {
-                statGain[1] += gain;
-                statUpdate[1] = newVal;
+            case DEX -> {
+                newVal = statUpdate[1] + gain;
+                if (newVal > maxAp) {
+                    statGain[1] += (gain - (newVal - maxAp));
+                    statUpdate[1] = maxAp;
+                } else {
+                    statGain[1] += gain;
+                    statUpdate[1] = newVal;
+                }
             }
-            break;
         }
 
-        if (newVal > GameConfig.getServerInt("max_ap")) {
-            return newVal - GameConfig.getServerInt("max_ap");
+        if (newVal > maxAp) {
+            return newVal - maxAp;
         }
         return 0;
     }
@@ -482,111 +537,121 @@ public class AssignAPProcessor {
         }
         return Stat.STR;
     }
-
+    /**
+     * 执行AP重置操作，将一种属性转换为另一种属性
+     * 处理流程：
+     * 1. 锁定客户端防止并发操作
+     * 2. 验证源属性是否有足够点数可重置
+     * 3. 根据不同类型执行减点操作：
+     *    - STR/DEX/INT/LUK: 直接减少
+     *    - HP/MP: 特殊处理，有最小限制
+     * 4. 将减去的点数加到目标属性
+     * 5. 处理HP/MP变化时的血量/魔法值更新
+     * 6. 解锁客户端
+     *
+     * @param c 客户端连接对象
+     * @param APFrom 源属性类型
+     * @param APTo 目标属性类型
+     * @return 操作是否成功
+     */
     public static boolean APResetAction(Client c, int APFrom, int APTo) {
+        reloadConfig();
         c.lockClient();
         try {
             Character player = c.getPlayer();
 
             switch (APFrom) {
-                case 64: // str
+                case 64 -> { // str
                     if (player.getStr() < 5) {
-                        player.message("You don't have the minimum STR required to swap.");
+                        player.message("你的力量(STR)不足，无法进行重置。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
                     if (!player.assignStr(-1)) {
-                        player.message("Couldn't execute AP reset operation.");
+                        player.message("AP重置操作执行失败。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
-                    break;
-                case 128: // dex
+                }
+                case 128 -> { // dex
                     if (player.getDex() < 5) {
-                        player.message("You don't have the minimum DEX required to swap.");
+                        player.message("你的敏捷(DEX)不足，无法进行重置。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
                     if (!player.assignDex(-1)) {
-                        player.message("Couldn't execute AP reset operation.");
+                        player.message("AP重置操作执行失败。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
-                    break;
-                case 256: // int
+                }
+                case 256 -> { // int
                     if (player.getInt() < 5) {
-                        player.message("You don't have the minimum INT required to swap.");
+                        player.message("你的智力(INT)不足，无法进行重置。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
                     if (!player.assignInt(-1)) {
-                        player.message("Couldn't execute AP reset operation.");
+                        player.message("AP重置操作执行失败。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
-                    break;
-                case 512: // luk
+                }
+                case 512 -> { // luk
                     if (player.getLuk() < 5) {
-                        player.message("You don't have the minimum LUK required to swap.");
+                        player.message("你的运气(LUK)不足，无法进行重置。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
                     if (!player.assignLuk(-1)) {
-                        player.message("Couldn't execute AP reset operation.");
+                        player.message("AP重置操作执行失败。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
-                    break;
-                case 2048: // HP
-                    if (GameConfig.getServerBoolean("use_enforce_hpmp_swap")) {
+                }
+                case 2048 -> { // HP
+                    if (useEnforceHpmpSwap) {
                         if (APTo != 8192) {
-                            player.message("You can only swap HP ability points to MP.");
+                            player.message("你只能将HP能力点重置到MP。");
                             c.sendPacket(PacketCreator.enableActions());
                             return false;
                         }
                     }
-
                     if (player.getHpMpApUsed() < 1) {
-                        player.message("You don't have enough HPMP stat points to spend on AP Reset.");
+                        player.message("你没有足够的HP、MP属性点用于AP重置。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
-
                     int hp = player.getMaxHp();
                     int level_ = player.getLevel();
                     if (hp < level_ * 14 + 148) {
-                        player.message("You don't have the minimum HP pool required to swap.");
+                        player.message("你的HP总量不足，无法进行重置。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
-
                     int curHp = player.getHp();
                     int hplose = -takeHp(player.getJob());
                     player.assignHP(hplose, -1);
-                    if (!GameConfig.getServerBoolean("use_fixed_ratio_hpmp_update")) {
+                    if (!useFixedRatioHpmpUpdate) {
                         player.updateHp(Math.max(1, curHp + hplose));
                     }
-
-                    break;
-                case 8192: // MP
-                    if (GameConfig.getServerBoolean("use_enforce_hpmp_swap")) {
+                }
+                case 8192 -> { // MP
+                    if (useEnforceHpmpSwap) {
                         if (APTo != 2048) {
-                            player.message("You can only swap MP ability points to HP.");
+                            player.message("你只能将MP能力点重置到HP。");
                             c.sendPacket(PacketCreator.enableActions());
                             return false;
                         }
                     }
-
                     if (player.getHpMpApUsed() < 1) {
-                        player.message("You don't have enough HPMP stat points to spend on AP Reset.");
+                        player.message("你没有足够的HP、MP属性点用于AP重置。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
-
                     int mp = player.getMaxMp();
                     int level = player.getLevel();
                     Job job = player.getJob();
-
                     boolean canWash = true;
                     if (job.isA(Job.SPEARMAN) && mp < 4 * level + 156) {
                         canWash = false;
@@ -597,23 +662,22 @@ public class AssignAPProcessor {
                     } else if (mp < level * 14 + 148) {
                         canWash = false;
                     }
-
                     if (!canWash) {
-                        player.message("You don't have the minimum MP pool required to swap.");
+                        player.message("你的MP总量不足，无法进行重置。");
                         c.sendPacket(PacketCreator.enableActions());
                         return false;
                     }
-
                     int curMp = player.getMp();
                     int mplose = -takeMp(job);
                     player.assignMP(mplose, -1);
-                    if (!GameConfig.getServerBoolean("use_fixed_ratio_hpmp_update")) {
+                    if (!useFixedRatioHpmpUpdate) {
                         player.updateMp(Math.max(0, curMp + mplose));
                     }
-                    break;
-                default:
+                }
+                default -> {
                     c.sendPacket(PacketCreator.updatePlayerStats(PacketCreator.EMPTY_STATUPDATE, true, player));
                     return false;
+                }
             }
 
             addStat(player, APTo, true);
@@ -622,7 +686,17 @@ public class AssignAPProcessor {
             c.unlockClient();
         }
     }
-
+    /**
+     * 手动分配AP点到指定属性
+     * 处理流程：
+     * 1. 锁定客户端防止并发操作
+     * 2. 根据属性类型调用对应的分配方法
+     * 3. 处理HP/MP分配时的特殊计算
+     * 4. 解锁客户端
+     *
+     * @param c 客户端连接对象
+     * @param num 目标属性类型编码
+     */
     public static void APAssignAction(Client c, int num) {
         c.lockClient();
         try {
@@ -633,229 +707,269 @@ public class AssignAPProcessor {
     }
 
     private static boolean addStat(Character chr, int apTo, boolean usedAPReset) {
+        int maxHp, maxMp;
         switch (apTo) {
-            case 64:
+            case 64 -> { // 力量(STR)
                 if (!chr.assignStr(1)) {
-                    chr.message("Couldn't execute AP assign operation.");
+                    chr.message("无法重新分配AP");
                     chr.sendPacket(PacketCreator.enableActions());
                     return false;
                 }
-                break;
-            case 128: // Dex
+            }
+            case 128 -> { // 敏捷(DEX)
                 if (!chr.assignDex(1)) {
-                    chr.message("Couldn't execute AP assign operation.");
+                    chr.message("无法重新分配AP");
                     chr.sendPacket(PacketCreator.enableActions());
                     return false;
                 }
-                break;
-            case 256: // Int
+            }
+            case 256 -> { // 智力(INT)
                 if (!chr.assignInt(1)) {
-                    chr.message("Couldn't execute AP assign operation.");
+                    chr.message("无法重新分配AP");
                     chr.sendPacket(PacketCreator.enableActions());
                     return false;
                 }
-                break;
-            case 512: // Luk
+            }
+            case 512 -> { // 运气(LUK)
                 if (!chr.assignLuk(1)) {
-                    chr.message("Couldn't execute AP assign operation.");
+                    chr.message("无法重新分配AP");
                     chr.sendPacket(PacketCreator.enableActions());
                     return false;
                 }
-                break;
-            case 2048:
-                if (!chr.assignHP(calcHpChange(chr, usedAPReset), 1)) {
-                    chr.message("Couldn't execute AP assign operation.");
+            }
+            case 2048 -> { // HP
+                maxHp = calcHpChange(chr, usedAPReset);
+                if (!chr.assignHP(maxHp, 1)) {
+                    chr.message("无法重新分配AP");
                     chr.sendPacket(PacketCreator.enableActions());
                     return false;
+                } else if (usedAPReset) {
+                    chr.dropMessage(6, "[重置卷轴] 最大HP +" + maxHp + " ↑");
                 }
-                break;
-            case 8192:
-                if (!chr.assignMP(calcMpChange(chr, usedAPReset), 1)) {
-                    chr.message("Couldn't execute AP assign operation.");
+            }
+            case 8192 -> { // MP
+                maxMp = calcMpChange(chr, usedAPReset);
+                if (!chr.assignMP(maxMp, 1)) {
+                    chr.message("无法重新分配AP");
                     chr.sendPacket(PacketCreator.enableActions());
                     return false;
+                } else if (usedAPReset) {
+                    chr.dropMessage(6, "[重置卷轴] 最大MP +" + maxMp + " ↑");
                 }
-                break;
-            default:
+            }
+            default -> {
                 chr.sendPacket(PacketCreator.updatePlayerStats(PacketCreator.EMPTY_STATUPDATE, true, chr));
                 return false;
+            }
         }
         return true;
     }
-
+    /**
+     * 计算HP增加量（根据职业不同有不同成长）
+     * 处理流程：
+     * 1. 初始化默认HP增长参数
+     * 2. 根据职业类型设置特定参数
+     * 3. 处理战士/海盗职业的技能加成
+     * 4. 根据配置计算最终HP增加值
+     *
+     * @param player 角色对象
+     * @param usedAPReset 是否来自AP重置操作
+     * @return HP增加量
+     */
     private static int calcHpChange(Character player, boolean usedAPReset) {
-        Job job = player.getJob();
-        int MaxHP = 0;
+        reloadConfig();  // 重新加载最新配置参数
 
+        //========== 基础参数初始化 ==========//
+        Job job = player.getJob();  // 获取当前职业
+        int MaxHP = 0;              // 最终HP增加值
+
+        //========== 默认配置（适用于新手等未定义职业） ==========//
+        int baseValue = 10;      // 基础增加值
+        int resetValue = 8;      // AP重置时增加值
+        int randomMin = 8;       // 随机最小值
+        int randomMax = 12;      // 随机最大值
+        Integer skillId = null;  // 需要检查的技能ID
+
+        //========== 职业专属配置 ==========//
+        // 战士/黎明战士（物理系职业）
         if (job.isA(Job.WARRIOR) || job.isA(Job.DAWNWARRIOR1)) {
-            if (!usedAPReset) {
-                Skill increaseHP = SkillFactory.getSkill(job.isA(Job.DAWNWARRIOR1) ? DawnWarrior.MAX_HP_INCREASE : Warrior.IMPROVED_MAXHP);
-                int sLvl = player.getSkillLevel(increaseHP);
-
-                if (sLvl > 0) {
-                    MaxHP += increaseHP.getEffect(sLvl).getY();
-                }
-            }
-
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (usedAPReset) {
-                    MaxHP += 20;
-                } else {
-                    MaxHP += Randomizer.rand(18, 22);
-                }
-            } else {
-                MaxHP += 20;
-            }
-        } else if (job.isA(Job.ARAN1)) {
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (usedAPReset) {
-                    MaxHP += 20;
-                } else {
-                    MaxHP += Randomizer.rand(26, 30);
-                }
-            } else {
-                MaxHP += 28;
-            }
-        } else if (job.isA(Job.MAGICIAN) || job.isA(Job.BLAZEWIZARD1)) {
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (usedAPReset) {
-                    MaxHP += 6;
-                } else {
-                    MaxHP += Randomizer.rand(5, 9);
-                }
-            } else {
-                MaxHP += 6;
-            }
-        } else if (job.isA(Job.THIEF) || job.isA(Job.NIGHTWALKER1)) {
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (usedAPReset) {
-                    MaxHP += 16;
-                } else {
-                    MaxHP += Randomizer.rand(14, 18);
-                }
-            } else {
-                MaxHP += 16;
-            }
-        } else if (job.isA(Job.BOWMAN) || job.isA(Job.WINDARCHER1)) {
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (usedAPReset) {
-                    MaxHP += 16;
-                } else {
-                    MaxHP += Randomizer.rand(14, 18);
-                }
-            } else {
-                MaxHP += 16;
-            }
-        } else if (job.isA(Job.PIRATE) || job.isA(Job.THUNDERBREAKER1)) {
-            if (!usedAPReset) {
-                Skill increaseHP = SkillFactory.getSkill(job.isA(Job.PIRATE) ? Brawler.IMPROVE_MAX_HP : ThunderBreaker.IMPROVE_MAX_HP);
-                int sLvl = player.getSkillLevel(increaseHP);
-
-                if (sLvl > 0) {
-                    MaxHP += increaseHP.getEffect(sLvl).getY();
-                }
-            }
-
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (usedAPReset) {
-                    MaxHP += 18;
-                } else {
-                    MaxHP += Randomizer.rand(16, 20);
-                }
-            } else {
-                MaxHP += 18;
-            }
-        } else if (usedAPReset) {
-            MaxHP += 8;
-        } else {
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                MaxHP += Randomizer.rand(8, 12);
-            } else {
-                MaxHP += 10;
-            }
+            baseValue = 20;       // 标准模式下基础值
+            resetValue = 20;      // 重置时增加值
+            randomMin = 18;       // 随机范围18-22
+            randomMax = 22;
+            skillId = job.isA(Job.DAWNWARRIOR1) ?
+                    DawnWarrior.MAX_HP_INCREASE :
+                    Warrior.IMPROVED_MAXHP;
+        }
+        // 战神（特殊战士职业）
+        else if (job.isA(Job.ARAN1)) {
+            baseValue = 28;       // 固定模式增加值
+            resetValue = 20;      // 重置时增加值
+            randomMin = 26;       // 随机范围26-30
+            randomMax = 30;
+        }
+        // 魔法师/烈焰巫师（法系职业）
+        else if (job.isA(Job.MAGICIAN) || job.isA(Job.BLAZEWIZARD1)) {
+            baseValue = 6;
+            resetValue = 6;
+            randomMin = 5;
+            randomMax = 9;
+        }
+        // 飞侠/暗夜行者（敏捷系职业）
+        else if (job.isA(Job.THIEF) || job.isA(Job.NIGHTWALKER1)) {
+            baseValue = 16;
+            resetValue = 16;
+            randomMin = 14;
+            randomMax = 18;
+        }
+        // 弓箭手/风灵使者（远程职业）
+        else if (job.isA(Job.BOWMAN) || job.isA(Job.WINDARCHER1)) {
+            baseValue = 16;
+            resetValue = 16;
+            randomMin = 14;
+            randomMax = 18;
+        }
+        // 海盗/冲锋队长（力量系职业）
+        else if (job.isA(Job.PIRATE) || job.isA(Job.THUNDERBREAKER1)) {
+            baseValue = 18;
+            resetValue = 18;
+            randomMin = 16;
+            randomMax = 20;
+            skillId = job.isA(Job.PIRATE) ?
+                    Brawler.IMPROVE_MAX_HP :
+                    ThunderBreaker.IMPROVE_MAX_HP;
         }
 
-        return MaxHP;
+        //========== 技能加成处理 ==========//
+        /* 战士/海盗职业在非重置时有技能加成 */
+        if (!usedAPReset) {
+            if(skillId != null) {
+                Skill hpSkill = SkillFactory.getSkill(skillId);
+                int skillLevel = player.getSkillLevel(hpSkill);
+
+                if (skillLevel > 0) {
+                    // 添加技能效果的Y值（HP增加量）
+                    MaxHP += hpSkill.getEffect(skillLevel).getY();
+                }
+            }
+        } else {
+            MaxHP += resetValue;    //基于洗血卷轴基础增加血量
+        }
+
+        //========== HP基础值计算 ==========//
+        if (useRandomizeHpmpGain && usedAPReset) {
+            // 随机模式：使用随机范围值
+            MaxHP += Randomizer.rand(randomMin, randomMax);
+        } else {
+            // 固定模式：使用基础值或重置值
+            MaxHP += usedAPReset ? resetValue : baseValue;
+        }
+
+        return MaxHP;  // 返回最终计算结果
     }
 
+    /**
+     * 计算MP增加量（根据职业不同有不同成长）
+     * 处理流程：
+     * 1. 初始化默认MP增长参数
+     * 2. 根据职业类型设置特定参数
+     * 3. 处理魔法师职业的技能加成
+     * 4. 根据配置计算最终MP增加值
+     *
+     * @param player 角色对象
+     * @param usedAPReset 是否来自AP重置操作
+     * @return MP增加量
+     */
     private static int calcMpChange(Character player, boolean usedAPReset) {
-        Job job = player.getJob();
-        int MaxMP = 0;
+        reloadConfig();  // 重新加载最新配置参数
 
+        //========== 基础参数初始化 ==========//
+        Job job = player.getJob();          // 获取当前职业
+        int playerInt = player.getInt();    // 缓存智力值（减少方法调用开销）
+        int MaxMP = 0;                      // 最终MP增加值
+
+        //========== 默认配置（适用于新手等未定义职业） ==========//
+        int baseValue = 6;       // 基础增加值
+        int resetValue = 6;      // AP重置时增加值
+        int randomMin = 4;       // 随机最小值
+        int randomMax = 6;       // 随机最大值
+        float intFactor = 0.5f;  // 智力系数（10%）
+        boolean hasSkill = false;// 是否检查技能加成
+
+        //========== 职业专属配置 ==========//
+        // 战士/黎明战士/战神（物理系职业）
         if (job.isA(Job.WARRIOR) || job.isA(Job.DAWNWARRIOR1) || job.isA(Job.ARAN1)) {
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (!usedAPReset) {
-                    MaxMP += (Randomizer.rand(2, 4) + (player.getInt() / 10));
-                } else {
-                    MaxMP += 2;
-                }
-            } else {
-                MaxMP += 3;
-            }
-        } else if (job.isA(Job.MAGICIAN) || job.isA(Job.BLAZEWIZARD1)) {
-            if (!usedAPReset) {
-                Skill increaseMP = SkillFactory.getSkill(job.isA(Job.BLAZEWIZARD1) ? BlazeWizard.INCREASING_MAX_MP : Magician.IMPROVED_MAX_MP_INCREASE);
-                int sLvl = player.getSkillLevel(increaseMP);
+            baseValue = 3;       // 标准模式下+3
+            resetValue = 2;      // 重置时+2
+            randomMin = 2;       // 随机范围2-4
+            randomMax = 4;
+            intFactor = 0.1f;    // 10%智力加成
+        }
+        // 魔法师/烈焰巫师（法系职业）
+        else if (job.isA(Job.MAGICIAN) || job.isA(Job.BLAZEWIZARD1)) {
+            baseValue = 18;      // 标准模式下+18
+            resetValue = 18;     // 重置时保持+18
+            randomMin = 12;      // 随机范围12-16
+            randomMax = 16;
+            intFactor = 0.05f;  // 5%智力加成
+            hasSkill = true;     // 需要检查技能加成
+        }
+        // 弓箭手/风灵使者（敏捷远程）
+        else if (job.isA(Job.BOWMAN) || job.isA(Job.WINDARCHER1)) {
+            baseValue = 10;      // 标准+10
+            resetValue = 10;     // 重置+10
+            randomMin = 6;       // 随机6-8
+            randomMax = 8;
+        }
+        // 飞侠/暗夜行者（敏捷近战）
+        else if (job.isA(Job.THIEF) || job.isA(Job.NIGHTWALKER1)) {
+            baseValue = 10;      // 配置同弓箭手
+            resetValue = 10;
+            randomMin = 6;
+            randomMax = 8;
+        }
+        // 海盗/冲锋队长（力量型）
+        else if (job.isA(Job.PIRATE) || job.isA(Job.THUNDERBREAKER1)) {
+            baseValue = 14;      // 标准+14
+            resetValue = 14;     // 重置+14
+            randomMin = 7;       // 随机7-9
+            randomMax = 9;
+        }
 
-                if (sLvl > 0) {
-                    MaxMP += increaseMP.getEffect(sLvl).getY();
-                }
-            }
+        //========== 技能加成处理 ==========//
+        /* 仅魔法师系职业在非重置时有技能加成 */
+        if (!usedAPReset && hasSkill) {
+            // 根据子职业选择正确的技能ID
+            int skillId = job.isA(Job.BLAZEWIZARD1) ?
+                    BlazeWizard.INCREASING_MAX_MP :
+                    Magician.IMPROVED_MAX_MP_INCREASE;
 
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (!usedAPReset) {
-                    MaxMP += (Randomizer.rand(12, 16) + (player.getInt() / 20));
-                } else {
-                    MaxMP += 18;
-                }
-            } else {
-                MaxMP += 18;
-            }
-        } else if (job.isA(Job.BOWMAN) || job.isA(Job.WINDARCHER1)) {
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (!usedAPReset) {
-                    MaxMP += (Randomizer.rand(6, 8) + (player.getInt() / 10));
-                } else {
-                    MaxMP += 10;
-                }
-            } else {
-                MaxMP += 10;
-            }
-        } else if (job.isA(Job.THIEF) || job.isA(Job.NIGHTWALKER1)) {
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (!usedAPReset) {
-                    MaxMP += (Randomizer.rand(6, 8) + (player.getInt() / 10));
-                } else {
-                    MaxMP += 10;
-                }
-            } else {
-                MaxMP += 10;
-            }
-        } else if (job.isA(Job.PIRATE) || job.isA(Job.THUNDERBREAKER1)) {
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (!usedAPReset) {
-                    MaxMP += (Randomizer.rand(7, 9) + (player.getInt() / 10));
-                } else {
-                    MaxMP += 14;
-                }
-            } else {
-                MaxMP += 14;
-            }
-        } else {
-            if (GameConfig.getServerBoolean("use_randomize_hpmp_gain")) {
-                if (!usedAPReset) {
-                    MaxMP += (Randomizer.rand(4, 6) + (player.getInt() / 10));
-                } else {
-                    MaxMP += 6;
-                }
-            } else {
-                MaxMP += 6;
+            Skill mpSkill = SkillFactory.getSkill(skillId);
+            int skillLevel = player.getSkillLevel(mpSkill);
+
+            if (skillLevel > 0) {
+                // 添加技能效果的Y值（MP增加量）
+                MaxMP += mpSkill.getEffect(skillLevel).getY();
             }
         }
 
-        return MaxMP;
-    }
+        //========== MP基础值计算 ==========//
+        if (useRandomizeHpmpGain && usedAPReset) {
+            // 随机模式：基础随机值 + 智力系数加成
+            MaxMP += Randomizer.rand(randomMin, randomMax) + (int)(playerInt * intFactor);
+        } else {
+            // 固定模式：使用基础值或重置值
+            MaxMP += usedAPReset ? resetValue : baseValue;
+        }
 
+        return MaxMP;  // 返回最终计算结果
+    }
+    /**
+     * 获取HP重置时的减少量（职业相关）
+     *
+     * @param job 职业
+     * @return HP减少量
+     */
     private static int takeHp(Job job) {
         int MaxHP = 0;
 
@@ -875,7 +989,12 @@ public class AssignAPProcessor {
 
         return MaxHP;
     }
-
+    /**
+     * 获取MP重置时的减少量（职业相关）
+     *
+     * @param job 职业
+     * @return MP减少量
+     */
     private static int takeMp(Job job) {
         int MaxMP = 0;
 

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/EnterCashShopHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/EnterCashShopHandler.java
@@ -58,6 +58,13 @@ public class EnterCashShopHandler extends AbstractPacketHandler {
             if (mc.getCashShop().isOpened()) {
                 return;
             }
+            /* 防止极端情况下点券为负数导致无法进入商城 */
+            for (int i = 0; i < 3; i++) {
+                int quantity = mc.getCashShop().getCash(i);
+                if (quantity < 0) {
+                    mc.getCashShop().gainCash(i,-quantity);
+                }
+            }
 
             mc.closePlayerInteractions();
             mc.closePartySearchInteractions();

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/MobDamageMobFriendlyHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/MobDamageMobFriendlyHandler.java
@@ -50,30 +50,23 @@ public final class MobDamageMobFriendlyHandler extends AbstractPacketHandler {
         }
 
         int damage = Randomizer.nextInt(((monster.getMaxHp() / 13 + monster.getPADamage() * 10)) * 2 + 500) / 10; // Formula planned by Beng.
-
+        String mopName = monster.getName();
         if (monster.getHp() - damage < 1) {     // friendly dies
             switch (monster.getId()) {
-            case MobId.WATCH_HOG:
-                map.broadcastMessage(PacketCreator.serverNotice(6, "The Watch Hog has been injured by the aliens. Better luck next time..."));
-                break;
-            case MobId.MOON_BUNNY: //moon bunny
-                map.broadcastMessage(PacketCreator.serverNotice(6, "The Moon Bunny went home because he was sick."));
-                break;
-            case MobId.TYLUS: //tylus
-                map.broadcastMessage(PacketCreator.serverNotice(6, "Tylus has fallen by the overwhelming forces of the ambush."));
-                break;
-            case MobId.JULIET: //juliet
-                map.broadcastMessage(PacketCreator.serverNotice(6, "Juliet has fainted in the middle of the combat."));
-                break;
-            case MobId.ROMEO: //romeo
-                map.broadcastMessage(PacketCreator.serverNotice(6, "Romeo has fainted in the middle of the combat."));
-                break;
-            case MobId.GIANT_SNOWMAN_LV1_EASY, MobId.GIANT_SNOWMAN_LV1_MEDIUM, MobId.GIANT_SNOWMAN_LV1_HARD:
-                map.broadcastMessage(PacketCreator.serverNotice(6, "The Snowman has melted on the heat of the battle."));
-                break;
-            case MobId.DELLI: //delli
-                map.broadcastMessage(PacketCreator.serverNotice(6, "Delli vanished after the ambush, sheets still laying on the ground..."));
-                break;
+                case MobId.WATCH_HOG ->
+                        map.broadcastMessage(PacketCreator.serverNotice(5, mopName + " 被外星人殴打致重伤，已被兽医紧急拉走抢救。"));    //护卫用小浣猪
+                case MobId.MOON_BUNNY -> //moon bunny
+                        map.broadcastMessage(PacketCreator.serverNotice(5, mopName + " 因为重伤被抬回去休养了。")); //月妙
+                case MobId.TYLUS -> //tylus
+                        map.broadcastMessage(PacketCreator.serverNotice(5, mopName + " 在伏击部队的强大攻势下倒下了。"));  //冒牌泰勒斯
+                case MobId.JULIET -> //juliet
+                        map.broadcastMessage(PacketCreator.serverNotice(5, mopName + " 在战斗中晕倒了。")); //朱丽叶
+                case MobId.ROMEO -> //romeo
+                        map.broadcastMessage(PacketCreator.serverNotice(5, mopName + " 在战斗中晕倒了。")); //罗密欧
+                case MobId.GIANT_SNOWMAN_LV1_EASY, MobId.GIANT_SNOWMAN_LV1_MEDIUM, MobId.GIANT_SNOWMAN_LV1_HARD ->
+                        map.broadcastMessage(PacketCreator.serverNotice(5, "雪人在战斗的热浪中融化了。"));
+                case MobId.DELLI -> //delli
+                        map.broadcastMessage(PacketCreator.serverNotice(5, mopName + " 在伏击后消失了，只留下地上的被单..."));  //德里
             }
             
             map.killFriendlies(monster);

--- a/gms-server/src/main/java/org/gms/net/server/world/World.java
+++ b/gms-server/src/main/java/org/gms/net/server/world/World.java
@@ -432,7 +432,7 @@ public class World {
     }
 
     public int getTransportationTime(int travelTime) {
-        return NumberTool.floatToInt(travelTime / travelRate);
+        return NumberTool.floatToInt(travelTime * travelRate);//交通工具、旅行时间倍率，由于支持小数，所以需要改为相乘
     }
 
     public void loadAccountCharactersView(Integer accountId, List<Character> chars) {

--- a/gms-server/src/main/java/org/gms/scripting/event/EventManager.java
+++ b/gms-server/src/main/java/org/gms/scripting/event/EventManager.java
@@ -209,7 +209,7 @@ public class EventManager {
             try {
                 iv.invokeFunction(methodName, eim);
             } catch (ScriptException | NoSuchMethodException ex) {
-                log.error("eim（"+eim+"），methodName（"+methodName+"），Event script schedule（事件脚本时间表）", ex);
+                log.error("eim（{}），methodName（{}），Event script schedule（事件脚本时间表）", eim,methodName,ex);
             }
         };
 

--- a/gms-server/src/main/java/org/gms/scripting/event/EventManager.java
+++ b/gms-server/src/main/java/org/gms/scripting/event/EventManager.java
@@ -1194,14 +1194,22 @@ public class EventManager {
     }
 
     /**
-     * 获取运输时间
+     * 修正运输时间
      * @param travelTime 旅行时间
-     * @return 运输时间
+     * @return 修正后的运输时间
      */
     public int getTransportationTime(int travelTime) {
         return this.getWorldServer().getTransportationTime(travelTime);
     }
 
+    /**
+     * 修正Boss刷新时间
+     * @param BossTime刷新时间
+     * @return 修正后的Boss刷新时间
+     */
+    public int getBossTime(int BossTime) {
+        return (int) (BossTime * GameConfig.getServerFloat("boss_respawn_mob_time_rate"));
+    }
     /**
      * 填充EIM队列
      */

--- a/gms-server/src/main/java/org/gms/scripting/event/EventScriptManager.java
+++ b/gms-server/src/main/java/org/gms/scripting/event/EventScriptManager.java
@@ -35,107 +35,144 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
+ * 事件脚本管理器，负责加载、初始化和执行 JavaScript 事件脚本
  * @author Matze
  */
 public class EventScriptManager extends AbstractScriptManager {
-    private static final org.slf4j.Logger log = LoggerFactory.getLogger(EventScriptManager.class);
-    private static final String INJECTED_VARIABLE_NAME = "em";
-    private static EventEntry fallback;
-    private final Map<String, EventEntry> events = new ConcurrentHashMap<>();
-    private boolean active = false;
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(EventScriptManager.class); // SLF4J 日志实例
+    private static final String INJECTED_VARIABLE_NAME = "em"; // 注入到 JS 引擎的变量名
+    private static EventEntry fallback; // 后备事件（如默认事件）
+    private final Map<String, EventEntry> events = new ConcurrentHashMap<>(); // 存储事件名与事件实体的映射
+    private boolean active = false; // 管理器是否激活
 
+    /**
+     * 事件实体类，封装 JS 调用接口和事件管理器
+     */
     private static class EventEntry {
+        public Invocable iv; // 可调用的 JS 引擎接口
+        public EventManager em; // 事件管理器
 
         public EventEntry(Invocable iv, EventManager em) {
-            this.iv = iv;
-            this.em = em;
+            this.iv = iv; // 初始化 JS 调用接口
+            this.em = em; // 初始化事件管理器
         }
-
-        public Invocable iv;
-        public EventManager em;
     }
 
+    /**
+     * 构造函数，加载并初始化所有事件脚本
+     * @param channel 游戏频道（上下文）
+     * @param scripts 事件脚本名称数组
+     */
     public EventScriptManager(final Channel channel, String[] scripts) {
         for (String script : scripts) {
             if (!script.isEmpty()) {
-                events.put(script, initializeEventEntry(script, channel));
+                events.put(script, initializeEventEntry(script, channel)); // 加载并存储每个脚本
             }
         }
 
-        init();
-        fallback = events.remove("0_EXAMPLE");
+        init(); // 初始化所有事件
+        fallback = events.remove("0_EXAMPLE"); // 移除并保留后备事件
     }
 
+    /**
+     * 获取指定事件的事件管理器
+     * @param event 事件名称
+     * @return 对应的事件管理器，若不存在则返回后备事件
+     */
     public EventManager getEventManager(String event) {
-        EventEntry entry = events.get(event);
+        EventEntry entry = events.get(event); // 查找事件
         if (entry == null) {
-            return fallback.em;
+            return fallback.em; // 返回后备事件
         }
-        return entry.em;
+        return entry.em; // 返回找到的事件
     }
 
+    /**
+     * 检查事件管理器是否激活
+     * @return true 表示已激活
+     */
     public boolean isActive() {
-        return active;
+        return active; // 返回激活状态
     }
 
+    /**
+     * 初始化所有事件脚本，调用其 JS 中的 init() 函数
+     */
     public final void init() {
         for (EventEntry entry : events.values()) {
             try {
-                entry.iv.invokeFunction("init", (Object) null);
+                entry.iv.invokeFunction("init", (Object) null); // 调用 JS 的 init 方法
             } catch (Exception ex) {
-                log.error("Error on script: {}", entry.em.getName(), ex);
+                log.error("Error on script（事件脚本初始化出错）: {}", entry.em.getName(), ex); // 记录错误日志
             }
         }
 
-        active = events.size() > 1; // bootup loads only 1 script
+        active = events.size() > 1; // 如果事件数 >1，标记为激活状态
     }
 
+    /**
+     * 重新加载所有事件脚本
+     */
     private void reloadScripts() {
-        Set<Entry<String, EventEntry>> eventEntries = new HashSet<>(events.entrySet());
+        Set<Entry<String, EventEntry>> eventEntries = new HashSet<>(events.entrySet()); // 复制当前事件集合
         if (eventEntries.isEmpty()) {
-            return;
+            return; // 无事件时直接返回
         }
 
-        Channel channel = eventEntries.iterator().next().getValue().em.getChannelServer();
+        Channel channel = eventEntries.iterator().next().getValue().em.getChannelServer(); // 获取频道上下文
         for (Entry<String, EventEntry> entry : eventEntries) {
             String script = entry.getKey();
-            events.put(script, initializeEventEntry(script, channel));
+            events.put(script, initializeEventEntry(script, channel)); // 重新加载每个脚本
         }
     }
 
+    /**
+     * 初始化单个事件脚本的入口
+     * @param script 脚本名称
+     * @param channel 游戏频道
+     * @return 事件实体（包含 JS 引擎和事件管理器）
+     */
     private EventEntry initializeEventEntry(String script, Channel channel) {
-        ScriptEngine engine = getInvocableScriptEngine("event/" + script + ".js");
-        Invocable iv = SynchronizedInvocable.of((Invocable) engine);
-        EventManager eventManager = new EventManager(channel, iv, script);
-        engine.put(INJECTED_VARIABLE_NAME, eventManager);
-        return new EventEntry(iv, eventManager);
+        ScriptEngine engine = getInvocableScriptEngine("event/" + script + ".js"); // 获取 JS 引擎
+        Invocable iv = SynchronizedInvocable.of((Invocable) engine); // 包装为线程安全的调用接口
+        EventManager eventManager = new EventManager(channel, iv, script); // 创建事件管理器
+        engine.put(INJECTED_VARIABLE_NAME, eventManager); // 向 JS 引擎注入变量 "em"
+        return new EventEntry(iv, eventManager); // 返回事件实体
     }
 
-    // Is never being called
+    /**
+     * 重新加载所有事件脚本（外部调用入口）
+     */
     public void reload() {
-        cancel();
-        reloadScripts();
-        init();
+        cancel(); // 取消当前所有事件
+        reloadScripts(); // 重新加载脚本
+        init(); // 重新初始化
     }
 
+    /**
+     * 取消所有事件执行
+     */
     public void cancel() {
-        active = false;
+        active = false; // 标记为未激活
         for (EventEntry entry : events.values()) {
-            entry.em.cancel();
+            entry.em.cancel(); // 调用每个事件的取消方法
         }
     }
 
+    /**
+     * 销毁事件管理器，清理资源
+     */
     public void dispose() {
         if (events.isEmpty()) {
-            return;
+            return; // 无事件时直接返回
         }
 
-        Set<EventEntry> eventEntries = new HashSet<>(events.values());
-        events.clear();
+        Set<EventEntry> eventEntries = new HashSet<>(events.values()); // 复制事件集合
+        events.clear(); // 清空映射表
 
-        active = false;
+        active = false; // 标记为未激活
         for (EventEntry entry : eventEntries) {
-            entry.em.cancel();
+            entry.em.cancel(); // 取消所有事件
         }
     }
 }

--- a/gms-server/src/main/java/org/gms/server/maps/MapleMap.java
+++ b/gms-server/src/main/java/org/gms/server/maps/MapleMap.java
@@ -1359,21 +1359,27 @@ public class MapleMap {
         return false;
     }
 
+    // 巴洛古(Balrog)讨伐胜利广播
     public void broadcastBalrogVictory(String leaderName) {
-        getWorldServer().dropMessage(6, "[Victory] " + leaderName + "'s party has successfully defeated the Balrog! Praise to them, they finished with " + countAlivePlayers() + " players alive.");
+        getWorldServer().dropMessage(6,"[远征凯旋] " + leaderName + "的远征队成功讨伐了火焰魔神巴洛古！" + "让我们歌颂这支队伍，他们以" + countAlivePlayers() + "名幸存者的战绩完成了壮举！");
     }
 
+    // 暗黑龙王(Horntail)讨伐胜利广播
     public void broadcastHorntailVictory() {
-        getWorldServer().dropMessage(6, "[Victory] To the crew that have finally conquered Horned Tail after numerous attempts, I salute thee! You are the true heroes of Leafre!!");
+        getWorldServer().dropMessage(6,"[远征凯旋] 致历经无数次挑战最终征服暗黑龙王的勇士们：" + "谨以此礼赞献给真正的神木村英雄！");
     }
 
+    // 扎昆(Zakum)讨伐胜利广播
     public void broadcastZakumVictory() {
-        getWorldServer().dropMessage(6, "[Victory] At last, the tree of evil that for so long overwhelmed Ossyria has fallen. To the crew that managed to finally conquer Zakum, after numerous attempts, victory! You are the true heroes of Ossyria!!");
+        getWorldServer().dropMessage(6,"[远征凯旋] 长久笼罩天空之城的邪恶之树终于倾倒！" +"致那些历经无数次尝试最终征服扎昆的远征队，胜利属于你们！" +"你们是天空之城真正的传说！");
     }
 
+    // 品克缤(PinkBean)讨伐胜利广播
     public void broadcastPinkBeanVictory(int channel) {
-        getWorldServer().dropMessage(6, "[Victory] In a swift stroke of sorts, the crew that has attempted Pink Bean at channel " + channel + " has ultimately defeated it. The Temple of Time shines radiantly once again, the day finally coming back, as the crew that managed to finally conquer it returns victoriously from the battlefield!!");
+        getWorldServer().dropMessage(6,"[远征凯旋] 在" + channel + "频道挑战品克缤的远征队，" +  "以雷霆之势完成了终极讨伐！时间神殿重现璀璨光辉，" + "当英雄们从战场凯旋之时，被夺走的白昼终于归来！"
+        );
     }
+
 
     private boolean removeKilledMonsterObject(Monster monster) {
         monster.lockMonster();
@@ -1385,7 +1391,7 @@ public class MapleMap {
             spawnedMonstersOnMap.decrementAndGet();
             removeMapObject(monster);
             monster.disposeMapObject();
-            if (monster.hasBossHPBar()) {   // thanks resinate for noticing boss HPbar not clearing after mob defeat in certain scenarios
+            if (monster.hasBossHPBar()) {   // thanks resinate for noticing boss HPbar not clearing after mob defeat in certain scenarios   //感谢resinate注意到在某些情况下暴徒失败后老板HPbar没有清除
                 broadcastBossHpMessage(monster, monster.hashCode(), monster.makeBossHPBarPacket(), monster.getPosition());
             }
 
@@ -1414,7 +1420,7 @@ public class MapleMap {
             if (removeKilledMonsterObject(monster)) {
                 try {
                     if (monster.getStats().getLevel() >= chr.getLevel() + 30 && !chr.isGM()) {
-                        AutobanFactory.GENERAL.alert(chr, " for killing a " + monster.getName() + " which is over 30 levels higher.");
+                        AutobanFactory.GENERAL.alert(chr, "因击杀超过自身30级的怪物[" + monster.getName() + "]被系统警告");
                     }
 
                     /*if (chr.getQuest(Quest.getInstance(29400)).getStatus().equals(QuestStatus.Status.STARTED)) {
@@ -2002,7 +2008,7 @@ public class MapleMap {
             }
         }
 
-        if (monster.getDropPeriodTime() > 0) { //9300102 - Watchhog, 9300061 - Moon Bunny (HPQ), 9300093 - Tylus
+        if (monster.getDropPeriodTime() > 0) { //9300102 - Watchhog, 9300061 - Moon Bunny (HPQ), 9300093 - Tylus    //9300102-护卫用小浣猪，9300061-月妙（HPQ），9300093-冒牌泰勒斯
             if (monster.getId() == MobId.WATCH_HOG) {
                 monsterItemDrop(monster, monster.getDropPeriodTime());
             } else if (monster.getId() == MobId.MOON_BUNNY) {
@@ -2012,7 +2018,7 @@ public class MapleMap {
             } else if (monster.getId() == MobId.GIANT_SNOWMAN_LV5_EASY || monster.getId() == MobId.GIANT_SNOWMAN_LV5_MEDIUM || monster.getId() == MobId.GIANT_SNOWMAN_LV5_HARD) {
                 monsterItemDrop(monster, monster.getDropPeriodTime());
             } else {
-                log.error("UNCODED TIMED MOB DETECTED: {}", monster.getId());
+                log.error("[异常刷怪] 检测到未配置定时刷新的怪物: ID={}", monster.getId());
             }
         }
 
@@ -2086,7 +2092,7 @@ public class MapleMap {
     public Portal getDoorPortal(int doorid) {
         Portal doorPortal = portals.get(0x80 + doorid);
         if (doorPortal == null) {
-            log.warn("[Door] {} ({}) does not contain door portalid {}", mapName, mapid, doorid);
+            log.warn("[传动点] 地图 {} (ID:{}) 不存在传送门ID为 {} 的入口", mapName, mapid, doorid);
             return portals.get(0x80);
         }
 
@@ -2876,7 +2882,7 @@ public class MapleMap {
                 String mobName = MonsterInformationProvider.getInstance().getMobNameFromId(monster.getId());
                 if (mobName != null) {
                     mobName = mobName.trim();
-                    this.dropMessage(5, "This lawn has been taken siege by " + mobName + "'s forces and will be kept hold until their defeat.");
+                    this.dropMessage(5, "这片草坪已被" + mobName + "的部队占领，击败他们才能夺回控制权！");
                 }
             }
         }
@@ -3226,10 +3232,19 @@ public class MapleMap {
     }
 
     public void reportMonsterSpawnPoints(Character chr) {
-        chr.dropMessage(6, "Mob spawnpoints on map " + getId() + ", with available Mob SPs " + monsterSpawn.size() + ", used " + spawnedMonstersOnMap.get() + ":");
+        // 输出地图刷怪点统计信息头
+        chr.dropMessage(6, "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        chr.dropMessage(6, "┃ 地图ID: " + getId() + " | 总刷怪点: " + monsterSpawn.size() +  " | 已刷怪: " + spawnedMonstersOnMap.get());
+        chr.dropMessage(6, "┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+
+        // 遍历所有刷怪点输出详细信息
         for (SpawnPoint sp : getAllMonsterSpawn()) {
-            chr.dropMessage(6, "  id: " + sp.getMonsterId() + " canSpawn: " + !sp.getDenySpawn() + " numSpawned: " + sp.getSpawned() + " x: " + sp.getPosition().getX() + " y: " + sp.getPosition().getY() + " time: " + sp.getMobTime() + " team: " + sp.getTeam());
+            chr.dropMessage(6,
+                    "┃ ID:" + sp.getMonsterId() + " | 可刷怪:" + (sp.getDenySpawn() ? "×" : "√") + " | 现存:" + sp.getSpawned() + "\n" +
+                    "┃ 坐标:(" +(int) sp.getPosition().getX() + " , " + (int) sp.getPosition().getY() + ") | 刷新:" + sp.getMobTime() + "ms | 阵营:" + sp.getTeam()
+            );
         }
+        chr.dropMessage(6, "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     }
 
     public Map<Integer, Character> getMapPlayers() {
@@ -4040,18 +4055,19 @@ public class MapleMap {
 
     public String getEventNPC() {
         StringBuilder sb = new StringBuilder();
-        sb.append("Talk to ");
+        sb.append("请与 "+ mapName + " 的 ");
         if (mapid == MapId.SOUTHPERRY) {
-            sb.append("Paul!");
+            sb.append("珀尔");
         } else if (mapid == MapId.LITH_HARBOUR) {
-            sb.append("Jean!");
+            sb.append("江");
         } else if (mapid == MapId.ORBIS) {
-            sb.append("Martin!");
+            sb.append("马丁");
         } else if (mapid == MapId.LUDIBRIUM) {
-            sb.append("Tony!");
+            sb.append("托尼");
         } else {
             return null;
         }
+        sb.append(" 进行对话。");
         return sb.toString();
     }
 
@@ -4259,7 +4275,7 @@ public class MapleMap {
         long timeNow = Server.getInstance().getCurrentTime();
         if (timeNow - mapOwnerLastActivityTime > 60000) {
             if (unclaimOwnership() != null) {
-                this.dropMessage(5, "This lawn is now free real estate.");
+                this.dropMessage(5, "这里现在是无主之地了。");
             }
         }
     }

--- a/gms-server/src/main/java/org/gms/server/maps/Reactor.java
+++ b/gms-server/src/main/java/org/gms/server/maps/Reactor.java
@@ -43,378 +43,560 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Lerk
  * @author Ronan
  */
+/**
+ * 反应器对象类，继承自AbstractMapObject
+ */
 public class Reactor extends AbstractMapObject {
-    private final int rid;
-    private final ReactorStats stats;
-    private byte state;
-    private byte evstate;
-    private int delay;
-    private MapleMap map;
-    private String name;
-    private boolean alive;
-    private boolean shouldCollect;
-    private boolean attackHit;
-    private ScheduledFuture<?> timeoutTask = null;
-    private Runnable delayedRespawnRun = null;
-    private GuardianSpawnPoint guardian = null;
-    private byte facingDirection = 0;
-    private final Lock reactorLock = new ReentrantLock(true);
-    private final Lock hitLock = new ReentrantLock(true);
+    private final int rid;  // 反应器ID
+    private final ReactorStats stats;  // 反应器状态统计
+    private byte state;  // 当前状态
+    private byte evstate;  // 事件状态
+    private int delay;  // 延迟时间
+    private MapleMap map;  // 所属地图
+    private String name;  // 名称
+    private boolean alive;  // 是否存活
+    private boolean shouldCollect;  // 是否应该收集物品
+    private boolean attackHit;  // 是否被攻击击中
+    private ScheduledFuture<?> timeoutTask = null;  // 超时任务
+    private Runnable delayedRespawnRun = null;  // 延迟重生任务
+    private GuardianSpawnPoint guardian = null;  // 守卫生成点
+    private byte facingDirection = 0;  // 面向方向
+    private final Lock reactorLock = new ReentrantLock(true);  // 反应器锁
+    private final Lock hitLock = new ReentrantLock(true);  // 击中锁
 
+    /**
+     * 构造函数
+     * @param stats 反应器状态统计
+     * @param rid 反应器ID
+     */
     public Reactor(ReactorStats stats, int rid) {
-        this.evstate = (byte) 0;
-        this.stats = stats;
-        this.rid = rid;
-        this.alive = true;
+        this.evstate = (byte) 0;  // 初始化事件状态为0
+        this.stats = stats;  // 设置状态统计
+        this.rid = rid;  // 设置反应器ID
+        this.alive = true;  // 初始状态为存活
     }
 
+    /**
+     * 设置是否应该收集物品
+     * @param collect 是否收集
+     */
     public void setShouldCollect(boolean collect) {
-        this.shouldCollect = collect;
+        this.shouldCollect = collect;  // 设置收集标志
     }
 
+    /**
+     * 获取是否应该收集物品
+     * @return 是否收集
+     */
     public boolean getShouldCollect() {
-        return shouldCollect;
+        return shouldCollect;  // 返回收集标志
     }
 
+    /**
+     * 锁定反应器
+     */
     public void lockReactor() {
-        reactorLock.lock();
+        reactorLock.lock();  // 获取反应器锁
     }
 
+    /**
+     * 解锁反应器
+     */
     public void unlockReactor() {
-        reactorLock.unlock();
+        reactorLock.unlock();  // 释放反应器锁
     }
 
+    /**
+     * 锁定击中相关操作
+     */
     public void hitLockReactor() {
-        hitLock.lock();
-        reactorLock.lock();
+        hitLock.lock();  // 获取击中锁
+        reactorLock.lock();  // 获取反应器锁
     }
 
+    /**
+     * 解锁击中相关操作
+     */
     public void hitUnlockReactor() {
-        reactorLock.unlock();
-        hitLock.unlock();
+        reactorLock.unlock();  // 释放反应器锁
+        hitLock.unlock();  // 释放击中锁
     }
 
+    /**
+     * 设置当前状态
+     * @param state 状态值
+     */
     public void setState(byte state) {
-        this.state = state;
+        this.state = state;  // 设置状态
     }
 
+    /**
+     * 获取当前状态
+     * @return 状态值
+     */
     public byte getState() {
-        return state;
+        return state;  // 返回当前状态
     }
 
+    /**
+     * 设置事件状态
+     * @param substate 事件状态值
+     */
     public void setEventState(byte substate) {
-        this.evstate = substate;
+        this.evstate = substate;  // 设置事件状态
     }
 
+    /**
+     * 获取事件状态
+     * @return 事件状态值
+     */
     public byte getEventState() {
-        return evstate;
+        return evstate;  // 返回事件状态
     }
 
+    /**
+     * 获取反应器状态统计
+     * @return 状态统计对象
+     */
     public ReactorStats getStats() {
-        return stats;
+        return stats;  // 返回状态统计
     }
 
+    /**
+     * 获取反应器ID
+     * @return 反应器ID
+     */
     public int getId() {
-        return rid;
+        return rid;  // 返回反应器ID
     }
 
+    /**
+     * 设置延迟时间
+     * @param delay 延迟时间(毫秒)
+     */
     public void setDelay(int delay) {
-        this.delay = delay;
+        this.delay = delay;  // 设置延迟时间
     }
 
+    /**
+     * 获取延迟时间
+     * @return 延迟时间(毫秒)
+     */
     public int getDelay() {
-        return delay;
+        return delay;  // 返回延迟时间
     }
 
     @Override
     public MapObjectType getType() {
-        return MapObjectType.REACTOR;
+        return MapObjectType.REACTOR;  // 返回对象类型为反应器
     }
 
+    /**
+     * 获取反应器类型
+     * @return 反应器类型
+     */
     public int getReactorType() {
-        return stats.getType(state);
+        return stats.getType(state);  // 返回当前状态的类型
     }
 
+    /**
+     * 检查是否最近被攻击击中
+     * @return 是否被击中
+     */
     public boolean isRecentHitFromAttack() {
-        return attackHit;
+        return attackHit;  // 返回攻击击中标志
     }
 
+    /**
+     * 设置所属地图
+     * @param map 地图对象
+     */
     public void setMap(MapleMap map) {
-        this.map = map;
+        this.map = map;  // 设置地图
     }
 
+    /**
+     * 获取所属地图
+     * @return 地图对象
+     */
     public MapleMap getMap() {
-        return map;
+        return map;  // 返回地图
     }
 
+    /**
+     * 获取反应物品
+     * @param index 物品索引
+     * @return 物品ID和数量对
+     */
     public Pair<Integer, Integer> getReactItem(byte index) {
-        return stats.getReactItem(state, index);
+        return stats.getReactItem(state, index);  // 返回指定状态的物品
     }
 
+    /**
+     * 检查是否存活
+     * @return 是否存活
+     */
     public boolean isAlive() {
-        return alive;
+        return alive;  // 返回存活状态
     }
 
+    /**
+     * 检查是否活跃
+     * @return 是否活跃
+     */
     public boolean isActive() {
-        return alive && stats.getType(state) != -1;
+        return alive && stats.getType(state) != -1;  // 存活且状态类型有效
     }
 
+    /**
+     * 设置存活状态
+     * @param alive 是否存活
+     */
     public void setAlive(boolean alive) {
-        this.alive = alive;
+        this.alive = alive;  // 设置存活状态
     }
 
     @Override
     public void sendDestroyData(Client client) {
-        client.sendPacket(makeDestroyData());
+        client.sendPacket(makeDestroyData());  // 发送销毁数据包
     }
 
+    /**
+     * 创建销毁数据包
+     * @return 数据包
+     */
     public final Packet makeDestroyData() {
-        return PacketCreator.destroyReactor(this);
+        return PacketCreator.destroyReactor(this);  // 生成反应器销毁包
     }
 
     @Override
     public void sendSpawnData(Client client) {
         if (this.isAlive()) {
-            client.sendPacket(makeSpawnData());
+            client.sendPacket(makeSpawnData());  // 如果存活则发送生成数据
         }
     }
 
+    /**
+     * 创建生成数据包
+     * @return 数据包
+     */
     public final Packet makeSpawnData() {
-        return PacketCreator.spawnReactor(this);
+        return PacketCreator.spawnReactor(this);  // 生成反应器生成包
     }
 
+    /**
+     * 重置反应器动作
+     * @param newState 新状态
+     */
     public void resetReactorActions(int newState) {
-        setState((byte) newState);
-        cancelReactorTimeout();
-        setShouldCollect(true);
-        refreshReactorTimeout();
+        setState((byte) newState);  // 设置新状态
+        cancelReactorTimeout();  // 取消超时任务
+        setShouldCollect(true);  // 设置可收集
+        refreshReactorTimeout();  // 刷新超时
 
         if (map != null) {
-            map.searchItemReactors(this);
+            map.searchItemReactors(this);  // 搜索物品反应器
         }
     }
 
+    /**
+     * 强制击中反应器
+     * @param newState 新状态
+     */
     public void forceHitReactor(final byte newState) {
-        this.lockReactor();
+        this.lockReactor();  // 锁定反应器
         try {
-            this.resetReactorActions(newState);
-            map.broadcastMessage(PacketCreator.triggerReactor(this, (short) 0));
+            this.resetReactorActions(newState);  // 重置动作
+            map.broadcastMessage(PacketCreator.triggerReactor(this, (short) 0));  // 广播触发消息
         } finally {
-            this.unlockReactor();
+            this.unlockReactor();  // 解锁反应器
         }
     }
 
-    private void tryForceHitReactor(final byte newState) {  // weak hit state signal, if already changed reactor state before timeout then drop this
+    /**
+     * 尝试强制击中反应器(弱信号)
+     * @param newState 新状态
+     */
+    private void tryForceHitReactor(final byte newState) {
         if (!reactorLock.tryLock()) {
-            return;
+            return;  // 如果无法获取锁则直接返回
         }
 
         try {
-            this.resetReactorActions(newState);
-            map.broadcastMessage(PacketCreator.triggerReactor(this, (short) 0));
+            this.resetReactorActions(newState);  // 重置动作
+            map.broadcastMessage(PacketCreator.triggerReactor(this, (short) 0));  // 广播触发消息
         } finally {
-            reactorLock.unlock();
+            reactorLock.unlock();  // 释放锁
         }
     }
 
+    /**
+     * 取消反应器超时
+     */
     public void cancelReactorTimeout() {
         if (timeoutTask != null) {
-            timeoutTask.cancel(false);
-            timeoutTask = null;
+            timeoutTask.cancel(false);  // 取消任务
+            timeoutTask = null;  // 清空引用
         }
     }
 
+    /**
+     * 刷新反应器超时
+     */
     private void refreshReactorTimeout() {
-        int timeOut = stats.getTimeout(state);
+        int timeOut = stats.getTimeout(state);  // 获取超时时间
         if (timeOut > -1) {
-            final byte nextState = stats.getTimeoutState(state);
+            final byte nextState = stats.getTimeoutState(state);  // 获取超时后状态
 
             timeoutTask = TimerManager.getInstance().schedule(() -> {
-                timeoutTask = null;
-                tryForceHitReactor(nextState);
-            }, timeOut);
+                timeoutTask = null;  // 清空任务引用
+                tryForceHitReactor(nextState);  // 尝试强制击中
+            }, timeOut);  // 调度超时任务
         }
     }
 
+    /**
+     * 延迟击中反应器
+     * @param c 客户端
+     * @param delay 延迟时间
+     */
     public void delayedHitReactor(final Client c, long delay) {
-        TimerManager.getInstance().schedule(() -> hitReactor(c), delay);
+        TimerManager.getInstance().schedule(() -> hitReactor(c), delay);  // 延迟执行击中
     }
 
+    /**
+     * 击中反应器
+     * @param c 客户端
+     */
     public void hitReactor(Client c) {
-        hitReactor(false, 0, (short) 0, 0, c);
+        hitReactor(false, 0, (short) 0, 0, c);  // 默认参数调用
     }
 
+    /**
+     * 击中反应器(完整参数)
+     * @param wHit 是否为武器击中
+     * @param charPos 角色位置
+     * @param stance 姿态
+     * @param skillid 技能ID
+     * @param c 客户端
+     */
     public void hitReactor(boolean wHit, int charPos, short stance, int skillid, Client c) {
         try {
             if (!this.isActive()) {
-                return;
+                return;  // 如果不活跃则直接返回
             }
 
             if (hitLock.tryLock()) {
-                this.lockReactor();
+                this.lockReactor();  // 锁定反应器
                 try {
-                    cancelReactorTimeout();
-                    attackHit = wHit;
+                    cancelReactorTimeout();  // 取消超时
+                    attackHit = wHit;  // 设置击中标志
 
                     Character player = c.getPlayer();
                     if (GameConfig.getServerBoolean("use_debug") && player.isGM()) {
-                        player.dropMessage(5, "Hitted REACTOR " + this.getId() + " with POS " + charPos + " , STANCE " + stance + " , SkillID " + skillid + " , STATE " + state + " STATESIZE " + stats.getStateSize(state));
+                        player.dropMessage(5, "击中反应器 " + this.getId() + " 位置 " + charPos + " , 姿态 " + stance + " , 技能ID " + skillid + " , 状态 " + state + " 状态大小 " + stats.getStateSize(state));  // GM调试信息
                     }
-                    ReactorScriptManager.getInstance().onHit(c, this);
+                    ReactorScriptManager.getInstance().onHit(c, this);  // 调用击中脚本
 
                     int reactorType = stats.getType(state);
-                    if (reactorType < 999 && reactorType != -1) {//type 2 = only hit from right (kerning swamp plants), 00 is air left 02 is ground left
-                        if (!(reactorType == 2 && (stance == 0 || stance == 2))) { //get next state
-                            for (byte b = 0; b < stats.getStateSize(state); b++) {//YAY?
+                    if (reactorType < 999 && reactorType != -1) {  // 类型2=只能从右侧击中(沼泽植物), 00是左侧空中 02是左侧地面
+                        if (!(reactorType == 2 && (stance == 0 || stance == 2))) {  // 获取下一状态
+                            for (byte b = 0; b < stats.getStateSize(state); b++) {  // 遍历状态
                                 List<Integer> activeSkills = stats.getActiveSkills(state, b);
                                 if (activeSkills != null) {
                                     if (!activeSkills.contains(skillid)) {
-                                        continue;
+                                        continue;  // 技能不匹配则跳过
                                     }
                                 }
 
-                                this.state = stats.getNextState(state, b);
+                                this.state = stats.getNextState(state, b);  // 设置下一状态
                                 byte nextState = stats.getNextState(state, b);
                                 boolean isInEndState = nextState < this.state;
-                                if (isInEndState) {//end of reactor
-                                    if (reactorType < 100) {//reactor broken
+                                if (isInEndState) {  // 反应器结束状态
+                                    if (reactorType < 100) {  // 反应器破坏
                                         if (delay > 0) {
-                                            map.destroyReactor(getObjectId());
-                                        } else {//trigger as normal
-                                            map.broadcastMessage(PacketCreator.triggerReactor(this, stance));
+                                            map.destroyReactor(getObjectId());  // 延迟销毁
+                                        } else {  // 正常触发
+                                            map.broadcastMessage(PacketCreator.triggerReactor(this, stance));  // 广播触发
                                         }
-                                    } else {//item-triggered on final step
-                                        map.broadcastMessage(PacketCreator.triggerReactor(this, stance));
+                                    } else {  // 最终步骤物品触发
+                                        map.broadcastMessage(PacketCreator.triggerReactor(this, stance));  // 广播触发
                                     }
 
-                                    ReactorScriptManager.getInstance().act(c, this);
-                                } else { //reactor not broken yet
-                                    map.broadcastMessage(PacketCreator.triggerReactor(this, stance));
-                                    if (state == stats.getNextState(state, b)) {//current state = next state, looping reactor
-                                        ReactorScriptManager.getInstance().act(c, this);
+                                    ReactorScriptManager.getInstance().act(c, this);  // 执行脚本动作
+                                } else {  // 反应器未完全破坏
+                                    map.broadcastMessage(PacketCreator.triggerReactor(this, stance));  // 广播触发
+                                    if (state == stats.getNextState(state, b)) {  // 当前状态=下一状态,循环反应器
+                                        ReactorScriptManager.getInstance().act(c, this);  // 执行脚本动作
                                     }
 
-                                    setShouldCollect(true);     // refresh collectability on item drop-based reactors
-                                    refreshReactorTimeout();
+                                    setShouldCollect(true);  // 刷新物品掉落反应器的可收集性
+                                    refreshReactorTimeout();  // 刷新超时
                                     if (stats.getType(state) == 100) {
-                                        map.searchItemReactors(this);
+                                        map.searchItemReactors(this);  // 搜索物品反应器
                                     }
                                 }
-                                break;
+                                break;  // 跳出循环
                             }
                         }
                     } else {
-                        state++;
-                        map.broadcastMessage(PacketCreator.triggerReactor(this, stance));
+                        state++;  // 状态自增
+                        map.broadcastMessage(PacketCreator.triggerReactor(this, stance));  // 广播触发
                         if (this.getId() != 9980000 && this.getId() != 9980001) {
-                            ReactorScriptManager.getInstance().act(c, this);
+                            ReactorScriptManager.getInstance().act(c, this);  // 执行脚本动作(特殊ID除外)
                         }
 
-                        setShouldCollect(true);
-                        refreshReactorTimeout();
+                        setShouldCollect(true);  // 设置可收集
+                        refreshReactorTimeout();  // 刷新超时
                         if (stats.getType(state) == 100) {
-                            map.searchItemReactors(this);
+                            map.searchItemReactors(this);  // 搜索物品反应器
                         }
                     }
                 } finally {
-                    this.unlockReactor();
-                    hitLock.unlock();   // non-encapsulated unlock found thanks to MiLin
+                    this.unlockReactor();  // 解锁反应器
+                    hitLock.unlock();  // 解锁击中(感谢MiLin发现非封装解锁)
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            e.printStackTrace();  // 打印异常
         }
     }
 
+    /**
+     * 销毁反应器
+     * @return 是否成功销毁
+     */
     public boolean destroy() {
         if (reactorLock.tryLock()) {
             try {
                 boolean alive = this.isAlive();
-                // reactor neither alive nor in delayed respawn, remove map object allowed
+                // 反应器既不存活也不在延迟重生中，允许移除地图对象
                 if (alive) {
-                    this.setAlive(false);
-                    this.cancelReactorTimeout();
+                    this.setAlive(false);  // 设置死亡
+                    this.cancelReactorTimeout();  // 取消超时
 
                     if (this.getDelay() > 0) {
-                        this.delayedRespawn();
+                        this.delayedRespawn();  // 延迟重生
                     }
                 } else {
-                    return !this.inDelayedRespawn();
+                    return !this.inDelayedRespawn();  // 返回是否不在延迟重生中
                 }
             } finally {
-                reactorLock.unlock();
+                reactorLock.unlock();  // 解锁
             }
         }
 
-        map.broadcastMessage(PacketCreator.destroyReactor(this));
-        return false;
+        map.broadcastMessage(PacketCreator.destroyReactor(this));  // 广播销毁消息
+        return false;  // 返回失败
     }
 
+    /**
+     * 重生反应器
+     */
     private void respawn() {
-        this.lockReactor();
+        this.lockReactor();  // 锁定
         try {
-            this.resetReactorActions(0);
-            this.setAlive(true);
+            this.resetReactorActions(0);  // 重置动作
+            this.setAlive(true);  // 设置存活
         } finally {
-            this.unlockReactor();
+            this.unlockReactor();  // 解锁
         }
 
-        map.broadcastMessage(this.makeSpawnData());
+        map.broadcastMessage(this.makeSpawnData());  // 广播生成消息
     }
 
+    /**
+     * 延迟重生
+     */
     public void delayedRespawn() {
         Runnable r = () -> {
-            delayedRespawnRun = null;
-            respawn();
+            delayedRespawnRun = null;  // 清空任务引用
+            respawn();  // 执行重生
         };
 
-        delayedRespawnRun = r;
+        delayedRespawnRun = r;  // 设置任务
 
         OverallService service = (OverallService) map.getChannelServer().getServiceAccess(ChannelServices.OVERALL);
-        service.registerOverallAction(map.getId(), r, this.getDelay());
+        service.registerOverallAction(map.getId(), r, this.getDelay());  // 注册全局动作
     }
 
+    /**
+     * 强制延迟重生
+     * @return 是否成功
+     */
     public boolean forceDelayedRespawn() {
         Runnable r = delayedRespawnRun;
 
         if (r != null) {
             OverallService service = (OverallService) map.getChannelServer().getServiceAccess(ChannelServices.OVERALL);
-            service.forceRunOverallAction(map.getId(), r);
-            return true;
+            service.forceRunOverallAction(map.getId(), r);  // 强制运行全局动作
+            return true;  // 返回成功
         } else {
-            return false;
+            return false;  // 返回失败
         }
     }
 
+    /**
+     * 检查是否在延迟重生中
+     * @return 是否在延迟重生中
+     */
     public boolean inDelayedRespawn() {
-        return delayedRespawnRun != null;
+        return delayedRespawnRun != null;  // 返回任务是否存在
     }
 
+    /**
+     * 获取区域矩形
+     * @return 矩形区域
+     */
     public Rectangle getArea() {
-        return new Rectangle(getPosition().x + stats.getTL().x, getPosition().y + stats.getTL().y, stats.getBR().x - stats.getTL().x, stats.getBR().y - stats.getTL().y);
+        return new Rectangle(getPosition().x + stats.getTL().x, getPosition().y + stats.getTL().y, stats.getBR().x - stats.getTL().x, stats.getBR().y - stats.getTL().y);  // 计算并返回区域
     }
 
+    /**
+     * 获取名称
+     * @return 名称
+     */
     public String getName() {
-        return name;
+        return name;  // 返回名称
     }
 
+    /**
+     * 设置名称
+     * @param name 名称
+     */
     public void setName(String name) {
-        this.name = name;
+        this.name = name;  // 设置名称
     }
 
+    /**
+     * 获取守卫生成点
+     * @return 守卫生成点
+     */
     public GuardianSpawnPoint getGuardian() {
-        return guardian;
+        return guardian;  // 返回守卫
     }
 
+    /**
+     * 设置守卫生成点
+     * @param guardian 守卫生成点
+     */
     public void setGuardian(GuardianSpawnPoint guardian) {
-        this.guardian = guardian;
+        this.guardian = guardian;  // 设置守卫
     }
 
+    /**
+     * 设置面向方向
+     * @param facingDirection 方向
+     */
     public final void setFacingDirection(final byte facingDirection) {
-        this.facingDirection = facingDirection;
+        this.facingDirection = facingDirection;  // 设置方向
     }
 
+    /**
+     * 获取面向方向
+     * @return 方向
+     */
     public final byte getFacingDirection() {
-        return facingDirection;
+        return facingDirection;  // 返回方向
     }
 }

--- a/gms-server/src/main/java/org/gms/service/GiveService.java
+++ b/gms-server/src/main/java/org/gms/service/GiveService.java
@@ -435,13 +435,13 @@ public class GiveService {
         long sum = (long) cash + (long) quantity;
         // 禁止点券小于0导致商城错误
         if (sum < 0) {
-            sum = -cash;
+            quantity = -cash;
         }
         // 禁止点券大于最大值
         if (sum > Integer.MAX_VALUE) {
-            sum = Integer.MAX_VALUE - cash;
+            quantity = Integer.MAX_VALUE - cash;
         }
-        chr.getCashShop().gainCash(type, (int) sum);
+        chr.getCashShop().gainCash(type, quantity);
     }
 
     private void doGainExp(Character chr, int quantity) {
@@ -449,22 +449,23 @@ public class GiveService {
         long sum = (long) exp + (long) quantity;
         // 最低只能把经验清0
         if (sum < 0) {
-            sum = -exp;
-        } else {
-            sum = quantity;
+            quantity = -exp;
         }
-        chr.gainExp((int) sum);
+        if (sum > Integer.MAX_VALUE) {
+            quantity = Integer.MAX_VALUE - exp;
+        }
+        chr.gainExp(quantity);
     }
 
     private void doGainMeso(Character chr, int quantity) {
         int meso = chr.getMeso();
         long sum = (long) meso + (long) quantity;
         if (sum < 0) {
-            sum = -meso;
+            quantity = -meso;
         }
         if (sum > Integer.MAX_VALUE) {
-            sum = Integer.MAX_VALUE - meso;
+            quantity = Integer.MAX_VALUE - meso;
         }
-        chr.gainMeso((int) sum);
+        chr.gainMeso(quantity);
     }
 }

--- a/gms-server/src/main/java/org/gms/service/GiveService.java
+++ b/gms-server/src/main/java/org/gms/service/GiveService.java
@@ -449,12 +449,11 @@ public class GiveService {
         long sum = (long) exp + (long) quantity;
         // 最低只能把经验清0
         if (sum < 0) {
-            quantity = -exp;
+            sum = -exp;
+        } else {
+            sum = quantity;
         }
-        if (sum > Integer.MAX_VALUE) {
-            quantity = Integer.MAX_VALUE - exp;
-        }
-        chr.gainExp(quantity);
+        chr.gainExp((int) sum);
     }
 
     private void doGainMeso(Character chr, int quantity) {

--- a/gms-server/src/main/java/org/gms/util/I18nUtil.java
+++ b/gms-server/src/main/java/org/gms/util/I18nUtil.java
@@ -6,6 +6,7 @@ import org.gms.manager.ServerManager;
 import org.gms.property.ServiceProperty;
 import org.springframework.context.MessageSource;
 
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -22,7 +23,11 @@ public class I18nUtil {
     public static String getMessage(String code, Object... args) {
         // 如果当前存在客户端请求，则以客户端的语言为准。如果当前非客户端请求，是服务端主动发给客户端的，则以服务端语言为准
         Locale clientLang = CharsetConstants.getLanguageLocale(ThreadLocalUtil.getClientLang());
-        return messageSource.getMessage(code, args, clientLang);
+        // 确保所有参数转为字符串，包括数字类型（避免千分符问题）
+        String[] stringArgs = Arrays.stream(args)
+                .map(String::valueOf)
+                .toArray(String[]::new);
+        return messageSource.getMessage(code, stringArgs, clientLang);
     }
 
     public static String getMessage(Locale locale, String code, Object... args) {

--- a/gms-server/src/main/resources/application.yml
+++ b/gms-server/src/main/resources/application.yml
@@ -40,6 +40,9 @@ spring:
     multipart:
       max-file-size: 1MB
       max-request-size: 10MB
+  jackson:
+    time-zone: Asia/Shanghai
+    date-format: yyyy-MM-dd HH:mm:ss
 
 gms:
   service:

--- a/gms-server/src/main/resources/db/migration/V1.8.2__insert_game_config_add_param.sql
+++ b/gms-server/src/main/resources/db/migration/V1.8.2__insert_game_config_add_param.sql
@@ -1,0 +1,62 @@
+-- 第一条记录
+INSERT INTO `game_config`(`config_type`, `config_sub_type`, `config_clazz`, `config_code`, `config_value`, `config_desc`, `update_time`)
+SELECT 'server', 'Game Mechanics', 'java.lang.Boolean', 'use_equipment_level_up_vicious', 'true', 'use_equipment_level_up_vicious', '2025-03-13 17:43:45'
+WHERE NOT EXISTS (
+    SELECT 1 FROM `game_config` WHERE `config_code` = 'use_equipment_level_up_vicious'
+);
+
+-- 第二条记录
+INSERT INTO `game_config`(`config_type`, `config_sub_type`, `config_clazz`, `config_code`, `config_value`, `config_desc`, `update_time`)
+SELECT 'server', 'Game Mechanics', 'java.lang.String', 'use_equipment_level_up_vicious_levelrange_chance', '[[0,129,0.3],[130,255,0.9]]', 'use_equipment_level_up_vicious_LevelRange_chance', '2025-03-13 17:53:59'
+WHERE NOT EXISTS (
+    SELECT 1 FROM `game_config` WHERE `config_code` = 'use_equipment_level_up_vicious_levelrange_chance'
+);
+
+-- 第三条记录
+INSERT INTO `game_config`(`config_type`, `config_sub_type`, `config_clazz`, `config_code`, `config_value`, `config_desc`, `update_time`)
+SELECT 'server', 'Game Mechanics', 'java.lang.Boolean', 'use_equipment_level_up_continuous', 'false', 'use_equipment_level_up_continuous', '2025-03-13 23:13:38'
+WHERE NOT EXISTS (
+    SELECT 1 FROM `game_config` WHERE `config_code` = 'use_equipment_level_up_continuous'
+);
+
+-- 第一条记录
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'zh-CN', 'game_config', 'use_equipment_level_up_vicious', '装备升级是否减少金锤子已使用次数', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'zh-CN' AND `lang_code` = 'use_equipment_level_up_vicious'
+);
+
+-- 第二条记录
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'en-US', 'game_config', 'use_equipment_level_up_vicious', 'Equipment upgrade reduces vicious numbers', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'en-US' AND `lang_code` = 'use_equipment_level_up_vicious'
+);
+
+-- 第三条记录
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'zh-CN', 'game_config', 'use_equipment_level_up_vicious_levelrange_chance', '装备升级减少金锤子次数的装备要求等级范围和概率。\n配置方法为数组，举例：\n配置两条概率判断，\n1、装备要求等级0~129，概率30%，\n2、装备要求等级130~255，概率90%\n配置如下：\n[[0,129,0.3],[130,255,0.9]]', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'zh-CN' AND `lang_code` = 'use_equipment_level_up_vicious_levelrange_chance'
+);
+
+-- 第四条记录
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'en-US', 'game_config', 'use_equipment_level_up_vicious_levelrange_chance', 'Equipment upgrade reduces the required level range and probability of the Golden Hammer frequency.\r\nThe configuration method is an array, for example:\r\nConfigure two probability judgments,\r\n1. EquipRepLv 0~129, chance 30%,\r\n2. EquipRepLv 130-255, chance 90%\r\nThe configuration is as follows:\r\n[[0,129,0.3],[130,255,0.9]]', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'en-US' AND `lang_code` = 'use_equipment_level_up_vicious_levelrange_chance'
+);
+
+-- 第五条记录
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'zh-CN', 'game_config', 'use_equipment_level_up_continuous', '是否允许装备连续升级', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'zh-CN' AND `lang_code` = 'use_equipment_level_up_continuous'
+);
+
+-- 第六条记录
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'en_US', 'game_config', 'use_equipment_level_up_continuous', 'Do you allow continuous equipment upgrades', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'en_US' AND `lang_code` = 'use_equipment_level_up_continuous'
+);

--- a/gms-server/src/main/resources/db/migration/V1.8.3.1__update_game_config_param.sql
+++ b/gms-server/src/main/resources/db/migration/V1.8.3.1__update_game_config_param.sql
@@ -1,0 +1,2 @@
+UPDATE `game_config` SET config_value = 'false' WHERE config_code = 'use_enable_party_level_limit_lift';
+UPDATE `game_config` SET config_value = 'false' WHERE config_code = 'use_equipment_level_up_vicious';

--- a/gms-server/src/main/resources/db/migration/V1.8.3__insert_game_config_add_param.sql
+++ b/gms-server/src/main/resources/db/migration/V1.8.3__insert_game_config_add_param.sql
@@ -1,0 +1,20 @@
+-- 是否解除组队副本默认等级范围限制，开启时允许任意等级的玩家进入副本
+INSERT INTO `game_config`(`config_type`, `config_sub_type`, `config_clazz`, `config_code`, `config_value`, `config_desc`, `update_time`)
+SELECT 'server', 'Game Mechanics', 'java.lang.Boolean', 'use_enable_party_level_limit_lift', 'true', 'use_enable_party_level_limit_lift', '2025-04-02 16:56:57'
+WHERE NOT EXISTS (
+    SELECT 1 FROM `game_config` WHERE `config_code` = 'use_enable_party_level_limit_lift'
+);
+
+-- 中文内容
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'zh-CN', 'game_config', 'use_enable_party_level_limit_lift', '是否解除组队副本默认等级范围限制，开启时允许任意等级的玩家进入副本', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'zh-CN' AND `lang_code` = 'use_enable_party_level_limit_lift'
+);
+
+-- 英文内容
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'en-US', 'game_config', 'use_enable_party_level_limit_lift', 'Should the default level range limit for teaming up dungeons be lifted, allowing players of any level to enter the dungeon when enableds', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'en-US' AND `lang_code` = 'use_enable_party_level_limit_lift'
+);

--- a/gms-server/src/main/resources/i18n/message_en_US.properties
+++ b/gms-server/src/main/resources/i18n/message_en_US.properties
@@ -846,7 +846,7 @@ InventoryManipulator.equip.message1=The gender of the character does not meet th
 NPCTalkHandler.handlePacket.message1 = Talking to NPC：
 
 ##############################
-# Equip
+# Equip.
 ##############################
 Equip.gainStats.message1 = DEX
 Equip.gainStats.message2 = STR

--- a/gms-server/src/main/resources/i18n/message_en_US.properties
+++ b/gms-server/src/main/resources/i18n/message_en_US.properties
@@ -673,13 +673,13 @@ PmobRemoveCommand.message3 = Cleared {0} pMob placements.
 DebugCommand.message1 = Show a debug message.
 DebugCommand.message2 = Syntax: !debug <type>
 DebugCommand.message3 = Available #bdebug types#k
-DebugCommand.message4 = Monster ID: {0} Aggro target: {1}
-DebugCommand.message5 = {0} Has aggro: {1} Knowns aggro: {2}
+DebugCommand.message4 = Monster: {0} ({1}), Aggro target: {1}
+DebugCommand.message5 = , {0} Has aggro: {1} Knowns aggro: {2}
 DebugCommand.message6 = Closest portal: {0} {1} Type: {2} --> toMap: {3} scriptname: {4} state: {5}.
 DebugCommand.message7 = There is no portal on this map.
 DebugCommand.message8 = Closest mob spawn point: Position: ({0},{1}) Spawns mobid: {2} --> canSpawn: {3} canSpawnRightNow: {4}.
 DebugCommand.message9 = There is no mob spawn point on this map.
-DebugCommand.message10 = Current map position: ({0},{1}).
+DebugCommand.message10 = Current map position: (x= {0}, y= {1}).
 DebugCommand.message11 = Current map id {0}, event: {1}; Players: {2}, Mobs: {3}, Reactors: {4}, Items: {5}, Objects: {6}.
 DebugCommand.message12 = Player currently not in an event.
 DebugCommand.message13 = Current event name: {0}.
@@ -690,6 +690,7 @@ DebugCommand.message17 = Id: {0} Oid: {1} name: {2} -> Type: {3} State: {4} Even
 DebugCommand.message18 = Currently active SERVER coupons:
 DebugCommand.message19 = Currently active PLAYER coupons:
 DebugCommand.message20 = Total Task: {0} Current Task: {1} Active Task: {2} Completed Task: {3}.
+DebugCommand.message21 = The debug command does not exist, can be entered !Debug help to view available commands
 
 SetCommand.message1 = Store value in an array, for testing.
 

--- a/gms-server/src/main/resources/i18n/message_zh_CN.properties
+++ b/gms-server/src/main/resources/i18n/message_zh_CN.properties
@@ -845,31 +845,27 @@ InventoryManipulator.equip.message1=角色性别不符合要求，无法装备�
 # NPCTalkHandler移动物品提示代码
 ##############################
 NPCTalkHandler.handlePacket.message1 = 对话NPC：
-
 ##############################
-# Equip装备升级提示
+# Equip装备升级提示（使用变量读取以下字段，代码里没有搜到时正常的，勿删）
 ##############################
-Equip.gainStats.message1 = 敏捷
-Equip.gainStats.message2 = 力量
-Equip.gainStats.message3 = 智力
-Equip.gainStats.message4 = 运气
-Equip.gainStats.message5 = HP
-Equip.gainStats.message6 = MP
-Equip.gainStats.message7 = 攻击力
-Equip.gainStats.message8 = 魔法力
-Equip.gainStats.message9 = 防御力
-Equip.gainStats.message10 = 魔法防御力
-Equip.gainStats.message11 = 回避率
-Equip.gainStats.message12 = 命中率
-Equip.gainStats.message13 = 移动速度
-Equip.gainStats.message14 = 跳跃力
-Equip.gainStats.message15 = 提升到了
-Equip.gainStats.message16 = #b 现在 #e级 #r
-Equip.gainStats.message17 = 等级
-Equip.gainStats.message18 = 装备
-Equip.gainStats.message19 = 提升了金锤子强化次数
-Equip.gainStats.message20 = 提升了可升级次数
-Equip.gainStats.message21 = 装备 {0} 提升到了 {1} 级
+Equip.gainStats.DEX = 敏捷
+Equip.gainStats.STR = 力量
+Equip.gainStats.INT = 智力
+Equip.gainStats.LUK = 运气
+Equip.gainStats.MHP = HP
+Equip.gainStats.MMP = MP
+Equip.gainStats.PAD = 攻击力
+Equip.gainStats.MAD = 魔法力
+Equip.gainStats.PDD = 防御力
+Equip.gainStats.MDD = 魔法防御力
+Equip.gainStats.EVA = 回避率
+Equip.gainStats.ACC = 命中率
+Equip.gainStats.Speed = 移动速度
+Equip.gainStats.Jump = 跳跃力
+Equip.gainStats.showHint = #e#b{0}#k#n 升到了 #b#e{1} 级#k#n
+Equip.gainStats.Vicious = 金锤子已强化次数 {0}
+Equip.gainStats.UPGSLOT = 可升级次数 {0}
+Equip.gainStats.lvupStr = 装备 {0} 提升到了 {1} 级
 
 ##############################
 # Monster攻击怪物提示

--- a/gms-server/src/main/resources/i18n/message_zh_CN.properties
+++ b/gms-server/src/main/resources/i18n/message_zh_CN.properties
@@ -673,13 +673,13 @@ PmobRemoveCommand.message3 = 已移除当前地图的 {0} 个永久怪物
 DebugCommand.message1 = 打印debug信息
 DebugCommand.message2 = 输入：!debug <类型>
 DebugCommand.message3 = 可用的 #bdebug类型#k：
-DebugCommand.message4 = 怪物id：{0}，仇恨目标：{1}
-DebugCommand.message5 = {0} 是否仇恨中：{1}，是否确认仇恨对象：{2}
+DebugCommand.message4 = 怪物：{0} ({1})，仇恨：{2}
+DebugCommand.message5 = ，{0} 仇恨中：{1}，确认仇恨：{2}
 DebugCommand.message6 = 最近的传送点：{0} {1}，类型：{2} --> 前往地图：{3}，脚本名：{4}，状态：{5}
 DebugCommand.message7 = 当前地图没有任何传送点
 DebugCommand.message8 = 最近的怪物刷新点：坐标：({0},{1})，生成的怪物id：{2} --> 能否生成：{3}，是否立即生成：{4}
 DebugCommand.message9 = 当前地图没有任何怪物刷新点
-DebugCommand.message10 = 玩家在当前地图坐标：({0},{1})
+DebugCommand.message10=玩家在当前地图坐标：(x= {0}，y= {1})
 DebugCommand.message11 = 当前地图id：{0}，活动：{1}。玩家数：{2}，怪物数：{3}，反应堆数：{4}，掉落物数：{5}，对象数：{6}
 DebugCommand.message12 = 玩家当前不在活动中
 DebugCommand.message13 = 当前活动名：{0}
@@ -690,6 +690,7 @@ DebugCommand.message17 = 反应堆Id：{0}，反应堆对象id：{1}，反应堆
 DebugCommand.message18 = 当前服务支持的倍率卡：
 DebugCommand.message19 = 当前玩家已使用的倍率卡：
 DebugCommand.message20 = 定时任务数：{0}，正在执行任务数：{1}，已注册任务数：{2}，已完成任务数：{3}
+DebugCommand.message21 = 该debug命令不存在，可以输入 !debug help 查看可用的命令
 
 SetCommand.message1 = 把传入的参数存到服务端变量中，用于后续测试
 

--- a/gms-ui/src/assets/style/global.less
+++ b/gms-ui/src/assets/style/global.less
@@ -92,3 +92,57 @@ body {
     }
   }
 }
+
+.td-nowrap {
+  white-space: nowrap;//内容不换行
+}
+
+/* 仅针对 IOS 的Safari和其它浏览器的CSS，安卓没有此烦恼。 */
+@supports (-webkit-touch-callout: none) {
+  /* 针对表格的列被压缩宽度的优化 */
+  table, .arco-table, .arco-table-container, .arco-scrollbar, .arco-scrollbar-container, .arco-table-element {
+    white-space: nowrap;  //禁止换行，防止Safari对表格列进行压缩
+  }
+  /* 保证表格里选择框最小宽度 */
+  .arco-table-checkbox {
+    min-width: 30px;
+  }
+  /* 保证表格里输入框最小宽度 */
+  td .arco-table-cell .arco-input {
+    min-width: 80px;
+  }
+  /* 允许表格里按钮列自动换行 */
+  td:has(.arco-table-cell .arco-table-td-content .arco-btn) {
+    white-space: normal;
+  }
+  /* 禁止输入框缩放 */
+  input, textarea {
+    resize: none; /* 禁用右下角缩放手柄 */
+    font-size: 16px !important;  /* iOS 对小于 16px 的输入框触发自动缩放 */
+    touch-action: manipulation;  /* 禁用双指手势 */
+  }
+}
+/* 针对所有移动端的a-modal模态框进行优化 */
+@media (max-width: @screen-sm) {
+  .arco-modal {
+    width: 90% !important;
+    max-width: 600px !important;
+    top: 0 !important;
+  }
+
+  .arco-pagination-size-medium {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .arco-pagination-list {
+    width: 100%;
+    margin-top: 8px;
+    margin-bottom: 15px;
+    white-space: normal;
+  }
+
+  .arco-form .arco-form-item-label-col > .arco-form-item-label {
+    white-space: nowrap;//内容不换行
+  }
+}

--- a/gms-ui/src/utils/stringUtils.ts
+++ b/gms-ui/src/utils/stringUtils.ts
@@ -16,13 +16,13 @@ export function isValidString(data: any) {
  * @param timestamp 时间戳
  * @returns 格式化的时间字符串
  */
-export function timestampToChineseTime(timestamp: number) {
+export function timestampToChineseTime(timestamp: number | string) {
   const { locale } = useI18n();
 
   if (timestamp === -1) {
     return locale.value === 'en-US' ? 'Permanent' : '永久';
   }
-
+  if (typeof timestamp === 'string') timestamp?.replace(' ', 'T');
   const date = new Date(timestamp);
 
   // 获取年、月、日、时、分、秒

--- a/gms-ui/src/views/account/list/index.vue
+++ b/gms-ui/src/views/account/list/index.vue
@@ -2,77 +2,52 @@
   <div class="container" :loading="true">
     <Breadcrumb />
     <a-card class="general-card" :title="$t('menu.account.list')">
-      <a-row style="margin-bottom: 16px">
-        <a-col :flex="1">
-          <a-form
-            :model="filterForm"
-            :label-col-props="{ span: 8 }"
-            :wrapper-col-props="{ span: 16 }"
-          >
-            <a-row :gutter="16">
-              <a-col :span="6">
-                <a-form-item :label="$t('account.list.filter.id')">
-                  <a-input-number v-model="filterForm.id" />
-                </a-form-item>
-              </a-col>
-              <a-col :span="6">
-                <a-form-item :label="$t('account.list.filter.name')">
-                  <a-input v-model="filterForm.name" />
-                </a-form-item>
-              </a-col>
-              <a-col :span="6">
-                <a-form-item :label="$t('account.list.filter.lastLoginStart')">
-                  <a-date-picker
-                    v-model="filterForm.lastLoginStart"
-                    style="width: 100%"
-                  />
-                </a-form-item>
-              </a-col>
-              <a-col :span="6">
-                <a-form-item :label="$t('account.list.filter.lastLoginEnd')">
-                  <a-date-picker
-                    v-model="filterForm.lastLoginEnd"
-                    style="width: 100%"
-                  />
-                </a-form-item>
-              </a-col>
-              <a-col :span="6">
-                <a-form-item :label="$t('account.list.filter.createdAtStart')">
-                  <a-date-picker
-                    v-model="filterForm.createdAtStart"
-                    style="width: 100%"
-                  />
-                </a-form-item>
-              </a-col>
-              <a-col :span="6">
-                <a-form-item :label="$t('account.list.filter.createdAtEnd')">
-                  <a-date-picker
-                    v-model="filterForm.createdAtEnd"
-                    style="width: 100%"
-                  />
-                </a-form-item>
-              </a-col>
-            </a-row>
-          </a-form>
-        </a-col>
-        <a-divider style="height: 84px" direction="vertical" />
-        <a-col :flex="'86px'" style="text-align: right">
-          <a-space direction="vertical" :size="18">
-            <a-button type="primary" @click="loadData()">
-              <template #icon>
-                <icon-search />
-              </template>
-              {{ $t('button.load') }}
-            </a-button>
-            <a-button @click="resetClick">
-              <template #icon>
-                <icon-refresh />
-              </template>
-              {{ $t('button.reset') }}
-            </a-button>
-          </a-space>
-        </a-col>
-      </a-row>
+      <a-form :model="filterForm" class="a-from-keyword">
+        <a-form-item :label="$t('account.list.filter.id')">
+          <a-input-number v-model="filterForm.id" />
+        </a-form-item>
+        <a-form-item :label="$t('account.list.filter.name')">
+          <a-input v-model="filterForm.name" />
+        </a-form-item>
+        <a-form-item :label="$t('account.list.filter.lastLoginStart')">
+          <a-date-picker
+            v-model="filterForm.lastLoginStart"
+            style="width: 100%"
+          />
+        </a-form-item>
+        <a-form-item :label="$t('account.list.filter.lastLoginEnd')">
+          <a-date-picker
+            v-model="filterForm.lastLoginEnd"
+            style="width: 100%"
+          />
+        </a-form-item>
+        <a-form-item :label="$t('account.list.filter.createdAtStart')">
+          <a-date-picker
+            v-model="filterForm.createdAtStart"
+            style="width: 100%"
+          />
+        </a-form-item>
+        <a-form-item :label="$t('account.list.filter.createdAtEnd')">
+          <a-date-picker
+            v-model="filterForm.createdAtEnd"
+            style="width: 100%"
+          />
+        </a-form-item>
+      </a-form>
+      <a-space class="a-space-btn">
+        <a-button type="primary" @click="loadData()">
+          <template #icon>
+            <icon-search />
+          </template>
+          {{ $t('button.load') }}
+        </a-button>
+        <a-button @click="resetClick">
+          <template #icon>
+            <icon-refresh />
+          </template>
+          {{ $t('button.reset') }}
+        </a-button>
+      </a-space>
       <a-divider />
       <a-row style="margin-bottom: 16px">
         <a-col>
@@ -93,7 +68,6 @@
         column-resizable
         :pagination="false"
         :bordered="{ cell: true }"
-        :scroll="{ y: 'calc(100vh - 502px)' }"
       >
         <template #columns>
           <a-table-column
@@ -138,7 +112,7 @@
           </a-table-column>
           <a-table-column
             :title="$t('account.list.column.gender')"
-            :width="80"
+            :width="60"
             align="center"
           >
             <template #cell="{ record }">
@@ -156,12 +130,20 @@
           <a-table-column
             :title="$t('account.list.column.lastLoginAt')"
             data-index="lastlogin"
+            :width="120"
+            align="center"
           />
           <a-table-column
             :title="$t('account.list.column.registerAt')"
             data-index="createdat"
+            :width="120"
+            align="center"
           />
-          <a-table-column :title="$t('account.list.column.operate')">
+          <a-table-column
+            :title="$t('account.list.column.operate')"
+            :width="150"
+            align="center"
+          >
             <template #cell="{ record }">
               <a-button
                 type="text"
@@ -222,7 +204,7 @@
         show-total
         show-jumper
         show-page-size
-        :page-size-options="[7, 14, 35, 70]"
+        :page-size-options="[10, 20, 50, 100]"
         @change="pageChange"
         @page-size-change="pageSizeChange"
       />
@@ -404,3 +386,47 @@
     name: 'AccountList',
   };
 </script>
+
+<style lang="less">
+  .a-from-keyword {
+    @media (min-width: @screen-sm) {
+      display: flex;
+      flex-direction: initial;
+      flex-wrap: wrap;
+      width: 100%;
+      div {
+        margin-right: 5px;
+      }
+      .arco-row {
+        width: max-content;
+        display: flex;
+      }
+      .arco-col {
+        flex: max-content;
+        width: 100%;
+      }
+      .arco-form-item-label-col,
+      .arco-form-item-label {
+        min-width: auto;
+        text-align: right;
+      }
+    }
+    @media (max-width: @screen-sm) {
+      display: block;
+      flex-direction: column;
+      .arco-row {
+        flex-flow: row wrap;
+        width: 100%;
+      }
+
+      .arco-col {
+        flex: 0 0 100%;
+        width: 100%;
+      }
+
+      .arco-form-item-label-col {
+        display: contents;
+      }
+    }
+  }
+</style>

--- a/gms-ui/src/views/account/player/index.vue
+++ b/gms-ui/src/views/account/player/index.vue
@@ -2,50 +2,39 @@
   <div class="container" :loading="true">
     <Breadcrumb />
     <a-card class="general-card" :title="$t('menu.account.player')">
-      <a-row style="margin-bottom: 16px">
-        <a-col :flex="1">
-          <a-form
-            :model="filterForm"
-            :label-col-props="{ span: 8 }"
-            :wrapper-col-props="{ span: 16 }"
-          >
-            <a-row :gutter="16">
-              <a-col :span="6">
-                <a-form-item :label="$t('account.player.id')">
-                  <a-input-number v-model="filterForm.id" />
-                </a-form-item>
-              </a-col>
-              <a-col :span="6">
-                <a-form-item :label="$t('account.player.name')">
-                  <a-input v-model="filterForm.name" />
-                </a-form-item>
-              </a-col>
-              <a-col :span="6">
-                <a-form-item :label="$t('account.player.mapId')">
-                  <a-input-number v-model="filterForm.map" />
-                </a-form-item>
-              </a-col>
-            </a-row>
-          </a-form>
-        </a-col>
-        <a-divider style="height: 84px" direction="vertical" />
-        <a-col :flex="'86px'" style="text-align: right">
-          <a-space direction="vertical" :size="18">
-            <a-button type="primary" @click="loadData()">
-              <template #icon>
-                <icon-search />
-              </template>
-              {{ $t('button.load') }}
-            </a-button>
-            <a-button @click="resetClick">
-              <template #icon>
-                <icon-refresh />
-              </template>
-              {{ $t('button.reset') }}
-            </a-button>
-          </a-space>
-        </a-col>
-      </a-row>
+      <a-form :model="filterForm" class="a-from-keyword">
+        <a-row :gutter="16">
+          <a-col :span="6">
+            <a-form-item :label="$t('account.player.id')">
+              <a-input-number v-model="filterForm.id" />
+            </a-form-item>
+          </a-col>
+          <a-col :span="6">
+            <a-form-item :label="$t('account.player.name')">
+              <a-input v-model="filterForm.name" />
+            </a-form-item>
+          </a-col>
+          <a-col :span="6">
+            <a-form-item :label="$t('account.player.mapId')">
+              <a-input-number v-model="filterForm.map" />
+            </a-form-item>
+          </a-col>
+        </a-row>
+      </a-form>
+      <a-space>
+        <a-button type="primary" @click="loadData()">
+          <template #icon>
+            <icon-search />
+          </template>
+          {{ $t('button.load') }}
+        </a-button>
+        <a-button @click="resetClick">
+          <template #icon>
+            <icon-refresh />
+          </template>
+          {{ $t('button.reset') }}
+        </a-button>
+      </a-space>
       <a-divider />
       <a-row style="margin-bottom: 16px">
         <a-col>
@@ -72,13 +61,12 @@
         column-resizable
         :pagination="false"
         :bordered="{ cell: true }"
-        :scroll="{ y: 'calc(100vh - 502px)' }"
       >
         <template #columns>
           <a-table-column
             :title="$t('account.player.id')"
             data-index="id"
-            :width="100"
+            :width="80"
             align="center"
           />
           <a-table-column
@@ -90,31 +78,31 @@
           <a-table-column
             :title="$t('account.player.map')"
             data-index="map"
-            :width="200"
+            :width="120"
             align="center"
           />
           <a-table-column
             :title="$t('account.player.job')"
             data-index="job"
-            :width="200"
+            :width="80"
             align="center"
           />
           <a-table-column
             :title="$t('account.player.jobName')"
             data-index="jobName"
-            :width="200"
+            :width="160"
             align="center"
           />
           <a-table-column
             :title="$t('account.player.level')"
             data-index="level"
-            :width="200"
+            :width="70"
             align="center"
           />
           <a-table-column
             :title="$t('account.player.gm.level')"
             data-index="gm"
-            :width="200"
+            :width="70"
             align="center"
           />
           <a-table-column :title="$t('account.list.column.operate')">
@@ -134,7 +122,7 @@
         show-total
         show-jumper
         show-page-size
-        :page-size-options="[7, 14, 35, 70]"
+        :page-size-options="[10, 20, 50, 100]"
         @change="pageChange"
         @page-size-change="pageSizeChange"
       />
@@ -518,3 +506,47 @@
     name: 'Player',
   };
 </script>
+
+<style lang="less">
+  .a-from-keyword {
+    @media (min-width: @screen-sm) {
+      display: flex;
+      flex-direction: initial;
+      flex-wrap: wrap;
+      width: 100%;
+      div {
+        margin-right: 5px;
+      }
+      .arco-row {
+        width: max-content;
+        display: flex;
+      }
+      .arco-col {
+        flex: max-content;
+        width: 100%;
+      }
+      .arco-form-item-label-col,
+      .arco-form-item-label {
+        min-width: auto;
+        text-align: right;
+      }
+    }
+    @media (max-width: @screen-sm) {
+      display: block;
+      flex-direction: column;
+      .arco-row {
+        flex-flow: row wrap;
+        width: 100%;
+      }
+
+      .arco-col {
+        flex: 0 0 100%;
+        width: 100%;
+      }
+
+      .arco-form-item-label-col {
+        display: contents;
+      }
+    }
+  }
+</style>

--- a/gms-ui/src/views/dashboard/informationSearch/index.vue
+++ b/gms-ui/src/views/dashboard/informationSearch/index.vue
@@ -6,60 +6,57 @@
       :title="$t('menu.dashboard.informationSearch')"
     >
       <a-row>
-        <a-col>
-          <a-space>
-            <a-select
-              v-model="condition.types"
-              :placeholder="$t('informationSearch.placeholder.type')"
-              :scrollbar="true"
-              :style="{ width: '200px' }"
-              multiple
-              :max-tag-count="1"
-              allow-clear
-            >
-              <a-option value="cash">
-                {{ $t('informationSearch.type.cash') }}
-              </a-option>
-              <a-option value="consume">
-                {{ $t('informationSearch.type.consume') }}
-              </a-option>
-              <a-option value="eqp">
-                {{ $t('informationSearch.type.eqp') }}
-              </a-option>
-              <a-option value="etc">
-                {{ $t('informationSearch.type.etc') }}
-              </a-option>
-              <a-option value="ins">
-                {{ $t('informationSearch.type.ins') }}
-              </a-option>
-              <a-option value="map">
-                {{ $t('informationSearch.type.map') }}
-              </a-option>
-              <a-option value="mob">
-                {{ $t('informationSearch.type.mob') }}
-              </a-option>
-              <a-option value="npc">
-                {{ $t('informationSearch.type.npc') }}
-              </a-option>
-              <a-option value="pet">
-                {{ $t('informationSearch.type.pet') }}
-              </a-option>
-              <a-option value="skill">
-                {{ $t('informationSearch.type.skill') }}
-              </a-option>
-            </a-select>
-            <a-input
-              v-model="condition.filter"
-              :placeholder="$t('informationSearch.placeholder.filter')"
-            />
-            <a-button type="primary" @click="searchData">
-              {{ $t('button.search') }}
-            </a-button>
-            <a-button @click="resetSearch">
-              {{ $t('button.reset') }}
-            </a-button>
-          </a-space>
-        </a-col>
+        <a-select
+          v-model="condition.types"
+          :placeholder="$t('informationSearch.placeholder.type')"
+          :readonly="true"
+          multiple
+          :max-tag-count="3"
+          allow-clear
+          class="a-space-son"
+        >
+          <a-option value="cash">
+            {{ $t('informationSearch.type.cash') }}
+          </a-option>
+          <a-option value="consume">
+            {{ $t('informationSearch.type.consume') }}
+          </a-option>
+          <a-option value="eqp">
+            {{ $t('informationSearch.type.eqp') }}
+          </a-option>
+          <a-option value="etc">
+            {{ $t('informationSearch.type.etc') }}
+          </a-option>
+          <a-option value="ins">
+            {{ $t('informationSearch.type.ins') }}
+          </a-option>
+          <a-option value="map">
+            {{ $t('informationSearch.type.map') }}
+          </a-option>
+          <a-option value="mob">
+            {{ $t('informationSearch.type.mob') }}
+          </a-option>
+          <a-option value="npc">
+            {{ $t('informationSearch.type.npc') }}
+          </a-option>
+          <a-option value="pet">
+            {{ $t('informationSearch.type.pet') }}
+          </a-option>
+          <a-option value="skill">
+            {{ $t('informationSearch.type.skill') }}
+          </a-option>
+        </a-select>
+        <a-input
+          v-model="condition.filter"
+          :placeholder="$t('informationSearch.placeholder.filter')"
+          class="a-space-son"
+        />
+        <a-button type="primary" @click="searchData">
+          {{ $t('button.search') }}
+        </a-button>
+        <a-button @click="resetSearch">
+          {{ $t('button.reset') }}
+        </a-button>
       </a-row>
       <a-table
         row-key="id"
@@ -67,13 +64,12 @@
         :data="informationList"
         column-resizable
         :pagination="false"
-        :bordered="{ cell: true }"
+        :bordered="{ wrapper: true, cell: true }"
       >
         <template #columns>
           <a-table-column
             :title="$t('informationSearch.column.type')"
             data-index="type"
-            :width="120"
             align="center"
           >
             <template #cell="{ record }">
@@ -85,13 +81,11 @@
           <a-table-column
             :title="$t('informationSearch.column.id')"
             data-index="id"
-            :width="100"
             align="center"
           />
           <a-table-column
             :title="$t('informationSearch.column.name')"
             data-index="name"
-            :width="100"
             align="center"
           >
             <template #cell="{ record }">
@@ -108,8 +102,9 @@
           <a-table-column
             :title="$t('informationSearch.column.desc')"
             data-index="desc"
-            :width="200"
             align="center"
+            :width="400"
+            :style="{ minWidth: '400px' }"
           />
         </template>
       </a-table>
@@ -196,4 +191,27 @@
   };
 </script>
 
-<style lang="less" scoped></style>
+<style lang="less" scoped>
+  .arco-card-body > .arco-row > {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+  :deep(.a-space-son) {
+    width: 400px;
+    max-width: 100%;
+  }
+  :deep(.arco-table-th:nth-child(1)) {
+    min-width: 70px;
+  }
+  :deep(.arco-table-th:nth-child(2)) {
+    min-width: 100px;
+  }
+  :deep(.arco-table-th:nth-child(3)) {
+    min-width: 50px;
+    max-width: 150px;
+  }
+  :deep(.arco-table-th:nth-child(4)) {
+    min-width: 400px;
+  }
+</style>

--- a/gms-ui/src/views/dashboard/workplace/index.vue
+++ b/gms-ui/src/views/dashboard/workplace/index.vue
@@ -25,7 +25,7 @@
         :title="$t('workplace.gameServer.serverControl')"
         :bordered="false"
       >
-        <a-space>
+        <a-space class="button-group" :size="16">
           <a-button
             v-for="(btn, index) in serverControlButtons"
             :key="index"
@@ -48,7 +48,7 @@
         :title="$t('workplace.dataReload')"
         :bordered="false"
       >
-        <a-space>
+        <a-space class="button-group" :size="16">
           <a-button
             v-for="(btn, index) in dataReloadButtons"
             :key="index + 'reload'"
@@ -64,10 +64,11 @@
         </a-space>
       </a-card>
 
-      <!-- Shutdown Confirmation Modal -->
+      <!-- 完全停服并退出BAT的确认框 -->
       <a-modal
         v-model:visible="shutdownConfirmVisible"
-        :width="400"
+        class="arco-modal-auto"
+        draggable
         @ok="handleShutdownConfirm"
         @cancel="handleShutdownCancel"
       >
@@ -77,10 +78,24 @@
         <p>{{ $t('workplace.button.shutdown.confirm') }}</p>
       </a-modal>
 
-      <!-- Stop Configuration Modal -->
+      <!-- 重启服务端的确认框 -->
+      <a-modal
+        v-model:visible="restartConfirmVisible"
+        modal-class="arco-modal-auto"
+        draggable
+        @ok="handleRestartConfirm"
+        @cancel="handleRestartCancel"
+      >
+        <template #title>
+          {{ $t('workplace.button.restart') }}
+        </template>
+        <p>{{ $t('workplace.button.restart.confirm') }}</p>
+      </a-modal>
+
+      <!-- 停服倒计时配置框 -->
       <a-modal
         v-model:visible="stopConfigVisible"
-        :width="600"
+        modal-class="arco-modal-auto"
         draggable
         @ok="handleStopConfigOk"
         @cancel="handleStopConfigCancel"
@@ -118,13 +133,13 @@
 
             <a-row :gutter="[16, 16]">
               <a-col :span="24">
-                <a-input v-model="stopConfigData.shutdownMsg" />
+                <a-textarea v-model="stopConfigData.shutdownMsg" />
               </a-col>
             </a-row>
           </a-card>
 
           <a-card :title="$t('workplace.stop.messageTypes')" :bordered="false">
-            <a-space>
+            <a-space class="button-group" :size="16">
               <a-checkbox v-model="stopConfigData.showServerMsg">
                 {{ $t('workplace.stop.showServerMsg') }}
               </a-checkbox>
@@ -166,6 +181,7 @@
   const serverStatus = ref<'resting' | 'running'>('resting');
   const stopConfigVisible = ref(false);
   const shutdownConfirmVisible = ref(false); // 新增用于确认关机的模态框可见性控制
+  const restartConfirmVisible = ref(false); // 新增用于确认重启的模态框可见性控制
   const router = useRouter();
   const stopConfigData = reactive({
     minutes: 0,
@@ -239,6 +255,10 @@
       shutdownConfirmVisible.value = true;
       return;
     }
+    if (action === 'restart') {
+      restartConfirmVisible.value = true;
+      return;
+    }
 
     setLoading(true);
     try {
@@ -296,6 +316,23 @@
     shutdownConfirmVisible.value = false;
   };
 
+  const handleRestartConfirm = async () => {
+    try {
+      setLoading(true);
+      await restartServer();
+      Message.success(t('common.operationSuccess'));
+    } catch (err) {
+      console.error(err);
+      Message.error(t('common.requestFailed'));
+    } finally {
+      restartConfirmVisible.value = false;
+      setLoading(false);
+    }
+  };
+
+  const handleRestartCancel = () => {
+    restartConfirmVisible.value = false;
+  };
   const handleStopConfigOk = async () => {
     try {
       setLoading(true);
@@ -347,4 +384,10 @@
   };
 </script>
 
-<style lang="less" scoped></style>
+<style lang="less" scoped>
+  .button-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+</style>

--- a/gms-ui/src/views/dashboard/workplace/locale/zh-CN.ts
+++ b/gms-ui/src/views/dashboard/workplace/locale/zh-CN.ts
@@ -4,12 +4,14 @@ export default {
   'workplace.gameServer.serverControl': '服务端控制',
   'workplace.running': '运行中...',
   'workplace.stopped': '休息中',
-  'workplace.button.start': '启动服务端',
-  'workplace.button.stop': '停止服务端',
-  'workplace.button.restart': '重启服务',
-  'workplace.button.shutdown': '停服',
+  'workplace.button.start': '启动',
+  'workplace.button.stop': '停止',
+  'workplace.button.restart': '重启',
+  'workplace.button.shutdown': '结束',
   'workplace.button.shutdown.confirm':
     '此操作将立即停止所有相关服务，需要在服务器中手动启动服务，确定停服吗？',
+  'workplace.button.restart.confirm':
+    '此操作将立即强制所有玩家下线并重新启动服务端，确定重启吗？',
   'workplace.stop.minutes': '倒计时分钟',
   'workplace.stop.shutdownMsg': '停服消息',
   'workplace.stop.showServerMsg': '顶部黄字公告',

--- a/gms-ui/src/views/game/cashShop/table.vue
+++ b/gms-ui/src/views/game/cashShop/table.vue
@@ -1,37 +1,39 @@
 <template>
   <a-card class="general-card">
-    <a-row>
-      <a-col>
-        <a-space>
-          <a-button
-            :disabled="condition.onSale === 1"
-            type="primary"
-            status="success"
-            @click="changeOnSaleFilter(1)"
-          >
-            上架中
-          </a-button>
-          <a-button
-            :disabled="condition.onSale === 0"
-            type="primary"
-            status="danger"
-            @click="changeOnSaleFilter(0)"
-          >
-            待售
-          </a-button>
-          <a-button
-            :disabled="condition.onSale === undefined"
-            type="primary"
-            @click="changeOnSaleFilter(undefined)"
-          >
-            全部
-          </a-button>
-          <a-input-number v-model="condition.itemId" placeholder="物品ID" />
-          <a-button @click="loadData">搜索</a-button>
-          <a-button type="primary" @click="showBatchForm">批量编辑</a-button>
-        </a-space>
-      </a-col>
-    </a-row>
+    <a-space>
+      <a-space>
+        <a-button
+          :disabled="condition.onSale === 1"
+          type="primary"
+          status="success"
+          @click="changeOnSaleFilter(1)"
+        >
+          上架中
+        </a-button>
+        <a-button
+          :disabled="condition.onSale === 0"
+          type="primary"
+          status="danger"
+          @click="changeOnSaleFilter(0)"
+        >
+          待售
+        </a-button>
+        <a-button
+          :disabled="condition.onSale === undefined"
+          type="primary"
+          @click="changeOnSaleFilter(undefined)"
+        >
+          全部
+        </a-button>
+      </a-space>
+      <a-space class="a-input">
+        <a-input-number v-model="condition.itemId" placeholder="物品ID" />
+      </a-space>
+      <a-space>
+        <a-button @click="loadData">搜索</a-button>
+        <a-button type="primary" @click="showBatchForm">批量编辑</a-button>
+      </a-space>
+    </a-space>
     <a-table
       v-model:selectedKeys="selectedKeys"
       row-key="sn"
@@ -48,15 +50,9 @@
           title="SN"
           data-index="sn"
           align="center"
-          :width="140"
-          fixed="left"
-        />
-        <a-table-column
-          title="物品图标"
-          align="center"
           :width="100"
-          fixed="left"
-        >
+        />
+        <a-table-column title="物品图标" align="center" :width="70">
           <template #cell="{ record }">
             <img
               :src="getIconUrl('item', record.itemId)"
@@ -68,21 +64,19 @@
           title="物品ID"
           data-index="itemId"
           align="center"
-          :width="140"
-          fixed="left"
+          :width="100"
         />
         <a-table-column
           title="物品名称"
           data-index="itemName"
           align="center"
           :width="140"
-          fixed="left"
         />
         <a-table-column
           title="数量"
           data-index="count"
           align="center"
-          :width="80"
+          :width="70"
         />
         <a-table-column
           title="优先级"
@@ -94,14 +88,14 @@
           title="售价"
           data-index="price"
           align="center"
-          :width="120"
+          :width="80"
         />
         <a-table-column title="Bonus" data-index="bonus" align="center" />
         <a-table-column
           title="有效期"
           data-index="period"
           align="center"
-          :width="120"
+          :width="80"
         >
           <template #cell="{ record }"> {{ record.period }} 天 </template>
         </a-table-column>
@@ -112,7 +106,12 @@
           data-index="forPremiumUser"
           align="center"
         />
-        <a-table-column title="性别" align="center">
+        <a-table-column
+          title="性别"
+          data-index="gender"
+          align="center"
+          :width="80"
+        >
           <template #cell="{ record }">
             <a-tag v-if="record.gender === 0" color="blue"> 男 </a-tag>
             <a-tag v-else-if="record.gender === 1" color="red"> 女 </a-tag>
@@ -123,7 +122,7 @@
           title="上架"
           data-index="onSale"
           align="center"
-          :width="120"
+          :width="90"
         >
           <template #cell="{ record }">
             <a-tag v-if="record.onSale" color="green">上架中</a-tag>
@@ -147,7 +146,7 @@
           data-index="packageSn"
           align="center"
         />
-        <a-table-column title="操作" fixed="right">
+        <a-table-column title="操作">
           <template #cell="{ record }">
             <a-button type="text" size="mini" @click="editClick(record)">
               编辑
@@ -316,3 +315,24 @@
     name: 'CashShopTable',
   };
 </script>
+
+<style scoped lang="less">
+  :deep(.arco-card-body .a-input .arco-space-item) {
+    width: 100%;
+  }
+  :deep(.arco-card-body .arco-space) {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+  :deep(.arco-card-body > .arco-space > .arco-space-item) {
+    margin-bottom: 5px;
+    margin-right: 0px;
+  }
+  :deep(.arco-card-body > .arco-space > .arco-space-item:nth-child(2)) {
+    width: 100%;
+    max-width: 400px;
+  }
+  :deep(.arco-card-body .arco-space .arco-space-item .arco-input-wrapper) {
+    width: 100%;
+  }
+</style>

--- a/gms-ui/src/views/game/commandInfo/index.vue
+++ b/gms-ui/src/views/game/commandInfo/index.vue
@@ -254,4 +254,10 @@
   };
 </script>
 
-<style lang="less" scoped></style>
+<style lang="less" scoped>
+  :deep(.arco-form-item-content-flex) {
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-start;
+  }
+</style>

--- a/gms-ui/src/views/game/config/index.vue
+++ b/gms-ui/src/views/game/config/index.vue
@@ -30,48 +30,40 @@
           </a-radio-group>
         </a-form-item>
         <a-form-item :hide-label="true">
-          <a-row :wrap="false">
-            <a-col :span="15" :offset="0">
-              <a-space>
-                <a-input
-                  v-model="condition.filter"
-                  :placeholder="$t('config.placeholder.filter')"
-                />
-                <a-button type="primary" @click="searchData">
-                  {{ $t('button.search') }}
-                </a-button>
-                <a-button @click="resetSearch">
-                  {{ $t('button.reset') }}
-                </a-button>
-                <a-button
-                  type="primary"
-                  status="success"
-                  :disabled="selectedKeys.length > 0"
-                  @click="addClick"
-                >
-                  {{ $t('button.add') }}
-                </a-button>
-                <a-button
-                  type="primary"
-                  status="danger"
-                  :disabled="selectedKeys.length === 0"
-                  @click="delClick"
-                >
-                  {{ $t('button.delete') }}
-                </a-button>
-              </a-space>
-            </a-col>
-            <a-col :span="6" :offset="3">
-              <a-space>
-                <a-button type="primary" @click="importClick">
-                  {{ $t('config.extra.import') }}
-                </a-button>
-                <a-button type="primary" @click="exportClick">
-                  {{ $t('config.extra.export') }}
-                </a-button>
-              </a-space>
-            </a-col>
-          </a-row>
+          <a-col :offset="0">
+            <a-input
+              v-model="condition.filter"
+              :placeholder="$t('config.placeholder.filter')"
+            />
+            <a-button type="primary" @click="searchData">
+              {{ $t('button.search') }}
+            </a-button>
+            <a-button @click="resetSearch">
+              {{ $t('button.reset') }}
+            </a-button>
+            <a-button
+              type="primary"
+              status="success"
+              :disabled="selectedKeys.length > 0"
+              @click="addClick"
+            >
+              {{ $t('button.add') }}
+            </a-button>
+            <a-button
+              type="primary"
+              status="danger"
+              :disabled="selectedKeys.length === 0"
+              @click="delClick"
+            >
+              {{ $t('button.delete') }}
+            </a-button>
+            <a-button type="primary" @click="importClick">
+              {{ $t('config.extra.import') }}
+            </a-button>
+            <a-button type="primary" @click="exportClick">
+              {{ $t('config.extra.export') }}
+            </a-button>
+          </a-col>
         </a-form-item>
       </a-space>
       <a-table
@@ -116,7 +108,7 @@
           <a-table-column
             :title="$t('config.column.clazz')"
             data-index="configClazz"
-            :width="100"
+            :width="120"
             align="center"
           >
             <template #cell="{ record }">
@@ -128,7 +120,7 @@
           <a-table-column
             :title="$t('config.column.code')"
             data-index="configCode"
-            :width="100"
+            :width="200"
             align="center"
           />
           <a-table-column
@@ -140,7 +132,7 @@
           <a-table-column
             :title="$t('config.column.desc')"
             data-index="configDesc"
-            :width="200"
+            :width="400"
             align="center"
           />
           <a-table-column
@@ -549,4 +541,49 @@
   };
 </script>
 
-<style scoped lang="less"></style>
+<style scoped lang="less">
+  :deep(.arco-form-item-content-flex) {
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-start;
+  }
+  :deep(.arco-space-horizontal, .arco-col arco-col-24) {
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  :deep(.arco-row-align-start > .arco-col) {
+    flex-wrap: wrap;
+  }
+  :deep(.arco-card-body > .arco-space-vertical) {
+    width: 100% !important;
+  }
+  :deep(.arco-space-item .arco-input-wrapper) {
+    width: 100% !important;
+    max-width: 400px !important;
+  }
+  :deep(.arco-space-item) {
+    width: 100%;
+  }
+  :deep(.arco-form-item-content > div) {
+    width: 100%;
+  }
+  :deep(.arco-form-item-content > div > *) {
+    margin-right: 5px;
+    margin-top: 5px;
+  }
+  :deep(.arco-table-th) {
+    min-width: 30px;
+  }
+  :deep(.arco-table-th:nth-child(4)) {
+    min-width: 70px;
+  }
+  :deep(.arco-table-th:nth-child(5)) {
+    min-width: 100px;
+  }
+  :deep(.arco-table-th:nth-child(6)) {
+    min-width: 100px;
+  }
+  :deep(.arco-table-th:nth-child(7)) {
+    min-width: 250px;
+  }
+</style>

--- a/gms-ui/src/views/game/drop/global.vue
+++ b/gms-ui/src/views/game/drop/global.vue
@@ -4,22 +4,22 @@
     <a-card class="general-card" :title="$t('menu.game.drop.global')">
       <a-row>
         <a-col>
+          <a-input-number
+            v-model="condition.continent"
+            placeholder="大区ID"
+            allow-clear
+          />
+          <a-input-number
+            v-model="condition.itemId"
+            placeholder="物品ID"
+            allow-clear
+          />
+          <a-input-number
+            v-model="condition.questId"
+            placeholder="任务ID"
+            allow-clear
+          />
           <a-space>
-            <a-input-number
-              v-model="condition.continent"
-              placeholder="地区ID"
-              allow-clear
-            />
-            <a-input-number
-              v-model="condition.itemId"
-              placeholder="物品ID"
-              allow-clear
-            />
-            <a-input-number
-              v-model="condition.questId"
-              placeholder="任务ID"
-              allow-clear
-            />
             <a-button type="primary" @click="loadData">查询</a-button>
             <a-button @click="resetClick">重置</a-button>
             <a-button type="primary" status="success" @click="insertClick">
@@ -43,7 +43,7 @@
             :width="80"
             align="center"
           />
-          <a-table-column title="地区ID" :width="160" align="center">
+          <a-table-column title="大区ID" :width="100" align="center">
             <template #cell="{ record }">
               <a-input-number
                 v-if="editId === record.id"
@@ -52,7 +52,7 @@
               <span v-else>{{ record.continent }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="物品ID" :width="140" align="center">
+          <a-table-column title="物品ID" :width="150" align="center">
             <template #cell="{ record }">
               <a-input-number
                 v-if="editId === record.id"
@@ -61,7 +61,7 @@
               <span v-else>{{ record.itemId }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="物品" :width="180" align="center">
+          <a-table-column title="物品" :width="230" align="center">
             <template #cell="{ record }">
               <a-button
                 v-if="record.itemId === 0"
@@ -109,7 +109,7 @@
               <span v-else>{{ record.maximumQuantity }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="爆率%" :width="140" align="right">
+          <a-table-column title="爆率%" :width="120" align="right">
             <template #cell="{ record }">
               <a-input-number
                 v-if="editId === record.id"
@@ -118,7 +118,7 @@
               <span v-else>{{ (record.chance / 10000).toFixed(4) }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="任务ID" :width="120" align="center">
+          <a-table-column title="任务ID" :width="100" align="center">
             <template #cell="{ record }">
               <a-input-number
                 v-if="editId === record.id"
@@ -129,13 +129,13 @@
           </a-table-column>
           <a-table-column
             title="任务"
-            :width="120"
+            :width="200"
             data-index="questName"
             align="center"
           />
           <a-table-column
             title="备注"
-            :width="180"
+            :width="250"
             data-index="comments"
             align="center"
           >
@@ -144,7 +144,7 @@
               <span v-else>{{ record.comments }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="操作" :width="200" fixed="right">
+          <a-table-column title="操作" :width="80">
             <template #cell="{ record }">
               <a-button
                 v-if="editId !== record.id"
@@ -171,15 +171,16 @@
               >
                 保存
               </a-button>
-              <a-button
+              <a-popconfirm
                 v-if="editId === record.id"
-                type="text"
-                size="mini"
-                status="danger"
-                @click="deleteClick(record)"
+                content="确定要删除吗？"
+                position="left"
+                @ok="() => deleteClick(record)"
               >
-                删除
-              </a-button>
+                <a-button type="text" size="mini" status="danger">
+                  删除
+                </a-button>
+              </a-popconfirm>
             </template>
           </a-table-column>
         </template>
@@ -329,4 +330,19 @@
   };
 </script>
 
-<style lang="less" scoped></style>
+<style lang="less" scoped>
+  :deep(.arco-card-body, .arco-row) {
+    width: 100%;
+  }
+  .arco-card-body > .arco-row > .arco-col > .arco-input-wrapper {
+    margin-right: 0;
+    margin-bottom: 5px;
+    width: 100%;
+  }
+  @media (min-width: 500px) {
+    .arco-card-body > .arco-row > .arco-col > .arco-input-wrapper {
+      margin-right: 8px;
+      width: 140px;
+    }
+  }
+</style>

--- a/gms-ui/src/views/game/drop/index.vue
+++ b/gms-ui/src/views/game/drop/index.vue
@@ -1,25 +1,29 @@
 <template>
   <div class="container">
     <Breadcrumb />
-    <a-card class="general-card" :title="$t('menu.game.drop')">
+    <a-card
+      class="general-card"
+      :title="$t('menu.game.drop')"
+      style="overflow-x: auto"
+    >
       <a-row>
         <a-col>
+          <a-input-number
+            v-model="condition.dropperId"
+            placeholder="怪物ID"
+            allow-clear
+          />
+          <a-input-number
+            v-model="condition.itemId"
+            placeholder="物品ID"
+            allow-clear
+          />
+          <a-input-number
+            v-model="condition.questId"
+            placeholder="任务ID"
+            allow-clear
+          />
           <a-space>
-            <a-input-number
-              v-model="condition.dropperId"
-              placeholder="怪物ID"
-              allow-clear
-            />
-            <a-input-number
-              v-model="condition.itemId"
-              placeholder="物品ID"
-              allow-clear
-            />
-            <a-input-number
-              v-model="condition.questId"
-              placeholder="任务ID"
-              allow-clear
-            />
             <a-button type="primary" @click="loadData">查询</a-button>
             <a-button @click="resetClick">重置</a-button>
             <a-button type="primary" status="success" @click="insertClick">
@@ -43,7 +47,12 @@
             :width="80"
             align="center"
           />
-          <a-table-column title="怪物ID" :width="120" align="center">
+          <a-table-column
+            title="怪物ID"
+            data-index="mobid"
+            :width="150"
+            align="center"
+          >
             <template #cell="{ record }">
               <a-input-number
                 v-if="editId === record.id"
@@ -73,7 +82,7 @@
               </a-popover>
             </template>
           </a-table-column>
-          <a-table-column title="物品ID" :width="140" align="center">
+          <a-table-column title="物品ID" :width="150" align="center">
             <template #cell="{ record }">
               <a-input-number
                 v-if="editId === record.id"
@@ -82,7 +91,7 @@
               <span v-else>{{ record.itemId }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="物品" :width="180" align="center">
+          <a-table-column title="物品" :width="230" align="center">
             <template #cell="{ record }">
               <a-button
                 v-if="record.itemId === 0"
@@ -130,7 +139,7 @@
               <span v-else>{{ record.maximumQuantity }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="爆率%" :width="140" align="right">
+          <a-table-column title="爆率%" :width="120" align="right">
             <template #cell="{ record }">
               <a-input-number
                 v-if="editId === record.id"
@@ -139,7 +148,7 @@
               <span v-else>{{ (record.chance / 10000).toFixed(4) }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="任务ID" :width="120" align="center">
+          <a-table-column title="任务ID" :width="100" align="center">
             <template #cell="{ record }">
               <a-input-number
                 v-if="editId === record.id"
@@ -150,11 +159,11 @@
           </a-table-column>
           <a-table-column
             title="任务"
-            :width="160"
+            :width="200"
             data-index="questName"
             align="center"
           />
-          <a-table-column title="操作" :width="200" fixed="right">
+          <a-table-column :width="80" title="操作">
             <template #cell="{ record }">
               <a-button
                 v-if="editId !== record.id"
@@ -181,15 +190,16 @@
               >
                 保存
               </a-button>
-              <a-button
+              <a-popconfirm
                 v-if="editId === record.id"
-                type="text"
-                size="mini"
-                status="danger"
-                @click="deleteClick(record)"
+                content="确定要删除吗？"
+                position="left"
+                @ok="() => deleteClick(record)"
               >
-                删除
-              </a-button>
+                <a-button type="text" size="mini" status="danger">
+                  删除
+                </a-button>
+              </a-popconfirm>
             </template>
           </a-table-column>
         </template>
@@ -346,4 +356,19 @@
   };
 </script>
 
-<style lang="less" scoped></style>
+<style lang="less" scoped>
+  :deep(.arco-card-body, .arco-row) {
+    width: 100%;
+  }
+  .arco-card-body > .arco-row > .arco-col > .arco-input-wrapper {
+    margin-right: 0;
+    margin-bottom: 5px;
+    width: 100%;
+  }
+  @media (min-width: 500px) {
+    .arco-card-body > .arco-row > .arco-col > .arco-input-wrapper {
+      margin-right: 8px;
+      width: 140px;
+    }
+  }
+</style>

--- a/gms-ui/src/views/game/gachapon/form.vue
+++ b/gms-ui/src/views/game/gachapon/form.vue
@@ -3,7 +3,7 @@
     v-model:visible="visible"
     :ok-loading="loading"
     :on-before-ok="handleBeforeOk"
-    :width="800"
+    :width="600"
     @cancel="handleCancel"
   >
     <template #title> {{ title }} </template>
@@ -114,9 +114,9 @@
               title="名称"
               data-index="name"
               align="center"
-              :width="200"
+              :width="180"
             />
-            <a-table-column title="公共池" align="center" :width="120">
+            <a-table-column title="公共池" align="center" :width="100">
               <template #cell="{ record }">
                 <a-tag v-if="record.isPublic" color="red">公共池</a-tag>
                 <a-tag v-else color="blue">非公共池</a-tag>
@@ -126,9 +126,9 @@
               title="权重"
               data-index="weight"
               align="center"
-              :width="120"
+              :width="100"
             />
-            <a-table-column title="真实概率" align="center">
+            <a-table-column title="真实概率" align="center" :width="90">
               <template #cell="{ record }">
                 {{ record.realProb / 10000 }} %
               </template>

--- a/gms-ui/src/views/game/gachapon/index.vue
+++ b/gms-ui/src/views/game/gachapon/index.vue
@@ -33,21 +33,19 @@
           <a-table-column
             title="ID"
             data-index="id"
-            :width="80"
+            :width="60"
             align="center"
-            fixed="left"
           />
           <a-table-column
             :title="$t('gachapon.list.column.name')"
             data-index="name"
             align="center"
-            :width="200"
-            fixed="left"
+            :width="150"
           />
           <a-table-column
             :title="$t('gachapon.list.column.gachaponId')"
             align="center"
-            :width="120"
+            :width="80"
           >
             <template #cell="{ record }">
               <a-button
@@ -86,7 +84,7 @@
           <a-table-column
             :title="$t('gachapon.list.column.isPublic')"
             align="center"
-            :width="120"
+            :width="80"
           >
             <template #cell="{ record }">
               <a-tag v-if="record.isPublic" color="red">
@@ -100,7 +98,7 @@
           <a-table-column
             :title="$t('gachapon.list.column.isPublic')"
             align="center"
-            :width="120"
+            :width="80"
           >
             <template #cell="{ record }">
               <span
@@ -119,7 +117,7 @@
           <a-table-column
             :title="$t('gachapon.list.column.startTime')"
             align="center"
-            :width="230"
+            :width="140"
           >
             <template #cell="{ record }">
               {{
@@ -132,7 +130,7 @@
           <a-table-column
             :title="$t('gachapon.list.column.endTime')"
             align="center"
-            :width="230"
+            :width="140"
           >
             <template #cell="{ record }">
               {{
@@ -146,7 +144,7 @@
             :title="$t('gachapon.list.column.notification')"
             data-index="notification"
             align="center"
-            :width="120"
+            :width="60"
           >
             <template #cell="{ record }">
               <a-tag v-if="record.notification" color="green">
@@ -160,12 +158,12 @@
           <a-table-column
             :title="$t('gachapon.list.column.comment')"
             data-index="comment"
-            :width="400"
+            :width="200"
             align="center"
           />
           <a-table-column
             :title="$t('operation')"
-            :width="220"
+            :width="80"
             align="center"
             fixed="right"
           >
@@ -183,7 +181,8 @@
                 </a-button>
                 <a-popconfirm
                   type="error"
-                  content="你确定要删除这个奖池吗？"
+                  :content="$t('gachapon.button.deleteTips')"
+                  position="left"
                   @ok="deleteClick(record)"
                 >
                   <a-button size="mini" status="danger" type="text">

--- a/gms-ui/src/views/game/gachapon/locale/en-US.ts
+++ b/gms-ui/src/views/game/gachapon/locale/en-US.ts
@@ -15,9 +15,11 @@ export default {
   'gachapon.isPublic.true.desc': 'PublicPool',
   'gachapon.isPublic.false.desc': 'OrdinaryPool',
   'gachapon.startTime.default': 'Started',
+  'gachapon.endTime.default': 'Started',
   'gachapon.notification.true.desc': 'Yes',
   'gachapon.notification.false.desc': 'No',
 
   'gachapon.button.detail': 'Rewards',
   'gachapon.button.operate': 'Operate',
+  'gachapon.button.deleteTips': 'Are you sure to delete?',
 };

--- a/gms-ui/src/views/game/gachapon/locale/zh-CN.ts
+++ b/gms-ui/src/views/game/gachapon/locale/zh-CN.ts
@@ -20,5 +20,6 @@ export default {
   'gachapon.notification.false.desc': '否',
 
   'gachapon.button.detail': '奖品',
-  'gachapon.button.operate': '显示操作按钮',
+  'gachapon.button.operate': '操作',
+  'gachapon.button.deleteTips': '你确定要删除这个奖池吗？',
 };

--- a/gms-ui/src/views/game/gachapon/reward.vue
+++ b/gms-ui/src/views/game/gachapon/reward.vue
@@ -25,13 +25,13 @@
           title="#"
           data-index="index"
           align="center"
-          width="50"
+          :width=50
           cell-class="td-nowrap"
         />
         <a-table-column
           title=" ID "
           data-index="id"
-          width="80"
+          :width=80
           align="center"
           cell-class="td-nowrap"
         />

--- a/gms-ui/src/views/game/gachapon/reward.vue
+++ b/gms-ui/src/views/game/gachapon/reward.vue
@@ -13,26 +13,35 @@
       :loading="loading"
       :data="tableData"
       column-resizable
-      :pagination="false"
-      :bordered="{ cell: true }"
-      :scroll="{
-        y: 600,
+      :pagination="{
+        pageSizeOptions: [10, 20, 50],
+        showPageSize: true,
+        showJumper: true,
       }"
+      :bordered="{ cell: true }"
     >
       <template #columns>
         <a-table-column
-          title="ID"
-          data-index="id"
-          :width="120"
+          title="#"
+          data-index="index"
           align="center"
+          width="50"
+          cell-class="td-nowrap"
+        />
+        <a-table-column
+          title=" ID "
+          data-index="id"
+          width="80"
+          align="center"
+          cell-class="td-nowrap"
         />
         <a-table-column
           title="奖池ID"
           data-index="poolId"
-          :width="120"
+          :width="80"
           align="center"
         />
-        <a-table-column title="物品ID" :width="140" align="center">
+        <a-table-column title="物品ID" :width="100" align="center">
           <template #cell="{ record }">
             <span v-if="editId !== record.id"> {{ record.itemId }}</span>
             <a-input-number v-else v-model="record.itemId" />
@@ -44,18 +53,18 @@
             <a-input-number v-else v-model="record.itemId" />
           </template>
         </a-table-column>
-        <a-table-column title="物品图标" :width="140" align="center">
+        <a-table-column title="物品图标" :width="90" align="center">
           <template #cell="{ record }">
             <img :src="getIconUrl('item', record.itemId)" alt="" />
           </template>
         </a-table-column>
-        <a-table-column title="数量" :width="120" align="center">
+        <a-table-column title="数量" :width="80" align="center">
           <template #cell="{ record }">
             <span v-if="editId !== record.id"> {{ record.quantity }}</span>
             <a-input-number v-else v-model="record.quantity" />
           </template>
         </a-table-column>
-        <a-table-column title="备注">
+        <a-table-column title="备注" :width="220" align="center">
           <template #cell="{ record }">
             <span v-if="editId !== record.id"> {{ record.comment }}</span>
             <a-input v-else v-model="record.comment" />
@@ -134,7 +143,10 @@
     editId.value = -1;
     try {
       const { data } = await getRewards(curPool.value);
-      tableData.value = data;
+      tableData.value = data.map((obj: any, i: number) => ({
+        ...obj,
+        index: i + 1,
+      }));
     } finally {
       setLoading(false);
     }

--- a/gms-ui/src/views/game/inventory/characterSelector.vue
+++ b/gms-ui/src/views/game/inventory/characterSelector.vue
@@ -64,24 +64,18 @@
     :width="750"
     :footer="false"
   >
-    <a-form :model="condition" layout="inline">
-      <a-form-item
-        :label="t('characterSelector.column.id')"
-        style="width: 200px"
-      >
+    <a-form :model="condition">
+      <a-form-item :label="t('characterSelector.column.id')">
         <a-input-number v-model="condition.characterId" allow-clear />
       </a-form-item>
-      <a-form-item
-        :label="t('characterSelector.column.name')"
-        style="width: 200px"
-      >
+      <a-form-item :label="t('characterSelector.column.name')">
         <a-input v-model="condition.characterName" allow-clear />
       </a-form-item>
-      <a-form-item style="width: 200px">
-        <a-button type="primary" @click="searchClick"
-          >{{ t('characterSelector.searchButton') }}
+      <a-space class="a-form-item-btn">
+        <a-button type="primary" @click="searchClick">
+          {{ t('characterSelector.searchButton') }}
         </a-button>
-      </a-form-item>
+      </a-space>
     </a-form>
     <a-table :data="tableData" row-key="characterId" :pagination="false">
       <template #columns>
@@ -131,4 +125,43 @@
   </a-modal>
 </template>
 
-<style scoped lang="less"></style>
+<style scoped lang="less">
+  .arco-form .arco-row {
+    display: flex;
+    width: 100%;
+    :deep(.arco-form-item-content-wrapper) {
+      max-width: 100%;
+    }
+  }
+  .a-form-item-btn {
+    margin-left: 0px;
+    margin-bottom: 15px;
+    width: 100%;
+    display: flex;
+    /* 水平居中 */
+    justify-content: right;
+    /* 垂直居中 */
+    align-items: center;
+  }
+  /* 最小宽度超过一定阈值 */
+  @media (min-width: @screen-xs) {
+    .arco-modal-body .arco-form {
+      display: flex;
+      flex-direction: initial;
+      width: 100%;
+      :deep(.arco-form-item-content-wrapper) {
+        max-width: 200px;
+      }
+    }
+    .a-form-item-btn {
+      margin-left: 10px;
+      margin-bottom: 0px;
+      width: auto;
+      display: flex;
+      /* 水平居中 */
+      justify-content: center;
+      /* 垂直居中 */
+      align-items: start;
+    }
+  }
+</style>

--- a/gms-ui/src/views/game/inventory/index.vue
+++ b/gms-ui/src/views/game/inventory/index.vue
@@ -3,36 +3,38 @@
     <Breadcrumb />
     <a-card class="general-card" :title="$t('menu.game.inventory')">
       <div class="button-group">
-        <character-selector @use-character="useCharacter" />
-        <div v-if="currentCid !== undefined" class="character-info">
-          <div class="info-line"
-            >{{ $t('characterSelector.column.id') }}: {{ currentCid }}
+        <a-space>
+          <character-selector @use-character="useCharacter" />
+          <div v-if="currentCid !== undefined" class="character-info">
+            <div class="info-line">
+              {{ $t('characterSelector.column.id') }}:{{ currentCid }}
+            </div>
+            <div class="info-line">
+              {{ $t('characterSelector.column.onlineStatus') }}:
+              <span :class="{ online: isOnline, offline: !isOnline }">
+                <span class="status-dot"></span>
+                {{
+                  isOnline
+                    ? $t('inventoryList.column.online')
+                    : $t('inventoryList.column.offline')
+                }}
+              </span>
+            </div>
           </div>
-          <div class="info-line">
-            {{ $t('characterSelector.column.onlineStatus') }}:
-            <span :class="{ online: isOnline, offline: !isOnline }">
-              <span class="status-dot"></span
-              >{{
-                isOnline
-                  ? $t('inventoryList.column.online')
-                  : $t('inventoryList.column.offline')
-              }}
-            </span>
-          </div>
-        </div>
-        <a-button
-          type="primary"
-          class="margin-left"
-          :disabled="
-            !currentCid ||
-            currentType === 0 ||
-            currentType === -1 ||
-            currentType === 6
-          "
-          @click="openInventoryUI(currentCid, currentType)"
-        >
-          {{ $t('inventory.placeholder.inventoryDraw') }}
-        </a-button>
+          <a-button
+            type="primary"
+            class="margin-left"
+            :disabled="
+              !currentCid ||
+              currentType === 0 ||
+              currentType === -1 ||
+              currentType === 6
+            "
+            @click="openInventoryUI(currentCid, currentType)"
+          >
+            {{ $t('inventory.placeholder.inventoryDraw') }}
+          </a-button>
+        </a-space>
       </div>
       <a-tabs
         :default-active-key="1"
@@ -152,7 +154,6 @@
   .button-group {
     display: flex;
     align-items: center;
-    margin-bottom: 16px;
   }
 
   .margin-left {
@@ -161,12 +162,13 @@
 
   .character-info {
     margin-left: 16px;
-    background-color: #f0f2f5;
+    //background-color: #f0f2f5;
     padding: 8px 12px;
     border-radius: 4px;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    min-width: 150px;
   }
 
   .info-line {
@@ -201,5 +203,39 @@
 
   .offline .status-dot {
     background-color: red;
+  }
+
+  @media (max-width: @screen-sm) {
+    :deep(.arco-space) {
+      width: 100%;
+      flex-wrap: wrap;
+      display: initial;
+      align-items: center;
+    }
+
+    :deep(.button-group > .arco-space > .arco-space-item) {
+      margin-top: 5px;
+      margin-bottom: 5px;
+    }
+
+    .arco-space-item > .arco-input-wrapper {
+      width: 100%;
+    }
+
+    .character-info {
+      margin-left: 0px;
+      //background-color: #f0f2f5;
+      padding: 8px 12px;
+      border-radius: 4px;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      min-width: 150px;
+      width: 100%;
+    }
+
+    .margin-left {
+      margin-left: 0px;
+    }
   }
 </style>

--- a/gms-ui/src/views/game/npcShop/index.vue
+++ b/gms-ui/src/views/game/npcShop/index.vue
@@ -4,12 +4,12 @@
     <a-card class="general-card" :title="$t('menu.game.npcShop')">
       <a-row>
         <a-col>
+          <a-input-number v-model="shopFilter.shopId" placeholder="商店 ID" />
+          <a-input-number v-model="shopFilter.npcId" placeholder="NPC ID" />
+          <a-input v-model="shopFilter.npcName" placeholder="NPC 名称" />
+          <a-input-number v-model="shopFilter.itemId" placeholder="物品 ID" />
+          <a-input v-model="shopFilter.itemName" placeholder="物品" />
           <a-space>
-            <a-input-number v-model="shopFilter.shopId" placeholder="商店 ID" />
-            <a-input-number v-model="shopFilter.npcId" placeholder="NPC ID" />
-            <a-input v-model="shopFilter.npcName" placeholder="NPC" />
-            <a-input-number v-model="shopFilter.itemId" placeholder="物品 ID" />
-            <a-input v-model="shopFilter.itemName" placeholder="物品" />
             <a-button type="primary" status="success" @click="loadClick">
               搜索
             </a-button>
@@ -63,7 +63,13 @@
               <img :src="getIconUrl('npc', record.npcId)" />
             </template>
           </a-table-column>
-          <a-table-column title="操作">
+          <a-table-column
+            title="操作"
+            data-index="edit"
+            :width="80"
+            fixed="right"
+            align="center"
+          >
             <template #cell="{ record }">
               <a-button
                 type="text"
@@ -103,7 +109,7 @@
               <img :src="getIconUrl('item', record.itemId)" />
             </template>
           </a-table-column>
-          <a-table-column title="物品ID" :width="140" align="center">
+          <a-table-column title="物品ID" :width="100" align="center">
             <template #cell="{ record }">
               <span v-if="record.id === undefined || editMode === record.id">
                 <a-input-number v-model="record.itemId" />
@@ -117,7 +123,7 @@
             :width="120"
             align="center"
           />
-          <a-table-column title="价格" :width="140" align="center">
+          <a-table-column title="价格" :width="100" align="center">
             <template #cell="{ record }">
               <span v-if="record.id === undefined || editMode === record.id">
                 <a-input-number v-model="record.price" />
@@ -125,7 +131,7 @@
               <span v-else>{{ record.price }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="音符" :width="140" align="center">
+          <a-table-column title="音符" :width="100" align="center">
             <template #cell="{ record }">
               <span v-if="record.id === undefined || editMode === record.id">
                 <a-input-number v-model="record.pitch" />
@@ -133,7 +139,7 @@
               <span v-else>{{ record.pitch }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="位置" :width="140" align="center">
+          <a-table-column title="位置" :width="100" align="center">
             <template #cell="{ record }">
               <span v-if="record.id === undefined || editMode === record.id">
                 <a-input-number v-model="record.position" />
@@ -141,45 +147,48 @@
               <span v-else>{{ record.position }}</span>
             </template>
           </a-table-column>
-          <a-table-column title="描述" data-index="itemDesc" />
+          <a-table-column title="描述" :width="250" data-index="itemDesc" />
           <a-table-column title="操作">
             <template #cell="{ record }">
-              <a-button
-                v-if="record.id !== undefined && editMode !== record.id"
-                type="text"
-                size="mini"
-                status="normal"
-                @click="editMode = record.id"
-              >
-                编辑
-              </a-button>
-              <a-button
-                v-if="record.id !== undefined && editMode !== record.id"
-                type="text"
-                size="mini"
-                status="danger"
-                @click="deleteClick(record.id)"
-              >
-                删除
-              </a-button>
-              <a-button
-                v-if="record.id === undefined || editMode === record.id"
-                type="text"
-                size="mini"
-                status="success"
-                @click="saveClick(record)"
-              >
-                保存
-              </a-button>
-              <a-button
-                v-if="record.id !== undefined && editMode === record.id"
-                type="text"
-                size="mini"
-                status="normal"
-                @click="rollbackClick(record)"
-              >
-                返回
-              </a-button>
+              <a-space :size="0">
+                <a-button
+                  v-if="record.id !== undefined && editMode !== record.id"
+                  type="text"
+                  size="mini"
+                  status="normal"
+                  @click="editMode = record.id"
+                >
+                  编辑
+                </a-button>
+                <a-popconfirm
+                  v-if="record.id !== undefined && editMode !== record.id"
+                  content="确定要删除吗？"
+                  position="top"
+                  @ok="deleteClick(record.id)"
+                >
+                  <a-button type="text" size="mini" status="danger">
+                    删除
+                  </a-button>
+                </a-popconfirm>
+                <a-button
+                  v-if="record.id === undefined || editMode === record.id"
+                  type="text"
+                  size="mini"
+                  status="success"
+                  @click="saveClick(record)"
+                >
+                  保存
+                </a-button>
+                <a-button
+                  v-if="record.id !== undefined && editMode === record.id"
+                  type="text"
+                  size="mini"
+                  status="normal"
+                  @click="rollbackClick(record)"
+                >
+                  返回
+                </a-button>
+              </a-space>
             </template>
           </a-table-column>
         </template>
@@ -365,4 +374,19 @@
   };
 </script>
 
-<style lang="less" scoped></style>
+<style lang="less" scoped>
+  :deep(.arco-card-body, .arco-row) {
+    width: 100%;
+  }
+  .arco-input-wrapper {
+    margin-right: 0;
+    margin-bottom: 5px;
+    width: 100%;
+  }
+  @media (min-width: 500px) {
+    .arco-input-wrapper {
+      margin-right: 8px;
+      width: 140px;
+    }
+  }
+</style>


### PR DESCRIPTION
[*] 修复交通工具、旅行时间计算不正确的BUG
[*] 修复参数use_randomize_hpmp_gain=true不生效
[*] 修复蜈蚣、妖僧不能正常结束事件的BUG
[*] 修复控制台发放全服资源（商城券、金币、经验）数量与实际到账不一致的BUG
[*] 修复脚本事件的野外BOSS刷新时间不受控制台参数控制的BUG
[*] 优化I18n对数值加千分符的问题
[*] 优化捡取点券支持数量相乘，可以在控制台里设置掉落数量了。
[*] 汉化很多脚本
[+] 组队副本增加解除等级限制参数，由控制台的use_enable_party_level_limit_lift控制