### PR TITLE
fix: 统一汉化丘比特的信使系列任务

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -7426,21 +7426,21 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="28103">
-        <string name="name" value="Amoria : Cupid&apos;s Courier - Pirate"/>
-        <string name="parent" value="Cupid&apos;s Courier - Pirate"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 海盗"/>
+        <string name="parent" value="丘比特的信使 - 海盗"/>
         <int name="order" value="1"/>
-        <string name="0" value="The wife of a sailor, eh? I&apos;ll bet she needs some help."/>
-        <string name="1" value="I spoke with the lovely Angelique, and I&apos;m going to deliver #b25 Soft Feathers#k to her husband, Richard, for her. He works on Tae Gong&apos;s ship in Aqua Road. Once I have everything, I&apos;ll head there, drop everything off, and let Angelique know her husband has everything."/>
-        <string name="2" value="I delivered the materials to Richard and he thanked me. His wife must be happy..."/>
+        <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b25个软羽毛#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="28104">
-        <string name="name" value="Amoria : Cupid&apos;s Courier - Pirate"/>
-        <string name="parent" value="Cupid&apos;s Courier - Pirate"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 海盗"/>
+        <string name="parent" value="丘比特的信使 - 海盗"/>
         <int name="order" value="2"/>
-        <string name="0" value="Okay, so now I gotta go see the sailor himself. Where must he be?"/>
-        <string name="1" value="I delivered everything to Richard and he asked me delivered his letter to his wife."/>
-        <string name="2" value="I delivered everything to Richard and returned to Angelique. She gave me something nice, and I can go back to here anytime for a quick job."/>
+        <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
+        <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
+        <string name="2" value="我把东西交给理查德后，又回去找安琪莉。她给了我奖励，还说以后随时都可以再来接这类简单的委托。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="28105">
@@ -18992,21 +18992,21 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8850">
-        <string name="name" value="Amoria : Cupid&apos;s Courier - Beginner"/>
-        <string name="parent" value="Cupid&apos;s Courier - Beginner"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 新手"/>
+        <string name="parent" value="丘比特的信使 - 新手"/>
         <int name="order" value="1"/>
-        <string name="0" value="The wife of a sailor, eh? I&apos;ll bet she needs some help."/>
-        <string name="1" value="I spoke with the lovely Angelique, and I&apos;m going to deliver #b25 Stiff Feathers#k to her husband, Richard, for her. He works on Tae Gong&apos;s ship in Aqua Road. Once I have everything, I&apos;ll head there, drop everything off, and let Angelique know her husband has everything."/>
-        <string name="2" value="I delivered the materials to Richard and he thanked me. His wife must be happy..."/>
+        <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b25个硬羽毛#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8851">
         <string name="name" value="阿莫里亚：丘比特的信使 - 战士"/>
         <string name="parent" value="丘比特的信使 - 战士"/>
         <int name="order" value="1"/>
-        <string name="0" value="海员的妻子？哦...我想她肯定有很多事情要忙，或许我能帮上忙。"/>
-        <string name="1" value="我已经和美丽的安琪莉聊过了，她拜托我给她在水下世界太公船上工作的丈夫理查德送 #b15个粘糊糊的蜘蛛网#k。等我这边的事情一结束，我就马上出发，确保这些物品能够顺利送到理查德手上，然后回来告诉安琪莉一切顺利。"/>
-        <string name="2" value="我把那些材料交给了理查德，他非常感谢我。安琪莉知道后一定会很开心的……"/>
+        <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b15个粘蜘蛛网#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8852">
@@ -19019,39 +19019,39 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8853">
-        <string name="name" value="Amoria : Cupid&apos;s Courier - Bowman"/>
-        <string name="parent" value="Cupid&apos;s Courier - Bowman"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 弓箭手"/>
+        <string name="parent" value="丘比特的信使 - 弓箭手"/>
         <int name="order" value="1"/>
-        <string name="0" value="The wife of a sailor, eh? I&apos;ll bet she needs some help."/>
-        <string name="1" value="I spoke with the lovely Angelique, and I&apos;m going to deliver #b20 Toy Ducklings#k to her husband, Richard, for her. He works on Tae Gong&apos;s ship in Aqua Road. Once I have everything, I&apos;ll head there, drop everything off, and let Angelique know her husband has everything."/>
-        <string name="2" value="I delivered the materials to Richard and he thanked me. His wife must be happy..."/>
+        <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b20个玩具小鸭#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8854">
-        <string name="name" value="Amoria : Cupid&apos;s Courier - Thief"/>
-        <string name="parent" value="Cupid&apos;s Courier - Thief"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 飞侠"/>
+        <string name="parent" value="丘比特的信使 - 飞侠"/>
         <int name="order" value="1"/>
-        <string name="0" value="The wife of a sailor, eh? I&apos;ll bet she needs some help."/>
-        <string name="1" value="I spoke with the lovely Angelique, and I&apos;m going to deliver #b20 Rat Traps#k to her husband, Richard, for her. He works on Tae Gong&apos;s ship in Aqua Road. Once I have everything, I&apos;ll head there, drop everything off, and let Angelique know her husband has everything."/>
-        <string name="2" value="I delivered the materials to Richard and he thanked me. His wife must be happy..."/>
+        <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b20个捕鼠器#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8855">
-        <string name="name" value="Amoria : Cupid&apos;s Courier  - Beginner"/>
-        <string name="parent" value="Cupid&apos;s Courier - Beginner"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 新手"/>
+        <string name="parent" value="丘比特的信使 - 新手"/>
         <int name="order" value="2"/>
