### PR TITLE
修复攻击距离判定

### DIFF
--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -401,6 +401,8 @@ public class Character extends AbstractCharacterObject {
     @Getter
     private final Set<Integer> disabledPartySearchInvites = new LinkedHashSet<>();
     private long portaldelay = 0;
+    // 记录最近一次“瞬移类位移”发生时间（用于短时间内的距离检测防误判）
+    private volatile long lastTeleportLikeMoveTime = 0;
     @Getter
     @Setter
     private long lastCombo = 0;
@@ -8897,6 +8899,20 @@ public class Character extends AbstractCharacterObject {
 
     public long portalDelay() {
         return portaldelay;
+    }
+
+    /**
+     * 标记一次瞬移类位移（例如树洞/传送动作）。
+     */
+    public void markTeleportLikeMove() {
+        this.lastTeleportLikeMoveTime = Server.getInstance().getCurrentTime();
+    }
+
+    /**
+     * 获取最近一次瞬移类位移时间戳。
+     */
+    public long getLastTeleportLikeMoveTime() {
+        return lastTeleportLikeMoveTime;
     }
 
     public void blockPortal(String scriptName) {

--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -401,8 +401,17 @@ public class Character extends AbstractCharacterObject {
     @Getter
     private final Set<Integer> disabledPartySearchInvites = new LinkedHashSet<>();
     private long portaldelay = 0;
-    // 记录最近一次“瞬移类位移”发生时间（用于短时间内的距离检测防误判）
+    // 记录最近一次“瞬移类位移”发生时间（单调时钟纳秒，用于短时间内的距离检测防误判）
     private volatile long lastTeleportLikeMoveTime = 0;
+    // 传送距离误判修正上下文：用于“传送前坐标 + 当前坐标”双坐标校验
+    private static final long TELEPORT_DISTANCE_CONTEXT_EXPIRE_NS = MILLISECONDS.toNanos(1200L); // 保护窗口，过长会增加可利用面
+    private static final byte TELEPORT_DISTANCE_CONTEXT_MAX_ATTACK_CHECKS = 2; // 最多保护 2 次攻击包
+    private static final double TELEPORT_DISTANCE_CONTEXT_MIN_SHIFT_SQ = 1600.0; // 至少 40px 位移才建立上下文
+    private Point teleportBeforePos = null; // 传送前服务端坐标（用于双坐标距离复核）
+    private Point teleportAfterPos = null; // 传送后服务端坐标（用于确认确实发生了传送位移）
+    private int teleportContextMapId = MapId.NONE; // 传送上下文所属地图，跨图后自动失效
+    private long teleportContextExpireTime = 0L; // 传送上下文过期时间戳（单调时钟纳秒）
+    private byte teleportContextRemainingChecks = 0; // 传送上下文剩余可用攻击校验次数
     @Getter
     @Setter
     private long lastCombo = 0;
@@ -1698,6 +1707,8 @@ public class Character extends AbstractCharacterObject {
         if (getMap(to.getId(), true) == null) return; //判断地图不存在则直接返回并发送提示消息。
 
         this.mapTransitioning.set(true);
+        // 显式清空“传送距离校验上下文”，避免跨图后旧上下文残留
+        clearTeleportDistanceContext();
 
         this.unregisterChairBuff();
         this.clearBanishPlayerData();
@@ -8905,14 +8916,106 @@ public class Character extends AbstractCharacterObject {
      * 标记一次瞬移类位移（例如树洞/传送动作）。
      */
     public void markTeleportLikeMove() {
-        this.lastTeleportLikeMoveTime = Server.getInstance().getCurrentTime();
+        this.lastTeleportLikeMoveTime = monotonicNow();
     }
 
     /**
-     * 获取最近一次瞬移类位移时间戳。
+     * 标记一次瞬移类位移，并记录传送前后坐标用于后续攻击距离双坐标校验。
+     *
+     * <p>只在位移明显时建立上下文，避免普通小步移动误入传送保护逻辑。</p>
+     */
+    public synchronized void markTeleportLikeMove(Point beforePos, Point afterPos) {
+        long now = monotonicNow();
+        this.lastTeleportLikeMoveTime = now;
+
+        if (!shouldBuildTeleportDistanceContext(beforePos, afterPos)) {
+            clearTeleportDistanceContextLocked();
+            return;
+        }
+
+        this.teleportBeforePos = copyPoint(beforePos);
+        this.teleportAfterPos = copyPoint(afterPos);
+        this.teleportContextMapId = getMapId();
+        this.teleportContextExpireTime = now + TELEPORT_DISTANCE_CONTEXT_EXPIRE_NS;
+        this.teleportContextRemainingChecks = TELEPORT_DISTANCE_CONTEXT_MAX_ATTACK_CHECKS;
+    }
+
+    /**
+     * 获取最近一次瞬移类位移时间戳（单调时钟纳秒）。
      */
     public long getLastTeleportLikeMoveTime() {
         return lastTeleportLikeMoveTime;
+    }
+
+    /**
+     * 获取用于攻击距离校验的“传送前坐标”。
+     *
+     * <p>仅在上下文仍有效时返回，超时/跨图/次数耗尽会自动清理。</p>
+     */
+    public synchronized Point getTeleportBeforePositionForDistanceCheck() {
+        if (!isTeleportDistanceContextActiveLocked(monotonicNow())) {
+            clearTeleportDistanceContextLocked();
+            return null;
+        }
+        return copyPoint(teleportBeforePos);
+    }
+
+    /**
+     * 消费一次传送距离保护校验次数（按攻击包维度消费）。
+     */
+    public synchronized void consumeTeleportDistanceCheckContext() {
+        if (!isTeleportDistanceContextActiveLocked(monotonicNow())) {
+            clearTeleportDistanceContextLocked();
+            return;
+        }
+
+        teleportContextRemainingChecks--;
+        if (teleportContextRemainingChecks <= 0) {
+            clearTeleportDistanceContextLocked();
+        }
+    }
+
+    /**
+     * 显式清空“传送距离校验上下文”。
+     *
+     * <p>用于跨图切换等关键状态变更点，确保不会携带旧地图上下文参与后续判定。</p>
+     */
+    public synchronized void clearTeleportDistanceContext() {
+        clearTeleportDistanceContextLocked();
+        lastTeleportLikeMoveTime = 0L;
+    }
+
+    private boolean isTeleportDistanceContextActiveLocked(long now) {
+        return teleportBeforePos != null
+                && teleportAfterPos != null
+                && teleportContextRemainingChecks > 0
+                && now <= teleportContextExpireTime
+                && teleportContextMapId == getMapId();
+    }
+
+    private void clearTeleportDistanceContextLocked() {
+        teleportBeforePos = null;
+        teleportAfterPos = null;
+        teleportContextMapId = MapId.NONE;
+        teleportContextExpireTime = 0L;
+        teleportContextRemainingChecks = 0;
+    }
+
+    /**
+     * 仅当传送前后坐标有效且位移幅度足够大时，才建立距离校验上下文。
+     */
+    private static boolean shouldBuildTeleportDistanceContext(Point beforePos, Point afterPos) {
+        return beforePos != null
+                && afterPos != null
+                && beforePos.distanceSq(afterPos) >= TELEPORT_DISTANCE_CONTEXT_MIN_SHIFT_SQ;
+    }
+
+    private static Point copyPoint(Point pos) {
+        return pos == null ? null : new Point(pos);
+    }
+
+    private static long monotonicNow() {
+        return System.nanoTime();
     }
 
     public void blockPortal(String scriptName) {

--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -412,6 +412,15 @@ public class Character extends AbstractCharacterObject {
     private int teleportContextMapId = MapId.NONE; // 传送上下文所属地图，跨图后自动失效
     private long teleportContextExpireTime = 0L; // 传送上下文过期时间戳（单调时钟纳秒）
     private byte teleportContextRemainingChecks = 0; // 传送上下文剩余可用攻击校验次数
+    // 普通移动距离误判修正上下文：只覆盖“移动包后紧跟攻击包”的极短时间窗
+    private static final long MOVEMENT_DISTANCE_CONTEXT_EXPIRE_NS = MILLISECONDS.toNanos(350L);
+    private static final byte MOVEMENT_DISTANCE_CONTEXT_MAX_ATTACK_CHECKS = 1;
+    private static final double MOVEMENT_DISTANCE_CONTEXT_MIN_SHIFT_SQ = 400.0; // 至少 20px 位移才建立上下文
+    private Point movementBeforePos = null;
+    private Point movementAfterPos = null;
+    private int movementContextMapId = MapId.NONE;
+    private long movementContextExpireTime = 0L;
+    private byte movementContextRemainingChecks = 0;
     @Getter
     @Setter
     private long lastCombo = 0;
@@ -8941,6 +8950,23 @@ public class Character extends AbstractCharacterObject {
     }
 
     /**
+     * 记录一次普通移动前后坐标，用于极短时间窗内的攻击距离双坐标校验。
+     */
+    public synchronized void markRegularMove(Point beforePos, Point afterPos) {
+        long now = monotonicNow();
+        if (!shouldBuildMovementDistanceContext(beforePos, afterPos)) {
+            clearMovementDistanceContextLocked();
+            return;
+        }
+
+        this.movementBeforePos = copyPoint(beforePos);
+        this.movementAfterPos = copyPoint(afterPos);
+        this.movementContextMapId = getMapId();
+        this.movementContextExpireTime = now + MOVEMENT_DISTANCE_CONTEXT_EXPIRE_NS;
+        this.movementContextRemainingChecks = MOVEMENT_DISTANCE_CONTEXT_MAX_ATTACK_CHECKS;
+    }
+
+    /**
      * 获取最近一次瞬移类位移时间戳（单调时钟纳秒）。
      */
     public long getLastTeleportLikeMoveTime() {
@@ -8961,6 +8987,17 @@ public class Character extends AbstractCharacterObject {
     }
 
     /**
+     * 获取用于攻击距离校验的“普通移动前坐标”。
+     */
+    public synchronized Point getMovementBeforePositionForDistanceCheck() {
+        if (!isMovementDistanceContextActiveLocked(monotonicNow())) {
+            clearMovementDistanceContextLocked();
+            return null;
+        }
+        return copyPoint(movementBeforePos);
+    }
+
+    /**
      * 消费一次传送距离保护校验次数（按攻击包维度消费）。
      */
     public synchronized void consumeTeleportDistanceCheckContext() {
@@ -8976,12 +9013,28 @@ public class Character extends AbstractCharacterObject {
     }
 
     /**
+     * 消费一次普通移动距离保护校验次数。
+     */
+    public synchronized void consumeMovementDistanceCheckContext() {
+        if (!isMovementDistanceContextActiveLocked(monotonicNow())) {
+            clearMovementDistanceContextLocked();
+            return;
+        }
+
+        movementContextRemainingChecks--;
+        if (movementContextRemainingChecks <= 0) {
+            clearMovementDistanceContextLocked();
+        }
+    }
+
+    /**
      * 显式清空“传送距离校验上下文”。
      *
      * <p>用于跨图切换等关键状态变更点，确保不会携带旧地图上下文参与后续判定。</p>
      */
     public synchronized void clearTeleportDistanceContext() {
         clearTeleportDistanceContextLocked();
+        clearMovementDistanceContextLocked();
         lastTeleportLikeMoveTime = 0L;
     }
 
@@ -8993,12 +9046,28 @@ public class Character extends AbstractCharacterObject {
                 && teleportContextMapId == getMapId();
     }
 
+    private boolean isMovementDistanceContextActiveLocked(long now) {
+        return movementBeforePos != null
+                && movementAfterPos != null
+                && movementContextRemainingChecks > 0
+                && now <= movementContextExpireTime
+                && movementContextMapId == getMapId();
+    }
+
     private void clearTeleportDistanceContextLocked() {
         teleportBeforePos = null;
         teleportAfterPos = null;
         teleportContextMapId = MapId.NONE;
         teleportContextExpireTime = 0L;
         teleportContextRemainingChecks = 0;
+    }
+
+    private void clearMovementDistanceContextLocked() {
+        movementBeforePos = null;
+        movementAfterPos = null;
+        movementContextMapId = MapId.NONE;
+        movementContextExpireTime = 0L;
+        movementContextRemainingChecks = 0;
     }
 
     /**
@@ -9008,6 +9077,12 @@ public class Character extends AbstractCharacterObject {
         return beforePos != null
                 && afterPos != null
                 && beforePos.distanceSq(afterPos) >= TELEPORT_DISTANCE_CONTEXT_MIN_SHIFT_SQ;
+    }
+
+    private static boolean shouldBuildMovementDistanceContext(Point beforePos, Point afterPos) {
+        return beforePos != null
+                && afterPos != null
+                && beforePos.distanceSq(afterPos) >= MOVEMENT_DISTANCE_CONTEXT_MIN_SHIFT_SQ;
     }
 
     private static Point copyPoint(Point pos) {

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -164,7 +164,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 return;
             }
 
-            final boolean skipDistanceHack = isFullScreenDistanceExempt(attack.skill);
+            final boolean skipDistanceHack = shouldSkipDistanceHackCheck(attack.skill, attackEffect);
             final boolean isChainLightning = attack.skill == ILArchMage.CHAIN_LIGHTNING;
             boolean chainLightningCheckedFirst = false;
             Point teleportBeforePosForDistanceCheck = player.getTeleportBeforePositionForDistanceCheck();
@@ -1121,6 +1121,27 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 || skillId == ILArchMage.BLIZZARD
                 || skillId == FPArchMage.METEOR_SHOWER
                 || skillId == BlazeWizard.METEOR_SHOWER;
+    }
+
+    /**
+     * 按客户端 WZ 语义决定是否跳过通用 DISTANCE_HACK 判定。
+     * 仅对明确不是“空间攻击框”语义的技能做豁免，避免误伤正常近战技能。
+     */
+    private static boolean shouldSkipDistanceHackCheck(int skillId, StatEffect attackEffect) {
+        return isFullScreenDistanceExempt(skillId) || isNonSpatialAttackSkill(skillId, attackEffect);
+    }
+
+    /**
+     * Energy Charge 在 Skill.wz 中没有 level/lt、level/rb，属于蓄能/状态触发语义，
+     * 不应按普通近战攻击框进入距离外挂判定。
+     */
+    private static boolean isNonSpatialAttackSkill(int skillId, StatEffect attackEffect) {
+        if (attackEffect != null && attackEffect.hasBoundingBox()) {
+            return false;
+        }
+
+        return skillId == Marauder.ENERGY_CHARGE
+                || skillId == ThunderBreaker.ENERGY_CHARGE;
     }
 
     /**

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -976,22 +976,11 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
         }
 
         Point playerPos = player.getPosition();
-        Point mobPos = monster.getPosition();
-
-        int minX;
-        int maxX;
-        if (monster.isFacingLeft()) {
-            // 面向左：直接叠加相对 lt/rb
-            minX = mobPos.x + stats.getBboxMinX();
-            maxX = mobPos.x + stats.getBboxMaxX();
-        } else {
-            // 面向右：需要镜像
-            minX = mobPos.x - stats.getBboxMaxX();
-            maxX = mobPos.x - stats.getBboxMinX();
-        }
-
-        int minY = mobPos.y + stats.getBboxMinY();
-        int maxY = mobPos.y + stats.getBboxMaxY();
+        int[] bbox = getWorldBbox(monster, stats);
+        int minX = bbox[0];
+        int maxX = bbox[1];
+        int minY = bbox[2];
+        int maxY = bbox[3];
 
         // 计算点到矩形的最短距离
         int dx = 0;
@@ -1023,22 +1012,14 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             return "BBOX{use=" + useBbox + ", valid=false, playerPos=" + playerPos + ", mobPos=" + mobPos + ", facingLeft=" + facingLeft + "}";
         }
 
-        int minX;
-        int maxX;
-        if (facingLeft) {
-            // 面向左：直接叠加相对 lt/rb
-            minX = mobPos.x + stats.getBboxMinX();
-            maxX = mobPos.x + stats.getBboxMaxX();
-        } else {
-            // 面向右：需要镜像
-            minX = mobPos.x - stats.getBboxMaxX();
-            maxX = mobPos.x - stats.getBboxMinX();
-        }
-
-        int minY = mobPos.y + stats.getBboxMinY();
-        int maxY = mobPos.y + stats.getBboxMaxY();
+        int[] bbox = getWorldBbox(monster, stats);
+        int minX = bbox[0];
+        int maxX = bbox[1];
+        int minY = bbox[2];
+        int maxY = bbox[3];
         int width = Math.max(0, maxX - minX);
         int height = Math.max(0, maxY - minY);
+        boolean noFlip = stats.getFixedStance() != 0;
 
         return "BBOX{use=" + useBbox
                 + ", rel=(" + stats.getBboxMinX() + "," + stats.getBboxMinY() + ")-(" + stats.getBboxMaxX() + "," + stats.getBboxMaxY() + ")"
@@ -1047,7 +1028,38 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 + ", playerPos=" + playerPos
                 + ", mobPos=" + mobPos
                 + ", facingLeft=" + facingLeft
+                + ", noFlip=" + noFlip
                 + "}";
+    }
+
+    /**
+     * 获取怪物碰撞框的世界坐标（考虑 noFlip）
+     * @param monster 怪物
+     * @param stats 怪物属性
+     * @return [minX, maxX, minY, maxY]
+     */
+    private static int[] getWorldBbox(Monster monster, MonsterStats stats) {
+        Point mobPos = monster.getPosition();
+        int minX = stats.getBboxMinX();
+        int maxX = stats.getBboxMaxX();
+        int minY = stats.getBboxMinY();
+        int maxY = stats.getBboxMaxY();
+
+        // noFlip 怪物不允许镜像，避免把碰撞框翻到反方向
+        boolean noFlip = stats.getFixedStance() != 0;
+        if (!noFlip && !monster.isFacingLeft()) {
+            int mirroredMinX = -maxX;
+            int mirroredMaxX = -minX;
+            minX = mirroredMinX;
+            maxX = mirroredMaxX;
+        }
+
+        return new int[]{
+                mobPos.x + minX,
+                mobPos.x + maxX,
+                mobPos.y + minY,
+                mobPos.y + maxY
+        };
     }
 
     /**

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -253,7 +253,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                                 chainLightningCheckedFirst = true;
                             }
                         }
-                        if (checkDistance) {
+                        if (checkDistance && !isWithinAttackBox(player, monster, attackEffect)) {
                             boolean useBbox = shouldUseBoundingBox(monster);
                             double distance = calculateDistanceSq(player, monster, useBbox);
 //                          AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
@@ -972,6 +972,39 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             ret.position.setLocation(p.readShort(), p.readShort());
         }
         return ret;
+    }
+
+    /**
+     * 优先用技能自身的范围框判断本次攻击是否合法命中怪物。
+     * 命中技能框时，跳过后续基于中心点距离的 DISTANCE_HACK 检测。
+     */
+    private static boolean isWithinAttackBox(Character player, Monster monster, StatEffect attackEffect) {
+        if (attackEffect == null || !attackEffect.hasBoundingBox()) {
+            return false;
+        }
+
+        Rectangle attackBounds = attackEffect.calculateBoundingBox(player.getPosition(), player.isFacingLeft());
+        Rectangle monsterBounds = getMonsterBounds(monster);
+        return attackBounds.intersects(monsterBounds) || attackBounds.contains(monster.getPosition());
+    }
+
+    /**
+     * 获取怪物在地图中的实际矩形范围。
+     * 有 bbox 时使用怪物 bbox；否则退化为怪物中心点的 1x1 矩形。
+     */
+    private static Rectangle getMonsterBounds(Monster monster) {
+        MonsterStats stats = monster.getStats();
+        if (stats == null || !stats.hasBbox()) {
+            Point mobPos = monster.getPosition();
+            return new Rectangle(mobPos.x, mobPos.y, 1, 1);
+        }
+
+        int[] bbox = getWorldBbox(monster, stats);
+        int minX = Math.min(bbox[0], bbox[1]);
+        int maxX = Math.max(bbox[0], bbox[1]);
+        int minY = Math.min(bbox[2], bbox[3]);
+        int maxY = Math.max(bbox[2], bbox[3]);
+        return new Rectangle(minX, minY, Math.max(1, maxX - minX), Math.max(1, maxY - minY));
     }
 
     /**

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -70,8 +70,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
 
     private static final Logger log = LoggerFactory.getLogger(ItemPickupHandler.class);
-    // 传送/树洞等瞬移后，短时间内跳过距离外挂记分，避免“位移包与攻击包相邻”造成误封
-    private static final long TELEPORT_DISTANCE_GRACE_MS = 300L;
 
     public static class AttackInfo {
 
@@ -114,6 +112,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
         Skill theSkill = null;
         StatEffect attackEffect = null;
         final int job = player.getJob().getId();
+        boolean consumeTeleportDistanceContext = false;
         try {
             if (player.isBanned()) {
                 return;
@@ -166,8 +165,11 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 return;
             }
 
-            // 统一封装距离检测豁免策略，避免主流程出现过多判定细节
-            final boolean skipDistanceHack = shouldSkipDistanceHack(player, attack.skill);
+            // 全屏技能直接跳过距离反外挂；其余技能继续走严格校验
+            final boolean skipDistanceHack = shouldSkipDistanceHack(attack.skill);
+            // 传送上下文：用于“传送前坐标 + 当前坐标”双坐标判定，降低内传送后的误报
+            final Point teleportBeforePos = player.getTeleportBeforePositionForDistanceCheck();
+            consumeTeleportDistanceContext = teleportBeforePos != null;
             final boolean isChainLightning = attack.skill == ILArchMage.CHAIN_LIGHTNING;
             boolean chainLightningCheckedFirst = false;
 
@@ -253,13 +255,9 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                             }
                         }
                         if (checkDistance) {
-                            boolean useBbox = shouldUseBoundingBox(monster);
-                            double distance = calculateDistanceSq(player, monster, useBbox);
-//                          AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
-                            if (distance > distanceToDetect) {
-                                String bboxInfo = buildBboxInfo(player, monster, useBbox);
-                                AutobanFactory.DISTANCE_HACK.addPoint(player.getAutoBanManager(), "玩家：" + player.getName() + "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId() + " " + bboxInfo);
-                                log.warn("玩家：{}距离Sq到怪物: {} SID: {} MID: {} {}", player.getName(), distance, attack.skill, monster.getId(), bboxInfo);
+                            DistanceHackCheckResult checkResult = evaluateDistanceHack(player, monster, teleportBeforePos, distanceToDetect);
+                            if (checkResult.shouldFlag()) {
+                                reportDistanceHack(player, attack.skill, monster, teleportBeforePos, checkResult);
                             }
                         }
                     }
@@ -553,8 +551,14 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                     }
                 }
             }
+
         } catch (Exception e) {
             e.printStackTrace();
+        } finally {
+            // 放在 finally 中，确保任何提前 return 都会消费一次上下文，避免保护窗口异常拉长
+            if (consumeTeleportDistanceContext) {
+                player.consumeTeleportDistanceCheckContext();
+            }
         }
     }
 
@@ -947,6 +951,95 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
     }
 
     /**
+     * 距离外挂判定结果载体：把主流程中的判定细节收敛到单个对象，便于维护。
+     */
+    private static final class DistanceHackCheckResult {
+        private final boolean shouldFlag;
+        private final boolean useBbox;
+        private final double currentDistanceSq;
+        private final double beforeDistanceSq;
+        private final boolean hasBeforeDistance;
+
+        private DistanceHackCheckResult(boolean shouldFlag, boolean useBbox, double currentDistanceSq, double beforeDistanceSq, boolean hasBeforeDistance) {
+            this.shouldFlag = shouldFlag;
+            this.useBbox = useBbox;
+            this.currentDistanceSq = currentDistanceSq;
+            this.beforeDistanceSq = beforeDistanceSq;
+            this.hasBeforeDistance = hasBeforeDistance;
+        }
+
+        private static DistanceHackCheckResult safe() {
+            return new DistanceHackCheckResult(false, false, 0, -1, false);
+        }
+
+        private static DistanceHackCheckResult flag(boolean useBbox, double currentDistanceSq, double beforeDistanceSq, boolean hasBeforeDistance) {
+            return new DistanceHackCheckResult(true, useBbox, currentDistanceSq, beforeDistanceSq, hasBeforeDistance);
+        }
+
+        private boolean shouldFlag() {
+            return shouldFlag;
+        }
+    }
+
+    /**
+     * 评估本次攻击目标是否应触发距离外挂记分。
+     *
+     * <p>规则：当前坐标超限后，若存在“传送前坐标”且前坐标未超限，则判定为可疑性不足并放行。</p>
+     */
+    private static DistanceHackCheckResult evaluateDistanceHack(Character player, Monster monster, Point teleportBeforePos, double distanceToDetect) {
+        boolean useBbox = shouldUseBoundingBox(monster);
+        double currentDistance = calculateDistanceSq(player, monster, useBbox);
+        if (currentDistance <= distanceToDetect) {
+            return DistanceHackCheckResult.safe();
+        }
+
+        if (teleportBeforePos == null) {
+            return DistanceHackCheckResult.flag(useBbox, currentDistance, -1, false);
+        }
+
+        double beforeDistance = calculateDistanceSq(teleportBeforePos, monster, useBbox);
+        if (beforeDistance <= distanceToDetect) {
+            return DistanceHackCheckResult.safe();
+        }
+
+        return DistanceHackCheckResult.flag(useBbox, currentDistance, beforeDistance, true);
+    }
+
+    /**
+     * 统一上报距离异常日志，避免主循环重复拼接字符串。
+     */
+    private static void reportDistanceHack(Character player, int skillId, Monster monster, Point teleportBeforePos, DistanceHackCheckResult checkResult) {
+        String bboxInfo = buildBboxInfo(player, monster, checkResult.useBbox);
+        String tpInfo = buildTeleportDistanceInfo(teleportBeforePos, checkResult);
+        AutobanFactory.DISTANCE_HACK.addPoint(
+                player.getAutoBanManager(),
+                "玩家：" + player.getName() + "距离Sq到怪物: " + checkResult.currentDistanceSq + " SID: " + skillId + " MID: " + monster.getId() + " " + bboxInfo + tpInfo
+        );
+        log.warn(
+                "玩家：{}距离Sq到怪物: {} SID: {} MID: {} {}{}",
+                player.getName(),
+                checkResult.currentDistanceSq,
+                skillId,
+                monster.getId(),
+                bboxInfo,
+                tpInfo
+        );
+    }
+
+    /**
+     * 传送上下文调试信息：仅在判定里真正用到“传送前坐标”时输出。
+     */
+    private static String buildTeleportDistanceInfo(Point teleportBeforePos, DistanceHackCheckResult checkResult) {
+        if (!checkResult.hasBeforeDistance || teleportBeforePos == null) {
+            return "";
+        }
+        return " TP{beforePos=" + teleportBeforePos
+                + ", beforeDistanceSq=" + checkResult.beforeDistanceSq
+                + ", currentDistanceSq=" + checkResult.currentDistanceSq
+                + "}";
+    }
+
+    /**
      * 全屏/大范围技能跳过距离检测
      */
     private static boolean isFullScreenDistanceExempt(int skillId) {
@@ -959,25 +1052,8 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
     /**
      * 是否跳过本次距离外挂检测。
      */
-    private static boolean shouldSkipDistanceHack(Character player, int skillId) {
-        // 1) 全屏技能本身豁免
-        if (isFullScreenDistanceExempt(skillId)) {
-            return true;
-        }
-
-        // 2) 传送/树洞后的短时保护窗口
-        return isTeleportDistanceGrace(player);
-    }
-
-    /**
-     * 瞬移后短窗口豁免距离检测，降低同帧位移+施法导致的误判概率。
-     */
-    private static boolean isTeleportDistanceGrace(Character player) {
-        long lastTeleportLikeMoveTime = player.getLastTeleportLikeMoveTime();
-        if (lastTeleportLikeMoveTime <= 0) {
-            return false;
-        }
-        return currentServerTime() - lastTeleportLikeMoveTime <= TELEPORT_DISTANCE_GRACE_MS;
+    private static boolean shouldSkipDistanceHack(int skillId) {
+        return isFullScreenDistanceExempt(skillId);
     }
 
     /**
@@ -993,16 +1069,26 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
      * useBbox=true 时按碰撞框最短距离计算
      */
     private static double calculateDistanceSq(Character player, Monster monster, boolean useBbox) {
+        return calculateDistanceSq(player.getPosition(), monster, useBbox);
+    }
+
+    /**
+     * 计算任意给定坐标到怪物的距离平方。
+     * useBbox=true 时按碰撞框最短距离计算
+     */
+    private static double calculateDistanceSq(Point playerPos, Monster monster, boolean useBbox) {
+        if (playerPos == null) {
+            return Double.MAX_VALUE;
+        }
+
         if (!useBbox) {
-            return player.getPosition().distanceSq(monster.getPosition());
+            return playerPos.distanceSq(monster.getPosition());
         }
 
         MonsterStats stats = monster.getStats();
         if (stats == null || !stats.hasBbox()) {
-            return player.getPosition().distanceSq(monster.getPosition());
+            return playerPos.distanceSq(monster.getPosition());
         }
-
-        Point playerPos = player.getPosition();
         int[] bbox = getWorldBbox(monster, stats);
         int minX = bbox[0];
         int maxX = bbox[1];

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -103,6 +103,26 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
         }
     }
 
+    /**
+     * 封装一次距离校验最终采用的坐标样本。
+     *
+     * <p>攻击包到达时，服务端可能同时持有当前位置、瞬移前坐标、位移前坐标。
+     * 主流程只需要关心最终选中了哪个点，以及它是否来自位移补偿上下文。</p>
+     */
+    private static final class DistanceCheckSample {
+        private final Point checkPos;
+        private final double distanceSq;
+        private final boolean usedTeleportContext;
+        private final boolean usedMovementContext;
+
+        private DistanceCheckSample(Point checkPos, double distanceSq, boolean usedTeleportContext, boolean usedMovementContext) {
+            this.checkPos = checkPos;
+            this.distanceSq = distanceSq;
+            this.usedTeleportContext = usedTeleportContext;
+            this.usedMovementContext = usedMovementContext;
+        }
+    }
+
     protected void applyAttack(AttackInfo attack, final Character player, int attackCount) {
         final MapleMap map = player.getMap();
         if (map.isOwnershipRestricted(player)) {
@@ -264,43 +284,24 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                         }
                         if (checkDistance && !isWithinAttackBox(player, monster, attackEffect, attack, teleportBeforePosForDistanceCheck, movementBeforePosForDistanceCheck)) {
                             boolean useBbox = shouldUseBoundingBox(monster);
-                            Point currentPlayerPos = player.getPosition();
-                            Point checkPos = currentPlayerPos;
-                            double distance = calculateDistanceSq(currentPlayerPos, monster, useBbox);
-                            boolean usedTeleportContext = false;
-                            boolean usedMovementContext = false;
-                            if (teleportBeforePosForDistanceCheck != null && !teleportBeforePosForDistanceCheck.equals(currentPlayerPos)) {
-                                double teleportDistance = calculateDistanceSq(teleportBeforePosForDistanceCheck, monster, useBbox);
-                                if (teleportDistance < distance) {
-                                    distance = teleportDistance;
-                                    checkPos = teleportBeforePosForDistanceCheck;
-                                    usedTeleportContext = true;
-                                    usedMovementContext = false;
-                                }
+                            if (!hasReliableDistanceGeometry(attackEffect, useBbox)) {
+                                continue;
                             }
-                            if (movementBeforePosForDistanceCheck != null && !movementBeforePosForDistanceCheck.equals(currentPlayerPos)) {
-                                double movementDistance = calculateDistanceSq(movementBeforePosForDistanceCheck, monster, useBbox);
-                                if (movementDistance < distance) {
-                                    distance = movementDistance;
-                                    checkPos = movementBeforePosForDistanceCheck;
-                                    usedTeleportContext = false;
-                                    usedMovementContext = true;
-                                }
-                            }
-//                          AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
-                            if (distance > distanceToDetect && distance > distanceHackWorstDistance) {
+                            DistanceCheckSample distanceSample = chooseBestDistanceCheckSample(
+                                    player.getPosition(),
+                                    monster,
+                                    useBbox,
+                                    teleportBeforePosForDistanceCheck,
+                                    movementBeforePosForDistanceCheck
+                            );
+                            if (distanceSample.distanceSq > distanceToDetect && distanceSample.distanceSq > distanceHackWorstDistance) {
                                 distanceHackWorstMonster = monster;
-                                distanceHackWorstDistance = distance;
+                                distanceHackWorstDistance = distanceSample.distanceSq;
                                 distanceHackWorstThreshold = distanceToDetect;
                                 distanceHackWorstUseBbox = useBbox;
-                                distanceHackWorstCheckPos = new Point(checkPos);
-                                distanceHackWorstUsedTeleportContext = usedTeleportContext;
-                                distanceHackWorstUsedMovementContext = usedMovementContext;
-                            }
-                            if (false && distance > distanceToDetect) {
-                                String bboxInfo = buildBboxInfo(player, monster, useBbox, checkPos, teleportBeforePosForDistanceCheck, movementBeforePosForDistanceCheck, usedTeleportContext, usedMovementContext);
-                                AutobanFactory.DISTANCE_HACK.addPoint(player.getAutoBanManager(), "玩家：" + player.getName() + "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId() + " " + bboxInfo);
-                                log.warn("玩家：{}距离Sq到怪物: {} SID: {} MID: {} {}", player.getName(), distance, attack.skill, monster.getId(), bboxInfo);
+                                distanceHackWorstCheckPos = new Point(distanceSample.checkPos);
+                                distanceHackWorstUsedTeleportContext = distanceSample.usedTeleportContext;
+                                distanceHackWorstUsedMovementContext = distanceSample.usedMovementContext;
                             }
                         }
                     }
@@ -1145,7 +1146,50 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
     }
 
     /**
-     * 是否使用碰撞框距离检测（Boss 或大体型）
+     * 判断当前攻击是否具备可靠的几何判定基础。
+     *
+     * <p>技能攻击框和怪物 bbox 至少要有一个可信来源，
+     * 否则距离判定会退化成粗糙的中心点比较，容易产生误判。</p>
+     */
+    private static boolean hasReliableDistanceGeometry(StatEffect attackEffect, boolean useBbox) {
+        return hasSkillAttackBox(attackEffect) || useBbox;
+    }
+
+    private static boolean hasSkillAttackBox(StatEffect attackEffect) {
+        return attackEffect != null && attackEffect.hasBoundingBox();
+    }
+
+    /**
+     * 从当前位置、瞬移前坐标、位移前坐标中选择最接近怪物的样本。
+     *
+     * <p>统一在这里做位移补偿，避免攻击主流程散落多套距离算法。</p>
+     */
+    private static DistanceCheckSample chooseBestDistanceCheckSample(Point currentPlayerPos, Monster monster, boolean useBbox, Point teleportBeforePos, Point movementBeforePos) {
+        DistanceCheckSample bestSample = new DistanceCheckSample(
+                currentPlayerPos,
+                calculateDistanceSq(currentPlayerPos, monster, useBbox),
+                false,
+                false
+        );
+        bestSample = chooseCloserDistanceSample(bestSample, teleportBeforePos, monster, useBbox, currentPlayerPos, true, false);
+        return chooseCloserDistanceSample(bestSample, movementBeforePos, monster, useBbox, currentPlayerPos, false, true);
+    }
+
+    private static DistanceCheckSample chooseCloserDistanceSample(DistanceCheckSample currentBest, Point candidatePos, Monster monster, boolean useBbox, Point currentPlayerPos, boolean usedTeleportContext, boolean usedMovementContext) {
+        if (candidatePos == null || candidatePos.equals(currentPlayerPos)) {
+            return currentBest;
+        }
+
+        double candidateDistanceSq = calculateDistanceSq(candidatePos, monster, useBbox);
+        if (candidateDistanceSq >= currentBest.distanceSq) {
+            return currentBest;
+        }
+
+        return new DistanceCheckSample(candidatePos, candidateDistanceSq, usedTeleportContext, usedMovementContext);
+    }
+
+    /**
+     * 怪物已具备有效 bbox 时，才使用矩形最短距离参与检测。
      */
     private static boolean shouldUseBoundingBox(Monster monster) {
         MonsterStats stats = monster.getStats();
@@ -1153,8 +1197,8 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
     }
 
     /**
-     * 计算玩家到怪物的距离平方
-     * useBbox=true 时按碰撞框最短距离计算
+     * 计算玩家到怪物的距离平方。
+     * useBbox=true 时按碰撞框最短距离计算。
      */
     private static double calculateDistanceSq(Point playerPos, Monster monster, boolean useBbox) {
         if (!useBbox) {

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -168,6 +168,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             final boolean isChainLightning = attack.skill == ILArchMage.CHAIN_LIGHTNING;
             boolean chainLightningCheckedFirst = false;
             Point teleportBeforePosForDistanceCheck = player.getTeleportBeforePositionForDistanceCheck();
+            Point movementBeforePosForDistanceCheck = player.getMovementBeforePositionForDistanceCheck();
 
             //WTF IS THIS F3,1
             /*if (attackCount != attack.numDamage && attack.skill != ChiefBandit.MESO_EXPLOSION && attack.skill != NightWalker.VAMPIRE && attack.skill != WindArcher.WIND_SHOT && attack.skill != Aran.COMBO_SMASH && attack.skill != Aran.COMBO_FENRIR && attack.skill != Aran.COMBO_TEMPEST && attack.skill != NightLord.NINJA_AMBUSH && attack.skill != Shadower.NINJA_AMBUSH) {
@@ -181,6 +182,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             boolean distanceHackWorstUseBbox = false;
             Point distanceHackWorstCheckPos = null;
             boolean distanceHackWorstUsedTeleportContext = false;
+            boolean distanceHackWorstUsedMovementContext = false;
 
             if (attack.skill == ChiefBandit.MESO_EXPLOSION) {
                 int delay = 0;
@@ -260,18 +262,29 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                                 chainLightningCheckedFirst = true;
                             }
                         }
-                        if (checkDistance && !isWithinAttackBox(player, monster, attackEffect, attack, teleportBeforePosForDistanceCheck)) {
+                        if (checkDistance && !isWithinAttackBox(player, monster, attackEffect, attack, teleportBeforePosForDistanceCheck, movementBeforePosForDistanceCheck)) {
                             boolean useBbox = shouldUseBoundingBox(monster);
                             Point currentPlayerPos = player.getPosition();
                             Point checkPos = currentPlayerPos;
                             double distance = calculateDistanceSq(currentPlayerPos, monster, useBbox);
                             boolean usedTeleportContext = false;
+                            boolean usedMovementContext = false;
                             if (teleportBeforePosForDistanceCheck != null && !teleportBeforePosForDistanceCheck.equals(currentPlayerPos)) {
                                 double teleportDistance = calculateDistanceSq(teleportBeforePosForDistanceCheck, monster, useBbox);
                                 if (teleportDistance < distance) {
                                     distance = teleportDistance;
                                     checkPos = teleportBeforePosForDistanceCheck;
                                     usedTeleportContext = true;
+                                    usedMovementContext = false;
+                                }
+                            }
+                            if (movementBeforePosForDistanceCheck != null && !movementBeforePosForDistanceCheck.equals(currentPlayerPos)) {
+                                double movementDistance = calculateDistanceSq(movementBeforePosForDistanceCheck, monster, useBbox);
+                                if (movementDistance < distance) {
+                                    distance = movementDistance;
+                                    checkPos = movementBeforePosForDistanceCheck;
+                                    usedTeleportContext = false;
+                                    usedMovementContext = true;
                                 }
                             }
 //                          AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
@@ -282,9 +295,10 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                                 distanceHackWorstUseBbox = useBbox;
                                 distanceHackWorstCheckPos = new Point(checkPos);
                                 distanceHackWorstUsedTeleportContext = usedTeleportContext;
+                                distanceHackWorstUsedMovementContext = usedMovementContext;
                             }
                             if (false && distance > distanceToDetect) {
-                                String bboxInfo = buildBboxInfo(player, monster, useBbox, checkPos, teleportBeforePosForDistanceCheck, usedTeleportContext);
+                                String bboxInfo = buildBboxInfo(player, monster, useBbox, checkPos, teleportBeforePosForDistanceCheck, movementBeforePosForDistanceCheck, usedTeleportContext, usedMovementContext);
                                 AutobanFactory.DISTANCE_HACK.addPoint(player.getAutoBanManager(), "玩家：" + player.getName() + "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId() + " " + bboxInfo);
                                 log.warn("玩家：{}距离Sq到怪物: {} SID: {} MID: {} {}", player.getName(), distance, attack.skill, monster.getId(), bboxInfo);
                             }
@@ -583,6 +597,9 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             if (teleportBeforePosForDistanceCheck != null) {
                 player.consumeTeleportDistanceCheckContext();
             }
+            if (movementBeforePosForDistanceCheck != null) {
+                player.consumeMovementDistanceCheckContext();
+            }
             if (distanceHackWorstMonster != null) {
                 String bboxInfo = buildBboxInfo(
                         player,
@@ -590,7 +607,9 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                         distanceHackWorstUseBbox,
                         distanceHackWorstCheckPos,
                         teleportBeforePosForDistanceCheck,
-                        distanceHackWorstUsedTeleportContext
+                        movementBeforePosForDistanceCheck,
+                        distanceHackWorstUsedTeleportContext,
+                        distanceHackWorstUsedMovementContext
                 );
                 AutobanFactory.DISTANCE_HACK.addPoint(
                         player.getAutoBanManager(),
@@ -1008,40 +1027,28 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
      * 优先用技能自身的范围框判断本次攻击是否合法命中怪物。
      * 命中技能框时，跳过后续基于中心点距离的 DISTANCE_HACK 检测。
      */
-    private static boolean isWithinAttackBox(Character player, Monster monster, StatEffect attackEffect, AttackInfo attack, Point alternatePlayerPos) {
+    private static boolean isWithinAttackBox(Character player, Monster monster, StatEffect attackEffect, AttackInfo attack, Point alternatePlayerPos, Point secondaryAlternatePlayerPos) {
         Rectangle monsterBounds = getMonsterBounds(monster);
         Point monsterPos = monster.getPosition();
         boolean directionFacingLeft = isFacingLeftByDirection(attack.direction);
         Point currentPlayerPos = player.getPosition();
-        if (isWithinAttackBox(currentPlayerPos, monsterBounds, monsterPos, attackEffect, directionFacingLeft)) {
-            return true;
-        }
-        if (alternatePlayerPos != null && !alternatePlayerPos.equals(currentPlayerPos)
-                && isWithinAttackBox(alternatePlayerPos, monsterBounds, monsterPos, attackEffect, directionFacingLeft)) {
+        if (intersectsAnyAttackBox(monsterBounds, monsterPos, attackEffect, directionFacingLeft, currentPlayerPos, alternatePlayerPos, secondaryAlternatePlayerPos)) {
             return true;
         }
 
         boolean stanceFacingLeft = isFacingLeftByStance(attack.stance);
-        if (stanceFacingLeft != directionFacingLeft && isWithinAttackBox(currentPlayerPos, monsterBounds, monsterPos, attackEffect, stanceFacingLeft)) {
-            return true;
-        }
-        if (alternatePlayerPos != null && !alternatePlayerPos.equals(currentPlayerPos)
-                && stanceFacingLeft != directionFacingLeft
-                && isWithinAttackBox(alternatePlayerPos, monsterBounds, monsterPos, attackEffect, stanceFacingLeft)) {
+        if (stanceFacingLeft != directionFacingLeft
+                && intersectsAnyAttackBox(monsterBounds, monsterPos, attackEffect, stanceFacingLeft, currentPlayerPos, alternatePlayerPos, secondaryAlternatePlayerPos)) {
             return true;
         }
 
         boolean currentFacingLeft = player.isFacingLeft();
         if (currentFacingLeft != directionFacingLeft
                 && currentFacingLeft != stanceFacingLeft
-                && isWithinAttackBox(currentPlayerPos, monsterBounds, monsterPos, attackEffect, currentFacingLeft)) {
+                && intersectsAnyAttackBox(monsterBounds, monsterPos, attackEffect, currentFacingLeft, currentPlayerPos, alternatePlayerPos, secondaryAlternatePlayerPos)) {
             return true;
         }
-        return alternatePlayerPos != null
-                && !alternatePlayerPos.equals(currentPlayerPos)
-                && currentFacingLeft != directionFacingLeft
-                && currentFacingLeft != stanceFacingLeft
-                && isWithinAttackBox(alternatePlayerPos, monsterBounds, monsterPos, attackEffect, currentFacingLeft);
+        return false;
     }
 
     /**
@@ -1054,6 +1061,22 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
 
         Rectangle attackBounds = attackEffect.calculateBoundingBox(playerPos, facingLeft);
         return attackBounds.intersects(monsterBounds) || attackBounds.contains(monsterPos);
+    }
+
+    private static boolean intersectsAnyAttackBox(Rectangle monsterBounds, Point monsterPos, StatEffect attackEffect, boolean facingLeft, Point... playerPositions) {
+        Point primaryPos = playerPositions.length > 0 ? playerPositions[0] : null;
+        for (Point playerPos : playerPositions) {
+            if (playerPos == null) {
+                continue;
+            }
+            if (primaryPos != null && playerPos != primaryPos && playerPos.equals(primaryPos)) {
+                continue;
+            }
+            if (isWithinAttackBox(playerPos, monsterBounds, monsterPos, attackEffect, facingLeft)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -1148,7 +1171,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
     /**
      * 生成异常日志的碰撞框信息（便于快速定位问题）
      */
-    private static String buildBboxInfo(Character player, Monster monster, boolean useBbox, Point checkPos, Point teleportBeforePos, boolean usedTeleportContext) {
+    private static String buildBboxInfo(Character player, Monster monster, boolean useBbox, Point checkPos, Point teleportBeforePos, Point movementBeforePos, boolean usedTeleportContext, boolean usedMovementContext) {
         MonsterStats stats = monster.getStats();
         Point playerPos = player.getPosition();
         Point mobPos = monster.getPosition();
@@ -1159,7 +1182,9 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                     + ", valid=false, playerPos=" + playerPos
                     + ", checkPos=" + effectiveCheckPos
                     + ", teleportBeforePos=" + teleportBeforePos
+                    + ", movementBeforePos=" + movementBeforePos
                     + ", usedTeleportContext=" + usedTeleportContext
+                    + ", usedMovementContext=" + usedMovementContext
                     + ", mobPos=" + mobPos
                     + ", facingLeft=" + facingLeft
                     + "}";
@@ -1181,7 +1206,9 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 + ", playerPos=" + playerPos
                 + ", checkPos=" + effectiveCheckPos
                 + ", teleportBeforePos=" + teleportBeforePos
+                + ", movementBeforePos=" + movementBeforePos
                 + ", usedTeleportContext=" + usedTeleportContext
+                + ", usedMovementContext=" + usedMovementContext
                 + ", mobPos=" + mobPos
                 + ", facingLeft=" + facingLeft
                 + ", noFlip=" + noFlip

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -253,7 +253,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                                 chainLightningCheckedFirst = true;
                             }
                         }
-                        if (checkDistance && !isWithinAttackBox(player, monster, attackEffect)) {
+                        if (checkDistance && !isWithinAttackBox(player, monster, attackEffect, isFacingLeftByStance(attack.stance))) {
                             boolean useBbox = shouldUseBoundingBox(monster);
                             double distance = calculateDistanceSq(player, monster, useBbox);
 //                          AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
@@ -978,14 +978,21 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
      * 优先用技能自身的范围框判断本次攻击是否合法命中怪物。
      * 命中技能框时，跳过后续基于中心点距离的 DISTANCE_HACK 检测。
      */
-    private static boolean isWithinAttackBox(Character player, Monster monster, StatEffect attackEffect) {
+    private static boolean isWithinAttackBox(Character player, Monster monster, StatEffect attackEffect, boolean facingLeft) {
         if (attackEffect == null || !attackEffect.hasBoundingBox()) {
             return false;
         }
 
-        Rectangle attackBounds = attackEffect.calculateBoundingBox(player.getPosition(), player.isFacingLeft());
+        Rectangle attackBounds = attackEffect.calculateBoundingBox(player.getPosition(), facingLeft);
         Rectangle monsterBounds = getMonsterBounds(monster);
         return attackBounds.intersects(monsterBounds) || attackBounds.contains(monster.getPosition());
+    }
+
+    /**
+     * 根据攻击包中的 stance 还原本次攻击时角色的朝向。
+     */
+    private static boolean isFacingLeftByStance(int stance) {
+        return Math.abs(stance) % 2 == 1;
     }
 
     /**

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -241,6 +241,10 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                         distanceToDetect += 250000;
                     } else if (attack.skill == Shadower.BOOMERANG_STEP || attack.skill == ILArchMage.CHAIN_LIGHTNING) {
                         distanceToDetect += 60000;
+                    } else if (attack.skill == Buccaneer.DRAGON_STRIKE) {
+                        // 龙之怒的客户端攻击范围较长，且近战包没有额外携带权威攻击原点，
+                        // 需要给距离检测留出一档同步误差余量，避免擦边命中被误判。
+                        distanceToDetect += 100000;
                     }
 
                     if (!skipDistanceHack) {
@@ -253,7 +257,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                                 chainLightningCheckedFirst = true;
                             }
                         }
-                        if (checkDistance && !isWithinAttackBox(player, monster, attackEffect, isFacingLeftByStance(attack.stance))) {
+                        if (checkDistance && !isWithinAttackBox(player, monster, attackEffect, attack)) {
                             boolean useBbox = shouldUseBoundingBox(monster);
                             double distance = calculateDistanceSq(player, monster, useBbox);
 //                          AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
@@ -978,14 +982,43 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
      * 优先用技能自身的范围框判断本次攻击是否合法命中怪物。
      * 命中技能框时，跳过后续基于中心点距离的 DISTANCE_HACK 检测。
      */
-    private static boolean isWithinAttackBox(Character player, Monster monster, StatEffect attackEffect, boolean facingLeft) {
+    private static boolean isWithinAttackBox(Character player, Monster monster, StatEffect attackEffect, AttackInfo attack) {
+        Rectangle monsterBounds = getMonsterBounds(monster);
+        Point monsterPos = monster.getPosition();
+        boolean directionFacingLeft = isFacingLeftByDirection(attack.direction);
+        if (isWithinAttackBox(player, monsterBounds, monsterPos, attackEffect, directionFacingLeft)) {
+            return true;
+        }
+
+        boolean stanceFacingLeft = isFacingLeftByStance(attack.stance);
+        if (stanceFacingLeft != directionFacingLeft && isWithinAttackBox(player, monsterBounds, monsterPos, attackEffect, stanceFacingLeft)) {
+            return true;
+        }
+
+        boolean currentFacingLeft = player.isFacingLeft();
+        return currentFacingLeft != directionFacingLeft
+                && currentFacingLeft != stanceFacingLeft
+                && isWithinAttackBox(player, monsterBounds, monsterPos, attackEffect, currentFacingLeft);
+    }
+
+    /**
+     * 使用指定朝向计算技能框，并判断是否命中怪物范围框。
+     */
+    private static boolean isWithinAttackBox(Character player, Rectangle monsterBounds, Point monsterPos, StatEffect attackEffect, boolean facingLeft) {
         if (attackEffect == null || !attackEffect.hasBoundingBox()) {
             return false;
         }
 
         Rectangle attackBounds = attackEffect.calculateBoundingBox(player.getPosition(), facingLeft);
-        Rectangle monsterBounds = getMonsterBounds(monster);
-        return attackBounds.intersects(monsterBounds) || attackBounds.contains(monster.getPosition());
+        return attackBounds.intersects(monsterBounds) || attackBounds.contains(monsterPos);
+    }
+
+    /**
+     * 根据攻击包中的 direction 还原本次攻击时角色的朝向。
+     * V83 攻击包中 direction 与 stance 分离，direction 更接近本次攻击的实时左右方向。
+     */
+    private static boolean isFacingLeftByDirection(int direction) {
+        return direction == 0;
     }
 
     /**

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -112,7 +112,6 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
         Skill theSkill = null;
         StatEffect attackEffect = null;
         final int job = player.getJob().getId();
-        boolean consumeTeleportDistanceContext = false;
         try {
             if (player.isBanned()) {
                 return;
@@ -165,11 +164,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 return;
             }
 
-            // 全屏技能直接跳过距离反外挂；其余技能继续走严格校验
-            final boolean skipDistanceHack = shouldSkipDistanceHack(attack.skill);
-            // 传送上下文：用于“传送前坐标 + 当前坐标”双坐标判定，降低内传送后的误报
-            final Point teleportBeforePos = player.getTeleportBeforePositionForDistanceCheck();
-            consumeTeleportDistanceContext = teleportBeforePos != null;
+            final boolean skipDistanceHack = isFullScreenDistanceExempt(attack.skill);
             final boolean isChainLightning = attack.skill == ILArchMage.CHAIN_LIGHTNING;
             boolean chainLightningCheckedFirst = false;
 
@@ -179,6 +174,10 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             }*/
 
             int totDamage = 0;
+            Monster distanceHackWorstMonster = null;
+            double distanceHackWorstDistance = Double.NEGATIVE_INFINITY;
+            double distanceHackWorstThreshold = 0.0;
+            boolean distanceHackWorstUseBbox = false;
 
             if (attack.skill == ChiefBandit.MESO_EXPLOSION) {
                 int delay = 0;
@@ -255,9 +254,19 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                             }
                         }
                         if (checkDistance) {
-                            DistanceHackCheckResult checkResult = evaluateDistanceHack(player, monster, teleportBeforePos, distanceToDetect);
-                            if (checkResult.shouldFlag()) {
-                                reportDistanceHack(player, attack.skill, monster, teleportBeforePos, checkResult);
+                            boolean useBbox = shouldUseBoundingBox(monster);
+                            double distance = calculateDistanceSq(player, monster, useBbox);
+//                          AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
+                            if (distance > distanceToDetect && distance > distanceHackWorstDistance) {
+                                distanceHackWorstMonster = monster;
+                                distanceHackWorstDistance = distance;
+                                distanceHackWorstThreshold = distanceToDetect;
+                                distanceHackWorstUseBbox = useBbox;
+                            }
+                            if (false && distance > distanceToDetect) {
+                                String bboxInfo = buildBboxInfo(player, monster, useBbox);
+                                AutobanFactory.DISTANCE_HACK.addPoint(player.getAutoBanManager(), "玩家：" + player.getName() + "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId() + " " + bboxInfo);
+                                log.warn("玩家：{}距离Sq到怪物: {} SID: {} MID: {} {}", player.getName(), distance, attack.skill, monster.getId(), bboxInfo);
                             }
                         }
                     }
@@ -551,14 +560,29 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                     }
                 }
             }
-
+            if (distanceHackWorstMonster != null) {
+                String bboxInfo = buildBboxInfo(player, distanceHackWorstMonster, distanceHackWorstUseBbox);
+                AutobanFactory.DISTANCE_HACK.addPoint(
+                        player.getAutoBanManager(),
+                        "Player: " + player.getName()
+                                + " maxDistanceSqToMob: " + distanceHackWorstDistance
+                                + " thresholdSq: " + distanceHackWorstThreshold
+                                + " SID: " + attack.skill
+                                + " MID: " + distanceHackWorstMonster.getId()
+                                + " " + bboxInfo
+                );
+                log.warn(
+                        "Player: {} maxDistanceSqToMob: {} thresholdSq: {} SID: {} MID: {} {}",
+                        player.getName(),
+                        distanceHackWorstDistance,
+                        distanceHackWorstThreshold,
+                        attack.skill,
+                        distanceHackWorstMonster.getId(),
+                        bboxInfo
+                );
+            }
         } catch (Exception e) {
             e.printStackTrace();
-        } finally {
-            // 放在 finally 中，确保任何提前 return 都会消费一次上下文，避免保护窗口异常拉长
-            if (consumeTeleportDistanceContext) {
-                player.consumeTeleportDistanceCheckContext();
-            }
         }
     }
 
@@ -951,95 +975,6 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
     }
 
     /**
-     * 距离外挂判定结果载体：把主流程中的判定细节收敛到单个对象，便于维护。
-     */
-    private static final class DistanceHackCheckResult {
-        private final boolean shouldFlag;
-        private final boolean useBbox;
-        private final double currentDistanceSq;
-        private final double beforeDistanceSq;
-        private final boolean hasBeforeDistance;
-
-        private DistanceHackCheckResult(boolean shouldFlag, boolean useBbox, double currentDistanceSq, double beforeDistanceSq, boolean hasBeforeDistance) {
-            this.shouldFlag = shouldFlag;
-            this.useBbox = useBbox;
-            this.currentDistanceSq = currentDistanceSq;
-            this.beforeDistanceSq = beforeDistanceSq;
-            this.hasBeforeDistance = hasBeforeDistance;
-        }
-
-        private static DistanceHackCheckResult safe() {
-            return new DistanceHackCheckResult(false, false, 0, -1, false);
-        }
-
-        private static DistanceHackCheckResult flag(boolean useBbox, double currentDistanceSq, double beforeDistanceSq, boolean hasBeforeDistance) {
-            return new DistanceHackCheckResult(true, useBbox, currentDistanceSq, beforeDistanceSq, hasBeforeDistance);
-        }
-
-        private boolean shouldFlag() {
-            return shouldFlag;
-        }
-    }
-
-    /**
-     * 评估本次攻击目标是否应触发距离外挂记分。
-     *
-     * <p>规则：当前坐标超限后，若存在“传送前坐标”且前坐标未超限，则判定为可疑性不足并放行。</p>
-     */
-    private static DistanceHackCheckResult evaluateDistanceHack(Character player, Monster monster, Point teleportBeforePos, double distanceToDetect) {
-        boolean useBbox = shouldUseBoundingBox(monster);
-        double currentDistance = calculateDistanceSq(player, monster, useBbox);
-        if (currentDistance <= distanceToDetect) {
-            return DistanceHackCheckResult.safe();
-        }
-
-        if (teleportBeforePos == null) {
-            return DistanceHackCheckResult.flag(useBbox, currentDistance, -1, false);
-        }
-
-        double beforeDistance = calculateDistanceSq(teleportBeforePos, monster, useBbox);
-        if (beforeDistance <= distanceToDetect) {
-            return DistanceHackCheckResult.safe();
-        }
-
-        return DistanceHackCheckResult.flag(useBbox, currentDistance, beforeDistance, true);
-    }
-
-    /**
-     * 统一上报距离异常日志，避免主循环重复拼接字符串。
-     */
-    private static void reportDistanceHack(Character player, int skillId, Monster monster, Point teleportBeforePos, DistanceHackCheckResult checkResult) {
-        String bboxInfo = buildBboxInfo(player, monster, checkResult.useBbox);
-        String tpInfo = buildTeleportDistanceInfo(teleportBeforePos, checkResult);
-        AutobanFactory.DISTANCE_HACK.addPoint(
-                player.getAutoBanManager(),
-                "玩家：" + player.getName() + "距离Sq到怪物: " + checkResult.currentDistanceSq + " SID: " + skillId + " MID: " + monster.getId() + " " + bboxInfo + tpInfo
-        );
-        log.warn(
-                "玩家：{}距离Sq到怪物: {} SID: {} MID: {} {}{}",
-                player.getName(),
-                checkResult.currentDistanceSq,
-                skillId,
-                monster.getId(),
-                bboxInfo,
-                tpInfo
-        );
-    }
-
-    /**
-     * 传送上下文调试信息：仅在判定里真正用到“传送前坐标”时输出。
-     */
-    private static String buildTeleportDistanceInfo(Point teleportBeforePos, DistanceHackCheckResult checkResult) {
-        if (!checkResult.hasBeforeDistance || teleportBeforePos == null) {
-            return "";
-        }
-        return " TP{beforePos=" + teleportBeforePos
-                + ", beforeDistanceSq=" + checkResult.beforeDistanceSq
-                + ", currentDistanceSq=" + checkResult.currentDistanceSq
-                + "}";
-    }
-
-    /**
      * 全屏/大范围技能跳过距离检测
      */
     private static boolean isFullScreenDistanceExempt(int skillId) {
@@ -1047,13 +982,6 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 || skillId == ILArchMage.BLIZZARD
                 || skillId == FPArchMage.METEOR_SHOWER
                 || skillId == BlazeWizard.METEOR_SHOWER;
-    }
-
-    /**
-     * 是否跳过本次距离外挂检测。
-     */
-    private static boolean shouldSkipDistanceHack(int skillId) {
-        return isFullScreenDistanceExempt(skillId);
     }
 
     /**
@@ -1069,26 +997,16 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
      * useBbox=true 时按碰撞框最短距离计算
      */
     private static double calculateDistanceSq(Character player, Monster monster, boolean useBbox) {
-        return calculateDistanceSq(player.getPosition(), monster, useBbox);
-    }
-
-    /**
-     * 计算任意给定坐标到怪物的距离平方。
-     * useBbox=true 时按碰撞框最短距离计算
-     */
-    private static double calculateDistanceSq(Point playerPos, Monster monster, boolean useBbox) {
-        if (playerPos == null) {
-            return Double.MAX_VALUE;
-        }
-
         if (!useBbox) {
-            return playerPos.distanceSq(monster.getPosition());
+            return player.getPosition().distanceSq(monster.getPosition());
         }
 
         MonsterStats stats = monster.getStats();
         if (stats == null || !stats.hasBbox()) {
-            return playerPos.distanceSq(monster.getPosition());
+            return player.getPosition().distanceSq(monster.getPosition());
         }
+
+        Point playerPos = player.getPosition();
         int[] bbox = getWorldBbox(monster, stats);
         int minX = bbox[0];
         int maxX = bbox[1];

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -70,6 +70,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
 
     private static final Logger log = LoggerFactory.getLogger(ItemPickupHandler.class);
+    // 传送/树洞等瞬移后，短时间内跳过距离外挂记分，避免“位移包与攻击包相邻”造成误封
+    private static final long TELEPORT_DISTANCE_GRACE_MS = 300L;
 
     public static class AttackInfo {
 
@@ -164,7 +166,8 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 return;
             }
 
-            final boolean skipDistanceHack = isFullScreenDistanceExempt(attack.skill);
+            // 统一封装距离检测豁免策略，避免主流程出现过多判定细节
+            final boolean skipDistanceHack = shouldSkipDistanceHack(player, attack.skill);
             final boolean isChainLightning = attack.skill == ILArchMage.CHAIN_LIGHTNING;
             boolean chainLightningCheckedFirst = false;
 
@@ -951,6 +954,30 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 || skillId == ILArchMage.BLIZZARD
                 || skillId == FPArchMage.METEOR_SHOWER
                 || skillId == BlazeWizard.METEOR_SHOWER;
+    }
+
+    /**
+     * 是否跳过本次距离外挂检测。
+     */
+    private static boolean shouldSkipDistanceHack(Character player, int skillId) {
+        // 1) 全屏技能本身豁免
+        if (isFullScreenDistanceExempt(skillId)) {
+            return true;
+        }
+
+        // 2) 传送/树洞后的短时保护窗口
+        return isTeleportDistanceGrace(player);
+    }
+
+    /**
+     * 瞬移后短窗口豁免距离检测，降低同帧位移+施法导致的误判概率。
+     */
+    private static boolean isTeleportDistanceGrace(Character player) {
+        long lastTeleportLikeMoveTime = player.getLastTeleportLikeMoveTime();
+        if (lastTeleportLikeMoveTime <= 0) {
+            return false;
+        }
+        return currentServerTime() - lastTeleportLikeMoveTime <= TELEPORT_DISTANCE_GRACE_MS;
     }
 
     /**

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -48,6 +48,7 @@ import org.gms.server.life.MobSkillFactory;
 import org.gms.server.life.MobSkillId;
 import org.gms.server.life.MobSkillType;
 import org.gms.server.life.Monster;
+import org.gms.server.life.MonsterStats;
 import org.gms.server.life.MonsterDropEntry;
 import org.gms.server.life.MonsterInformationProvider;
 import org.gms.server.maps.MapItem;
@@ -163,6 +164,10 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 return;
             }
 
+            final boolean skipDistanceHack = isFullScreenDistanceExempt(attack.skill);
+            final boolean isChainLightning = attack.skill == ILArchMage.CHAIN_LIGHTNING;
+            boolean chainLightningCheckedFirst = false;
+
             //WTF IS THIS F3,1
             /*if (attackCount != attack.numDamage && attack.skill != ChiefBandit.MESO_EXPLOSION && attack.skill != NightWalker.VAMPIRE && attack.skill != WindArcher.WIND_SHOT && attack.skill != Aran.COMBO_SMASH && attack.skill != Aran.COMBO_FENRIR && attack.skill != Aran.COMBO_TEMPEST && attack.skill != NightLord.NINJA_AMBUSH && attack.skill != Shadower.NINJA_AMBUSH) {
                 return;
@@ -208,7 +213,6 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             for (Integer oned : attack.allDamage.keySet()) {
                 final Monster monster = map.getMonsterByOid(oned);
                 if (monster != null) {
-                    double distance = player.getPosition().distanceSq(monster.getPosition());
                     double distanceToDetect = 200000.0;
 
                     if (attack.ranged) {
@@ -235,11 +239,26 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                         distanceToDetect += 60000;
                     }
 
-                    if (distance > distanceToDetect) {
-//                        AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
-                        AutobanFactory.DISTANCE_HACK.addPoint(player.getAutoBanManager(), "玩家：" + player.getName() + "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
-                        log.warn("玩家：{}距离Sq到怪物: {} SID: {} MID: {}", player.getName(), distance, attack.skill, monster.getId());
-
+                    if (!skipDistanceHack) {
+                        boolean checkDistance = true;
+                        if (isChainLightning) {
+                            // 链式技能后续目标来源于跳跃，不以玩家距离判断
+                            if (chainLightningCheckedFirst) {
+                                checkDistance = false;
+                            } else {
+                                chainLightningCheckedFirst = true;
+                            }
+                        }
+                        if (checkDistance) {
+                            boolean useBbox = shouldUseBoundingBox(monster);
+                            double distance = calculateDistanceSq(player, monster, useBbox);
+//                          AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
+                            if (distance > distanceToDetect) {
+                                String bboxInfo = buildBboxInfo(player, monster, useBbox);
+                                AutobanFactory.DISTANCE_HACK.addPoint(player.getAutoBanManager(), "玩家：" + player.getName() + "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId() + " " + bboxInfo);
+                                log.warn("玩家：{}距离Sq到怪物: {} SID: {} MID: {} {}", player.getName(), distance, attack.skill, monster.getId(), bboxInfo);
+                            }
+                        }
                     }
 
                     int totDamageToOneMonster = 0;
@@ -922,6 +941,113 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             ret.position.setLocation(p.readShort(), p.readShort());
         }
         return ret;
+    }
+
+    /**
+     * 全屏/大范围技能跳过距离检测
+     */
+    private static boolean isFullScreenDistanceExempt(int skillId) {
+        return skillId == Bishop.GENESIS
+                || skillId == ILArchMage.BLIZZARD
+                || skillId == FPArchMage.METEOR_SHOWER
+                || skillId == BlazeWizard.METEOR_SHOWER;
+    }
+
+    /**
+     * 是否使用碰撞框距离检测（Boss 或大体型）
+     */
+    private static boolean shouldUseBoundingBox(Monster monster) {
+        MonsterStats stats = monster.getStats();
+        return stats != null && stats.hasBbox() && (monster.isBoss() || stats.isLargeSize());
+    }
+
+    /**
+     * 计算玩家到怪物的距离平方
+     * useBbox=true 时按碰撞框最短距离计算
+     */
+    private static double calculateDistanceSq(Character player, Monster monster, boolean useBbox) {
+        if (!useBbox) {
+            return player.getPosition().distanceSq(monster.getPosition());
+        }
+
+        MonsterStats stats = monster.getStats();
+        if (stats == null || !stats.hasBbox()) {
+            return player.getPosition().distanceSq(monster.getPosition());
+        }
+
+        Point playerPos = player.getPosition();
+        Point mobPos = monster.getPosition();
+
+        int minX;
+        int maxX;
+        if (monster.isFacingLeft()) {
+            // 面向左：直接叠加相对 lt/rb
+            minX = mobPos.x + stats.getBboxMinX();
+            maxX = mobPos.x + stats.getBboxMaxX();
+        } else {
+            // 面向右：需要镜像
+            minX = mobPos.x - stats.getBboxMaxX();
+            maxX = mobPos.x - stats.getBboxMinX();
+        }
+
+        int minY = mobPos.y + stats.getBboxMinY();
+        int maxY = mobPos.y + stats.getBboxMaxY();
+
+        // 计算点到矩形的最短距离
+        int dx = 0;
+        if (playerPos.x < minX) {
+            dx = minX - playerPos.x;
+        } else if (playerPos.x > maxX) {
+            dx = playerPos.x - maxX;
+        }
+
+        int dy = 0;
+        if (playerPos.y < minY) {
+            dy = minY - playerPos.y;
+        } else if (playerPos.y > maxY) {
+            dy = playerPos.y - maxY;
+        }
+
+        return (double) dx * dx + (double) dy * dy;
+    }
+
+    /**
+     * 生成异常日志的碰撞框信息（便于快速定位问题）
+     */
+    private static String buildBboxInfo(Character player, Monster monster, boolean useBbox) {
+        MonsterStats stats = monster.getStats();
+        Point playerPos = player.getPosition();
+        Point mobPos = monster.getPosition();
+        boolean facingLeft = monster.isFacingLeft();
+        if (stats == null || !stats.hasBbox()) {
+            return "BBOX{use=" + useBbox + ", valid=false, playerPos=" + playerPos + ", mobPos=" + mobPos + ", facingLeft=" + facingLeft + "}";
+        }
+
+        int minX;
+        int maxX;
+        if (facingLeft) {
+            // 面向左：直接叠加相对 lt/rb
+            minX = mobPos.x + stats.getBboxMinX();
+            maxX = mobPos.x + stats.getBboxMaxX();
+        } else {
+            // 面向右：需要镜像
+            minX = mobPos.x - stats.getBboxMaxX();
+            maxX = mobPos.x - stats.getBboxMinX();
+        }
+
+        int minY = mobPos.y + stats.getBboxMinY();
+        int maxY = mobPos.y + stats.getBboxMaxY();
+        int width = Math.max(0, maxX - minX);
+        int height = Math.max(0, maxY - minY);
+
+        return "BBOX{use=" + useBbox
+                + ", rel=(" + stats.getBboxMinX() + "," + stats.getBboxMinY() + ")-(" + stats.getBboxMaxX() + "," + stats.getBboxMaxY() + ")"
+                + ", world=(" + minX + "," + minY + ")-(" + maxX + "," + maxY + ")"
+                + ", size=" + width + "x" + height
+                + ", playerPos=" + playerPos
+                + ", mobPos=" + mobPos
+                + ", facingLeft=" + facingLeft
+                + "}";
     }
 
     /**

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -167,6 +167,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             final boolean skipDistanceHack = isFullScreenDistanceExempt(attack.skill);
             final boolean isChainLightning = attack.skill == ILArchMage.CHAIN_LIGHTNING;
             boolean chainLightningCheckedFirst = false;
+            Point teleportBeforePosForDistanceCheck = player.getTeleportBeforePositionForDistanceCheck();
 
             //WTF IS THIS F3,1
             /*if (attackCount != attack.numDamage && attack.skill != ChiefBandit.MESO_EXPLOSION && attack.skill != NightWalker.VAMPIRE && attack.skill != WindArcher.WIND_SHOT && attack.skill != Aran.COMBO_SMASH && attack.skill != Aran.COMBO_FENRIR && attack.skill != Aran.COMBO_TEMPEST && attack.skill != NightLord.NINJA_AMBUSH && attack.skill != Shadower.NINJA_AMBUSH) {
@@ -178,6 +179,8 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             double distanceHackWorstDistance = Double.NEGATIVE_INFINITY;
             double distanceHackWorstThreshold = 0.0;
             boolean distanceHackWorstUseBbox = false;
+            Point distanceHackWorstCheckPos = null;
+            boolean distanceHackWorstUsedTeleportContext = false;
 
             if (attack.skill == ChiefBandit.MESO_EXPLOSION) {
                 int delay = 0;
@@ -257,18 +260,31 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                                 chainLightningCheckedFirst = true;
                             }
                         }
-                        if (checkDistance && !isWithinAttackBox(player, monster, attackEffect, attack)) {
+                        if (checkDistance && !isWithinAttackBox(player, monster, attackEffect, attack, teleportBeforePosForDistanceCheck)) {
                             boolean useBbox = shouldUseBoundingBox(monster);
-                            double distance = calculateDistanceSq(player, monster, useBbox);
+                            Point currentPlayerPos = player.getPosition();
+                            Point checkPos = currentPlayerPos;
+                            double distance = calculateDistanceSq(currentPlayerPos, monster, useBbox);
+                            boolean usedTeleportContext = false;
+                            if (teleportBeforePosForDistanceCheck != null && !teleportBeforePosForDistanceCheck.equals(currentPlayerPos)) {
+                                double teleportDistance = calculateDistanceSq(teleportBeforePosForDistanceCheck, monster, useBbox);
+                                if (teleportDistance < distance) {
+                                    distance = teleportDistance;
+                                    checkPos = teleportBeforePosForDistanceCheck;
+                                    usedTeleportContext = true;
+                                }
+                            }
 //                          AutobanFactory.DISTANCE_HACK.alert(player, "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId());
                             if (distance > distanceToDetect && distance > distanceHackWorstDistance) {
                                 distanceHackWorstMonster = monster;
                                 distanceHackWorstDistance = distance;
                                 distanceHackWorstThreshold = distanceToDetect;
                                 distanceHackWorstUseBbox = useBbox;
+                                distanceHackWorstCheckPos = new Point(checkPos);
+                                distanceHackWorstUsedTeleportContext = usedTeleportContext;
                             }
                             if (false && distance > distanceToDetect) {
-                                String bboxInfo = buildBboxInfo(player, monster, useBbox);
+                                String bboxInfo = buildBboxInfo(player, monster, useBbox, checkPos, teleportBeforePosForDistanceCheck, usedTeleportContext);
                                 AutobanFactory.DISTANCE_HACK.addPoint(player.getAutoBanManager(), "玩家：" + player.getName() + "距离Sq到怪物: " + distance + " SID: " + attack.skill + " MID: " + monster.getId() + " " + bboxInfo);
                                 log.warn("玩家：{}距离Sq到怪物: {} SID: {} MID: {} {}", player.getName(), distance, attack.skill, monster.getId(), bboxInfo);
                             }
@@ -564,8 +580,18 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                     }
                 }
             }
+            if (teleportBeforePosForDistanceCheck != null) {
+                player.consumeTeleportDistanceCheckContext();
+            }
             if (distanceHackWorstMonster != null) {
-                String bboxInfo = buildBboxInfo(player, distanceHackWorstMonster, distanceHackWorstUseBbox);
+                String bboxInfo = buildBboxInfo(
+                        player,
+                        distanceHackWorstMonster,
+                        distanceHackWorstUseBbox,
+                        distanceHackWorstCheckPos,
+                        teleportBeforePosForDistanceCheck,
+                        distanceHackWorstUsedTeleportContext
+                );
                 AutobanFactory.DISTANCE_HACK.addPoint(
                         player.getAutoBanManager(),
                         "Player: " + player.getName()
@@ -982,34 +1008,51 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
      * 优先用技能自身的范围框判断本次攻击是否合法命中怪物。
      * 命中技能框时，跳过后续基于中心点距离的 DISTANCE_HACK 检测。
      */
-    private static boolean isWithinAttackBox(Character player, Monster monster, StatEffect attackEffect, AttackInfo attack) {
+    private static boolean isWithinAttackBox(Character player, Monster monster, StatEffect attackEffect, AttackInfo attack, Point alternatePlayerPos) {
         Rectangle monsterBounds = getMonsterBounds(monster);
         Point monsterPos = monster.getPosition();
         boolean directionFacingLeft = isFacingLeftByDirection(attack.direction);
-        if (isWithinAttackBox(player, monsterBounds, monsterPos, attackEffect, directionFacingLeft)) {
+        Point currentPlayerPos = player.getPosition();
+        if (isWithinAttackBox(currentPlayerPos, monsterBounds, monsterPos, attackEffect, directionFacingLeft)) {
+            return true;
+        }
+        if (alternatePlayerPos != null && !alternatePlayerPos.equals(currentPlayerPos)
+                && isWithinAttackBox(alternatePlayerPos, monsterBounds, monsterPos, attackEffect, directionFacingLeft)) {
             return true;
         }
 
         boolean stanceFacingLeft = isFacingLeftByStance(attack.stance);
-        if (stanceFacingLeft != directionFacingLeft && isWithinAttackBox(player, monsterBounds, monsterPos, attackEffect, stanceFacingLeft)) {
+        if (stanceFacingLeft != directionFacingLeft && isWithinAttackBox(currentPlayerPos, monsterBounds, monsterPos, attackEffect, stanceFacingLeft)) {
+            return true;
+        }
+        if (alternatePlayerPos != null && !alternatePlayerPos.equals(currentPlayerPos)
+                && stanceFacingLeft != directionFacingLeft
+                && isWithinAttackBox(alternatePlayerPos, monsterBounds, monsterPos, attackEffect, stanceFacingLeft)) {
             return true;
         }
 
         boolean currentFacingLeft = player.isFacingLeft();
-        return currentFacingLeft != directionFacingLeft
+        if (currentFacingLeft != directionFacingLeft
                 && currentFacingLeft != stanceFacingLeft
-                && isWithinAttackBox(player, monsterBounds, monsterPos, attackEffect, currentFacingLeft);
+                && isWithinAttackBox(currentPlayerPos, monsterBounds, monsterPos, attackEffect, currentFacingLeft)) {
+            return true;
+        }
+        return alternatePlayerPos != null
+                && !alternatePlayerPos.equals(currentPlayerPos)
+                && currentFacingLeft != directionFacingLeft
+                && currentFacingLeft != stanceFacingLeft
+                && isWithinAttackBox(alternatePlayerPos, monsterBounds, monsterPos, attackEffect, currentFacingLeft);
     }
 
     /**
      * 使用指定朝向计算技能框，并判断是否命中怪物范围框。
      */
-    private static boolean isWithinAttackBox(Character player, Rectangle monsterBounds, Point monsterPos, StatEffect attackEffect, boolean facingLeft) {
+    private static boolean isWithinAttackBox(Point playerPos, Rectangle monsterBounds, Point monsterPos, StatEffect attackEffect, boolean facingLeft) {
         if (attackEffect == null || !attackEffect.hasBoundingBox()) {
             return false;
         }
 
-        Rectangle attackBounds = attackEffect.calculateBoundingBox(player.getPosition(), facingLeft);
+        Rectangle attackBounds = attackEffect.calculateBoundingBox(playerPos, facingLeft);
         return attackBounds.intersects(monsterBounds) || attackBounds.contains(monsterPos);
     }
 
@@ -1062,24 +1105,22 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
      */
     private static boolean shouldUseBoundingBox(Monster monster) {
         MonsterStats stats = monster.getStats();
-        return stats != null && stats.hasBbox() && (monster.isBoss() || stats.isLargeSize());
+        return stats != null && stats.hasBbox();
     }
 
     /**
      * 计算玩家到怪物的距离平方
      * useBbox=true 时按碰撞框最短距离计算
      */
-    private static double calculateDistanceSq(Character player, Monster monster, boolean useBbox) {
+    private static double calculateDistanceSq(Point playerPos, Monster monster, boolean useBbox) {
         if (!useBbox) {
-            return player.getPosition().distanceSq(monster.getPosition());
+            return playerPos.distanceSq(monster.getPosition());
         }
 
         MonsterStats stats = monster.getStats();
         if (stats == null || !stats.hasBbox()) {
-            return player.getPosition().distanceSq(monster.getPosition());
+            return playerPos.distanceSq(monster.getPosition());
         }
-
-        Point playerPos = player.getPosition();
         int[] bbox = getWorldBbox(monster, stats);
         int minX = bbox[0];
         int maxX = bbox[1];
@@ -1107,13 +1148,21 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
     /**
      * 生成异常日志的碰撞框信息（便于快速定位问题）
      */
-    private static String buildBboxInfo(Character player, Monster monster, boolean useBbox) {
+    private static String buildBboxInfo(Character player, Monster monster, boolean useBbox, Point checkPos, Point teleportBeforePos, boolean usedTeleportContext) {
         MonsterStats stats = monster.getStats();
         Point playerPos = player.getPosition();
         Point mobPos = monster.getPosition();
         boolean facingLeft = monster.isFacingLeft();
+        Point effectiveCheckPos = checkPos != null ? checkPos : playerPos;
         if (stats == null || !stats.hasBbox()) {
-            return "BBOX{use=" + useBbox + ", valid=false, playerPos=" + playerPos + ", mobPos=" + mobPos + ", facingLeft=" + facingLeft + "}";
+            return "BBOX{use=" + useBbox
+                    + ", valid=false, playerPos=" + playerPos
+                    + ", checkPos=" + effectiveCheckPos
+                    + ", teleportBeforePos=" + teleportBeforePos
+                    + ", usedTeleportContext=" + usedTeleportContext
+                    + ", mobPos=" + mobPos
+                    + ", facingLeft=" + facingLeft
+                    + "}";
         }
 
         int[] bbox = getWorldBbox(monster, stats);
@@ -1130,6 +1179,9 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 + ", world=(" + minX + "," + minY + ")-(" + maxX + "," + maxY + ")"
                 + ", size=" + width + "x" + height
                 + ", playerPos=" + playerPos
+                + ", checkPos=" + effectiveCheckPos
+                + ", teleportBeforePos=" + teleportBeforePos
+                + ", usedTeleportContext=" + usedTeleportContext
                 + ", mobPos=" + mobPos
                 + ", facingLeft=" + facingLeft
                 + ", noFlip=" + noFlip

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractMovementPacketHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractMovementPacketHandler.java
@@ -191,11 +191,19 @@ public abstract class AbstractMovementPacketHandler extends AbstractPacketHandle
                 case 19: // Springs on maps
                 case 20: // Aran Combat Step
                 case 22: {
-                    //Relative movement - server only cares about stance
-                    p.skip(4); //xpos = lea.readShort(); ypos = lea.readShort();
+                    Point beforePos = snapshotPosition(target);
+                    short deltaX = p.readShort();
+                    short deltaY = p.readShort();
+                    Point afterPos = target instanceof Character
+                            ? estimateRelativeMovePosition(beforePos, deltaX, deltaY)
+                            : null;
                     byte newstate = p.readByte();
+                    if (afterPos != null) {
+                        target.setPosition(afterPos);
+                    }
                     target.setStance(newstate);
                     p.readShort(); //duration
+                    recordRegularMove(target, beforePos, afterPos);
                     break;
                 }
                 case 3:
@@ -309,6 +317,18 @@ public abstract class AbstractMovementPacketHandler extends AbstractPacketHandle
         short xpos = p.readShort();
         short ypos = p.readShort();
         return new Point(xpos, ypos + yOffset);
+    }
+
+    /**
+     * Relative movement 包里给的是相对位移量。
+     * 服务端不需要做精确物理模拟，但要把当前位置推进到接近客户端的落点，
+     * 否则攻击包会长期拿旧坐标参与距离校验。
+     */
+    private static Point estimateRelativeMovePosition(Point beforePos, short deltaX, short deltaY) {
+        if (beforePos == null) {
+            return null;
+        }
+        return new Point(beforePos.x + deltaX, beforePos.y + deltaY);
     }
 
     private static void applyPositionAndStance(AnimatedMapObject target, Point position, byte newstate) {

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractMovementPacketHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractMovementPacketHandler.java
@@ -197,30 +197,18 @@ public abstract class AbstractMovementPacketHandler extends AbstractPacketHandle
                 }
                 case 3:
                 case 4: { // teleport disappear/appear
-                    // 修复点：瞬移动作必须同步服务器坐标，否则下一帧攻击会拿旧坐标参与反外挂距离判定
-                    short xpos = p.readShort();
-                    short ypos = p.readShort();
-                    p.skip(4); // xwobble / ywobble
-                    target.setPosition(new Point(xpos, ypos + yOffset));
-                    byte newstate = p.readByte();
-                    target.setStance(newstate);
-
-                    // 仅玩家记录“瞬移类位移时间”，供攻击距离检测短窗口豁免使用
-                    if (target instanceof Character chr) {
-                        chr.markTeleportLikeMove();
-                    }
+                    handleTeleportMove(p, target, yOffset);
                     break;
                 }
                 case 7: // assaulter
                 case 8: // assassinate
-                case 9: // rush
+                case 9: { // rush
+                    handleDashLikeMove(p, target, yOffset);
+                    break;
+                }
                 case 11: //chair
                 {
-//                case 14: { 
-                    // 这类位移在服务端只关心姿态，不做坐标覆盖，保持原逻辑
-                    p.skip(8); //xpos = lea.readShort(); ypos = lea.readShort(); xwobble = lea.readShort(); ywobble = lea.readShort();
-                    byte newstate = p.readByte();
-                    target.setStance(newstate);
+                    handleChairMove(p, target);
                     break;
                 }
                 case 14:
@@ -242,11 +230,7 @@ public abstract class AbstractMovementPacketHandler extends AbstractPacketHandle
                     break;
                 }*/
                 case 15: {
-                    //Jump down movement - stance only
-                    p.skip(12); //short xpos = lea.readShort(); ypos = lea.readShort(); xwobble = lea.readShort(); ywobble = lea.readShort(); fh = lea.readShort(); ofh = lea.readShort();
-                    byte newstate = p.readByte();
-                    target.setStance(newstate);
-                    p.readShort(); // duration
+                    handleJumpDownMove(p, target, yOffset);
                     break;
                 }
                 case 21: {//Causes aran to do weird stuff when attacking o.o
@@ -262,5 +246,68 @@ public abstract class AbstractMovementPacketHandler extends AbstractPacketHandle
                     throw new EmptyMovementException(p);
             }
         }
+    }
+
+    /**
+     * 处理瞬移动作（3/4）：同步坐标并在玩家对象上记录传送前后坐标。
+     */
+    private static void handleTeleportMove(InPacket p, AnimatedMapObject target, int yOffset) {
+        Point beforePos = snapshotPosition(target);
+        Point afterPos = readPositionWithOffset(p, yOffset);
+        p.skip(4); // xwobble / ywobble
+        byte newstate = p.readByte();
+        applyPositionAndStance(target, afterPos, newstate);
+
+        // 仅玩家记录“瞬移前后坐标”，供攻击距离双坐标校验使用
+        if (target instanceof Character chr) {
+            chr.markTeleportLikeMove(beforePos, afterPos);
+        }
+    }
+
+    /**
+     * 处理突进类位移（7/8/9）：同步服务端坐标，降低位移后首包攻击误判概率。
+     */
+    private static void handleDashLikeMove(InPacket p, AnimatedMapObject target, int yOffset) {
+        Point afterPos = readPositionWithOffset(p, yOffset);
+        p.skip(4); // xwobble / ywobble
+        byte newstate = p.readByte();
+        applyPositionAndStance(target, afterPos, newstate);
+    }
+
+    /**
+     * 椅子动作（11）：保持原逻辑，仅同步姿态不覆盖坐标。
+     */
+    private static void handleChairMove(InPacket p, AnimatedMapObject target) {
+        p.skip(8); // xpos / ypos / xwobble / ywobble
+        byte newstate = p.readByte();
+        target.setStance(newstate);
+    }
+
+    /**
+     * 处理 jump down（15）：同步坐标，其余字段按协议顺序跳过。
+     */
+    private static void handleJumpDownMove(InPacket p, AnimatedMapObject target, int yOffset) {
+        Point afterPos = readPositionWithOffset(p, yOffset);
+        target.setPosition(afterPos);
+        p.skip(8); // xwobble / ywobble / fh / ofh
+        byte newstate = p.readByte();
+        target.setStance(newstate);
+        p.readShort(); // duration
+    }
+
+    private static Point snapshotPosition(AnimatedMapObject target) {
+        Point currentPos = target.getPosition();
+        return currentPos != null ? new Point(currentPos) : null;
+    }
+
+    private static Point readPositionWithOffset(InPacket p, int yOffset) {
+        short xpos = p.readShort();
+        short ypos = p.readShort();
+        return new Point(xpos, ypos + yOffset);
+    }
+
+    private static void applyPositionAndStance(AnimatedMapObject target, Point position, byte newstate) {
+        target.setPosition(position);
+        target.setStance(newstate);
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractMovementPacketHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractMovementPacketHandler.java
@@ -21,6 +21,7 @@
  */
 package org.gms.net.server.channel.handlers;
 
+import org.gms.client.Character;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
 import org.slf4j.Logger;
@@ -195,14 +196,28 @@ public abstract class AbstractMovementPacketHandler extends AbstractPacketHandle
                     break;
                 }
                 case 3:
-                case 4: // tele... -.-
+                case 4: { // teleport disappear/appear
+                    // 修复点：瞬移动作必须同步服务器坐标，否则下一帧攻击会拿旧坐标参与反外挂距离判定
+                    short xpos = p.readShort();
+                    short ypos = p.readShort();
+                    p.skip(4); // xwobble / ywobble
+                    target.setPosition(new Point(xpos, ypos + yOffset));
+                    byte newstate = p.readByte();
+                    target.setStance(newstate);
+
+                    // 仅玩家记录“瞬移类位移时间”，供攻击距离检测短窗口豁免使用
+                    if (target instanceof Character chr) {
+                        chr.markTeleportLikeMove();
+                    }
+                    break;
+                }
                 case 7: // assaulter
                 case 8: // assassinate
                 case 9: // rush
                 case 11: //chair
                 {
-//                case 14: {
-                    //Teleport movement - same as above
+//                case 14: { 
+                    // 这类位移在服务端只关心姿态，不做坐标覆盖，保持原逻辑
                     p.skip(8); //xpos = lea.readShort(); ypos = lea.readShort(); xwobble = lea.readShort(); ywobble = lea.readShort();
                     byte newstate = p.readByte();
                     target.setStance(newstate);

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractMovementPacketHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractMovementPacketHandler.java
@@ -169,13 +169,16 @@ public abstract class AbstractMovementPacketHandler extends AbstractPacketHandle
                 case 5:
                 case 17: { // Float
                     //Absolute movement - only this is important for the server, other movement can be passed to the client
+                    Point beforePos = snapshotPosition(target);
                     short xpos = p.readShort(); //is signed fine here?
                     short ypos = p.readShort();
-                    target.setPosition(new Point(xpos, ypos + yOffset));
+                    Point afterPos = new Point(xpos, ypos + yOffset);
+                    target.setPosition(afterPos);
                     p.skip(6); //xwobble = lea.readShort(); ywobble = lea.readShort(); fh = lea.readShort();
                     byte newstate = p.readByte();
                     target.setStance(newstate);
                     p.readShort(); //duration
+                    recordRegularMove(target, beforePos, afterPos);
                     break;
                 }
                 case 1:
@@ -287,12 +290,14 @@ public abstract class AbstractMovementPacketHandler extends AbstractPacketHandle
      * 处理 jump down（15）：同步坐标，其余字段按协议顺序跳过。
      */
     private static void handleJumpDownMove(InPacket p, AnimatedMapObject target, int yOffset) {
+        Point beforePos = snapshotPosition(target);
         Point afterPos = readPositionWithOffset(p, yOffset);
         target.setPosition(afterPos);
         p.skip(8); // xwobble / ywobble / fh / ofh
         byte newstate = p.readByte();
         target.setStance(newstate);
         p.readShort(); // duration
+        recordRegularMove(target, beforePos, afterPos);
     }
 
     private static Point snapshotPosition(AnimatedMapObject target) {
@@ -309,5 +314,11 @@ public abstract class AbstractMovementPacketHandler extends AbstractPacketHandle
     private static void applyPositionAndStance(AnimatedMapObject target, Point position, byte newstate) {
         target.setPosition(position);
         target.setStance(newstate);
+    }
+
+    private static void recordRegularMove(AnimatedMapObject target, Point beforePos, Point afterPos) {
+        if (target instanceof Character chr) {
+            chr.markRegularMove(beforePos, afterPos);
+        }
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/InnerPortalHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/InnerPortalHandler.java
@@ -21,15 +21,34 @@
 */
 package org.gms.net.server.channel.handlers;
 
+import org.gms.client.Character;
 import org.gms.client.Client;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
+import org.gms.server.maps.Portal;
 
 /**
  * @author BubblesDev
  */
 public final class InnerPortalHandler extends AbstractPacketHandler {
+    // 玩家需要处在内传送门附近，才认为这是一次有效“树洞/内传送”触发
+    private static final double INNER_PORTAL_TRIGGER_DISTANCE_SQ = 90000.0; // 约 300 像素
+
     @Override
     public final void handlePacket(InPacket p, Client c) {
+        Character player = c.getPlayer();
+        if (player == null || player.getMap() == null) {
+            return;
+        }
+
+        // 防滥用：只有靠近真实内传送门时才打“瞬移”标记，避免任意发包获得距离豁免
+        Portal nearestTeleportPortal = player.getMap().findClosestTeleportPortal(player.getPosition());
+        if (nearestTeleportPortal == null) {
+            return;
+        }
+
+        if (nearestTeleportPortal.getPosition().distanceSq(player.getPosition()) <= INNER_PORTAL_TRIGGER_DISTANCE_SQ) {
+            player.markTeleportLikeMove();
+        }
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/InnerPortalHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/InnerPortalHandler.java
@@ -25,7 +25,10 @@ import org.gms.client.Character;
 import org.gms.client.Client;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
+import org.gms.server.maps.MapleMap;
 import org.gms.server.maps.Portal;
+
+import java.awt.Point;
 
 /**
  * @author BubblesDev
@@ -37,18 +40,81 @@ public final class InnerPortalHandler extends AbstractPacketHandler {
     @Override
     public final void handlePacket(InPacket p, Client c) {
         Character player = c.getPlayer();
-        if (player == null || player.getMap() == null) {
+        if (!isPlayerReady(player) || p.available() <= 0) {
             return;
         }
 
-        // 防滥用：只有靠近真实内传送门时才打“瞬移”标记，避免任意发包获得距离豁免
-        Portal nearestTeleportPortal = player.getMap().findClosestTeleportPortal(player.getPosition());
-        if (nearestTeleportPortal == null) {
+        String portalName = readPortalNameSafely(p);
+        if (portalName == null || portalName.isEmpty()) {
             return;
         }
 
-        if (nearestTeleportPortal.getPosition().distanceSq(player.getPosition()) <= INNER_PORTAL_TRIGGER_DISTANCE_SQ) {
-            player.markTeleportLikeMove();
+        Portal sourcePortal = resolveValidSourcePortal(player, portalName);
+        if (sourcePortal == null) {
+            return;
         }
+
+        Point playerPos = player.getPosition();
+        if (!isPlayerNearPortal(playerPos, sourcePortal)) {
+            return;
+        }
+
+        // 内传送仅处理“同图传送”；跨图传送交给常规换图流程，不记录本地传送上下文
+        if (!isSameMapInnerTeleport(player, sourcePortal)) {
+            return;
+        }
+
+        Portal targetPortal = resolveValidTargetPortal(player, sourcePortal);
+        if (targetPortal == null) {
+            return;
+        }
+
+        // 立即同步服务端坐标与可见对象状态，避免传送后首个攻击包仍使用旧坐标参与距离检测
+        Point beforePos = new Point(playerPos);
+        Point afterPos = new Point(targetPortal.getPosition());
+        movePlayerInMap(player, afterPos);
+        player.markTeleportLikeMove(beforePos, afterPos);
+    }
+
+    private static boolean isPlayerReady(Character player) {
+        return player != null && player.getMap() != null;
+    }
+
+    private static String readPortalNameSafely(InPacket p) {
+        // 协议通常会携带“当前触发的内传送门名”
+        try {
+            return p.readString();
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static Portal resolveValidSourcePortal(Character player, String portalName) {
+        Portal sourcePortal = player.getMap().getPortal(portalName);
+        if (sourcePortal == null || sourcePortal.getType() != Portal.TELEPORT_PORTAL) {
+            return null;
+        }
+        return sourcePortal;
+    }
+
+    private static boolean isPlayerNearPortal(Point playerPos, Portal portal) {
+        return playerPos != null && portal.getPosition().distanceSq(playerPos) <= INNER_PORTAL_TRIGGER_DISTANCE_SQ;
+    }
+
+    private static boolean isSameMapInnerTeleport(Character player, Portal sourcePortal) {
+        return sourcePortal.getTargetMapId() == player.getMapId();
+    }
+
+    private static Portal resolveValidTargetPortal(Character player, Portal sourcePortal) {
+        Portal targetPortal = player.getMap().getPortal(sourcePortal.getTarget());
+        if (targetPortal == null || targetPortal.getPosition() == null) {
+            return null;
+        }
+        return targetPortal;
+    }
+
+    private static void movePlayerInMap(Character player, Point afterPos) {
+        MapleMap map = player.getMap();
+        map.movePlayer(player, afterPos);
     }
 }

--- a/gms-server/src/main/java/org/gms/server/StatEffect.java
+++ b/gms-server/src/main/java/org/gms/server/StatEffect.java
@@ -1214,7 +1214,17 @@ public class StatEffect {
         }
     }
 
-    private Rectangle calculateBoundingBox(Point posFrom, boolean facingLeft) {
+    /**
+     * 技能是否定义了攻击/作用范围框。
+     */
+    public boolean hasBoundingBox() {
+        return lt != null && rb != null;
+    }
+
+    /**
+     * 根据角色当前位置和朝向，计算技能范围框在地图中的实际矩形。
+     */
+    public Rectangle calculateBoundingBox(Point posFrom, boolean facingLeft) {
         Point mylt;
         Point myrb;
         if (facingLeft) {

--- a/gms-server/src/main/java/org/gms/server/life/LifeFactory.java
+++ b/gms-server/src/main/java/org/gms/server/life/LifeFactory.java
@@ -87,6 +87,151 @@ public class LifeFactory {
         }
     }
 
+    private static final class BoundingBox {
+        private int minX = Integer.MAX_VALUE;
+        private int minY = Integer.MAX_VALUE;
+        private int maxX = Integer.MIN_VALUE;
+        private int maxY = Integer.MIN_VALUE;
+        private boolean valid = false;
+
+        /**
+         * 合并单帧的碰撞框到当前包围盒
+         *
+         * @param lt 单帧左上角
+         * @param rb 单帧右下角
+         */
+        public void update(Point lt, Point rb) {
+            if (lt == null || rb == null) {
+                return;
+            }
+            minX = Math.min(minX, lt.x);
+            minY = Math.min(minY, lt.y);
+            maxX = Math.max(maxX, rb.x);
+            maxY = Math.max(maxY, rb.y);
+            valid = true;
+        }
+
+        public boolean isValid() {
+            return valid;
+        }
+
+        public int getMinX() {
+            return minX;
+        }
+
+        public int getMinY() {
+            return minY;
+        }
+
+        public int getMaxX() {
+            return maxX;
+        }
+
+        public int getMaxY() {
+            return maxY;
+        }
+    }
+
+    /**
+     * 解析 UOL 引用，返回最终的数据节点
+     *
+     * @param data 原始数据节点
+     * @return 解析后的节点（可能与入参相同）
+     */
+    private static Data resolveUol(Data data) {
+        if (data == null) {
+            return null;
+        }
+        if (data.getType() == DataType.UOL) {
+            Object path = data.getData();
+            if (path instanceof String) {
+                Data resolved = data.getChildByPath((String) path);
+                if (resolved != null) {
+                    return resolved;
+                }
+            }
+        }
+        return data;
+    }
+
+    /**
+     * 判断动作名是否参与碰撞框计算
+     *
+     * @param name 动作名
+     * @return 是否参与
+     */
+    private static boolean isBboxAction(String name) {
+        return name.startsWith("stand") || name.startsWith("move") || name.startsWith("fly")
+                || name.startsWith("jump") || name.startsWith("attack") || name.startsWith("hit");
+    }
+
+    /**
+     * 计算怪物多动作帧的最大包围碰撞框
+     *
+     * @param mid       怪物 ID
+     * @param mobName   怪物名称
+     * @param monsterData 怪物数据根节点
+     * @return 最大包围碰撞框
+     */
+    private static BoundingBox buildMonsterBoundingBox(int mid, String mobName, Data monsterData) {
+        BoundingBox bbox = new BoundingBox();
+        int actionCount = 0;
+        int frameCount = 0;
+        int frameWithLtRb = 0;
+        int frameFallback = 0;
+        int frameSkipped = 0;
+        for (Data action : monsterData.getChildren()) {
+            String actionName = action.getName();
+            if (actionName.equals("info") || actionName.startsWith("die") || !isBboxAction(actionName)) {
+                continue;
+            }
+            // 处理 UOL 指向的动作节点
+            Data actionData = resolveUol(action);
+            if (actionData == null) {
+                continue;
+            }
+            actionCount++;
+            for (Data frame : actionData.getChildren()) {
+                // 处理 UOL 指向的帧节点
+                Data frameData = resolveUol(frame);
+                if (frameData == null || frameData.getType() != DataType.CANVAS) {
+                    frameSkipped++;
+                    continue;
+                }
+                frameCount++;
+                Point lt = DataTool.getPoint("lt", frameData, null);
+                Point rb = DataTool.getPoint("rb", frameData, null);
+                boolean usedFallback = false;
+                Point origin = null;
+                int width = -1;
+                int height = -1;
+                if (lt == null || rb == null) {
+                    // lt/rb 缺失时，使用 origin + 宽高推算
+                    origin = DataTool.getPoint("origin", frameData, null);
+                    width = DataTool.getAttributeValueInt(frameData, "width", -1);
+                    height = DataTool.getAttributeValueInt(frameData, "height", -1);
+                    if (origin != null && width > 0 && height > 0) {
+                        lt = new Point(-origin.x, -origin.y);
+                        rb = new Point(width - origin.x, height - origin.y);
+                        usedFallback = true;
+                    }
+                }
+                if (lt != null && rb != null) {
+                    if (usedFallback) {
+                        frameFallback++;
+                    } else {
+                        frameWithLtRb++;
+                    }
+                } else {
+                    frameSkipped++;
+                }
+                // 合并到整体包围框
+                bbox.update(lt, rb);
+            }
+        }
+        return bbox;
+    }
+
     private static void setMonsterAttackInfo(int mid, List<MobAttackInfoHolder> attackInfos) {
         if (!attackInfos.isEmpty()) {
             MonsterInformationProvider mi = MonsterInformationProvider.getInstance();
@@ -260,6 +405,19 @@ public class LifeFactory {
                 stats.setImgheight(DataTool.getAttributeValueInt(stand,"height",-1));
             }
 
+        }
+        // 计算怪物碰撞框（多动作帧合并），用于后续距离判定和大体型识别
+        BoundingBox bbox = buildMonsterBoundingBox(mid, stats.getName(), monsterData);
+        if (bbox.isValid()) {
+            stats.setBbox(bbox.getMinX(), bbox.getMinY(), bbox.getMaxX(), bbox.getMaxY());
+        } else {
+            Point origin = DataTool.getPoint("stand/0/origin", monsterData, null);
+            if (origin == null) {
+                origin = DataTool.getPoint("fly/0/origin", monsterData, null);
+            }
+            if (origin != null && stats.getImgwidth() > 0 && stats.getImgheight() > 0) {
+                stats.setBbox(-origin.x, -origin.y, stats.getImgwidth() - origin.x, stats.getImgheight() - origin.y);
+            }
         }
         return new Pair<>(stats, attackInfos);
     }

--- a/gms-server/src/main/java/org/gms/server/life/LifeFactory.java
+++ b/gms-server/src/main/java/org/gms/server/life/LifeFactory.java
@@ -232,6 +232,125 @@ public class LifeFactory {
         return bbox;
     }
 
+    /**
+     * 读取指定怪物的 WZ 根节点。
+     */
+    private static Data getMonsterData(int mid) {
+        return data.getData(StringUtil.getLeftPaddedStr(mid + ".img", '0', 11));
+    }
+
+    /**
+     * 解析当前怪物真正应当用于可视判定的数据节点。
+     *
+     * <p>部分怪物只保留自身属性，动作帧、lt/rb、origin 等视觉信息全部挂在 link 怪身上。
+     * 如果这里不沿着 link 查找，后续 bbox 会退化为“没有碰撞数据”，DISTANCE_HACK 就会误判。</p>
+     */
+    private static Data resolveMonsterVisualData(int mid, Data monsterData) {
+        if (monsterData == null) {
+            return null;
+        }
+
+        Set<Integer> visitedMobs = new HashSet<>();
+        Data currentMonsterData = monsterData;
+        int currentMid = mid;
+        while (currentMonsterData != null && visitedMobs.add(currentMid)) {
+            if (hasVisualBoundingBoxSource(currentMonsterData)) {
+                return currentMonsterData;
+            }
+
+            Data currentInfoData = currentMonsterData.getChildByPath("info");
+            int linkMid = currentInfoData == null ? 0 : DataTool.getIntConvert("link", currentInfoData, 0);
+            if (linkMid == 0) {
+                break;
+            }
+
+            currentMonsterData = getMonsterData(linkMid);
+            currentMid = linkMid;
+        }
+        return monsterData;
+    }
+
+    /**
+     * 判断一个怪物节点是否已经具备可用于距离判定的视觉来源。
+     *
+     * <p>只要存在主可视帧，或者任意动作帧能解析出 bbox，即视为可用。</p>
+     */
+    private static boolean hasVisualBoundingBoxSource(Data monsterData) {
+        if (monsterData == null) {
+            return false;
+        }
+        if (resolvePrimaryVisualFrame(monsterData) != null) {
+            return true;
+        }
+        return buildMonsterBoundingBox(0, "", monsterData).isValid();
+    }
+
+    /**
+     * 获取怪物的主可视帧。
+     *
+     * <p>保持与原逻辑一致，优先使用 fly/0，其次 stand/0。</p>
+     */
+    private static Data resolvePrimaryVisualFrame(Data monsterData) {
+        if (monsterData == null) {
+            return null;
+        }
+
+        Data flyFrame = resolveVisualFrame(monsterData.getChildByPath("fly/0"));
+        if (flyFrame != null) {
+            return flyFrame;
+        }
+        return resolveVisualFrame(monsterData.getChildByPath("stand/0"));
+    }
+
+    /**
+     * 将帧节点解析到最终的 Canvas 节点。
+     */
+    private static Data resolveVisualFrame(Data frameData) {
+        Data resolvedFrame = resolveUol(frameData);
+        if (resolvedFrame == null || resolvedFrame.getType() != DataType.CANVAS) {
+            return null;
+        }
+        return resolvedFrame;
+    }
+
+    /**
+     * 从最终视觉来源中回填怪物图片尺寸、移动类型和碰撞框。
+     */
+    private static void applyMonsterVisualStats(int mid, MonsterStats stats, Data visualMonsterData) {
+        if (stats == null || visualMonsterData == null) {
+            return;
+        }
+
+        Data flyFrame = resolveVisualFrame(visualMonsterData.getChildByPath("fly/0"));
+        Data standFrame = resolveVisualFrame(visualMonsterData.getChildByPath("stand/0"));
+        Data primaryFrame = flyFrame != null ? flyFrame : standFrame;
+
+        if (flyFrame != null) {
+            stats.setMovetype(1);
+            stats.setImgwidth(DataTool.getAttributeValueInt(flyFrame, "width", -1));
+            stats.setImgheight(DataTool.getAttributeValueInt(flyFrame, "height", -1));
+        } else if (standFrame != null) {
+            stats.setMovetype(0);
+            stats.setImgwidth(DataTool.getAttributeValueInt(standFrame, "width", -1));
+            stats.setImgheight(DataTool.getAttributeValueInt(standFrame, "height", -1));
+        }
+
+        BoundingBox bbox = buildMonsterBoundingBox(mid, stats.getName(), visualMonsterData);
+        if (bbox.isValid()) {
+            stats.setBbox(bbox.getMinX(), bbox.getMinY(), bbox.getMaxX(), bbox.getMaxY());
+            return;
+        }
+
+        if (primaryFrame == null) {
+            return;
+        }
+
+        Point origin = DataTool.getPoint("origin", primaryFrame, null);
+        if (origin != null && stats.getImgwidth() > 0 && stats.getImgheight() > 0) {
+            stats.setBbox(-origin.x, -origin.y, stats.getImgwidth() - origin.x, stats.getImgheight() - origin.y);
+        }
+    }
+
     private static void setMonsterAttackInfo(int mid, List<MobAttackInfoHolder> attackInfos) {
         if (!attackInfos.isEmpty()) {
             MonsterInformationProvider mi = MonsterInformationProvider.getInstance();
@@ -244,7 +363,7 @@ public class LifeFactory {
     }
 
     private static Pair<MonsterStats, List<MobAttackInfoHolder>> getMonsterStats(int mid) {
-        Data monsterData = data.getData(StringUtil.getLeftPaddedStr(mid + ".img", '0', 11));
+        Data monsterData = getMonsterData(mid);
         if (monsterData == null) {
             return null;
         }
@@ -381,15 +500,22 @@ public class LifeFactory {
             stats.setBanishInfo(new BanishInfo(DataTool.getString("banMsg", banishData), DataTool.getInt("banMap/0/field", banishData, -1), DataTool.getString("banMap/0/portal", banishData, "sp")));
         }
 
+        Data visualMonsterData = resolveMonsterVisualData(mid, monsterData);
         int noFlip = DataTool.getInt("noFlip", monsterInfoData, 0);
         if (noFlip > 0) {
-            Point origin = DataTool.getPoint("stand/0/origin", monsterData, null);
+            Data fixedStanceFrame = resolveVisualFrame(visualMonsterData.getChildByPath("stand/0"));
+            if (fixedStanceFrame == null) {
+                fixedStanceFrame = resolvePrimaryVisualFrame(visualMonsterData);
+            }
+            Point origin = fixedStanceFrame == null ? null : DataTool.getPoint("origin", fixedStanceFrame, null);
             if (origin != null) {
                 stats.setFixedStance(origin.getX() < 1 ? 5 : 4);    // fixed left/right
             }
         }
+        // 统一从最终视觉来源回填尺寸与碰撞框，避免 link 怪重复走本地旧逻辑。
+        applyMonsterVisualStats(mid, stats, visualMonsterData);
+        /* 已废弃：以下旧的本地 visual 解析路径仅作留档，当前统一走上面的 link 可视数据解析。
         Data fly = monsterData.getChildByPath("fly/0");
-        Data stand = monsterData.getChildByPath("stand/0");
         if (fly != null) {
             stats.setMovetype(1);   //设定怪物类型为：fly
             fly = fly.getType() == DataType.UOL ? fly.getChildByPath((String) fly.getData()) : fly;  //呼叫转移...
@@ -419,6 +545,7 @@ public class LifeFactory {
                 stats.setBbox(-origin.x, -origin.y, stats.getImgwidth() - origin.x, stats.getImgheight() - origin.y);
             }
         }
+        */
         return new Pair<>(stats, attackInfos);
     }
 

--- a/gms-server/src/main/java/org/gms/server/life/MonsterStats.java
+++ b/gms-server/src/main/java/org/gms/server/life/MonsterStats.java
@@ -57,6 +57,11 @@ public class MonsterStats {
     public int movetype = -1;    //怪物类型，-1=未知，0=stand（陆地），1=fly（飞天）
     public int imgwidth = 0;     //第一帧图片宽度
     public int imgheight = 0;    //第一帧图片高度
+    public int bboxMinX = 0;
+    public int bboxMinY = 0;
+    public int bboxMaxX = 0;
+    public int bboxMaxY = 0;
+    public boolean bboxValid = false;
 
     public void setChange(boolean change) {
         this.changeable = change;
@@ -392,6 +397,85 @@ public class MonsterStats {
      */
     public int getImgheight() {
         return this.imgheight;
+    }
+
+    /**
+     * 设置怪物碰撞框（相对 origin 的 lt/rb）
+     */
+    public void setBbox(int minX, int minY, int maxX, int maxY) {
+        this.bboxMinX = minX;
+        this.bboxMinY = minY;
+        this.bboxMaxX = maxX;
+        this.bboxMaxY = maxY;
+        this.bboxValid = true;
+    }
+
+    /**
+     * 是否已计算碰撞框
+     */
+    public boolean hasBbox() {
+        return bboxValid;
+    }
+
+    /**
+     * 碰撞框相对 lt.x
+     */
+    public int getBboxMinX() {
+        return bboxMinX;
+    }
+
+    /**
+     * 碰撞框相对 lt.y
+     */
+    public int getBboxMinY() {
+        return bboxMinY;
+    }
+
+    /**
+     * 碰撞框相对 rb.x
+     */
+    public int getBboxMaxX() {
+        return bboxMaxX;
+    }
+
+    /**
+     * 碰撞框相对 rb.y
+     */
+    public int getBboxMaxY() {
+        return bboxMaxY;
+    }
+
+    /**
+     * 碰撞框宽度（相对值）
+     */
+    public int getBboxWidth() {
+        if (bboxValid) {
+            return Math.max(0, bboxMaxX - bboxMinX);
+        }
+        return imgwidth;
+    }
+
+    /**
+     * 碰撞框高度（相对值）
+     */
+    public int getBboxHeight() {
+        if (bboxValid) {
+            return Math.max(0, bboxMaxY - bboxMinY);
+        }
+        return imgheight;
+    }
+
+    /**
+     * 大体型判定：用于决定是否启用碰撞框距离检测
+     */
+    public boolean isLargeSize() {
+        int width = getBboxWidth();
+        int height = getBboxHeight();
+        if (width <= 0 || height <= 0) {
+            return false;
+        }
+        // 宽高或面积满足阈值即可视为大体型
+        return width >= 160 || height >= 160 || width * height >= 25000;
     }
 
     public MonsterStats copy() {


### PR DESCRIPTION
根据计算实际碰撞体积，判断玩家的攻击距离是否过远用来检测全屏攻击外挂