### PR TITLE
fix: 修复在线时长bug

### DIFF
--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -91,6 +91,7 @@ import org.slf4j.LoggerFactory;
 import java.awt.*;
 import java.lang.ref.WeakReference;
 import java.sql.*;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.*;
 import java.util.Map.Entry;
@@ -9822,19 +9823,103 @@ public class Character extends AbstractCharacterObject {
 
     /////////////////////////////////////////////////////////////////////////////////
     //module: 角色在线时间
+    private static final String DAILY_ONLINE_TIME_EXTEND_NAME = "每日在线时间";
+    private static final int ONLINE_TIME_TICK_SECONDS = 5;
+    private static final int MAX_DAILY_ONLINE_TIME_SECONDS = 24 * 60 * 60;
+
     private int m_iCurrentOnlineTime = -1;//-1用于服务器重启时角色初始变量时间
+    private LocalDate m_dCurrentOnlineDate;
 
-    public int getCurrentOnlineTime() {
-        return this.m_iCurrentOnlineTime;
+    public synchronized int getCurrentOnlineTime() {
+        return Math.max(this.m_iCurrentOnlineTime, 0);
     }
 
-    public void setCurrentOnlineTime(final int iTime) {
-        this.m_iCurrentOnlineTime = iTime;
+    public synchronized void setCurrentOnlineTime(final int iTime) {
+        applyOnlineTimeState(LocalDate.now(), iTime);
     }
 
-    public void updateOnlineTime() {
-        String strNewOnlineTime = String.valueOf(m_iCurrentOnlineTime);
-        getAbstractPlayerInteraction().saveOrUpdateAccountExtendValue("每日在线时间", strNewOnlineTime, true);
+    /**
+     * 登录后同步初始化今日在线时长，避免首次定时任务执行前仍保留 -1 或上一天的值。
+     */
+    public synchronized void initOnlineTimeForToday() {
+        LocalDate today = LocalDate.now();
+        applyOnlineTimeState(today, loadOnlineTimeForDate(today));
+    }
+
+    /**
+     * 定时任务统一从这里推进在线时长，跨天时只做归零，不再把昨天的值继续累加到今天。
+     */
+    public synchronized void tickOnlineTime() {
+        LocalDate today = LocalDate.now();
+        if (!isOnlineTimeInitialized()) {
+            applyOnlineTimeState(today, loadOnlineTimeForDate(today));
+            return;
+        }
+        if (!today.equals(m_dCurrentOnlineDate)) {
+            applyOnlineTimeState(today, 0);
+            return;
+        }
+        applyOnlineTimeState(today, m_iCurrentOnlineTime + ONLINE_TIME_TICK_SECONDS);
+    }
+
+    /**
+     * 退出时只允许写入“今天且合法”的在线时长，避免把 -1 或跨天残留值写回每日扩展表。
+     */
+    public synchronized void updateOnlineTime() {
+        LocalDate today = LocalDate.now();
+        int safeOnlineTime = resolvePersistedOnlineTime(today);
+        applyOnlineTimeState(today, safeOnlineTime);
+        getAbstractPlayerInteraction().saveOrUpdateAccountExtendValue(DAILY_ONLINE_TIME_EXTEND_NAME, String.valueOf(safeOnlineTime), true);
+    }
+
+    private boolean isOnlineTimeInitialized() {
+        return m_dCurrentOnlineDate != null && m_iCurrentOnlineTime >= 0;
+    }
+
+    private int resolvePersistedOnlineTime(LocalDate targetDate) {
+        if (targetDate.equals(m_dCurrentOnlineDate)) {
+            return normalizeOnlineTime(m_iCurrentOnlineTime);
+        }
+        // 当前内存值如果不属于今天，优先回读今天的库值，避免旧角色把昨天的数据覆盖到今天。
+        return loadOnlineTimeForDate(targetDate);
+    }
+
+    private int loadOnlineTimeForDate(LocalDate targetDate) {
+        ExtendValueDO extendValueDO = ExtendUtil.getExtendValue(String.valueOf(getAccountId()), ExtendType.ACCOUNT_EXTEND_DAILY.getType(), DAILY_ONLINE_TIME_EXTEND_NAME);
+        if (!isOnlineTimeRecordForDate(extendValueDO, targetDate)) {
+            return 0;
+        }
+        return parseOnlineTime(extendValueDO.getExtendValue());
+    }
+
+    private boolean isOnlineTimeRecordForDate(ExtendValueDO extendValueDO, LocalDate targetDate) {
+        if (extendValueDO == null || extendValueDO.getCreateTime() == null) {
+            return false;
+        }
+        return extendValueDO.getCreateTime().toLocalDate().isEqual(targetDate);
+    }
+
+    private int parseOnlineTime(String onlineTimeValue) {
+        if (onlineTimeValue == null || onlineTimeValue.isEmpty()) {
+            return 0;
+        }
+        try {
+            return normalizeOnlineTime(Integer.parseInt(onlineTimeValue));
+        } catch (NumberFormatException ignore) {
+            return 0;
+        }
+    }
+
+    private int normalizeOnlineTime(int onlineTime) {
+        if (onlineTime < 0 || onlineTime > MAX_DAILY_ONLINE_TIME_SECONDS) {
+            return 0;
+        }
+        return onlineTime;
+    }
+
+    private void applyOnlineTimeState(LocalDate targetDate, int onlineTime) {
+        m_dCurrentOnlineDate = targetDate;
+        m_iCurrentOnlineTime = normalizeOnlineTime(onlineTime);
     }
 
     /**

--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -9866,10 +9866,21 @@ public class Character extends AbstractCharacterObject {
      * 退出时只允许写入“今天且合法”的在线时长，避免把 -1 或跨天残留值写回每日扩展表。
      */
     public synchronized void updateOnlineTime() {
-        LocalDate today = LocalDate.now();
-        int safeOnlineTime = resolvePersistedOnlineTime(today);
-        applyOnlineTimeState(today, safeOnlineTime);
-        getAbstractPlayerInteraction().saveOrUpdateAccountExtendValue(DAILY_ONLINE_TIME_EXTEND_NAME, String.valueOf(safeOnlineTime), true);
+        syncOnlineTimeToDailyRecord();
+    }
+
+    /**
+     * 将当前在线时长同步到每日扩展值。
+     */
+    public synchronized void syncOnlineTimeToDailyRecord() {
+        persistOnlineTimeForDate(LocalDate.now());
+    }
+
+    /**
+     * 会话迁移前先同步在线时长。
+     */
+    public synchronized void syncOnlineTimeBeforeSessionTransition() {
+        syncOnlineTimeToDailyRecord();
     }
 
     private boolean isOnlineTimeInitialized() {
@@ -9915,6 +9926,15 @@ public class Character extends AbstractCharacterObject {
             return 0;
         }
         return onlineTime;
+    }
+
+    /**
+     * 将指定日期的在线时长同时同步到角色内存与每日扩展值。
+     */
+    private void persistOnlineTimeForDate(LocalDate targetDate) {
+        int safeOnlineTime = resolvePersistedOnlineTime(targetDate);
+        applyOnlineTimeState(targetDate, safeOnlineTime);
+        getAbstractPlayerInteraction().saveOrUpdateAccountExtendValue(DAILY_ONLINE_TIME_EXTEND_NAME, String.valueOf(safeOnlineTime), true);
     }
 
     private void applyOnlineTimeState(LocalDate targetDate, int onlineTime) {

--- a/gms-server/src/main/java/org/gms/client/Client.java
+++ b/gms-server/src/main/java/org/gms/client/Client.java
@@ -1535,6 +1535,9 @@ public class Client extends ChannelInboundHandlerAdapter {
         player.clearBanishPlayerData();
         player.getClient().getChannelServer().removePlayer(player);
 
+        // 切换频道后会重新登录频道服。
+        // 这里必须先同步在线时长，避免新会话用旧库值覆盖当前进度。
+        player.syncOnlineTimeBeforeSessionTransition();
         player.saveCharToDB();
 
         /*

--- a/gms-server/src/main/java/org/gms/client/command/commands/gm6/SaveAllCommand.java
+++ b/gms-server/src/main/java/org/gms/client/command/commands/gm6/SaveAllCommand.java
@@ -43,6 +43,8 @@ public class SaveAllCommand extends Command {
         Character player = c.getPlayer();
         for (World world : Server.getInstance().getWorlds()) {
             for (Character chr : world.getPlayerStorage().getAllCharacters()) {
+                // 手动全量存档时同步在线时长，避免只保存角色数据却遗漏每日在线时长。
+                chr.syncOnlineTimeToDailyRecord();
                 chr.saveCharToDB();
             }
         }

--- a/gms-server/src/main/java/org/gms/client/command/commands/gm6/WarpWorldCommand.java
+++ b/gms-server/src/main/java/org/gms/client/command/commands/gm6/WarpWorldCommand.java
@@ -53,6 +53,9 @@ public class WarpWorldCommand extends Command {
                 String[] socket = server.getInetSocket(c, worldb, c.getChannel());
                 c.getWorldServer().removePlayer(player);
                 player.getMap().removePlayer(player);//LOL FORGOT THIS ><
+                // 跨世界会重新加载角色对象。
+                // 先同步在线时长，避免回流时使用旧库值。
+                player.syncOnlineTimeBeforeSessionTransition();
                 player.setSessionTransitionState();
                 player.setWorld(worldb);
                 player.saveCharToDB();//To set the new world :O (true because else 2 player instances are created, one in both worlds)

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/EnterCashShopHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/EnterCashShopHandler.java
@@ -94,6 +94,9 @@ public class EnterCashShopHandler extends AbstractPacketHandler {
             c.getChannelServer().removePlayer(mc);
             mc.getMap().removePlayer(mc);
             mc.getCashShop().open(true);
+            // 进入商城不会走完整断线流程。
+            // 返回频道后会重新初始化在线时长，先落库可以避免被旧值覆盖。
+            mc.syncOnlineTimeBeforeSessionTransition();
             mc.saveCharToDB();
         } catch (Exception e) {
             e.printStackTrace();

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/EnterMTSHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/EnterMTSHandler.java
@@ -103,6 +103,9 @@ public final class EnterMTSHandler extends AbstractPacketHandler {
         chr.forfeitExpirableQuests();
         chr.cancelQuestExpirationTask();
 
+        // 进入 MTS 与进入商城同理。
+        // 后续回频道会重新初始化在线时长，必须先同步当前进度。
+        chr.syncOnlineTimeBeforeSessionTransition();
         chr.saveCharToDB();
 
         c.getChannelServer().removePlayer(chr);

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/PlayerLoggedinHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/PlayerLoggedinHandler.java
@@ -224,6 +224,8 @@ public final class PlayerLoggedinHandler extends AbstractPacketHandler {
                 c.setCharacterSlots((byte) player.getClient().getCharacterSlots());
                 player.newClient(c);
             }
+            // 登录阶段先同步初始化今日在线时长，避免首次定时任务前出现 -1 或沿用上一天的值。
+            player.initOnlineTimeForToday();
 
             // 增加参数判断，避免给客户端发未知包导致异常
             if (GameConfig.getServerBoolean("use_server_auto_pot")) {

--- a/gms-server/src/main/java/org/gms/net/server/task/CharacterAutosaverTask.java
+++ b/gms-server/src/main/java/org/gms/net/server/task/CharacterAutosaverTask.java
@@ -47,6 +47,8 @@ public class CharacterAutosaverTask extends BaseTask implements Runnable {  // t
         PlayerStorage ps = wserv.getPlayerStorage();
         for (Character chr : ps.getAllCharacters()) {
             if (chr != null && chr.isLoggedIn()) {
+                // 自动存档时一并同步在线时长，降低异常停服后每日在线时长大幅回退的概率。
+                chr.syncOnlineTimeToDailyRecord();
                 chr.saveCharToDB(false);
             }
         }

--- a/gms-server/src/main/java/org/gms/net/server/task/OnlineTimeTask.java
+++ b/gms-server/src/main/java/org/gms/net/server/task/OnlineTimeTask.java
@@ -4,19 +4,12 @@ import org.gms.client.Character;
 import org.gms.net.server.Server;
 import org.gms.net.server.channel.Channel;
 
-import java.time.LocalDate;
-import java.util.concurrent.atomic.AtomicReference;
-
 public class OnlineTimeTask implements Runnable {
-    private final AtomicReference<LocalDate> lastUpdated = new AtomicReference<>(LocalDate.now());
-
     @Override
     public void run() {
         if (!Server.getInstance().isOnline()) {
             return;
         }
-        LocalDate now = LocalDate.now();
-        boolean isNextDay = now.isAfter(lastUpdated.get());
         for (final Channel chan : Server.getInstance().getAllChannels()) {
             if (chan == null || chan.getPlayerStorage() == null) {
                 continue;
@@ -25,19 +18,9 @@ public class OnlineTimeTask implements Runnable {
                 if (chr == null) {
                     continue;
                 }
-                int onlineTime = chr.getCurrentOnlineTime();
-                if (onlineTime == -1) {
-                    String timeStr = chr.getAbstractPlayerInteraction().getAccountExtendValue("每日在线时间", true);
-                    onlineTime = timeStr == null ? 0 : Integer.parseInt(timeStr);
-                } else {
-                    onlineTime += 5;
-                }
-                if (isNextDay || onlineTime < 0) {
-                    onlineTime = 0;
-                }
-                chr.setCurrentOnlineTime(onlineTime);
+                // 在线时长的初始化、跨日归零和递增都统一收口到角色对象内部，避免任务层重复散落判断。
+                chr.tickOnlineTime();
             }
         }
-        lastUpdated.set(now);
     }
 }


### PR DESCRIPTION
  本次 online-time-only 升级仅聚焦“在线时长”功能，不包含其他玩法或脚本改动，目标是提升在线时长统计在切场景、切服、跨日等场景下的准确性与稳定性。

  ### 核心改动

  1. 修复小退后今日在线时长清零、跨日累计异常问题。
  2. 登录阶段同步初始化今日在线时长，避免使用旧值覆盖当前值。
  3. 统一封装在线时长初始化、递增、写库逻辑，防止 -1 或跨天残留值回写。
  4. 修复今日在线时长异常超过 24 小时的问题。
  5. 修复会话迁移（商城、MTS、换频道、跨世界）前未及时同步在线时长导致的回档。
  6. 为自动存档与 SaveAll 增加在线时长同步，降低异常场景下的数据丢失风险。

  ### 影响范围

  - 在线时长计时与每日在线数据写入链路
  - 登录流程、在线定时任务
  - 换频道/跨世界/进入商城与MTS等会话迁移流程
  - 自动存档与GM批量保存流程

  ### 升级收益

  - 今日在线时长更准确
  - 跨场景操作不再导致时长回退或清零
  - 跨日切换更稳定，异常值明显减少
  - 在线奖励、日常统计类功能的数据基础更可靠
