### PR TITLE
修复上海城市广场武陵道场布告牌NPC

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2091006.js
+++ b/gms-server/scripts-zh-CN/npc/2091006.js
@@ -27,6 +27,8 @@ function action(mode, type, selection) {
             cm.getPlayer().saveLocation("MIRROR");
             cm.warp(925020000, 4);
             cm.dispose();
+        } else {
+            cm.dispose();
         }
     }
 }


### PR DESCRIPTION
该NPC打开后，点结束后会导致再次无法打开的问题，重构代码修复