### PR TITLE
修复家族对抗副本封印锁链可以击破直接过关的问题

### DIFF
--- a/gms-server/wz/Reactor.wz/9208004.img.xml
+++ b/gms-server/wz/Reactor.wz/9208004.img.xml
@@ -65,14 +65,6 @@
       <int name="delay" value="150"/>
     </canvas>
     <int name="repeat" value="1"/>
-    <imgdir name="event">
-      <imgdir name="0">
-        <int name="type" value="0"/>
-        <int name="state" value="1"/>
-      </imgdir>
-    </imgdir>
-    <imgdir name="hit">
-    </imgdir>
   </imgdir>
   <imgdir name="1">
     <canvas name="0" width="231" height="231">
@@ -136,14 +128,6 @@
       <int name="delay" value="150"/>
     </canvas>
     <int name="repeat" value="1"/>
-    <imgdir name="event">
-      <imgdir name="0">
-        <int name="type" value="0"/>
-        <int name="state" value="2"/>
-      </imgdir>
-    </imgdir>
-    <imgdir name="hit">
-    </imgdir>
   </imgdir>
   <imgdir name="2">
     <canvas name="0" width="231" height="231">
@@ -207,14 +191,6 @@
       <int name="delay" value="150"/>
     </canvas>
     <int name="repeat" value="1"/>
-    <imgdir name="event">
-      <imgdir name="0">
-        <int name="type" value="0"/>
-        <int name="state" value="3"/>
-      </imgdir>
-    </imgdir>
-    <imgdir name="hit">
-    </imgdir>
   </imgdir>
   <imgdir name="3">
     <canvas name="0" width="231" height="231">
@@ -338,12 +314,6 @@
         <int name="z" value="0"/>
         <int name="delay" value="120"/>
       </canvas>
-    </imgdir>
-    <imgdir name="event">
-      <imgdir name="0">
-        <int name="type" value="0"/>
-        <int name="state" value="4"/>
-      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="4">


### PR DESCRIPTION
之前对文件结构不够了解，找不到这个封印锁在这里是这里直接去修改了脚本解决，其实这里才是问题的根源！
修改后，封印锁链不可被攻击，只有在放上4把隆奇努斯之枪的反应堆改为speargate为4时直接开启！


对应的客户端文件最好修改一下，不改也可以，锁链被攻击会闪一下！

<img width="1534" height="748" alt="image" src="https://github.com/user-attachments/assets/7b75a070-1495-4c6f-a7ae-c7a0503db2f0" />
