### PR TITLE
fix: 修复光之祭典任务掉落并校正西蒙中文脚本

### DIFF
--- a/gms-server/scripts-zh-CN/npc/9201033.js
+++ b/gms-server/scripts-zh-CN/npc/9201033.js
@@ -24,13 +24,14 @@
     Jayd
 -- Version Info -----------------------------------------------------------------------------------
     1.0 - First Version by Jayd
----------------------------------------------------------------------------------------------------    
+---------------------------------------------------------------------------------------------------
  */
 
 var status;
-var smap = 681000000;
-var hv = 209000000;
-var tst, b2h;
+// 西蒙负责在快乐村和沙龙神殿之间传送玩家。
+var SHALOM_TEMPLE = 681000000;
+var HAPPYVILLE = 209000000;
+var toShalomTemple, backToHappyville;
 
 function start() {
     status = -1;
@@ -42,7 +43,7 @@ function action(mode, type, selection) {
         cm.dispose();
     } else {
         if (status == 0 && mode == 0) {
-            cm.sendNext("如果你改变主意了，告诉我！");
+            cm.sendNext("如果你改变主意了，随时再来找我。");
             cm.dispose();
         }
 
@@ -53,19 +54,19 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.getMapId() == hv) {
-                tst = 1; //to shalom temple
-                cm.sendYesNo("“沙龙神殿与快乐村的其他地方都不一样，你想前往 #b沙龙神殿#k 吗？”"); //not GMS lol
-            } else if (cm.getMapId() == smap) {
-                b2h = 1; //back to happyville
-                cm.sendYesNo("你想回到快乐村吗？");
+            if (cm.getMapId() == HAPPYVILLE) {
+                toShalomTemple = 1;
+                cm.sendYesNo("沙龙神殿和快乐村的其他地方不太一样，你想前往 #b沙龙神殿#k 吗？");
+            } else if (cm.getMapId() == SHALOM_TEMPLE) {
+                backToHappyville = 1;
+                cm.sendYesNo("你想返回 #b快乐村#k 吗？");
             }
         } else if (status == 1) {
-            if (tst == 1) {
-                cm.warp(smap, 0);
+            if (toShalomTemple == 1) {
+                cm.warp(SHALOM_TEMPLE, 0);
                 cm.dispose();
-            } else if (b2h == 1) {
-                cm.warp(hv, 0);
+            } else if (backToHappyville == 1) {
+                cm.warp(HAPPYVILLE, 0);
                 cm.dispose();
             }
         }

--- a/gms-server/src/main/resources/db/migration/V1.8.6__add_festival_of_lights_drops.sql
+++ b/gms-server/src/main/resources/db/migration/V1.8.6__add_festival_of_lights_drops.sql
@@ -1,0 +1,27 @@
+-- 光之祭典（Festival of Lights）任务掉落修复
+-- 相关任务 / 道具 / 怪物：
+--   8295 / 8829 : 建造祭坛
+--   8830        : 点亮祭坛
+--   4031445     : 祭坛零件
+--   4031444     : 安息日蜡烛
+--   1130100     : 斧木妖
+--   2130100     : 黑斧木妖
+--   2110200     : 刺蘑菇
+--
+-- 说明：
+-- 1. 当前 WZ 数据里“建造祭坛”同时存在 8295 与 8829 两套任务 ID。
+-- 2. `drop_data` 表对 `(dropperid, itemid)` 有唯一索引，无法为同一怪物 + 同一道具同时绑定两个 questid。
+-- 3. 因此“祭坛零件”这里使用 `questid = 0`，让 8295 / 8829 两套任务都能正常拾取。
+-- 4. “安息日蜡烛”只对应第二环 8830，因此仍然绑定到该任务。
+-- 5. 掉率先给 300000（约 30% 基础概率，实际还会乘频道掉率），后续可按服内体验再调整。
+
+INSERT INTO `drop_data` (`dropperid`, `itemid`, `minimum_quantity`, `maximum_quantity`, `questid`, `chance`)
+VALUES
+    (1130100, 4031445, 1, 1, 0, 300000),
+    (2130100, 4031445, 1, 1, 0, 300000),
+    (2110200, 4031444, 1, 1, 8830, 300000)
+ON DUPLICATE KEY UPDATE
+    `minimum_quantity` = VALUES(`minimum_quantity`),
+    `maximum_quantity` = VALUES(`maximum_quantity`),
+    `questid` = VALUES(`questid`),
+    `chance` = VALUES(`chance`);


### PR DESCRIPTION
## 变更说明

本 PR 修复了 `Festival of Lights / 光之祭典` 活动任务无法正常推进的问题。并同步整理了相关中文 NPC 脚本。

## 主要改动

- 新增 `V1.8.6__add_festival_of_lights_drops.sql`
- 补充以下任务掉落?
  - `1130100` 斧木妖 / `2130100` 黑斧木妖 -> `4031445` 祭坛零件
  - `2110200` 刺蘑菇 -> `4031444` 安息日蜡烛
- 兼容 WZ 中两套建造祭坛任务 ID：`8295` / `8829`
- 修正 `scripts-zh-CN/npc/9201033.js` 的中文文案与变量命名

## 问题原因

WZ 中已有任务需求定义，但数据库 `drop_data` 缺少对应任务掉落配置，导致玩家接取任务后无法通过击杀怪物获得活动任务道具。

## 验证建议

1. 从 `汉娜` 接取第一环任务
2. 前往 `东部岩山 IV / V` 击杀 `斧木妖 / 黑斧木妖`，确认可掉落 `祭坛零件`
3. 完成第一环后接第二环
4. 击杀 `刺蘑菇`，确认可掉落 `安息日蜡烛`
5. 与 `西蒙` 对话，确认中文传送文案显示正常