### PR TITLE
修复家族对抗副本中封印锁链直接能击开进入下一关的问题

### DIFF
--- a/gms-server/scripts-zh-CN/portal/speargate_open.js
+++ b/gms-server/scripts-zh-CN/portal/speargate_open.js
@@ -26,7 +26,8 @@
 */
 
 function enter(pi) {
-    if (pi.getPlayer().getMap().getReactorByName("speargate").getState() == 4) {
+	var eim = pi.getPlayer().getEventInstance();
+    if (eim.getIntProperty("speargate") == 4) {
         pi.playPortalSound();
         pi.warp(990000401, 0);
         return true;


### PR DESCRIPTION
更改进度缓存的方式，和刚才提交的一样