### PR TITLE
修复保护雪人副本大于30~40级传送的等级为41~50级的副本的错误

### DIFF
--- a/gms-server/scripts-zh-CN/quest/28004.js
+++ b/gms-server/scripts-zh-CN/quest/28004.js
@@ -48,7 +48,7 @@ function start(mode, type, selection) {
         } else if (status == 2) {
             var level = qm.getPlayer().getLevel();
 
-            cm.warp(level <= 30 ? 889100000 : level <= 40 ? 889100010 : 889100020);
+            qm.warp(level <= 30 ? 889100000 : level <= 40 ? 889100010 : 889100020);
             qm.dispose();
         }
     }


### PR DESCRIPTION
修复等级判断错误的问题


保护雪人副本为三个档级
21~30
31~40
41~50

分别进入不同的地图，，此处判断有误，角色大于31~40级传送的副本为41~50的，无法参加！