### PR TITLE
﻿fix: 海盗组队任务心腹地图怪物消失后不重生

### DIFF
--- a/gms-server/scripts-zh-CN/event/PiratePQ.js
+++ b/gms-server/scripts-zh-CN/event/PiratePQ.js
@@ -219,6 +219,8 @@ function respawnStages(eim) {
     }
 
     eim.getMapInstance(925100400).instanceMapRespawn();
+    eim.getMapInstance(925100202).instanceMapForceRespawn();
+    eim.getMapInstance(925100302).instanceMapForceRespawn();
     eim.schedule("respawnStages", 10 * 1000);
 }
 
@@ -366,6 +368,12 @@ function passedGrindMode(map, eim) {
 
 function monsterKilled(mob, eim) {
     var map = mob.getMap();
+    var mapId = map.getId();
+
+    // 仆人地图是过道房间，怪物自生自灭，不处理clear特效
+    if (mapId == 925100202 || mapId == 925100302) {
+        return;
+    }
 
     if (isLordPirate(mob)) {  // lord pirate defeated, spawn the little fella!
         map.broadcastStringMessage(5, "随着海盗领主死亡，无恙被释放了！");
@@ -373,13 +381,13 @@ function monsterKilled(mob, eim) {
     }
 
     if (map.countMonsters() == 0) {
-        var stage = ((map.getId() % 1000) / 100) + 1;
+        var stage = ((mapId % 1000) / 100) + 1;
 
         if ((stage == 1 || stage == 3 || stage == 4) && passedGrindMode(map, eim)) {
-            eim.showClearEffect(map.getId());
+            eim.showClearEffect(mapId);
         } else if (stage == 5) {
             if (map.getReactorByName("sMob1").getState() >= 1 && map.getReactorByName("sMob2").getState() >= 1 && map.getReactorByName("sMob3").getState() >= 1 && map.getReactorByName("sMob4").getState() >= 1) {
-                eim.showClearEffect(map.getId());
+                eim.showClearEffect(mapId);
             }
         }
     }

--- a/gms-server/scripts-zh-CN/portal/davy2_hd1.js
+++ b/gms-server/scripts-zh-CN/portal/davy2_hd1.js
@@ -1,12 +1,12 @@
-var windowTime = 10 * 1000;
-
 function enter(pi) {
     var eim = pi.getEventInstance();
-    var level = eim.getIntProperty("level");
-    if (eim.getProperty("stage2b") == "0") {
-        pi.getMap(925100202).spawnAllMonstersFromMapSpawnList(level, true);
-        eim.setProperty("stage2b", "1");
+    if (eim == null) {
+        return false;
     }
+    var map = pi.getMap(925100202);
+    map.killAllMonsters();
+    map.restoreMapSpawnPoints();
+    map.instanceMapForceRespawn();
 
     pi.playPortalSound();
     pi.warp(925100202, 0);

--- a/gms-server/scripts-zh-CN/portal/davy3_hd1.js
+++ b/gms-server/scripts-zh-CN/portal/davy3_hd1.js
@@ -1,12 +1,12 @@
-var windowTime = 10 * 1000;
-
 function enter(pi) {
     var eim = pi.getEventInstance();
-    var level = eim.getIntProperty("level");
-    if (eim.getProperty("stage3b") == "0") {
-        pi.getMap(925100302).spawnAllMonstersFromMapSpawnList(level, true);
-        eim.setProperty("stage3b", "1");
+    if (eim == null) {
+        return false;
     }
+    var map = pi.getMap(925100302);
+    map.killAllMonsters();
+    map.restoreMapSpawnPoints();
+    map.instanceMapForceRespawn();
 
     pi.playPortalSound();
     pi.warp(925100302, 0);

--- a/gms-server/scripts/event/PiratePQ.js
+++ b/gms-server/scripts/event/PiratePQ.js
@@ -212,6 +212,8 @@ function respawnStages(eim) {
     }
 
     eim.getMapInstance(925100400).instanceMapRespawn();
+    eim.getMapInstance(925100202).instanceMapForceRespawn();
+    eim.getMapInstance(925100302).instanceMapForceRespawn();
     eim.schedule("respawnStages", 10 * 1000);
 }
 
@@ -359,6 +361,12 @@ function passedGrindMode(map, eim) {
 
 function monsterKilled(mob, eim) {
     var map = mob.getMap();
+    var mapId = map.getId();
+
+    // 仆人地图是过道房间，怪物自生自灭，不处理clear特效
+    if (mapId == 925100202 || mapId == 925100302) {
+        return;
+    }
 
     if (isLordPirate(mob)) {  // lord pirate defeated, spawn the little fella!
         map.broadcastStringMessage(5, "As Lord Pirate dies, Wu Yang is released!");
@@ -366,13 +374,13 @@ function monsterKilled(mob, eim) {
     }
 
     if (map.countMonsters() == 0) {
-        var stage = ((map.getId() % 1000) / 100) + 1;
+        var stage = ((mapId % 1000) / 100) + 1;
 
         if ((stage == 1 || stage == 3 || stage == 4) && passedGrindMode(map, eim)) {
-            eim.showClearEffect(map.getId());
+            eim.showClearEffect(mapId);
         } else if (stage == 5) {
             if (map.getReactorByName("sMob1").getState() >= 1 && map.getReactorByName("sMob2").getState() >= 1 && map.getReactorByName("sMob3").getState() >= 1 && map.getReactorByName("sMob4").getState() >= 1) {
-                eim.showClearEffect(map.getId());
+                eim.showClearEffect(mapId);
             }
         }
     }

--- a/gms-server/scripts/portal/davy2_hd1.js
+++ b/gms-server/scripts/portal/davy2_hd1.js
@@ -1,12 +1,12 @@
-var windowTime = 10 * 1000;
-
 function enter(pi) {
     var eim = pi.getEventInstance();
-    var level = eim.getIntProperty("level");
-    if (eim.getProperty("stage2b") == "0") {
-        pi.getMap(925100202).spawnAllMonstersFromMapSpawnList(level, true);
-        eim.setProperty("stage2b", "1");
+    if (eim == null) {
+        return false;
     }
+    var map = pi.getMap(925100202);
+    map.killAllMonsters();
+    map.restoreMapSpawnPoints();
+    map.instanceMapForceRespawn();
 
     pi.playPortalSound();
     pi.warp(925100202, 0);

--- a/gms-server/scripts/portal/davy3_hd1.js
+++ b/gms-server/scripts/portal/davy3_hd1.js
@@ -1,12 +1,12 @@
-var windowTime = 10 * 1000;
-
 function enter(pi) {
     var eim = pi.getEventInstance();
-    var level = eim.getIntProperty("level");
-    if (eim.getProperty("stage3b") == "0") {
-        pi.getMap(925100302).spawnAllMonstersFromMapSpawnList(level, true);
-        eim.setProperty("stage3b", "1");
+    if (eim == null) {
+        return false;
     }
+    var map = pi.getMap(925100302);
+    map.killAllMonsters();
+    map.restoreMapSpawnPoints();
+    map.instanceMapForceRespawn();
 
     pi.playPortalSound();
     pi.warp(925100302, 0);


### PR DESCRIPTION
【原版设计分析】
官方 WZ 数据中，心腹地图怪物同时配置了：
- removeAfter=10（出生10秒后自动消失）
- mobTime=0（消失后应立即重生） 两字段配合表达的意图是：怪物以'出现→消失→重生'的节奏无限循环，
这是海盗仆人'巡逻→回船→再巡逻'主题的 gameplay 表现，
玩家可在窗口期内击杀，非一次性刷怪。
【问题】
实际表现为首次刷怪后怪物消失即空场，不再重生。
根因：传送门脚本用 stage2b/stage3b 标志限制只刷一次，
且事件实例地图不受全局 RespawnTask 管理。
【修复】
传送门脚本：移除首次限制，每次进入都清怪重置并用统一刷怪路径重新填充地图
事件循环：在每10秒的补刷循环中覆盖心腹地图，确保怪物循环不停
怪物事件：跳过仆人地图的 clear 特效处理，避免自动消失触发通关效果
【效果】
还原官方设计行为——进入地图后怪物循环出现，无限轮回，想打就打，想走就走