### PR TITLE
fix: 修复宠物过滤配置清空与残留数据问题

### DIFF
--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -2812,6 +2812,10 @@ public class Character extends AbstractCharacterObject {
                                 }
 
                                 if (ItemConstants.isExpirablePet(item.getItemId())) {
+                                    if (item.getPetId() > -1) {
+                                        // 宠物道具真正过期销毁时，同时清理 pets/petignores，避免数据库残留孤儿数据。
+                                        Pet.deleteFromDb(this, item.getPetId());
+                                    }
                                     sendPacket(PacketCreator.itemExpired(item.getItemId()));
                                     toberemove.add(item);
                                 } else {
@@ -4423,6 +4427,82 @@ public class Character extends AbstractCharacterObject {
         chrLock.lock();
         try {
             excluded.get(petId).add(x);
+        } finally {
+            chrLock.unlock();
+        }
+    }
+
+    /**
+     * 统一从数据库加载单只宠物的过滤配置，确保召唤时内存状态与数据库保持一致。
+     */
+    public void loadPetExcludedItems(int petId) {
+        List<Integer> excludedItemIds = inventoryService.getPetIgnoreByPetId(petId).stream()
+                .map(PetignoresDO::getItemid)
+                .filter(Objects::nonNull)
+                .toList();
+        replacePetExcludedItemsInMemory(petId, excludedItemIds);
+    }
+
+    /**
+     * 客户端提交过滤设置时，直接按差异增量更新数据库，避免角色保存时再做危险的全量删写。
+     */
+    public void updatePetExcludedItems(int petId, Set<Integer> newExcludedItems) {
+        Set<Integer> currentExcludedItems = getExcludedForPet(petId);
+        Set<Integer> normalizedExcludedItems = new LinkedHashSet<>(newExcludedItems);
+
+        Set<Integer> toAdd = new LinkedHashSet<>(normalizedExcludedItems);
+        toAdd.removeAll(currentExcludedItems);
+
+        Set<Integer> toRemove = new LinkedHashSet<>(currentExcludedItems);
+        toRemove.removeAll(normalizedExcludedItems);
+
+        inventoryService.addPetIgnoreItems(petId, toAdd);
+        inventoryService.removePetIgnoreItems(petId, toRemove);
+        replacePetExcludedItemsInMemory(petId, normalizedExcludedItems);
+    }
+
+    /**
+     * 宠物被永久删除时同步清理数据库和角色内存中的过滤配置，避免残留脏数据。
+     */
+    public void deletePetExcludedData(int petId) {
+        inventoryService.deletePetData(petId);
+        removeExcluded(petId);
+    }
+
+    public Set<Integer> getExcludedForPet(int petId) {
+        chrLock.lock();
+        try {
+            Set<Integer> petExcludedItems = excluded.get(petId);
+            if (petExcludedItems == null) {
+                return Collections.emptySet();
+            }
+            return Collections.unmodifiableSet(new LinkedHashSet<>(petExcludedItems));
+        } finally {
+            chrLock.unlock();
+        }
+    }
+
+    private void replacePetExcludedItemsInMemory(int petId, Collection<Integer> itemIds) {
+        chrLock.lock();
+        try {
+            excluded.remove(petId);
+            if (itemIds != null && !itemIds.isEmpty()) {
+                LinkedHashSet<Integer> normalizedItems = itemIds.stream()
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+                if (!normalizedItems.isEmpty()) {
+                    excluded.put(petId, normalizedItems);
+                }
+            }
+        } finally {
+            chrLock.unlock();
+        }
+    }
+
+    private void removeExcluded(int petId) {
+        chrLock.lock();
+        try {
+            excluded.remove(petId);
         } finally {
             chrLock.unlock();
         }
@@ -6308,8 +6388,8 @@ public class Character extends AbstractCharacterObject {
                     Pet pet = item.getPet();
                     if (pet != null && pet.isSummoned()) {
                         chr.addPet(pet);
-                        chr.resetExcluded(item.getPetId());
-                        inventoryService.getPetIgnoreByPetId(item.getPetId()).forEach(petignoresDO -> chr.addExcluded(petignoresDO.getPetid(), petignoresDO.getItemid()));
+                        // 登录时对已召唤宠物统一走同一套过滤配置加载逻辑，避免后续入口行为不一致。
+                        chr.loadPetExcludedItems(item.getPetId());
                     }
                     continue;
                 }
@@ -7528,22 +7608,6 @@ public class Character extends AbstractCharacterObject {
 
                 for (Pet pet : petList) {
                     pet.saveToDb();
-                }
-
-                for (Entry<Integer, Set<Integer>> es : getExcluded().entrySet()) {    // this set is already protected
-                    try (PreparedStatement psIgnore = con.prepareStatement("DELETE FROM petignores WHERE petid=?")) {
-                        psIgnore.setInt(1, es.getKey());
-                        psIgnore.executeUpdate();
-                    }
-
-                    try (PreparedStatement psIgnore = con.prepareStatement("INSERT INTO petignores (petid, itemid) VALUES (?, ?)")) {
-                        psIgnore.setInt(1, es.getKey());
-                        for (Integer x : es.getValue()) {
-                            psIgnore.setInt(2, x);
-                            psIgnore.addBatch();
-                        }
-                        psIgnore.executeBatch();
-                    }
                 }
 
                 // Key config

--- a/gms-server/src/main/java/org/gms/client/inventory/Pet.java
+++ b/gms-server/src/main/java/org/gms/client/inventory/Pet.java
@@ -97,14 +97,11 @@ public class Pet extends Item {
     }
 
     public static void deleteFromDb(Character owner, int petid) {
-        try (Connection con = DatabaseConnection.getConnection();
-             PreparedStatement ps = con.prepareStatement("DELETE FROM pets WHERE `petid` = ?")) {
-            // thanks Vcoc for detecting petignores remaining after deletion
-            ps.setInt(1, petid);
-
-            owner.resetExcluded(petid);
+        try {
+            // 宠物基础数据删除后，petignores 会通过外键级联清理，这里同步移除角色内存中的缓存。
+            owner.deletePetExcludedData(petid);
             CashIdGenerator.freeCashId(petid);
-        } catch (SQLException ex) {
+        } catch (Exception ex) {
             ex.printStackTrace();
         }
     }

--- a/gms-server/src/main/java/org/gms/client/processor/action/SpawnPetProcessor.java
+++ b/gms-server/src/main/java/org/gms/client/processor/action/SpawnPetProcessor.java
@@ -86,6 +86,8 @@ public class SpawnPetProcessor {
                     pet.setSummoned(true);
                     pet.saveToDb();
                     chr.addPet(pet);
+                    // 登录时未召唤的宠物不会预加载过滤配置，这里补载后再同步给客户端。
+                    chr.loadPetExcludedItems(pet.getUniqueId());
                     chr.getMap().broadcastMessage(c.getPlayer(), PacketCreator.showPet(c.getPlayer(), pet, false, false), true);
                     c.sendPacket(PacketCreator.petStatUpdate(c.getPlayer()));
                     c.sendPacket(PacketCreator.enableActions());

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/PetExcludeItemsHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/PetExcludeItemsHandler.java
@@ -28,6 +28,9 @@ import org.gms.client.inventory.Pet;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 /**
  * @author BubblesDev
  * @author Ronan
@@ -50,17 +53,21 @@ public final class PetExcludeItemsHandler extends AbstractPacketHandler {
             return;
         }
 
-        chr.resetExcluded(petId);
+        Set<Integer> newExcludedItems = new LinkedHashSet<>();
         byte amount = p.readByte();
         for (int i = 0; i < amount; i++) {
             int itemId = p.readInt();
             if (itemId >= 0) {
-                chr.addExcluded(petId, itemId);
+                newExcludedItems.add(itemId);
             } else {
                 AutobanFactory.PACKET_EDIT.alert(chr, "negative item id value in PetExcludeItemsHandler (" + itemId + ")");
                 return;
             }
         }
+
+        // 客户端会提交完整过滤列表，这里先确保旧配置已加载，再按差异增量更新数据库和内存。
+        chr.loadPetExcludedItems(petId);
+        chr.updatePetExcludedItems(petId, newExcludedItems);
         chr.commitExcludedItems();
     }
 }

--- a/gms-server/src/main/java/org/gms/service/InventoryService.java
+++ b/gms-server/src/main/java/org/gms/service/InventoryService.java
@@ -379,6 +379,54 @@ public class InventoryService {
         return petignoresMapper.selectListByQuery(QueryWrapper.create().where(PETIGNORES_D_O.PETID.eq(petId)));
     }
 
+        /**
+     * 添加宠物忽略物品列表
+     *
+     * @param petId 宠物 ID
+     * @param itemIds 物品 ID 集合，将添加到宠物的忽略列表中
+     */
+    public void addPetIgnoreItems(Integer petId, Collection<Integer> itemIds) {
+        if (petId == null || itemIds == null || itemIds.isEmpty()) {
+            return;
+        }
+        for (Integer itemId : itemIds) {
+            petignoresMapper.insertSelective(PetignoresDO.builder()
+                    .petid(petId)
+                    .itemid(itemId)
+                    .build());
+        }
+    }
+
+        /**
+         * 移除宠物忽略物品列表中的物品
+         *
+         * @param petId 宠物 ID
+         * @param itemIds 物品 ID 集合，将从宠物的忽略列表中移除
+         */
+        public void removePetIgnoreItems(Integer petId, Collection<Integer> itemIds) {
+            if (petId == null || itemIds == null || itemIds.isEmpty()) {
+                return;
+            }
+            petignoresMapper.deleteByQuery(QueryWrapper.create()
+                    .where(PETIGNORES_D_O.PETID.eq(petId))
+                    .and(PETIGNORES_D_O.ITEMID.in(itemIds)));
+        }
+
+        /**
+         * 删除宠物相关数据
+         * 包括宠物的忽略物品列表和宠物本身的信息
+         *
+         * @param petId 宠物 ID
+         */
+        public void deletePetData(Integer petId) {
+            if (petId == null) {
+                return;
+            }
+            petignoresMapper.deleteByQuery(QueryWrapper.create().where(PETIGNORES_D_O.PETID.eq(petId)));
+            petsMapper.deleteById(Long.valueOf(petId));
+        }
+
+
     private void modifyInventoryCheck(InventorySearchRtnDTO data) {
         RequireUtil.requireNotNull(data.getItemId(), I18nUtil.getExceptionMessage("PARAMETER_SHOULD_NOT_EMPTY", "itemId"));
         RequireUtil.requireNotNull(data.getInventoryType(), I18nUtil.getExceptionMessage("PARAMETER_SHOULD_NOT_EMPTY", "inventoryType"));


### PR DESCRIPTION
 - 修复登录时未召唤宠物后续召唤时过滤配置未加载的问题
 - 改为在宠物过滤设置变更时增量更新 petignores，避免角色保存时全量删写导致误清空
 - 移除 Character.saveToDB 中对 petignores 的危险重写逻辑
 - 修复宠物过期删除时 pets/petignores 残留未清理的问题

(cherry picked from commit 3d9cba89506a545e2d0268107a9177eb5136e922)