### PR TITLE
修复巨魔蝙蝠怪被击杀后的再次召唤报错的问题

### DIFF
--- a/gms-server/scripts-zh-CN/event/BalrogBattle_Easy.js
+++ b/gms-server/scripts-zh-CN/event/BalrogBattle_Easy.js
@@ -159,6 +159,7 @@ function spawnBalrog(eim) {
 }
 
 function spawnSealedBalrog(eim) {
+    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
     const Point = Java.type('java.awt.Point');
     eim.getInstanceMap(entryMap).spawnMonsterOnGroundBelow(LifeFactory.getMonster(bossMobId), new Point(412, 258));
 }


### PR DESCRIPTION
巨魔蝙蝠怪被击杀后召唤新怪物报错，此处没有加载LifeFactory实例成功