### PR TITLE
Feat: 增加由服务端控制的小范围宠物吸物功能（非全屏，仅宠物周围）

### DIFF
--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/MovePetHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/MovePetHandler.java
@@ -23,12 +23,19 @@ package org.gms.net.server.channel.handlers;
 
 import org.gms.client.Character;
 import org.gms.client.Client;
+import org.gms.client.inventory.Pet;
+import org.gms.config.GameConfig;
 import org.gms.net.packet.InPacket;
+import org.gms.server.maps.MapObject;
+import org.gms.server.maps.MapObjectType;
+import org.gms.server.maps.MapItem;
 import org.gms.server.movement.LifeMovementFragment;
 import org.gms.util.PacketCreator;
 import org.gms.exception.EmptyMovementException;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public final class MovePetHandler extends AbstractMovementPacketHandler {
     @Override
@@ -50,5 +57,53 @@ public final class MovePetHandler extends AbstractMovementPacketHandler {
         }
         player.getPet(slot).updatePosition(res);
         player.getMap().broadcastMessage(player, PacketCreator.movePet(player.getId(), petId, slot, res), false);
+        if (GameConfig.getServerBoolean("pet_itemvac")) {
+            // 根据游戏config参数确定是否开启宠吸
+            itemVac(player,slot);
+        }
+
+    }
+    //解决宠吸物品过滤器问题 by pkoukk
+    private final boolean shouldPickupItem(Character player, MapItem mapitem) {
+        if (mapitem == null || mapitem.isPickedUp()) {
+            return false;
+        }
+        if (mapitem.getMeso() > 0) {
+            if (!player.isEquippedMesoMagnet()) {
+                return false;
+            }
+
+            if (player.isEquippedPetItemIgnore()) {
+                final Set<Integer> petIgnore = player.getExcludedItems();
+                return petIgnore.isEmpty() || !petIgnore.contains(Integer.MAX_VALUE);
+            }
+        } else {
+            if (!player.isEquippedItemPouch()) {
+                return false;
+            }
+
+            if (player.isEquippedPetItemIgnore()) {
+                final Set<Integer> petIgnore = player.getExcludedItems();
+                return petIgnore.isEmpty() || !petIgnore.contains(mapitem.getItem().getItemId());
+            }
+        }
+        return true;
+    }
+
+    public void itemVac(Character player,byte slot) {
+        Pet pet = player.getPet(slot);
+        if (pet == null) return;
+        List<MapObject> list = player.getMap().getMapObjectsInRange(pet.getPos(), 30000.0, Arrays.asList(MapObjectType.ITEM));//获取全屏物品列表
+        for (MapObject item : list) {  // 遍历宠物身边一定范围内的物品列表
+            MapItem mapItem = (MapItem) item;
+            //不拾取不可见的任务道具
+            if (mapItem.isPlayerDrop()||!player.needQuestItem(mapItem.getQuest(), mapItem.getItemId())) {
+                continue;
+            }
+            if (shouldPickupItem(player, mapItem) && (mapItem.getOwnerId() == player.getId()
+                    || mapItem.getOwnerId() == player.getPartyId())) {
+            player.pickupItem(item, (int) slot);  // 执行拾取操作
+                }
+        }
     }
 }

--- a/gms-server/src/main/resources/db/migration/V1.11.1__insert_game_config_add_param.sql
+++ b/gms-server/src/main/resources/db/migration/V1.11.1__insert_game_config_add_param.sql
@@ -1,0 +1,20 @@
+-- 是否开启范围宠吸功能
+INSERT INTO `game_config`(`config_type`, `config_sub_type`, `config_clazz`, `config_code`, `config_value`, `config_desc`, `update_time`)
+SELECT 'server', 'Game Mechanics', 'java.lang.Boolean', 'pet_itemvac', 'true', 'pet_itemvac', '2026-06-01 14:00:00'
+WHERE NOT EXISTS (
+    SELECT 1 FROM `game_config` WHERE `config_code` = 'pet_itemvac'
+);
+
+-- 中文内容
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'zh-CN', 'game_config', 'pet_itemvac', '是否开启范围宠吸功能', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'zh-CN' AND `lang_code` = 'pet_itemvac'
+);
+
+-- 英文内容
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'en-US', 'game_config', 'use_enable_party_level_limit_lift', 'Whether to enable pets to vacuum items', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'en-US' AND `lang_code` = 'pet_itemvac'
+);


### PR DESCRIPTION
控制台新增参数pet_itemvac，宠物吸物功能由pet_itemvac参数开启或关闭，需要装备相应的宠物装备。拾取物可以通过宠物装备过滤，不会持续尝试拾取不可见的任务道具，不拾取玩家丢弃道具。