### PR TITLE
fix(npc): 修复NPC查理中士兑换异常并加固发奖链路防护

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2010000.js
+++ b/gms-server/scripts-zh-CN/npc/2010000.js
@@ -106,7 +106,7 @@ eQuestPrizes[14] = [[2000006, 30],	// Mana Elixir
     [2040805, 1]];   // 10% Glove Attack
 eQuestPrizes[15] = [[2000006, 30],   // Mana Elixir
     [4020006, 7],	// Topaz Ore
-    [4020008.2],	// Black Crystal Ore
+    [4020008, 2],	// Black Crystal Ore
     [4020007, 2],	// Diamond Ore
     [2041020, 1]];	// 10% Cape Dex
 eQuestPrizes[16] = [[2000001, 30],	// Orange Potions
@@ -159,7 +159,7 @@ eQuestPrizes[23] = [[2000006, 25],	// Mana Elixir
     [2041023, 1]];	// 10% Cape LUK
 eQuestPrizes[24] = [[2000006, 35],	// Mana Elixir
     [4020006, 9],	// Topaz Ore
-    [4010008, 4],	// Black Crystal Ore
+    [4020008, 4],	// Black Crystal Ore
     [4020007, 4],	// Diamond Ore
     [2041008, 1]];   // 10% Cape HP
 var requiredItem = 0;
@@ -199,12 +199,14 @@ function action(mode, type, selection) {
         prizeQuantity = reward[itemSet][1];
         if (!cm.haveItem(requiredItem, 100)) {
             cm.sendOk("嗯... 你确定你有 #b100 #t" + requiredItem + "##k 吗？如果是的话，请检查一下你的物品栏是否已满。");
-        } else if (!cm.canHold(prizeItem)) {
+        } else if (prizeItem <= 0 || prizeQuantity <= 0) {
+            cm.sendOk("奇怪……我这边的交易清单好像出了点问题。你先稍等一下，晚点再来找我交易吧。");
+        } else if (!cm.canHold(prizeItem, prizeQuantity, requiredItem, 100)) {
             cm.sendOk("你的使用等等物品栏似乎已经满了。你需要腾出空间才能和我交易！清理一下，然后找到我。");
+        } else if (!cm.exchangeItems(requiredItem, 100, prizeItem, prizeQuantity)) {
+            cm.sendOk("这次交易没能顺利完成。你先整理下背包，稍后再来试一次。");
         } else {
-            cm.gainItem(requiredItem, -100);
             cm.gainExp(500 * cm.getPlayer().getExpRate());
-            cm.gainItem(prizeItem, prizeQuantity);
             cm.sendOk("对于你的#b100 #t" + requiredItem + "##k，这里是我的#b" + prizeQuantity + " #t" + prizeItem + "##k。你觉得怎么样？你喜欢我给你的物品吗？我打算在这里待一段时间，所以如果你收集到更多物品，我随时可以交易…");
         }
         cm.dispose();

--- a/gms-server/scripts/npc/2010000.js
+++ b/gms-server/scripts/npc/2010000.js
@@ -106,7 +106,7 @@ eQuestPrizes[14] = [[2000006, 30],	// Mana Elixir
     [2040805, 1]];   // 10% Glove Attack
 eQuestPrizes[15] = [[2000006, 30],   // Mana Elixir
     [4020006, 7],	// Topaz Ore
-    [4020008.2],	// Black Crystal Ore
+    [4020008, 2],	// Black Crystal Ore
     [4020007, 2],	// Diamond Ore
     [2041020, 1]];	// 10% Cape Dex
 eQuestPrizes[16] = [[2000001, 30],	// Orange Potions
@@ -159,7 +159,7 @@ eQuestPrizes[23] = [[2000006, 25],	// Mana Elixir
     [2041023, 1]];	// 10% Cape LUK
 eQuestPrizes[24] = [[2000006, 35],	// Mana Elixir
     [4020006, 9],	// Topaz Ore
-    [4010008, 4],	// Black Crystal Ore
+    [4020008, 4],	// Black Crystal Ore
     [4020007, 4],	// Diamond Ore
     [2041008, 1]];   // 10% Cape HP
 var requiredItem = 0;
@@ -199,12 +199,14 @@ function action(mode, type, selection) {
         prizeQuantity = reward[itemSet][1];
         if (!cm.haveItem(requiredItem, 100)) {
             cm.sendOk("Hmmm... are you sure you have #b100 #t" + requiredItem + "##k? If so, then please check and see if your item inventory is full or not.");
-        } else if (!cm.canHold(prizeItem)) {
+        } else if (prizeItem <= 0 || prizeQuantity <= 0) {
+            cm.sendOk("Something's wrong with my trade list right now. Please try again later.");
+        } else if (!cm.canHold(prizeItem, prizeQuantity, requiredItem, 100)) {
             cm.sendOk("Your use and etc. inventory seems to be full. You need the free spaces to trade with me! Make room, and then find me.");
+        } else if (!cm.exchangeItems(requiredItem, 100, prizeItem, prizeQuantity)) {
+            cm.sendOk("I can't complete this trade right now. Please try again in a moment.");
         } else {
-            cm.gainItem(requiredItem, -100);
             cm.gainExp(500 * cm.getPlayer().getExpRate());
-            cm.gainItem(prizeItem, prizeQuantity);
             cm.sendOk("For your #b100 #t" + requiredItem + "##k, here's my #b" + prizeQuantity + " #t" + prizeItem + "##k. What do you think? Do you like the items I gave you in return? I plan on being here for a while, so if you gather up more items, I'm always open for a trade ...");
         }
         cm.dispose();

--- a/gms-server/src/main/java/org/gms/client/inventory/manipulator/InventoryManipulator.java
+++ b/gms-server/src/main/java/org/gms/client/inventory/manipulator/InventoryManipulator.java
@@ -85,8 +85,16 @@ public class InventoryManipulator {
 
     private static boolean addByIdInternal(Client c, Character chr, InventoryType type, Inventory inv, int itemId, short quantity, String owner, int petid, short flag, long expiration) {
         ItemInformationProvider ii = ItemInformationProvider.getInstance();
+        if (!ii.itemExists(itemId)) {
+            log.warn("拦截发放物品：物品ID不存在，itemId={}，角色ID={}", itemId, chr.getId());
+            return false;
+        }
         if (!type.equals(InventoryType.EQUIP)) {
             short slotMax = ii.getSlotMax(c, itemId);
+            if (slotMax <= 0) {
+                log.warn("拦截发放物品：slotMax非法，itemId={}，slotMax={}，角色ID={}", itemId, slotMax, chr.getId());
+                return false;
+            }
             List<Item> existing = inv.listById(itemId);
             if (!ItemConstants.isRechargeable(itemId) && petid == -1) {
                 if (existing.size() > 0) { // first update all existing slots to slotMax
@@ -150,6 +158,10 @@ public class InventoryManipulator {
             }
         } else if (quantity == 1) {
             Item nEquip = ii.getEquipById(itemId);
+            if (nEquip == null) {
+                log.warn("拦截发放装备：物品ID不存在，itemId={}，角色ID={}", itemId, chr.getId());
+                return false;
+            }
             nEquip.setFlag(flag);
             nEquip.setExpiration(expiration);
             if (owner != null) {
@@ -200,10 +212,20 @@ public class InventoryManipulator {
             c.sendPacket(PacketCreator.showItemUnavailable());
             return false;
         }
+        if (!ii.itemExists(itemid)) {
+            log.warn("拦截掉落入包：物品ID不存在，itemId={}，角色ID={}", itemid, chr.getId());
+            c.sendPacket(PacketCreator.showItemUnavailable());
+            return false;
+        }
         short quantity = item.getQuantity();
 
         if (!type.equals(InventoryType.EQUIP)) {
             short slotMax = ii.getSlotMax(c, itemid);
+            if (slotMax <= 0) {
+                log.warn("拦截掉落入包：slotMax非法，itemId={}，slotMax={}，角色ID={}", itemid, slotMax, chr.getId());
+                c.sendPacket(PacketCreator.showItemUnavailable());
+                return false;
+            }
             List<Item> existing = inv.listById(itemid);
             if (!ItemConstants.isRechargeable(itemid) && petId == -1) {
                 if (existing.size() > 0) { // first update all existing slots to slotMax
@@ -226,6 +248,10 @@ public class InventoryManipulator {
                 }
                 while (quantity > 0) {
                     short newQ = (short) Math.min(quantity, slotMax);
+                    if (newQ <= 0) {
+                        log.warn("中止掉落入包：数量非法，itemId={}，quantity={}，slotMax={}，角色ID={}", itemid, quantity, slotMax, chr.getId());
+                        return false;
+                    }
                     quantity -= newQ;
                     Item nItem = new Item(itemid, (short) 0, newQ, petId);
                     nItem.setExpiration(item.getExpiration());
@@ -297,6 +323,10 @@ public class InventoryManipulator {
         InventoryType type = ItemConstants.getInventoryType(itemid);
         Character chr = c.getPlayer();
         Inventory inv = chr.getInventory(type);
+        if (!ii.itemExists(itemid)) {
+            log.warn("背包空间校验失败：物品ID不存在，itemId={}，角色ID={}", itemid, chr.getId());
+            return false;
+        }
 
         if (ii.isPickupRestricted(itemid)) {
             if (haveItemWithId(inv, itemid)) {
@@ -308,6 +338,9 @@ public class InventoryManipulator {
 
         if (!type.equals(InventoryType.EQUIP)) {
             short slotMax = ii.getSlotMax(c, itemid);
+            if (slotMax <= 0) {
+                return false;
+            }
             List<Item> existing = inv.listById(itemid);
 
             final int numSlotsNeeded;
@@ -352,6 +385,9 @@ public class InventoryManipulator {
         InventoryType type = !useProofInv ? ItemConstants.getInventoryType(itemid) : InventoryType.CANHOLD;
         Character chr = c.getPlayer();
         Inventory inv = chr.getInventory(type);
+        if (!ii.itemExists(itemid)) {
+            return 0;
+        }
 
         if (ii.isPickupRestricted(itemid)) {
             if (haveItemWithId(inv, itemid)) {
@@ -363,6 +399,9 @@ public class InventoryManipulator {
 
         if (!type.equals(InventoryType.EQUIP)) {
             short slotMax = ii.getSlotMax(c, itemid);
+            if (slotMax <= 0) {
+                return 0;
+            }
             final int numSlotsNeeded;
 
             if (ItemConstants.isRechargeable(itemid)) {

--- a/gms-server/src/main/java/org/gms/scripting/AbstractPlayerInteraction.java
+++ b/gms-server/src/main/java/org/gms/scripting/AbstractPlayerInteraction.java
@@ -597,6 +597,10 @@ public class AbstractPlayerInteraction {
         int petId = -1;
 
         if (quantity >= 0) {
+            if (quantity == 0) {
+                log.warn("拦截gainItem：数量不能为0，角色ID={}，itemId={}", getPlayer().getId(), id);
+                return null;
+            }
             if (ItemConstants.isPet(id)) {
                 petId = Pet.createPet(id);
 
@@ -622,6 +626,10 @@ public class AbstractPlayerInteraction {
             }
 
             ItemInformationProvider ii = ItemInformationProvider.getInstance();
+            if (!ii.itemExists(id)) {
+                log.warn("拦截gainItem：物品ID不存在，itemId={}，角色ID={}", id, getPlayer().getId());
+                return null;
+            }
 
             if (ItemConstants.getInventoryType(id).equals(InventoryType.EQUIP)) {
                 item = ii.getEquipById(id);
@@ -643,6 +651,10 @@ public class AbstractPlayerInteraction {
             } else {
                 item = new Item(id, (short) 0, quantity, petId);
             }
+            if (item == null) {
+                log.warn("拦截gainItem：物品对象为空，角色ID={}，itemId={}", getPlayer().getId(), id);
+                return null;
+            }
 
             if (expires >= 0) {
                 item.setExpiration(System.currentTimeMillis() + expires);
@@ -654,12 +666,18 @@ public class AbstractPlayerInteraction {
             }
             if (ItemConstants.getInventoryType(id) == InventoryType.EQUIP) {
                 if (randomStats) {
-                    InventoryManipulator.addFromDrop(c, ii.randomizeStats((Equip) item), false, petId);
+                    if (!InventoryManipulator.addFromDrop(c, ii.randomizeStats((Equip) item), false, petId)) {
+                        return null;
+                    }
                 } else {
-                    InventoryManipulator.addFromDrop(c, item, false, petId);
+                    if (!InventoryManipulator.addFromDrop(c, item, false, petId)) {
+                        return null;
+                    }
                 }
             } else {
-                InventoryManipulator.addFromDrop(c, item, false, petId);
+                if (!InventoryManipulator.addFromDrop(c, item, false, petId)) {
+                    return null;
+                }
             }
         } else {
             InventoryManipulator.removeById(c, ItemConstants.getInventoryType(id), id, -quantity, true, false);
@@ -669,6 +687,49 @@ public class AbstractPlayerInteraction {
         }
 
         return item;
+    }
+
+    public boolean exchangeItems(int requiredItemId, int requiredQuantity, int rewardItemId, int rewardQuantity) {
+        if (requiredQuantity <= 0 || rewardQuantity <= 0) {
+            log.warn("拦截exchangeItems：参数数量非法，角色ID={}，requiredItemId={}，requiredQuantity={}，rewardItemId={}，rewardQuantity={}",
+                    getPlayer().getId(), requiredItemId, requiredQuantity, rewardItemId, rewardQuantity);
+            return false;
+        }
+        if (!haveItem(requiredItemId, requiredQuantity)) {
+            return false;
+        }
+        if (!canHold(rewardItemId, rewardQuantity, requiredItemId, requiredQuantity)) {
+            return false;
+        }
+
+        int beforeRequired = getPlayer().getItemQuantity(requiredItemId, false);
+        try {
+            gainItem(requiredItemId, (short) -requiredQuantity, false, false);
+        } catch (Exception e) {
+            int removed = beforeRequired - getPlayer().getItemQuantity(requiredItemId, false);
+            if (removed > 0) {
+                gainItem(requiredItemId, (short) removed, false, false);
+            }
+            log.warn("exchangeItems扣除材料失败，角色ID={}，requiredItemId={}，requiredQuantity={}",
+                    getPlayer().getId(), requiredItemId, requiredQuantity, e);
+            return false;
+        }
+
+        Item reward = gainItem(rewardItemId, (short) rewardQuantity, false, false);
+        if (reward == null) {
+            try {
+                Item rollback = gainItem(requiredItemId, (short) requiredQuantity, false, false);
+                if (rollback == null) {
+                    log.error("exchangeItems回滚材料失败，角色ID={}，requiredItemId={}，requiredQuantity={}，rewardItemId={}，rewardQuantity={}",
+                            getPlayer().getId(), requiredItemId, requiredQuantity, rewardItemId, rewardQuantity);
+                }
+            } catch (Exception e) {
+                log.error("exchangeItems回滚材料异常，角色ID={}，requiredItemId={}，requiredQuantity={}，rewardItemId={}，rewardQuantity={}",
+                        getPlayer().getId(), requiredItemId, requiredQuantity, rewardItemId, rewardQuantity, e);
+            }
+            return false;
+        }
+        return true;
     }
 
     public void gainFame(int delta) {

--- a/gms-server/src/main/java/org/gms/server/ItemInformationProvider.java
+++ b/gms-server/src/main/java/org/gms/server/ItemInformationProvider.java
@@ -106,6 +106,7 @@ public class ItemInformationProvider {
     protected Map<Integer, Boolean> accountItemRestrictionCache = new HashMap<>();
     protected Map<Integer, Boolean> dropRestrictionCache = new HashMap<>();
     protected Map<Integer, Boolean> pickupRestrictionCache = new HashMap<>();
+    protected Map<Integer, Boolean> itemExistenceCache = new HashMap<>();
     protected Map<Integer, Integer> getMesoCache = new HashMap<>();
     protected Map<Integer, Integer> monsterBookID = new HashMap<>();
     protected Map<Integer, Boolean> untradeableCache = new HashMap<>();
@@ -317,6 +318,20 @@ public class ItemInformationProvider {
             }
         }
         return ret;
+    }
+
+    /**
+     * 检查物品ID是否存在于WZ资源中，结果会缓存，避免重复遍历资源目录。
+     */
+    public boolean itemExists(int itemId) {
+        Boolean cached = itemExistenceCache.get(itemId);
+        if (cached != null) {
+            return cached;
+        }
+
+        boolean exists = getItemData(itemId) != null;
+        itemExistenceCache.put(itemId, exists);
+        return exists;
     }
 
     public List<Integer> getItemIdsInRange(int minId, int maxId, boolean ignoreCashItem) {


### PR DESCRIPTION
- 修正了黑水晶矿石的物品ID错误，统一使用正确的4020008 ID
- 添加了物品数量为0或负数的边界条件验证
- 实现了安全的物品交换方法exchangeItems，确保交易原子性
- 增加了对无效物品ID的拦截和日志记录
- 修复了背包容量检测的参数传递问题
- 添加了交易失败时的物品回滚机制
- 优化了物品发放过程中的异常处理逻辑

<img width="563" height="1105" alt="image" src="https://github.com/user-attachments/assets/6b86b2e0-f6e2-4e95-a0b3-c6e8fec3128a" />
<img width="631" height="1071" alt="image" src="https://github.com/user-attachments/assets/8d710b6b-fc80-4869-92fb-06da24d0e962" />
<img width="593" height="1096" alt="image" src="https://github.com/user-attachments/assets/fc13f6d1-6ca0-49a9-9eb3-c06f128f80d8" />
