### PR TITLE
修复玩具塔100层娃娃之家任务中打错宝箱传送至74层

### DIFF
--- a/gms-server/scripts-zh-CN/reactor/2200000.js
+++ b/gms-server/scripts-zh-CN/reactor/2200000.js
@@ -27,5 +27,5 @@
 
 function act() {
     rm.playerMessage(5, "差一点就成功了！下次再挑战吧！");
-    rm.warp(221023200);
+    rm.warp(221024400,1);
 }


### PR DESCRIPTION
改为传送至100层的副本入口