### PR TITLE
毒雾森林毒珠净化后获得的经验值不应该收到经验加成影响

### DIFF
--- a/gms-server/scripts-zh-CN/reactor/3008000.js
+++ b/gms-server/scripts-zh-CN/reactor/3008000.js
@@ -9,7 +9,7 @@ function hit() {
     var players = rm.getMap().getAllPlayers().toArray();
 
     for (var i = 0; i < players.length; i++) {
-        rm.giveCharacterExp(52000, players[i]);
+        players[i].gainExp(52000);
     }
 }
 


### PR DESCRIPTION
giveCharacterExp如果玩家使用了双倍经验加成是直接加倍的

改为gainExp增加即可