### PR TITLE
fix: 修正揭晓秘密任务怪物翻译与需求摘要

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -8134,10 +8134,10 @@
         <string name="parent" value="揭晓秘密"/>
         <int name="order" value="2"/>
         <string name="0" value="#b勇士部落#k的#b#@1022000:##k说他认出了徽章。我们一起去看看他有什么发现。"/>
-        <string name="1" value="他说，徽章代表的是#r牛魔王#k，他擅长传播疾病。他被关在#b魔法密林#k中，但有人解开了封印。\n\n但是他说，首先，你需要很多树木来阻止病毒传播。\n他说，为了捕捉 #r黑木妖#k和#r大公斧木妖#k。\n（他说，可在#b#m102020100##k轻松找到它们。）\n\n一旦完成，即返回勇士部落的#b#@1022000:##k。"/>
+        <string name="1" value="他说，徽章代表的是#r牛魔王#k，他擅长传播疾病。他被关在#b魔法密林#k中，但有人解开了封印。\n\n但是他说，首先，你需要很多树木来阻止病毒传播。\n他说，为了捕捉#r黑木妖#k和#r斧木妖#k。\n（他说，可在#b#m102020100##k轻松找到它们。）\n\n一旦完成，即返回勇士部落的#b#@1022000:##k。"/>
         <string name="2" value="徽章代表的是恶魔#r牛魔王#k；病毒通过用树木堵住水管得以制止。"/>
         <int name="area" value="10"/>
-        <string name="demandSummary" value="#o1110101# #a281961# #o1130100# #a281961# "/>
+        <string name="demandSummary" value="#o1110101# #a281961# \r\n#o1130100# #a281962# "/>
         <string name="rewardSummary" value="经验值 1,200\r\n进行‘返回魔法密林’作为下一个任务。\r\n"/>
     </imgdir>
     <imgdir name="28197">


### PR DESCRIPTION
## 变更说明
- 修正任务“揭晓秘密”中将 `Axe Stumps` 误译为“大公斧木妖”的问题，改为正确怪物目标
- 修正同任务 `demandSummary` 第二个目标错误复用 `#a281961#` 的问题，改为 `#a281962#`

## 校对与同步
- 对照 `gms-server/wz/Quest.wz/QuestInfo.img.xml` 英文原文，确认目标怪物为 `Dark Stumps` 与 `Axe Stumps`
- 已同步更新发布目录 `D:/BeiDou-docker/beidou-server-release/wz-zh-CN/Quest.wz/QuestInfo.img.xml`
