### PR TITLE
修复魔法五角星NPC没有启动

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2111026.js
+++ b/gms-server/scripts-zh-CN/npc/2111026.js
@@ -47,11 +47,10 @@ function action(mode, type, selection) {
 
         if (status == 0) {
             cm.sendAcceptDecline("这个魔法五角星还没有完成。您想完成这个魔法五角星的绘制吗？");
-            return;
+            
         } else if (status == 1) {
             cm.weakenAreaBoss(8090000, "魔法五角星已经完成。用于消除迪特（Deet）和罗伊（Roi）的咒语已经被启动了。");
+			cm.dispose();
         }
-
-        cm.dispose();
     }
 }


### PR DESCRIPTION
有拦截代码，询问点接受和拒绝都无法启动。修改后可以执行，和小路灯NPC都一样