### PR TITLE
战士四转技能“磁石”吸BOSS导致相同频道内的所有玩家闪退问题

### DIFF
--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/SpecialMoveHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/SpecialMoveHandler.java
@@ -97,8 +97,6 @@ public final class SpecialMoveHandler extends AbstractPacketHandler {
             int num = p.readInt();
             for (int i = 0; i < num; i++) {
                 int mobOid = p.readInt();
-                byte success = p.readByte();
-                chr.getMap().broadcastMessage(chr, PacketCreator.catchMonster(mobOid, success), false);
                 Monster monster = chr.getMap().getMonsterByOid(mobOid);
                 if (monster != null) {
                     if (!monster.isBoss()) {
@@ -108,6 +106,10 @@ public final class SpecialMoveHandler extends AbstractPacketHandler {
                         // thanks onechord for pointing out Magnet crashing the caster (issue would actually happen upon failing to catch mob)
                         // thanks Conrad for noticing Magnet crashing when trying to pull bosses and fixed mobs
                         monster.aggroSwitchController(chr, true);
+
+						// 磁石技能吸的不是BOSS时广播给图内的其他玩家（因客户端问题）
+						byte success = p.readByte();
+						chr.getMap().broadcastMessage(chr, PacketCreator.catchMonster(mobOid, success), false);
                     }
                 }
             }


### PR DESCRIPTION
关于这个技能在客户端中存在BUG可能大家已经知道了
我个人理解官方设计BOSS不能被磁吸，比如固定位置的，鱼，巨魔蝙蝠等。但是在客户端对于这个技能的MISS问题处理的不够好，就闪退了。 北斗目前客户端解决方案是让这个技能不存在MISS问题。
但BOSS被吸仍然导致闪退，也会影响同频道同地图的所有玩家，比如一个团队在打远征，战士一个磁吸全员掉线，这不能被允许 所以我觉得目前没有办法解决客户端的问题时，取消对其他玩家广播该技能，仅让战士自己崩掉算了！