### PR TITLE
修复战士二转完成后导致该NPC卡住的问题

### DIFF
--- a/gms-server/scripts-zh-CN/npc/1022000.js
+++ b/gms-server/scripts-zh-CN/npc/1022000.js
@@ -221,7 +221,8 @@ function action(mode, type, selection) {
                 cm.getPlayer().removePartyQuestItem("JB3");
                 cm.getPlayer().setPartyQuestItemObtained("JBP");
             }
-            cm.sendNextPrev("我的分身相当强大，他会使用特殊技能，你应该跟他一对一战斗，击败他并带回#b#t4031059##k，祝你好运！");
+            cm.sendNext("我的分身相当强大，他会使用特殊技能，你应该跟他一对一战斗，击败他并带回#b#t4031059##k，祝你好运！");
+			cm.dispose();
         }
     } else if (actionx["3thJobC"]) {
         cm.getPlayer().removePartyQuestItem("JBP");


### PR DESCRIPTION
结束了没有销毁NPC，导致再次打开无法打开的问题！

另外文字也有问题，三转明明是到雪域找长老，为什么还还要来找你，，害我白跑一趟！