### PR TITLE
女神塔副本进入时处理背包中已存在的所需道具

### DIFF
--- a/gms-server/scripts-zh-CN/event/OrbisPQ.js
+++ b/gms-server/scripts-zh-CN/event/OrbisPQ.js
@@ -187,6 +187,7 @@ function afterSetup(eim) {
         var rnd = Math.floor(Math.random() * 4);
         eim.applyEventPlayersItemBuff(2022090 + rnd);
     }
+    eim.dropAllExclusiveItems();
 }
 
 function respawnStages(eim) {}


### PR DESCRIPTION
进入女神塔时如背包中已存在任务道具未清理，有可能玩家直接过关！