### PR TITLE
修复家族对抗赛骑士大厅封印锁重复增加了1次GP

### DIFF
--- a/gms-server/scripts-zh-CN/reactor/9208004.js
+++ b/gms-server/scripts-zh-CN/reactor/9208004.js
@@ -22,5 +22,9 @@
 // Stage 2 GP for Guild Quest
 
 function act() {
-    rm.getGuild().gainGP(20);
+    //封印锁击败后进入传送门增加了20GP。这里重复增加了20GP是不对的
+    //rm.getGuild().gainGP(20);
+
+    //4把隆奇努斯之枪放入完成进入本图时自动将封印锁消除
+    rm.message("封印被解开了！");
 }


### PR DESCRIPTION
此封印锁与传送门在一起，封印打开进入传送门增加GP，而不是这里