### PR TITLE
修复：兵法书经验溢出

### DIFF
--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -2830,8 +2830,10 @@ public class Character extends AbstractCharacterObject {
     public void gainGachaExp() {
         int expgain = 0;
         long currentgexp = gachaExp.get();
-        if ((currentgexp + exp.get()) >= ExpTable.getExpNeededForLevel(level)) {
-            expgain += ExpTable.getExpNeededForLevel(level) - exp.get();
+
+        int levelUpNeed = ExpTable.getExpNeededForLevel(level) - exp.get();
+        if (currentgexp >= levelUpNeed) {
+            expgain += Math.max(0, levelUpNeed);
 
             int nextneed = ExpTable.getExpNeededForLevel(level + 1);
             if (currentgexp - expgain >= nextneed) {


### PR DESCRIPTION
#370 

错误原因：  
当开启 **升级保护**`use_level_up_protect` 时，超出当前升级所需经验不会自动升级，此时`gainGachaExp`中计算升级所需经验为负数，`gainExp`对于负数经验会取`Integer.MAX_VALUE`。