### PR TITLE
阿里安特竞技王的房间NPC取消对GM的判断

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2101016.js
+++ b/gms-server/scripts-zh-CN/npc/2101016.js
@@ -41,7 +41,7 @@ function action(mode, type, selection) {
             arena.clearAriantScore(cm.getPlayer());
             cm.removeAll(4031868);
 
-            cm.getPlayer().gainExp(92 * cm.getPlayer().getExpRate() * copns, true, true);
+            cm.getPlayer().gainExp(Math.ceil(92 * cm.getPlayer().getExpRate() * copns, true, true));
             cm.getPlayer().gainAriantPoints(copns);
             cm.sendOk("好的！下次再给我更多的宝石！啊哈哈哈哈哈！");
             cm.dispose();


### PR DESCRIPTION
因之前对GM的判断导致每次都对角色发放奖励，即便任务宝石道具为0，这是不对的！