### PR TITLE
修复毒雾森林队员无法获得奖励的问题

### DIFF
--- a/gms-server/scripts-zh-CN/portal/party6_stage800.js
+++ b/gms-server/scripts-zh-CN/portal/party6_stage800.js
@@ -1,20 +1,6 @@
+
+// 毒雾森林最后一个传送门
 function enter(pi) {
-    pi.removeAll(4001162);
-    pi.removeAll(4001163);
-    pi.removeAll(4001164);
-    pi.removeAll(4001169);
-    pi.removeAll(2270004);
-
-    var spring = pi.getMap().getReactorById(3008000);  // thanks Chloek3, seth1 for noticing fragments not being awarded properly
-    if (spring != null && spring.getState() > 0) {
-        if (!pi.canHold(4001198, 1)) {
-            pi.playerMessage(5, "进入传送门前请给背包的 其它栏 空出至少1个空格子。");
-            return false;
-        }
-
-        pi.gainItem(4001198, 1);
-    }
-
     pi.playPortalSound();
     pi.warp(300030100, 0);
     return true;


### PR DESCRIPTION
这里以前是别人修复没有发送碎片的问题，但是修复错了，领取之后不应该是把全员传送出去，这导致队员无法参与抽奖的问题，也不应该是这个传送门修复，应该关联的是party6_out。