### PR TITLE
修改洗血判断存在的if-else穿透缺陷

### DIFF
--- a/gms-server/src/main/java/org/gms/client/processor/stat/AssignAPProcessor.java
+++ b/gms-server/src/main/java/org/gms/client/processor/stat/AssignAPProcessor.java
@@ -653,14 +653,14 @@ public class AssignAPProcessor {
                     int level = player.getLevel();
                     Job job = player.getJob();
                     boolean canWash = true;
-                    if (job.isA(Job.SPEARMAN) && mp < 4 * level + 156) {
-                        canWash = false;
-                    } else if ((job.isA(Job.FIGHTER) || job.isA(Job.ARAN1)) && mp < 4 * level + 56) {
-                        canWash = false;
-                    } else if (job.isA(Job.THIEF) && job.getId() % 100 > 0 && mp < level * 14 - 4) {
-                        canWash = false;
-                    } else if (mp < level * 14 + 148) {
-                        canWash = false;
+					if (job.isA(Job.SPEARMAN)) {
+                        canWash = mp >= 4 * level + 156;
+                    } else if (job.isA(Job.FIGHTER) || job.isA(Job.ARAN1)) {
+                        canWash = mp >= 4 * level + 56;
+                    } else if (job.isA(Job.THIEF) && job.getId() % 100 > 0) {
+                        canWash = mp >= level * 14 - 4;
+                    } else {
+                        canWash = mp >= level * 14 + 148;
                     }
                     if (!canWash) {
                         player.message("你的MP总量不足，无法进行重置。");


### PR DESCRIPTION
原有洗血判断逻辑存在if-else穿透缺陷，特定职业如战神的mp值高于本职业门槛，但低于通用门槛，理应可以继续降低，但是当前判断逻辑会在职业分支判断为假之后进入通用分支判断，导致特定职业洗血时低于通用门槛mp值时设置无效。