### PR TITLE
修复巨魔蝙蝠怪被击杀后的再次召唤报错的问题

### DIFF
--- a/gms-server/scripts-zh-CN/event/BalrogBattle.js
+++ b/gms-server/scripts-zh-CN/event/BalrogBattle.js
@@ -159,6 +159,7 @@ function spawnBalrog(eim) {
 }
 
 function spawnSealedBalrog(eim) {
+    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
     const Point = Java.type('java.awt.Point');
     eim.getInstanceMap(entryMap).spawnMonsterOnGroundBelow(LifeFactory.getMonster(bossMobId), new Point(412, 258));
 }


### PR DESCRIPTION
这个副本有一个简单模式，和之前修复的一样，被击杀后再次召唤的LifeFactory没有加载实例