### PR TITLE
卡地图拯救系统修复与优化，部分信息汉化，北斗指南书奖励脚本重构，!spwan 召唤不存在怪物时进行提示。

### DIFF
--- a/gms-server/scripts-zh-CN/item/BeiDouSatelliteManual.js
+++ b/gms-server/scripts-zh-CN/item/BeiDouSatelliteManual.js
@@ -3,65 +3,197 @@
 北斗之星-2430033
 
 ---By hanmburger*/
-var status = -1;
-var text;
+/**
+ * 名称：北斗指导书奖励脚本
+ * 功能：用于使用指定物品进行兑换的脚本，采用JSON配置奖品，NextLevel构造脚本，具有配置清晰便捷、代码逻辑清晰的特点。
+ * 		支持配置的奖励有 金币、经验、点券、抵用券、信用点 和 有效物品
+ * 		支持输入整数按份领取奖励列表
+ * 作者：Magical-H (https://github.com/Magical-H)
+ * 版本：1.0
+ * 日期：2025-06-07
+ */
 
-function start() 
-{
+/* 可配置区域 */
+var itemCountMax = 100;	//单次兑换份数上限
+var config = {
+	haveitem: {id: 2430033,qty: 1, unit:"本"},	//需求物品ID和数量
+	reward: [//奖励列表
+		// id解释：0：金币;  1：点券;  2：抵用券;  4、信用点; 5、经验值;  id ≥ 1_000_000 的为有效物品ID，自动区分，你只需要操心客户端有没有填入的物品即可。
+		//{id：物品ID，qty：数量},
+		{id: 0,qty: 1000},	//金币
+		{id: 5,qty: 1000},	//经验值
+		{id: 1,qty: 10000},	//点券
+		{id: 2000016,qty: 10},
+		{id: 2000018,qty: 10},
+		{id: 2050004,qty: 1},
+		{id: 4006001,qty: 2},
+		{id: 5451000,qty: 1}
+	]
+};
+
+/* 无需配置区域 */
+var status = -1;
+var itemQty = 0;		//持有硬币数量
+var itemCount = 0;		//最大可兑换份数
+var itemDeduct = 0;		//总扣除硬币数量
+var itemIcoName = '';	//硬币图标与名称（客户端代码）
+
+// 定义物品显示模板的映射表（ES6对象字面量优化）
+const ITEM_TEMPLATES = {
+	0: '#fUI/Basic.img/BtCoin/normal/0#   #fUI/UIWindow.img/QuestIcon/7/0#',	//金币
+	1: '#fUI/CashShop.img/CashItem/0#   #e#b点券#k#n',
+	2: '#fUI/CashShop.img/CashItem/0#   #e#b抵用券#k#n',
+	4: '#fUI/CashShop.img/CashItem/0#   #e#b信用点#k#n',
+	5: '#fUI/UIWindow.img/AriantMatch/characterIcon/2#   #fUI/UIWindow.img/QuestIcon/8/0#'	//经验值
+};
+
+/* 函数方法区域 */
+function start() {
   status = -1;
   action(1, 0, 0);
 }
 
-function action(mode, type, selection) 
-{
-	if (CheckStatus(mode))
-	{
-	    if (status == 0)
-	    {
-			//第一层对话
-			if (im.haveItem(2430033, 7))
-			{
-				im.gainMeso(1000000);
-				im.sendOk("这是赏你的，拿去吧.");
-				im.gainItem(2430033,-7);
-				im.dispose();
-			}
-			else
-			{
-				im.sendOk("请搜集7本以后再使用吧.");
-				im.dispose();				
-			}
-	    }
-		else
-		{
-			im.dispose();
+function action(mode, type, selection) {
+	levelmain();
+}
+
+function level() {
+	im.dispose();
+}
+
+function levelnull() {
+	level();
+}
+
+function leveldispose() {
+	level();
+}
+
+function levelmain() {
+	if (config.haveitem.qty < 1) config.haveitem.qty = 1;	//至少需要扣除1个道具
+
+		itemIcoName = getCoinInfo();
+	let msg = `\r\n传说只要能集齐 #r${config.haveitem.qty + config.haveitem.unit}#k ${itemIcoName} `;
+		itemQty = im.itemQuantity(config.haveitem.id);				//获取硬币持有数
+		itemCount = parseInt(itemQty / config.haveitem.qty);		//计算已持有硬币可兑换的最大份数
+		CountMax = Math.min(itemCount,itemCountMax);
+	if (itemQty >= config.haveitem.qty) {
+		msg += `即可获得以下奖励：\r\n\r\n#fUI/CashShop.img/CSDiscount/bonus#\r\n`;
+		msg += getRewardList() + `\r\n\r\n\r\n你当前最多可以兑换 #b${itemCount} 份 #k奖励，你想兑换多少份奖励？\r\n目前单次兑换上限： #r${itemCountMax} 份#k\r\n `;
+		im.getInputNumberLevel("ConfirmReceipt", msg, CountMax, 1,CountMax);
+	} else {
+		msg += "即可获得神秘奖励！\r\n快去收集吧！";
+		im.sendOkLevel("",msg);
+	}
+}
+
+function levelConfirmReceipt(count) {
+	if (count <= 0 || count > itemCount) {
+		im.sendOkLevel("","输入的份数不能 ≤0 且 不能超过最大份数 " + itemCount);
+	} else {
+			itemDeduct = count * config.haveitem.qty;	//计算硬币扣除数量
+			itemCount = count;							//更新硬币兑换份数
+		let msg = `即将兑换 #r${count} 份#k 以下奖励：\r\n\r\n#fUI/CashShop.img/CSDiscount/bonus#\r\n`;
+			msg += getRewardList(count) + `\r\n\r\n\r\n是否使用  ${itemIcoName} × #r${itemDeduct} ${config.haveitem.unit}#k 进行兑换？`;
+		im.sendYesNoLevel("main","giveRewardItems",msg);
+	}
+}
+
+function levelgiveRewardItems() {
+	im.sendOkLevel("",giveRewardItems(itemCount));
+}
+/**
+ * 生成奖励物品的显示列表
+ * @param {Number} count - 包含奖励数据的配置对象
+ * @returns {string} 格式化后的奖励列表字符串，每项用换行符分隔
+ */
+function getRewardList(count) {
+	return config.reward.map(obj => {
+		let { id, qty } = obj;// 通过解构赋值获取当前物品属性
+		let itemshow = ITEM_TEMPLATES[id] ?? '';// 根据物品ID获取基础显示模板（使用空值合并运算符??）
+		if (count > 1) qty = `${qty}#k × ${count}份 = #b${qty * count}#k`;
+		// 处理不同物品类型的显示逻辑
+		if (id >= 1_000_000) {  // 有效的物品ID≥7位数，使用数字分隔符提高可读性
+			itemshow = `#i${id}#   #e#b#t${id}##k#n × #r${qty}#k`;
+		} else if (itemshow) {// 已知物品追加数量显示
+			itemshow += ` × #r${qty}#k`;
+		} else {// 未知物品显示错误提示
+			itemshow = `#fUI/UIWindow.img/KeyConfig/BtHelp/mouseOver/0# #e#r未知物品ID：[#k ${id} #r]#k#n`;
+		}
+		return `#fUI/CashShop.img/CSDiscount/arrow# ${itemshow}`;// 为每项添加统一前缀并返回
+	}).join('\r\n');  // 用回车换行符连接所有项
+}
+
+/**
+ * 发放奖励道具（支持多份兑换）
+ * @param {number} [count=1] - 兑换份数（默认为1）
+ * @returns {string} 发放结果信息（失败时返回无法兑换的物品列表）
+ */
+function giveRewardItems(count) {
+	if (count <= 0 || count > itemCount) {
+		return "输入的份数不能 ≤0 且 不能超过最大份数 " + itemCount;
+	}
+	// 再次验证兑换硬币持有数量
+	itemQty = im.itemQuantity(config.haveitem.id);	//获取背包持有量
+	itemDeduct = count * config.haveitem.qty;		//计算硬币扣除数量
+	if (itemQty < itemDeduct) {	//验证硬币数量是否足够扣除
+		return `当前持有的\r\n${itemIcoName} × #r${itemQty + config.haveitem.unit}#k \r\n不足以兑换 #r${count} 份#k \r\n所需的数量 #r${itemDeduct + config.haveitem.unit}#k`;
+	}
+	// 验证普通物品
+	const failedItems = [];
+	const normalItems = config.reward.filter(obj => obj.id >= 1_000_000);
+
+	for (const {id, qty} of normalItems) {
+		const totalQty = qty * count;
+		if (!im.canHold(id, totalQty)) {
+			failedItems.push(`#fUI/UIWindow.img/FadeYesNo/BtCancel/mouseOver/0# #i${id}#   #b#t${id}##k × #r${totalQty}#k`);
 		}
 	}
-			
+
+	if (failedItems.length > 0) {
+		return ` 背包空间不足，无法兑换以下物品：\r\n\r\n${failedItems.join('\r\n')}`;
+	} else {
+		im.gainItem(config.haveitem.id,-itemDeduct);	//扣除对应份数的硬币数量
+	}
+
+	// 实际发放所有物品
+	const successItems = [];
+	for (const {id, qty} of config.reward) {
+		const totalQty = qty * count;
+		let succitemshow;
+
+		if (id >= 1_000_000) {
+			im.gainItem(id, totalQty);
+			succitemshow = `#i${id}#   #b#t${id}##k × #r${totalQty}#k`;
+		} else {
+			switch(id) {
+				case 0:
+					im.gainMeso(totalQty);
+					succitemshow = `${ITEM_TEMPLATES[id]} × #r${totalQty}#k`;
+					break;
+				case 1:
+				case 2:
+				case 4:
+					im.getPlayer().getCashShop().gainCash(id, totalQty);
+					succitemshow =`${ITEM_TEMPLATES[id]} × #r${totalQty}#k`;
+					break;
+				case 5:
+					im.gainExp(totalQty);
+					succitemshow =`${ITEM_TEMPLATES[id]} × #r${totalQty}#k`;
+					break;
+			}
+		}
+		if (succitemshow) {
+			successItems.push(`#fUI/Basic.img/CheckBox/1# ${succitemshow}`);
+		}
+	}
+
+	return `#fUI/UIWindow.img/QuestIcon/4/0#\r\n\r\n${successItems.join('\r\n')}`;
 }
 
-function CheckStatus(mode)
-{
-	if (mode == -1)
-	{
-		cm.dispose();
-		return false;
-	}
-	
-	if (mode == 1)
-	{
-		status++;
-	}
-	else
-	{
-		status--;
-	}
-	
-	if (status == -1)
-	{
-		cm.dispose();
-		return false;
-	}	
-	return true;
+/**
+ * 返回硬币图标与名称
+ */
+function getCoinInfo() {
+	return `#i${config.haveitem.id}# #e#b#t${config.haveitem.id}##k#n`;
 }
-

--- a/gms-server/src/main/java/org/gms/client/Client.java
+++ b/gms-server/src/main/java/org/gms/client/Client.java
@@ -244,10 +244,10 @@ public class Client extends ChannelInboundHandlerAdapter {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        if (player != null) {
+        if (player != null && !player.isLoggedInWorld()) {  //判断玩家不为空且不在线才进行救援
             String MapName = player.getMap().getMapName().isEmpty() ? I18nUtil.getLogMessage("SystemRescue.info.map.message1") : player.getMap().getMapName();  //读取出错地图名称，这里是读取服务端String.wz地图名称，不存在则设为 未知地图
             log.warn(I18nUtil.getLogMessage("Client.warn.map.message1"), player, MapName , player.getMapId(), cause);
-            sysRescue.setMapChange();   // 尝试解救那些卡地图的倒霉蛋。
+            sysRescue.setMapChange(player);   // 尝试解救那些卡地图的倒霉蛋。
         }
 
         if (cause instanceof InvalidPacketHeaderException) {
@@ -326,7 +326,7 @@ public class Client extends ChannelInboundHandlerAdapter {
      */
     public void setPlayer(Character player) {
         this.player = player;
-        this.sysRescue = new SystemRescue(player);
+        this.sysRescue = new SystemRescue();
     }
 
     public AbstractPlayerInteraction getAbstractPlayerInteraction() {

--- a/gms-server/src/main/java/org/gms/client/command/commands/gm3/SpawnCommand.java
+++ b/gms-server/src/main/java/org/gms/client/command/commands/gm3/SpawnCommand.java
@@ -45,6 +45,7 @@ public class SpawnCommand extends Command {
 
         Monster monster = LifeFactory.getMonster(Integer.parseInt(params[0]));
         if (monster == null) {
+            player.dropMessage(6,"怪物ID：[" + params[0] + "] 不存在，无法召唤。");
             return;
         }
         if (params.length == 2) {

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -138,7 +138,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             }
             if (display > 80) { //Hmm
                 if (!mySkill.getAction()) {
-                    AutobanFactory.FAST_ATTACK.autoban(chr, "WZ Edit; adding action to a skill: " + display);
+                    AutobanFactory.FAST_ATTACK.autoban(chr, "WZ编辑；为技能添加动作：" + display);
                     return null;
                 }
             }
@@ -168,7 +168,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 }
 
                 if (player.getMp() < attackEffect.getMpCon()) {
-                    AutobanFactory.MPCON.addPoint(player.getAutoBanManager(), "Skill: " + attack.skill + "; Player MP: " + player.getMp() + "; MP Needed: " + attackEffect.getMpCon());
+                    AutobanFactory.MPCON.addPoint(player.getAutoBanManager(), "技能: " + attack.skill + "; 玩家 MP: " + player.getMp() + "; MP 需要: " + attackEffect.getMpCon());
                 }
 
                 int mobCount = attackEffect.getMobCount();
@@ -199,7 +199,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 }
 
                 if (attack.numAttacked > mobCount) {
-                    AutobanFactory.MOB_COUNT.autoban(player, "Skill: " + attack.skill + "; Count: " + attack.numAttacked + " Max: " + attackEffect.getMobCount());
+                    AutobanFactory.MOB_COUNT.autoban(player, "技能: " + attack.skill + "; Count: " + attack.numAttacked + " Max: " + attackEffect.getMobCount());
                     return;
                 }
             }
@@ -280,7 +280,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                     }
 
                     if (distance > distanceToDetect) {
-                        AutobanFactory.DISTANCE_HACK.alert(player, "Distance Sq to monster: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
+                        AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
                         monster.refreshMobPosition();
                     }
 
@@ -514,7 +514,8 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                                             api.gainItem(shellId, (short) -1, false);
                                             totDamageToOneMonster *= player.getLevel();
                                         } else {
-                                            player.dropMessage(5, "You have ran out of shells to activate the hidden power of Three Snails.");
+                                            player.dropMessage(5, "你的蜗牛壳已经用完了，无法使用蜗牛投掷术。");  //蜗牛壳消耗完了
+                                            totDamageToOneMonster = 0;
                                         }
                                     } else {
                                         totDamageToOneMonster = 0;

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/PlayerLoggedinHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/PlayerLoggedinHandler.java
@@ -337,7 +337,7 @@ public final class PlayerLoggedinHandler extends AbstractPacketHandler {
             //展示服务信息
             noteService.show(player);
             //异常地图掉线信息提示
-            c.getSysRescue().showMapChangeMessage();
+            c.getSysRescue().showMapChangeMessage(player);
 
             if (player.getParty() != null) {
                 PartyCharacter pchar = player.getMPC();

--- a/gms-server/src/main/java/org/gms/server/SystemRescue.java
+++ b/gms-server/src/main/java/org/gms/server/SystemRescue.java
@@ -10,6 +10,7 @@ package org.gms.server;
 import lombok.Getter;
 import org.gms.client.Character;
 import org.gms.config.GameConfig;
+import org.gms.server.maps.MapleMap;
 import org.gms.util.I18nUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,23 +22,17 @@ import java.util.Random;
 
 @Getter
 public class SystemRescue {
-    private final Character player;
     private static final Logger log = LoggerFactory.getLogger(SystemRescue.class);
     private static final List<Integer> MapIdList = Arrays.asList(100000000, 101000000, 102000000, 103000000, 104000000);   //射手村，魔法密林，勇士部落，废弃都市，明珠港
     private static final String Lebel = I18nUtil.getLogMessage("SystemRescue.info.map.label") + " ";
 
     private static final String key_mapError_sysmsg = "系统救援_卡地图_系统通知";
 
-    // 构造函数，接受参数
-    public SystemRescue(Character player) {
-        this.player = player;
-    }
-
     /**
      * 卡地图救援，将某个倒霉蛋解救到其它地图。
      */
-    public void setMapChange() {
-        if (player == null) return;   // 预防空指针
+    public void setMapChange(Character player) {
+        MapleMap MapObj = player.getMap();
         int MapId = GameConfig.getServerInt("system_rescue_maperror_changeid");    // 该参数为控制台配置，设置地图ID大于0则启用。设置不存在的ID则改为随机传送到金银岛某个城镇。
         if (MapId <= 0 && !player.isChangingMaps()) return;  // 如果 MapId 不大于0 且 玩家角色非切换地图状态，直接返回
 
@@ -48,7 +43,7 @@ public class SystemRescue {
         try {
             MapId_error = player.getMapId();       // 读取出错地图ID
             // 读取出错地图名称，这里是读取服务端String.wz地图名称，不存在则设为 未知地图
-            MapName_error = player.getMap().getMapName().isEmpty() ? MapName_error : player.getMap().getMapName();
+            MapName_error = MapObj.getMapName().isEmpty() ? MapName_error : MapObj.getMapName();
         } catch (Exception ignored) {
         }
 
@@ -68,25 +63,30 @@ public class SystemRescue {
                 MapId = filteredList.get(random.nextInt(filteredList.size()));
             }
         }
+        if (MapId == org.gms.constants.id.MapId.FM_ENTRANCE) {
+            int MapId_ret = MapObj.getForcedReturnMap().getId();
+            if (MapObj.getTimeLimit() != -1 || MapObj.isEventMap() || MapObj.getEventInstance() != null) player.changeMap(MapId_ret);  //为迷你地图或者事件地图，先转移到返回地图
+            player.saveLocation("FREE_MARKET");    //如果传送的地图时自由市场则保存当前地图，方便下次出来。
+        }
         //考虑到可能会出现地图文件改错改坏造成的闪退，因此不判定地图是否存在再进行转移。
         player.changeMap(MapId);    // 更改角色地图ID，之后才可以执行下方的读取转移后的地图信息。
-        String MapName = player.getMap().getMapName();
+        String MapName = MapObj.getMapName();
         String Message_system = I18nUtil.getMessage("SystemRescue.map.message1", MapName_error, MapName);
-        player.getAbstractPlayerInteraction().saveOrUpdateCharacterExtendValue(key_mapError_sysmsg, Message_system);
+        player.getAbstractPlayerInteraction().saveOrUpdateCharacterExtendValue(key_mapError_sysmsg, Message_system);    //记录通知消息
         log.info(Lebel + I18nUtil.getLogMessage("SystemRescue.info.map.message2"), player.getName(), MapName_error, MapId_error, MapName, MapId);
     }
 
     /**
      * 卡地图救援：玩家重新上线后会收到提示信息。
      */
-    public void showMapChangeMessage() {
+    public void showMapChangeMessage(Character player) {
         try {
             if (player == null) return;   //预防空指针
+
             //聊天窗口红色提示
-            if (dropMessage(key_mapError_sysmsg, 5)) {
+            if (dropMessage(player,key_mapError_sysmsg, 5)) {
                 String Message = I18nUtil.getMessage("SystemRescue.map.message2");
-                if (!Message.isEmpty()) {
-                    //卡地图救援提示判断，弹窗
+                if (!Message.isEmpty()) {//卡地图救援提示判断，弹窗
                     player.dropMessage(1, Message);
                 }
             }
@@ -102,7 +102,7 @@ public class SystemRescue {
      * @param type 消息类型。
      * @return 如果成功处理消息返回 true，否则返回 false。
      */
-    private boolean dropMessage(String keyname, int type) {
+    private boolean dropMessage(Character player, String keyname, int type) {
         if (player == null || keyname == null || keyname.isEmpty()) return false;  //预防空指针
         String Message = player.getAbstractPlayerInteraction().getCharacterExtendValue(keyname);      //从玩家扩展表里提取指定键值
         if (Message != null && Message.length() > 1) {


### PR DESCRIPTION
>  卡地图拯救系统修复救错人和乱救的BUG，改为判断当前玩家不在线再进行转移。

> 北斗指南书碎片兑换脚本展示
> ![image](https://github.com/user-attachments/assets/25032db1-59c3-46fa-a843-abd6a748518c)
> 
> 不同份数的奖励兑换
> 1份
> ![image](https://github.com/user-attachments/assets/58df2260-3ad5-4122-a451-2de6a42ef406)
> 
> 20份
> ![image](https://github.com/user-attachments/assets/b0592fad-f570-4768-846e-05b3161b3fd0)
> 
> 背包检测空间不够
> ![image](https://github.com/user-attachments/assets/2175df8f-58c4-4e88-a7da-25507e0f3168)
> 
> 发放成功
> ![image](https://github.com/user-attachments/assets/0b875cf2-0e5b-4fd6-adb9-3bf9eb68b651)
> 

> 召唤怪物不存在的提示
> 
> ![image](https://github.com/user-attachments/assets/d503fb3b-bf19-424e-908e-747a4ad4ea0c)
> 

