### PR TITLE
修复并优化废弃组队副本

### DIFF
--- a/gms-server/scripts-zh-CN/npc/9020001.js
+++ b/gms-server/scripts-zh-CN/npc/9020001.js
@@ -136,15 +136,17 @@ function action(mode, type, selection) {
                 }
             } else if (curMap == 103000800) {   // stage 1
                 if (cm.isEventLeader()) {
-                    var numpasses = eim.getPlayerCount() - 1;     // minus leader
-
-                    if (cm.hasItem(4001008, numpasses)) {
-                        cm.sendNext("你收集了" + numpasses + "张通行证！恭喜你通过了这个关卡！我会制作一个传送你到下一个关卡的传送门。到那里有时间限制，所以请赶快。祝你们好运！");
+					var numpasses = eim.getPlayerCount()- 1 || 1;
+					var needItem = 4001007; 						//需求证书ID
+					var needCount = numpasses * 2;   				//需求数量(队员数*需求数)
+					var haveItem = cm.getItemQuantity(needItem); 	//获得对查看身上拥有证书数量数量
+                    if (haveItem >= needCount) {
+                        cm.sendNext("你已收集满足通关条件！恭喜你通过了这个关卡！我会制作一个传送你到下一个关卡的传送门。到那里有时间限制，所以请赶快。祝你们好运！");
                         clearStage(stage, eim, curMap);
                         eim.gridClear();
-                        cm.gainItem(4001008, -numpasses);
+						cm.gainItem(needItem, -haveItem);
                     } else {
-                        cm.sendNext("对不起，但你的通行证数量不够。你需要给我正确数量的通行证；应该是你队伍成员数量减去队长的数量，在这种情况下需要 " + numpasses + " 张通行证来通过这个关卡。告诉你的队伍成员解决问题，收集通行证，然后交给你。");
+                        cm.sendNext("你的通行证书数量不够。需求数量应该是你队伍人数减去队长数，至少 #b需要 " + needCount + " 张通行证书#k 来通过这个关卡。告诉你的队伍成员收集足够然后交给我。");
                     }
                 } else {
                     var data = eim.gridCheck(cm.getPlayer());


### PR DESCRIPTION
此副本需求的证书数量是队员人数-队长=所需证书数量
由于开启了单人副本，本人是队长，减去了队长后需求数变为0直接过关的问题。
1、修复了这个需求证书算法并增加了注释
2、通关NPC直接扣除身上所获得的证书


测试过了。之前理解的通行许可证是第三关掉落的，我以为是现金道具。改过了。