### PR TITLE
扩展一个脚本调用方法，发送全服聊天框提示消息

### DIFF
--- a/gms-server/src/main/java/org/gms/scripting/AbstractPlayerInteraction.java
+++ b/gms-server/src/main/java/org/gms/scripting/AbstractPlayerInteraction.java
@@ -695,6 +695,10 @@ public class AbstractPlayerInteraction {
         getPlayer().getMap().broadcastMessage(PacketCreator.serverNotice(type, message));
     }
 
+    public void serverMessage(int type, String message){
+        Server.getInstance().broadcastMessage(getPlayer().getWorld(),PacketCreator.serverNotice(type,message));
+   	}
+
     public void mapEffect(String path) {
         c.sendPacket(PacketCreator.mapEffect(path));
     }


### PR DESCRIPTION
在脚本中调用全服消息很麻烦，扩展方法为了简写！
cm.serverMessage(5,"红色文字消息");
cm.serverMessage(6,"蓝色文字消息");