### PR TITLE
修复家族对抗副本中封印锁链直接能击开进入下一关的问题

### DIFF
--- a/gms-server/scripts-zh-CN/reactor/9208007.js
+++ b/gms-server/scripts-zh-CN/reactor/9208007.js
@@ -27,17 +27,15 @@ Stage 2: Spear destinations - Guild Quest
 */
 
 function act() {
-    var react = rm.getPlayer().getEventInstance().getMapInstance(990000400).getReactorByName("speargate");
-    react.forceHitReactor(react.getState() + 1);
-
-    if (react.getState() == 4) {
-        var eim = rm.getPlayer().getEventInstance();
-
+    var eim = rm.getPlayer().getEventInstance();
+    var count = eim.getIntProperty("speargate");
+    count++;
+    eim.setIntProperty("speargate" , count);
+    if(count == 4){
         var maps = [990000400, 990000410, 990000420, 990000430, 990000431, 990000440];
         for (var i = 0; i < maps.length; i++) {
             eim.showClearEffect(false, maps[i]);
         }
-
         rm.getGuild().gainGP(20);
     }
 }


### PR DESCRIPTION
由于之前这个反应堆攻击一下就增加人物进度，导致不放隆奇努斯之枪也能过关，这是不正确的！

更新了改变保存进度的方式