### PR TITLE
修改废弃组队任务副本进入时清空通行证

### DIFF
--- a/gms-server/scripts-zh-CN/event/KerningPQ.js
+++ b/gms-server/scripts-zh-CN/event/KerningPQ.js
@@ -128,7 +128,9 @@ function setup(level, lobbyid) {
     return eim;
 }
 
-function afterSetup(eim) {}
+function afterSetup(eim) {
+    eim.dropAllExclusiveItems();
+}
 
 function respawnStages(eim) {
     eim.getMapInstance(103000800).instanceMapRespawn();


### PR DESCRIPTION
目前脚本存漏洞：
玩家进入副本时背包中存在通行证可以直接过关

通行证获取方法，在别的副本或其他需要通行证的副本时中途下线，通行证就会存在背包中

改为：进入副本时直接删除需求的通行证
