### PR TITLE
修复：战神任务【奇怪的情报搜集】【人偶师的洞穴】

### DIFF
--- a/gms-server/scripts-zh-CN/npc/PupeteerPassword.js
+++ b/gms-server/scripts-zh-CN/npc/PupeteerPassword.js
@@ -19,7 +19,7 @@ function action(mode, type, selection) {
     if (status == 0) {
         if (cm.isQuestStarted(21728)) {
             cm.sendOk("你寻找着线索，试图找到操纵者的蛛丝马迹，但似乎有一股强大的力量挡住了你的去路……最好返回找 #b#p1061019##k。");
-            cm.setQuestProgress(21728, 21761, 0);
+            cm.setQuestProgress(21728, 21761, "0");
             cm.dispose();
             return;
         }

--- a/gms-server/scripts-zh-CN/portal/enterInfo.js
+++ b/gms-server/scripts-zh-CN/portal/enterInfo.js
@@ -4,7 +4,7 @@ function enter(pi) {
         const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
         const Point = Java.type('java.awt.Point');
         mapobj.spawnMonsterOnGroundBelow(LifeFactory.getMonster(9300345), new Point(0, 0));
-        pi.setQuestProgress(21733, 21762, 2);
+        pi.setQuestProgress(21733, 21762, "2");
     }
 
     pi.playPortalSound();

--- a/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
@@ -22238,6 +22238,12 @@
                     <int name="id" value="9300345"/>
                 </imgdir>
             </imgdir>
+            <int name="infoNumber" value="21762"/>
+            <imgdir name="infoex">
+              <imgdir name="0">
+                <string name="value" value="2"/>
+              </imgdir>
+            </imgdir>
         </imgdir>
     </imgdir>
     <imgdir name="21734">


### PR DESCRIPTION
fixes #351 
涉及以下战神任务修复，由于问题原因相同一并提交，该修复的有效性已验证：
## 1、奇怪的情报搜集
### 问题描述
在击杀弗朗西斯后任务进度不更新
### 修复方法
问题的本质是第三个参数为int 2，但根据任务配置,infoex 中定义的值是字符串 "2"。setQuestProgress 函数接收的第三个参数是 String 类型，进度匹配是基于字符串比较的，所以任务状态没有更新。
## 2、人偶师的洞穴
### 问题描述
在到人偶师洞穴前触发并完成任务后，无法向NPC交付任务。
### 修复方法
同样的问题，没有正确设置任务进度