### PR TITLE
修复强弩技能汉化文字数值与技能实际输出不一致的问题

### DIFF
--- a/gms-server/wz-zh-CN/String.wz/Skill.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Skill.img.xml
@@ -9172,27 +9172,27 @@
     </imgdir>
     <imgdir name="3201003">
         <string name="name" value="强弩"/>
-        <string name="h1" value="消耗MP8，比率33%增加， 伤害110%，对象6个"/>
-        <string name="h10" value="消耗MP8，比率60%增加， 伤害200%，对象6个"/>
-        <string name="h11" value="消耗MP15，比率63%增加， 伤害210%，对象6个"/>
-        <string name="h12" value="消耗MP15，比率66%增加， 伤害220%，对象6个"/>
-        <string name="h13" value="消耗MP15，比率69%增加， 伤害230%，对象6个"/>
-        <string name="h14" value="消耗MP15，比率72%增加， 伤害240%，对象6个"/>
-        <string name="h15" value="消耗MP15，比率75%增加， 伤害250%，对象6个"/>
-        <string name="h16" value="消耗MP15，比率78%增加， 伤害260%，对象6个"/>
-        <string name="h17" value="消耗MP15，比率81%增加， 伤害270%，对象6个"/>
-        <string name="h18" value="消耗MP15，比率84%增加， 伤害280%，对象6个"/>
-        <string name="h19" value="消耗MP15，比率87%增加， 伤害290%，对象6个"/>
-        <string name="h2" value="消耗MP8，比率36%增加， 伤害120%，对象6个"/>
-        <string name="h20" value="消耗MP15，比率90%增加， 伤害300%，对象6个"/>
-        <string name="h3" value="消耗MP8，比率39%增加， 伤害130%，对象6个"/>
-        <string name="h4" value="消耗MP8，比率42%增加， 伤害140%，对象6个"/>
-        <string name="h5" value="消耗MP8，比率45%增加， 伤害150%，对象6个"/>
-        <string name="h6" value="消耗MP8，比率48%增加， 伤害160%，对象6个"/>
-        <string name="h7" value="消耗MP8，比率51%增加， 伤害170%，对象6个"/>
-        <string name="h8" value="消耗MP8，比率54%增加， 伤害180%，对象6个"/>
-        <string name="h9" value="消耗MP8，比率57%增加， 伤害190%，对象6个"/>
-        <string name="desc" value="[最高等级 : 20]\n用弩攻击时，使怪物后退的比率增加，\n随着等级上升击退怪物数量会增加"/>
+        <string name="h1" value="消耗MP8，概率13%伤害+105%，目标2个"/>
+		<string name="h10" value="消耗MP8，概率40%伤害+150%，对象3个"/>
+		<string name="h11" value="消耗MP15，概率43%伤害+155%，对象4个"/>
+		<string name="h12" value="消耗MP15，概率46%伤害+160%，对象4个"/>
+		<string name="h13" value="消耗MP15，概率49%伤害+165%，对象4个"/>
+		<string name="h14" value="消耗MP15，概率52%伤害+170%，对象4个"/>
+		<string name="h15" value="消耗MP15，概率55%伤害+175%，对象4个"/>
+		<string name="h16" value="消耗MP15，概率58%伤害+180%，对象5个"/>
+		<string name="h17" value="消耗MP15，概率61%伤害+185%，对象5个"/>
+		<string name="h18" value="消耗MP15，概率64%伤害+190%，对象5个"/>
+		<string name="h19" value="消耗MP15，概率67%伤害+195%，对象5个"/>
+		<string name="h2" value="消耗MP8，概率16%伤害+110%，对象2个"/>
+		<string name="h20" value="消耗MP15，概率70%伤害+200%，对象6个"/>
+		<string name="h3" value="消耗MP8，概率19%伤害+115%，对象2个"/>
+		<string name="h4" value="消耗MP8，概率22%伤害+120%，对象2个"/>
+		<string name="h5" value="消耗MP8，概率25%伤害+125%，对象2个"/>
+		<string name="h6" value="消耗MP8，概率28%伤害+130%，对象3个"/>
+		<string name="h7" value="消耗MP8，概率31%伤害+135%，对象3个"/>
+		<string name="h8" value="消耗MP8，概率34%伤害+140%，对象3个"/>
+		<string name="h9" value="消耗MP8，概率37%伤害+145%，对象3个"/>
+        <string name="desc" value="[最高等级 : 20]\n用弩攻击时，使怪物后退的概率增加，\n随着等级上升击退怪物数量会增加"/>
     </imgdir>
     <imgdir name="3201004">
         <string name="name" value="无形箭"/>


### PR DESCRIPTION
这数值差太多了。