-        <string name="0" value="Okay, so now I gotta go see the sailor himself. Where must he be?"/>
-        <string name="1" value="I delivered everything to Richard and he asked me delivered his letter to his wife."/>
-        <string name="2" value="I delivered everything to Richard and returned to Angelique. She gave me something nice, and I can go back to here anytime for a quick job."/>
+        <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
+        <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
+        <string name="2" value="我把东西交给理查德后，又回去找安琪莉。她给了我奖励，还说以后随时都可以再来接这类简单的委托。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8856">
         <string name="name" value="阿莫里亚：丘比特的信使 - 战士"/>
         <string name="parent" value="丘比特的信使 - 战士"/>
         <int name="order" value="2"/>
-        <string name="0" value="好吧，现在我必须亲自去见见那个水手。他应该在哪里呢？"/>
-        <string name="1" value="我把所有东西都送给了理查德，然后他让我把他的信送给他妻子。"/>
-        <string name="2" value="我把所有东西都交给理查德后，就回到了安琪莉身边。她给了我一些好东西，而且我随时都可以回来做些简单的工作。"/>
+        <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
+        <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
+        <string name="2" value="我把东西交给理查德后，又回去找安琪莉。她给了我奖励，还说以后随时都可以再来接这类简单的委托。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8857">
@@ -19064,21 +19064,21 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8858">
-        <string name="name" value="Amoria : Cupid&apos;s Courier - Bowman"/>
-        <string name="parent" value="Cupid&apos;s Courier - Bowman"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 弓箭手"/>
+        <string name="parent" value="丘比特的信使 - 弓箭手"/>
         <int name="order" value="2"/>
-        <string name="0" value="Okay, so now I gotta go see the sailor himself. Where must he be?"/>
-        <string name="1" value="I delivered everything to Richard and he asked me delivered his letter to his wife."/>
-        <string name="2" value="I delivered everything to Richard and returned to Angelique. She gave me something nice, and I can go back to here anytime for a quick job."/>
+        <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
+        <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
+        <string name="2" value="我把东西交给理查德后，又回去找安琪莉。她给了我奖励，还说以后随时都可以再来接这类简单的委托。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8859">
-        <string name="name" value="Amoria : Cupid&apos;s Courier - Thief"/>
-        <string name="parent" value="Cupid&apos;s Courier - Thief"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 飞侠"/>
+        <string name="parent" value="丘比特的信使 - 飞侠"/>
         <int name="order" value="2"/>
-        <string name="0" value="Okay, so now I gotta go see the sailor himself. Where must he be?"/>
-        <string name="1" value="I delivered everything to Richard and he asked me delivered his letter to his wife."/>
-        <string name="2" value="I delivered everything to Richard and returned to Angelique. She gave me something nice, and I can go back to here anytime for a quick job."/>
+        <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
+        <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
+        <string name="2" value="我把东西交给理查德后，又回去找安琪莉。她给了我奖励，还说以后随时都可以再来接这类简单的委托。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8860">

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -19010,12 +19010,12 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8852">
-        <string name="name" value="Amoria : Cupid&apos;s Courier - Magician"/>
-        <string name="parent" value="Cupid&apos;s Courier - Magician"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 法师"/>
+        <string name="parent" value="丘比特的信使 - 法师"/>
         <int name="order" value="1"/>
-        <string name="0" value="The wife of a sailor, eh? I&apos;ll bet she needs some help."/>
-        <string name="1" value="I spoke with the lovely Angelique, and I&apos;m going to deliver #bLunar Pixie&apos;s Moonpiece#k to her husband, Richard, for her. He works on Tae Gong&apos;s ship in Aqua Road. Once I have everything, I&apos;ll head there, drop everything off, and let Angelique know her husband has everything."/>
-        <string name="2" value="I delivered the materials to Richard and he thanked me. His wife must be happy..."/>
+        <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b月光精灵的月块#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8853">
@@ -19055,12 +19055,12 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8857">
-        <string name="name" value="Amoria : Cupid&apos;s Courier - Magician"/>
-        <string name="parent" value="Cupid&apos;s Courier - Magician"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 法师"/>
+        <string name="parent" value="丘比特的信使 - 法师"/>
         <int name="order" value="2"/>
-        <string name="0" value="Okay, so now I gotta go see the sailor himself. Where must he be?"/>
-        <string name="1" value="I delivered everything to Richard and he asked me delivered his letter to his wife."/>
-        <string name="2" value="I delivered everything to Richard and returned to Angelique. She gave me something nice, and I can go back to here anytime for a quick job."/>
+        <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
+        <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
+        <string name="2" value="我把东西交给理查德后，又回去找安琪莉。她给了我奖励，还说以后随时都可以再来接这类简单的委托。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8858">


### PR DESCRIPTION
## 变更说明
- 统一汉化 `Cupid's Courier` 系列任务的海盗、新手、战士、法师、弓箭手、飞侠版本
- 修正任务标题、父任务标题、任务说明与任务对话中的中英混杂问题
- 统一 NPC 对话文本风格，并修正安琪莉、理查德、阿奎路等专有名词表述
- 统一材料名称表述，如“软羽毛”、“硬羽毛”、“粘蜘蛛网”、“月光精灵的月块”、“玩具小鸭”、“捕鼠器”

## 涉及任务
- `28103 / 28104` 海盗版 Cupid's Courier
- `8850 ~ 8859` 新手 / 战士 / 法师 / 弓箭手 / 飞侠版 Cupid's Courier

## 同步说明
- 已同步更新发布目录 `D:/BeiDou-docker/beidou-server-release/wz-zh-CN/Quest.wz/QuestInfo.img.xml`
- 已同步更新发布目录 `D:/BeiDou-docker/beidou-server-release/wz-zh-CN/Quest.wz/Say.img.xml`
