### PR TITLE
fix(game): 修复攻击间隔检测逻辑

### DIFF
--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -510,7 +510,8 @@ public class Character extends AbstractCharacterObject {
      */
     @Setter
     @Getter
-    private long lastAttackTime = 0;
+    private final ConcurrentHashMap<Integer, Long> lastAttackTimes = new ConcurrentHashMap<>();
+
 
     private Character() {
         super.setListener(new CharacterListener(this));

--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -99,6 +99,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
@@ -508,9 +509,24 @@ public class Character extends AbstractCharacterObject {
      * 最后攻击时间
      * 用来校验攻击速度是否过快
      */
-    @Setter
-    @Getter
     private final ConcurrentHashMap<Integer, Long> lastAttackTimes = new ConcurrentHashMap<>();
+
+    /**
+     * 原子更新指定技能的最后攻击时间，并返回与上次记录的时间间隔（毫秒）。
+     * 若是首次记录或出现时钟回退，返回 Long.MAX_VALUE 表示本次不参与间隔判定。
+     */
+    public long updateLastAttackTimeAndGetInterval(int skillId, long currentTimeMillis) {
+        AtomicLong intervalMillis = new AtomicLong(Long.MAX_VALUE);
+        lastAttackTimes.compute(skillId, (ignored, previousTime) -> {
+            long previous = previousTime == null ? 0L : previousTime;
+            if (previous > 0L && currentTimeMillis > previous) {
+                intervalMillis.set(currentTimeMillis - previous);
+            }
+            // 保证每个技能的时间记录单调不回退，避免并发写入覆盖新值。
+            return Math.max(previous, currentTimeMillis);
+        });
+        return intervalMillis.get();
+    }
 
 
     private Character() {

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -63,6 +63,7 @@ import org.slf4j.LoggerFactory;
 import java.awt.*;
 import java.util.*;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -1316,22 +1317,24 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
      * @param chr
      */
     private static void detectionAttackInterval(Character chr, AttackInfo ret) {
+        ConcurrentHashMap<Integer, Long> lastAttackTimeMap = chr.getLastAttackTimes();
+        int skill = ret.skill;
         //需要跳过检测的技能 比如弓箭手的暴风箭雨 火枪手的金属风暴
-        if (!SKIP_SKILL_ID_SET.contains(ret.skill)) {
+        if (!SKIP_SKILL_ID_SET.contains(skill)) {
+            long lastAttackTime = lastAttackTimeMap.get(skill) != null ? lastAttackTimeMap.get(skill) : 0L;
             long serverTime = System.currentTimeMillis();
-            if (serverTime - chr.getLastAttackTime() < 250) {
+            if (serverTime - lastAttackTime < 250) {
                 // 检测攻击间隔 小于350mm封号
-                AutobanFactory.ATTACK_INTERVAL.addPoint(chr.getAutoBanManager(), "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "攻击间隔: " + (serverTime - chr.getLastAttackTime()));
-                log.warn("玩家{}地图ID：{}攻击间隔: {}", chr.getName(), chr.getMapId(), serverTime - chr.getLastAttackTime());
-            } else if (serverTime - chr.getLastAttackTime() < 350) {
+                AutobanFactory.ATTACK_INTERVAL.addPoint(chr.getAutoBanManager(), "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "攻击间隔: " + (serverTime - lastAttackTime) + "技能ID：" + skill);
+                log.warn("玩家{}地图ID：{}攻击间隔: {}技能ID：{}", chr.getName(), chr.getMapId(), serverTime - lastAttackTime, skill);
+            } else if (serverTime - lastAttackTime < 350) {
                 // 检测攻击间隔 小于500mm警告
-                AutobanFactory.ATTACK_INTERVAL.alert(chr, "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "攻击间隔: " + (serverTime - chr.getLastAttackTime()));
-                log.warn("玩家{}地图ID：{}攻击间隔: {}", chr.getName(), chr.getMapId(), serverTime - chr.getLastAttackTime());
+                AutobanFactory.ATTACK_INTERVAL.alert(chr, "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "攻击间隔: " + (serverTime - lastAttackTime) + "技能ID：" + skill);
+                log.warn("玩家{}地图ID：{}攻击间隔: {}技能ID：{}", chr.getName(), chr.getMapId(), serverTime - lastAttackTime, skill);
             }
-            chr.setLastAttackTime(serverTime);
+            lastAttackTimeMap.put(skill, serverTime);
         }
     }
-
     /**
      * 跳过攻击速度检测的技能ID
      */

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -63,7 +63,6 @@ import org.slf4j.LoggerFactory;
 import java.awt.*;
 import java.util.*;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -1317,22 +1316,19 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
      * @param chr
      */
     private static void detectionAttackInterval(Character chr, AttackInfo ret) {
-        ConcurrentHashMap<Integer, Long> lastAttackTimeMap = chr.getLastAttackTimes();
         int skill = ret.skill;
         //需要跳过检测的技能 比如弓箭手的暴风箭雨 火枪手的金属风暴
         if (!SKIP_SKILL_ID_SET.contains(skill)) {
-            long lastAttackTime = lastAttackTimeMap.get(skill) != null ? lastAttackTimeMap.get(skill) : 0L;
-            long serverTime = System.currentTimeMillis();
-            if (serverTime - lastAttackTime < 250) {
+            long interval = chr.updateLastAttackTimeAndGetInterval(skill, System.currentTimeMillis());
+            if (interval < 250) {
                 // 检测攻击间隔 小于350mm封号
-                AutobanFactory.ATTACK_INTERVAL.addPoint(chr.getAutoBanManager(), "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "攻击间隔: " + (serverTime - lastAttackTime) + "技能ID：" + skill);
-                log.warn("玩家{}地图ID：{}攻击间隔: {}技能ID：{}", chr.getName(), chr.getMapId(), serverTime - lastAttackTime, skill);
-            } else if (serverTime - lastAttackTime < 350) {
+                AutobanFactory.ATTACK_INTERVAL.addPoint(chr.getAutoBanManager(), "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "攻击间隔: " + interval + "技能ID：" + skill);
+                log.warn("玩家{}地图ID：{}攻击间隔: {}技能ID：{}", chr.getName(), chr.getMapId(), interval, skill);
+            } else if (interval < 350) {
                 // 检测攻击间隔 小于500mm警告
-                AutobanFactory.ATTACK_INTERVAL.alert(chr, "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "攻击间隔: " + (serverTime - lastAttackTime) + "技能ID：" + skill);
-                log.warn("玩家{}地图ID：{}攻击间隔: {}技能ID：{}", chr.getName(), chr.getMapId(), serverTime - lastAttackTime, skill);
+                AutobanFactory.ATTACK_INTERVAL.alert(chr, "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "攻击间隔: " + interval + "技能ID：" + skill);
+                log.warn("玩家{}地图ID：{}攻击间隔: {}技能ID：{}", chr.getName(), chr.getMapId(), interval, skill);
             }
-            lastAttackTimeMap.put(skill, serverTime);
         }
     }
     /**


### PR DESCRIPTION
- 解决部分职业有被动反击技叠加输出技造成误封
- 引入 ConcurrentHashMap 存储每个技能的最后攻击时间
- 修改攻击间隔检测使用技能特定的时间记录
- 更新反作弊系统日志包含技能ID信息
- 移除全局攻击时间改为按技能分别记录
