### PR TITLE
修复：在线奖励在奖励全部领取后，不再使用`sendNextSelectLevel`

### DIFF
--- a/gms-server/scripts-zh-CN/BeiDouSpecial/在线奖励_nextlevel.js
+++ b/gms-server/scripts-zh-CN/BeiDouSpecial/在线奖励_nextlevel.js
@@ -138,7 +138,11 @@ function levelmain() {
 	text += "我们为您准备了丰厚的在线时长奖励，点击领取下方的奖励：\r\n";
 	text += getOnlineRewardListText() + "\r\n\r\n";
 	text += "\r\n【领取说明】\r\n · 每份奖励需手动领取\r\n · #b每日0点#e#r重置#b#n累计时长#k\r\n · 背包空间不足将不会发放奖励\r\n · 坚持在线时间越长，获得奖励越丰厚！"
-	cm.sendNextSelectLevel("claimrewards",text);
+	if (g_ClaimStatus == ((1 << config.reward.length) - 1)) {
+		cm.sendOkLevel("",text);	
+	} else {
+		cm.sendNextSelectLevel("claimrewards",text);
+	}
 }
 
 function levelclaimrewards(Select) {


### PR DESCRIPTION
fixes #571 

<img width="367" height="316" alt="image" src="https://github.com/user-attachments/assets/109bdb3c-3372-404b-ad70-1a94229d8660" />
