### PR TITLE
修复BUG几点

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2101016.js
+++ b/gms-server/scripts-zh-CN/npc/2101016.js
@@ -27,7 +27,7 @@ function action(mode, type, selection) {
             status--;
         }
         if (status == 0) {
-            var copns = arena.getAriantScore(cm.getPlayer());
+            copns = arena.getAriantScore(cm.getPlayer());
             if (copns < 1) {
                 cm.sendOk("太糟糕了，你没有得到任何珠宝！");
                 cm.dispose();


### PR DESCRIPTION
1、取消之前可能因前辈调试对GM的判断
2、完成任务删除副本专属道具
3、因经验计算公式有误导致发放经验和竞技点失败导致GS报错的问题