### PR TITLE
feat(packet-protocol) 添加数据包协议功能

### DIFF
--- a/gms-server/src/main/java/org/gms/constants/net/OpcodeConstants.java
+++ b/gms-server/src/main/java/org/gms/constants/net/OpcodeConstants.java
@@ -19,6 +19,7 @@
 */
 package org.gms.constants.net;
 
+import org.gms.net.opcodes.Opcode;
 import org.gms.net.opcodes.RecvOpcode;
 import org.gms.net.opcodes.SendOpcode;
 
@@ -33,13 +34,19 @@ public class OpcodeConstants {
     public static Map<Integer, String> recvOpcodeNames = new HashMap<>();
 
     public static void generateOpcodeNames() {
-        for (SendOpcode op : SendOpcode.values()) {
-            sendOpcodeNames.put(op.getValue(), op.name());
-        }
-
-        for (RecvOpcode op : RecvOpcode.values()) {
-            recvOpcodeNames.put(op.getValue(), op.name());
+        switch (ServerConstants.VERSION) {
+            case 83  -> init(SendOpcode.values(), RecvOpcode.values());
+            default  -> throw new RuntimeException("不支援的版本: " + ServerConstants.VERSION);
         }
     }
 
+    public static void init(Opcode[] sendValues, Opcode[] recvValues) {
+        for (Opcode op : sendValues) {
+            sendOpcodeNames.put(op.getValue(), op.getName());
+        }
+
+        for (Opcode op : recvValues) {
+            recvOpcodeNames.put(op.getValue(), op.getName());
+        }
+    }
 }

--- a/gms-server/src/main/java/org/gms/net/PacketProcessor.java
+++ b/gms-server/src/main/java/org/gms/net/PacketProcessor.java
@@ -21,7 +21,9 @@
  */
 package org.gms.net;
 
+import org.gms.constants.net.ServerConstants;
 import org.gms.net.netty.LoginServer;
+import org.gms.net.opcodes.Opcode;
 import org.gms.net.opcodes.RecvOpcode;
 import org.gms.net.server.channel.handlers.*;
 import org.gms.net.server.handlers.CustomPacketHandler;
@@ -95,11 +97,11 @@ public final class PacketProcessor {
         return handler;
     }
 
-    public void registerHandler(RecvOpcode code, PacketHandler handler) {
+    public void registerHandler(Opcode code, PacketHandler handler) {
         try {
             handlers[code.getValue()] = handler;
         } catch (ArrayIndexOutOfBoundsException e) {
-            log.error("Error registering handler {}", code.name(), e);
+            log.error("Error registering handler {}", code.getName(), e);
         }
     }
 
@@ -117,12 +119,19 @@ public final class PacketProcessor {
     public void reset(int channel) {
         handlers = new PacketHandler[handlers.length];
 
-        registerCommonHandlers();
+        switch (ServerConstants.VERSION) {
+            case 83:
+                registerCommonHandlers();
 
-        if (channel < 0) {
-            registerLoginHandlers();
-        } else {
-            registerChannelHandlers();
+                if (channel < 0) {
+                    registerLoginHandlers();
+                } else {
+                    registerChannelHandlers();
+                }
+                break;
+            default:
+                log.warn("找不到指定的版本注册 Opcode Handler");
+                break;
         }
     }
 

--- a/gms-server/src/main/java/org/gms/net/encryption/PacketCodec.java
+++ b/gms-server/src/main/java/org/gms/net/encryption/PacketCodec.java
@@ -1,9 +1,10 @@
 package org.gms.net.encryption;
 
 import io.netty.channel.CombinedChannelDuplexHandler;
+import org.gms.net.encryption.protocol.ProtocolFactory;
 
 public class PacketCodec extends CombinedChannelDuplexHandler<PacketDecoder, PacketEncoder> {
-    public PacketCodec(ClientCyphers clientCyphers) {
-        super(new PacketDecoder(clientCyphers.getReceiveCypher()), new PacketEncoder(clientCyphers.getSendCypher()));
+    public PacketCodec(ProtocolFactory protocolFactory) {
+        super(new PacketDecoder(protocolFactory), new PacketEncoder(protocolFactory));
     }
 }

--- a/gms-server/src/main/java/org/gms/net/encryption/PacketEncoder.java
+++ b/gms-server/src/main/java/org/gms/net/encryption/PacketEncoder.java
@@ -3,26 +3,19 @@ package org.gms.net.encryption;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
+import org.gms.constants.net.ServerConstants;
+import org.gms.net.encryption.protocol.ProtocolFactory;
 import org.gms.net.packet.Packet;
 
 public class PacketEncoder extends MessageToByteEncoder<Packet> {
-    private final MapleAESOFB sendCypher;
+    private final ProtocolFactory protocolFactory;
 
-    public PacketEncoder(MapleAESOFB sendCypher) {
-        this.sendCypher = sendCypher;
+    public PacketEncoder(ProtocolFactory protocolFactory) {
+        this.protocolFactory = protocolFactory;
     }
 
     @Override
     protected void encode(ChannelHandlerContext ctx, Packet in, ByteBuf out) {
-        byte[] packet = in.getBytes();
-        out.writeBytes(getEncodedHeader(packet.length));
-
-        MapleCustomEncryption.encryptData(packet);
-        sendCypher.crypt(packet);
-        out.writeBytes(packet);
-    }
-
-    private byte[] getEncodedHeader(int length) {
-        return sendCypher.getPacketHeader(length);
+        protocolFactory.getProtocol(ServerConstants.VERSION).encode(ctx, in, out);
     }
 }

--- a/gms-server/src/main/java/org/gms/net/encryption/protocol/GMSV83PacketProtocol.java
+++ b/gms-server/src/main/java/org/gms/net/encryption/protocol/GMSV83PacketProtocol.java
@@ -1,0 +1,77 @@
+package org.gms.net.encryption.protocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.SocketChannel;
+import org.gms.client.Client;
+import org.gms.constants.net.ServerConstants;
+import org.gms.net.encryption.ClientCyphers;
+import org.gms.net.encryption.InitializationVector;
+import org.gms.net.encryption.MapleAESOFB;
+import org.gms.net.encryption.MapleCustomEncryption;
+import org.gms.net.netty.InvalidPacketHeaderException;
+import org.gms.net.packet.ByteBufInPacket;
+import org.gms.net.packet.Packet;
+import org.gms.util.PacketCreator;
+
+import java.util.List;
+
+public class GMSV83PacketProtocol implements PacketProtocol {
+    private final MapleAESOFB receiveCypher;
+    private final MapleAESOFB sendCypher;
+
+    public GMSV83PacketProtocol(ClientCyphers clientCyphers) {
+        this.receiveCypher = clientCyphers.getReceiveCypher();
+        this.sendCypher = clientCyphers.getSendCypher();
+    }
+
+    @Override
+    public void decode(ChannelHandlerContext context, ByteBuf in, List<Object> out) {
+        final int header = in.readInt();
+
+        if (!receiveCypher.isValidHeader(header)) {
+            throw new InvalidPacketHeaderException("Attempted to decode a packet with an invalid header", header);
+        }
+
+        final int packetLength = decodePacketLength(header);
+        byte[] packet = new byte[packetLength];
+        in.readBytes(packet);
+        receiveCypher.crypt(packet);
+        MapleCustomEncryption.decryptData(packet);
+        out.add(new ByteBufInPacket(Unpooled.wrappedBuffer(packet)));
+    }
+
+    /**
+     * @param header Packet header - the first 4 bytes of the packet
+     * @return Packet size in bytes
+     */
+    private static int decodePacketLength(byte[] header) {
+        return (((header[1] ^ header[3]) & 0xFF) << 8) | ((header[0] ^ header[2]) & 0xFF);
+    }
+
+    private int decodePacketLength(int header) {
+        int length = ((header >>> 16) ^ (header & 0xFFFF));
+        length = ((length << 8) & 0xFF00) | ((length >>> 8) & 0xFF);
+        return length;
+    }
+
+    @Override
+    public void encode(ChannelHandlerContext ctx, Packet in, ByteBuf out) {
+        byte[] packet = in.getBytes();
+        out.writeBytes(getEncodedHeader(packet.length));
+
+        MapleCustomEncryption.encryptData(packet);
+        sendCypher.crypt(packet);
+        out.writeBytes(packet);
+    }
+
+    private byte[] getEncodedHeader(int length) {
+        return sendCypher.getPacketHeader(length);
+    }
+
+    @Override
+    public void writeInitialUnencryptedHelloPacket(SocketChannel socketChannel, InitializationVector sendIv, InitializationVector recvIv, Client client) {
+        socketChannel.writeAndFlush(Unpooled.wrappedBuffer(PacketCreator.getHello(ServerConstants.VERSION, sendIv, recvIv).getBytes()));
+    }
+}

--- a/gms-server/src/main/java/org/gms/net/encryption/protocol/PacketProtocol.java
+++ b/gms-server/src/main/java/org/gms/net/encryption/protocol/PacketProtocol.java
@@ -1,0 +1,16 @@
+package org.gms.net.encryption.protocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.SocketChannel;
+import org.gms.client.Client;
+import org.gms.net.encryption.InitializationVector;
+import org.gms.net.packet.Packet;
+
+import java.util.List;
+
+public interface PacketProtocol {
+    void decode(ChannelHandlerContext context, ByteBuf in, List<Object> out);
+    void encode(ChannelHandlerContext ctx, Packet in, ByteBuf out);
+    void writeInitialUnencryptedHelloPacket(SocketChannel socketChannel, InitializationVector sendIv, InitializationVector recvIv, Client client);
+}

--- a/gms-server/src/main/java/org/gms/net/encryption/protocol/ProtocolConstants.java
+++ b/gms-server/src/main/java/org/gms/net/encryption/protocol/ProtocolConstants.java
@@ -1,0 +1,5 @@
+package org.gms.net.encryption.protocol;
+
+public class ProtocolConstants {
+    public static final short GMS_V83 = 83;
+}

--- a/gms-server/src/main/java/org/gms/net/encryption/protocol/ProtocolFactory.java
+++ b/gms-server/src/main/java/org/gms/net/encryption/protocol/ProtocolFactory.java
@@ -1,0 +1,25 @@
+package org.gms.net.encryption.protocol;
+
+import org.gms.net.encryption.ClientCyphers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ProtocolFactory {
+    private final Map<Short, PacketProtocol> PROTOCOLS = new HashMap<>();
+
+    public ProtocolFactory(ClientCyphers clientCyphers){
+        // 在这里注册版本与对应的处理器
+        PROTOCOLS.put(ProtocolConstants.GMS_V83, new GMSV83PacketProtocol(clientCyphers));
+    }
+
+    public PacketProtocol getProtocol(short version) {
+        PacketProtocol protocol = PROTOCOLS.get(version);
+
+        if (protocol == null) {
+            throw new UnsupportedOperationException("PacketProtocol is a unsupported version: " + version);
+        }
+
+        return protocol;
+    }
+}

--- a/gms-server/src/main/java/org/gms/net/opcodes/Opcode.java
+++ b/gms-server/src/main/java/org/gms/net/opcodes/Opcode.java
@@ -1,0 +1,6 @@
+package org.gms.net.opcodes;
+
+public interface Opcode {
+    int getValue();
+    String getName();
+}

--- a/gms-server/src/main/java/org/gms/net/opcodes/RecvOpcode.java
+++ b/gms-server/src/main/java/org/gms/net/opcodes/RecvOpcode.java
@@ -21,7 +21,7 @@
 */
 package org.gms.net.opcodes;
 
-public enum RecvOpcode {
+public enum RecvOpcode implements Opcode {
     CUSTOM_PACKET(0x3713),//13 37 lol // 自定义封包
 
     LOGIN_PASSWORD(0x01), // 登录密码
@@ -214,7 +214,13 @@ public enum RecvOpcode {
         this.code = code;
     }
 
+    @Override
     public int getValue() {
         return code;
+    }
+
+    @Override
+    public String getName() {
+        return this.name();
     }
 }

--- a/gms-server/src/main/java/org/gms/net/opcodes/SendOpcode.java
+++ b/gms-server/src/main/java/org/gms/net/opcodes/SendOpcode.java
@@ -21,7 +21,7 @@
  */
 package org.gms.net.opcodes;
 
-public enum SendOpcode {
+public enum SendOpcode implements Opcode {
 
     LOGIN_STATUS(0x00), // 登录状态
     GUEST_ID_LOGIN(0x01), // 游客ID登录
@@ -364,7 +364,13 @@ public enum SendOpcode {
         this.code = code;
     }
 
+    @Override
     public int getValue() {
         return code;
+    }
+
+    @Override
+    public String getName() {
+        return this.name();
     }
 }

--- a/gms-server/src/main/java/org/gms/net/packet/ByteBufOutPacket.java
+++ b/gms-server/src/main/java/org/gms/net/packet/ByteBufOutPacket.java
@@ -6,6 +6,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import net.jcip.annotations.NotThreadSafe;
+import org.gms.net.opcodes.Opcode;
 import org.gms.net.opcodes.SendOpcode;
 import org.gms.util.ThreadLocalUtil;
 
@@ -21,7 +22,7 @@ public class ByteBufOutPacket implements OutPacket {
         this.byteBuf = Unpooled.buffer();
     }
 
-    public ByteBufOutPacket(SendOpcode op) {
+    public ByteBufOutPacket(Opcode op) {
         ByteBuf byteBuf = Unpooled.buffer();
         byteBuf.writeShortLE((short) op.getValue());
         this.byteBuf = byteBuf;

--- a/gms-server/src/main/java/org/gms/net/packet/OutPacket.java
+++ b/gms-server/src/main/java/org/gms/net/packet/OutPacket.java
@@ -1,5 +1,6 @@
 package org.gms.net.packet;
 
+import org.gms.net.opcodes.Opcode;
 import org.gms.net.opcodes.SendOpcode;
 
 import java.awt.*;
@@ -18,7 +19,7 @@ public interface OutPacket extends Packet {
     void writePos(Point value);
     void skip(int numberOfBytes);
 
-    static OutPacket create(SendOpcode opcode) {
+    static OutPacket create(Opcode opcode) {
         return new ByteBufOutPacket(opcode);
     }
 }


### PR DESCRIPTION
- 引入 PacketProtocol interface 与 Opcode interface 用于未来扩展不同版本之需求
- Implementation PacketProtocol interface 处理原先 PacketDecoder 与 PacketEncoder 的逻辑以及 getHello 包呼叫
- Opcode interface 统一 registerHandler 与 OutPacket.create 与 ByteBufOutPacket 的 SendOpcode
- 未来如有扩展不同版本之需求可以参照以下步骤 Implementation
  1. 自行 Implementation PacketProtocol 并从 ProtocolFactory 注册版本对应的处理器
  2. 自行 Implementation Opcode RecvOpcode 与 SendOpcode
  3. PacketProcessor reset 处理不同版本的 registerHandler 逻辑
  4. OpcodeConstants 处理不同版本的 OpcodeNamesMap