### PR TITLE
反作弊优化

### DIFF
--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -484,6 +484,14 @@ public class Character extends AbstractCharacterObject {
     private static final HpMpAlertService hpMpAlertService = ServerManager.getApplicationContext().getBean(HpMpAlertService.class);
     private static final InventoryService inventoryService = ServerManager.getApplicationContext().getBean(InventoryService.class);
 
+    /**
+     * 最后攻击时间
+     * 用来校验攻击速度是否过快
+     */
+    @Setter
+    @Getter
+    private long lastAttackTime = 0;
+
     private Character() {
         super.setListener(new CharacterListener(this));
         useCS = false;

--- a/gms-server/src/main/java/org/gms/client/autoban/AutobanFactory.java
+++ b/gms-server/src/main/java/org/gms/client/autoban/AutobanFactory.java
@@ -58,7 +58,12 @@ public enum AutobanFactory {
     ITEM_VAC,
     FAST_ITEM_PICKUP(5, SECONDS.toMillis(30)),
     FAST_ATTACK(10, SECONDS.toMillis(30)),
-    MPCON(25, SECONDS.toMillis(30));
+    MPCON(25, SECONDS.toMillis(30)),
+
+    /**
+     * 攻击频率
+     */
+    ATTACK_INTERVAL(20, SECONDS.toMillis(30));
 
     private static final Logger log = LoggerFactory.getLogger(AutobanFactory.class);
     private static final Set<Integer> ignoredChrIds = new HashSet<>();

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/ItemPickupHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/ItemPickupHandler.java
@@ -23,6 +23,7 @@ package org.gms.net.server.channel.handlers;
 
 import org.gms.client.Character;
 import org.gms.client.Client;
+import org.gms.client.autoban.AutobanFactory;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
 import org.slf4j.Logger;
@@ -53,8 +54,10 @@ public final class ItemPickupHandler extends AbstractPacketHandler {
         Point charPos = chr.getPosition();
         Point obPos = ob.getPosition();
         if (Math.abs(charPos.getX() - obPos.getX()) > 800 || Math.abs(charPos.getY() - obPos.getY()) > 600) {
-            log.warn("Chr {} tried to pick up an item too far away. Mapid: {}, player pos: {}, object pos: {}",
-                    c.getPlayer().getName(), chr.getMapId(), charPos, obPos);
+
+//            AutobanFactory.DISTANCE_HACK.alert(chr, "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "距离物品: " + Math.abs(charPos.getX() - obPos.getX()) + " " + Math.abs(charPos.getY() - obPos.getY()));
+            AutobanFactory.DISTANCE_HACK.addPoint(chr.getAutoBanManager(), "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "距离物品: " + Math.abs(charPos.getX() - obPos.getX()) + " " + Math.abs(charPos.getY() - obPos.getY()));
+            log.warn("玩家{}地图ID：{}距离物品: {} {}", chr.getName(), chr.getMapId(), Math.abs(charPos.getX() - obPos.getX()), Math.abs(charPos.getY() - obPos.getY()));
             return;
         }
 


### PR DESCRIPTION
feat(game): 添加攻击间隔检测和距离验证反作弊功能
- 优化自动封号机制
- 新增ATTACK_INTERVAL反作弊类型用于检测攻击频率
- 实现攻击间隔检测逻辑，小于350ms触发封号，小于450ms触发警告
- 为角色类添加lastAttackTime字段记录最后攻击时间
- 修改距离检测逻辑，将直接封号改为积分制处理
- 添加SLF4J日志记录用于调试和监控
- 修复Boomerang Step技能的距离检测，新增Chain Lightning支持
- 优化代码格式和条件判断逻辑