### PR TITLE
修复：宠物相关

### DIFF
--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -5259,57 +5259,53 @@ public class Character extends AbstractCharacterObject {
         }
     }
 
-    private static boolean isValidPetIndex(byte petIndex) {
-        return petIndex >= 0 && petIndex < 3;
-    }
-
     public int getPetEquipItemId(byte petIndex) {
-        if (!isValidPetIndex(petIndex)) {
+        if (!ItemConstants.isValidPetIndex(petIndex)) {
             return 0;
         }
 
-        Item petEqp = getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).equip());
+        Item petEqp = getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PET_EQUIP_SLOTS.get(petIndex).equip());
         return petEqp == null ? 0 : petEqp.getItemId();
     }
 
     public boolean hasPetNameTag(byte petIndex) {
-        if (!isValidPetIndex(petIndex)) {
+        if (!ItemConstants.isValidPetIndex(petIndex)) {
             return false;
         }
 
-        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).nameTag()) != null;
+        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PET_EQUIP_SLOTS.get(petIndex).nameTag()) != null;
     }
 
     public boolean hasPetChatballoon(byte petIndex) {
-        if (!isValidPetIndex(petIndex)) {
+        if (!ItemConstants.isValidPetIndex(petIndex)) {
             return false;
         }
 
-        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).chatBalloon()) != null;
+        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PET_EQUIP_SLOTS.get(petIndex).chatBalloon()) != null;
     }
 
     public boolean isEquippedMesoMagnet(byte petIndex) {
-        if (!isValidPetIndex(petIndex)) {
+        if (!ItemConstants.isValidPetIndex(petIndex)) {
             return false;
         }
 
-        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).mesoMagnet()) != null;
+        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PET_EQUIP_SLOTS.get(petIndex).mesoMagnet()) != null;
     }
 
     public boolean isEquippedItemPouch(byte petIndex) {
-        if (!isValidPetIndex(petIndex)) {
+        if (!ItemConstants.isValidPetIndex(petIndex)) {
             return false;
         }
 
-        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).itemPouch()) != null;
+        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PET_EQUIP_SLOTS.get(petIndex).itemPouch()) != null;
     }
 
     public boolean isEquippedPetItemIgnore(byte petIndex) {
-        if (!isValidPetIndex(petIndex)) {
+        if (!ItemConstants.isValidPetIndex(petIndex)) {
             return false;
         }
 
-        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).itemIgnore()) != null;
+        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PET_EQUIP_SLOTS.get(petIndex).itemIgnore()) != null;
     }
 
     public final byte getQuestStatus(final int quest) {

--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -258,12 +258,6 @@ public class Character extends AbstractCharacterObject {
     private boolean equipchanged = true, berserk, hasMerchant, hasSandboxItem = false, whiteChat = false;
     @Setter
     private boolean canRecvPartySearchInvite = true;
-    @Getter
-    private boolean equippedMesoMagnet = false;
-    @Getter
-    private boolean equippedItemPouch = false;
-    @Getter
-    private boolean equippedPetItemIgnore = false;
     private boolean usedSafetyCharm = false;
     @Getter
     @Setter
@@ -5265,6 +5259,59 @@ public class Character extends AbstractCharacterObject {
         }
     }
 
+    private static boolean isValidPetIndex(byte petIndex) {
+        return petIndex >= 0 && petIndex < 3;
+    }
+
+    public int getPetEquipItemId(byte petIndex) {
+        if (!isValidPetIndex(petIndex)) {
+            return 0;
+        }
+
+        Item petEqp = getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).equip());
+        return petEqp == null ? 0 : petEqp.getItemId();
+    }
+
+    public boolean hasPetNameTag(byte petIndex) {
+        if (!isValidPetIndex(petIndex)) {
+            return false;
+        }
+
+        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).nameTag()) != null;
+    }
+
+    public boolean hasPetChatballoon(byte petIndex) {
+        if (!isValidPetIndex(petIndex)) {
+            return false;
+        }
+
+        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).chatBalloon()) != null;
+    }
+
+    public boolean isEquippedMesoMagnet(byte petIndex) {
+        if (!isValidPetIndex(petIndex)) {
+            return false;
+        }
+
+        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).mesoMagnet()) != null;
+    }
+
+    public boolean isEquippedItemPouch(byte petIndex) {
+        if (!isValidPetIndex(petIndex)) {
+            return false;
+        }
+
+        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).itemPouch()) != null;
+    }
+
+    public boolean isEquippedPetItemIgnore(byte petIndex) {
+        if (!isValidPetIndex(petIndex)) {
+            return false;
+        }
+
+        return getInventory(InventoryType.EQUIPPED).getItem(ItemConstants.PetEquipSlots.get(petIndex).itemIgnore()) != null;
+    }
+
     public final byte getQuestStatus(final int quest) {
         synchronized (quests) {
             QuestStatus mqs = quests.get((short) quest);
@@ -9305,12 +9352,6 @@ public class Character extends AbstractCharacterObject {
 
         if (itemid == ItemId.PENDANT_OF_THE_SPIRIT) {
             this.equipPendantOfSpirit();
-        } else if (itemid == ItemId.MESO_MAGNET) {
-            equippedMesoMagnet = true;
-        } else if (itemid == ItemId.ITEM_POUCH) {
-            equippedItemPouch = true;
-        } else if (itemid == ItemId.ITEM_IGNORE) {
-            equippedPetItemIgnore = true;
         }
     }
 
@@ -9319,12 +9360,6 @@ public class Character extends AbstractCharacterObject {
 
         if (itemid == ItemId.PENDANT_OF_THE_SPIRIT) {
             this.unequipPendantOfSpirit();
-        } else if (itemid == ItemId.MESO_MAGNET) {
-            equippedMesoMagnet = false;
-        } else if (itemid == ItemId.ITEM_POUCH) {
-            equippedItemPouch = false;
-        } else if (itemid == ItemId.ITEM_IGNORE) {
-            equippedPetItemIgnore = false;
         }
     }
 

--- a/gms-server/src/main/java/org/gms/client/inventory/Pet.java
+++ b/gms-server/src/main/java/org/gms/client/inventory/Pet.java
@@ -227,7 +227,7 @@ public class Pet extends Item {
             enjoyed = false;
         }
 
-        owner.getMap().broadcastMessage(PacketCreator.petFoodResponse(owner.getId(), slot, enjoyed, false));
+        owner.getMap().broadcastMessage(PacketCreator.petFoodResponse(owner.getId(), slot, enjoyed, owner.hasPetChatballoon(slot)));
         saveToDb();
 
         Item petz = owner.getInventory(InventoryType.CASH).getItem(getPosition());

--- a/gms-server/src/main/java/org/gms/client/inventory/manipulator/InventoryManipulator.java
+++ b/gms-server/src/main/java/org/gms/client/inventory/manipulator/InventoryManipulator.java
@@ -662,11 +662,11 @@ public class InventoryManipulator {
             chr.cancelBuffStats(BuffStat.BOOSTER);
         }
 
-        byte petIndex = (byte)ItemConstants.PetsNameTag.indexOf(dst);
+        int petIndex = ItemConstants.PETS_NAME_TAG.indexOf(dst);
         if (petIndex != -1) {
             Pet pet = chr.getPet(petIndex);
             if (pet != null) {
-                chr.getMap().broadcastMessage(chr, PacketCreator.changePetName(chr, pet.getName(), petIndex), false);
+                chr.getMap().broadcastMessage(chr, PacketCreator.changePetName(chr, pet.getName(), (byte)petIndex), false);
             }
         }
 
@@ -714,11 +714,11 @@ public class InventoryManipulator {
             eqpdInv.addItemFromDB(target);
         }
 
-        byte petIndex = (byte)ItemConstants.PetsNameTag.indexOf(src);
+        int petIndex = ItemConstants.PETS_NAME_TAG.indexOf(src);
         if (petIndex != -1) {
             Pet pet = chr.getPet(petIndex);
             if (pet != null) {
-                chr.getMap().broadcastMessage(chr, PacketCreator.changePetName(chr, pet.getName(), petIndex), false);
+                chr.getMap().broadcastMessage(chr, PacketCreator.changePetName(chr, pet.getName(), (byte)petIndex), false);
             }
         }
         

--- a/gms-server/src/main/java/org/gms/client/inventory/manipulator/InventoryManipulator.java
+++ b/gms-server/src/main/java/org/gms/client/inventory/manipulator/InventoryManipulator.java
@@ -662,6 +662,14 @@ public class InventoryManipulator {
             chr.cancelBuffStats(BuffStat.BOOSTER);
         }
 
+        byte petIndex = (byte)ItemConstants.PetsNameTag.indexOf(dst);
+        if (petIndex != -1) {
+            Pet pet = chr.getPet(petIndex);
+            if (pet != null) {
+                chr.getMap().broadcastMessage(chr, PacketCreator.changePetName(chr, pet.getName(), petIndex), false);
+            }
+        }
+
         mods.add(new ModifyInventory(2, source, src));
         c.sendPacket(PacketCreator.modifyInventory(true, mods));
         chr.equipChanged();
@@ -705,6 +713,15 @@ public class InventoryManipulator {
             target.setPosition(src);
             eqpdInv.addItemFromDB(target);
         }
+
+        byte petIndex = (byte)ItemConstants.PetsNameTag.indexOf(src);
+        if (petIndex != -1) {
+            Pet pet = chr.getPet(petIndex);
+            if (pet != null) {
+                chr.getMap().broadcastMessage(chr, PacketCreator.changePetName(chr, pet.getName(), petIndex), false);
+            }
+        }
+        
         c.sendPacket(PacketCreator.modifyInventory(true, Collections.singletonList(new ModifyInventory(2, source, src))));
         chr.equipChanged();
     }

--- a/gms-server/src/main/java/org/gms/constants/inventory/ItemConstants.java
+++ b/gms-server/src/main/java/org/gms/constants/inventory/ItemConstants.java
@@ -25,10 +25,11 @@ import org.gms.client.inventory.InventoryType;
 import org.gms.config.GameConfig;
 import org.gms.constants.id.ItemId;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -356,11 +357,15 @@ public final class ItemConstants {
     public final static short Pet1ItemIgnore = -147;
     public final static short Pet2ItemIgnore = -148;
 
-    public static ArrayList<PetEquipSlot> PetEquipSlots = new ArrayList<>(Arrays.asList(
+    public static final List<PetEquipSlot> PET_EQUIP_SLOTS = Collections.unmodifiableList(Arrays.asList(
         new PetEquipSlot(Pet0Equip, Pet0NameTag, Pet0ChatBalloon, Pet0MesoMagnet, Pet0ItemPouch, Pet0ItemIgnore),
         new PetEquipSlot(Pet1Equip, Pet1NameTag, Pet1ChatBalloon, Pet1MesoMagnet, Pet1ItemPouch, Pet1ItemIgnore),
         new PetEquipSlot(Pet2Equip, Pet2NameTag, Pet2ChatBalloon, Pet2MesoMagnet, Pet2ItemPouch, Pet2ItemIgnore)
     ));
 
-    public static ArrayList<Short> PetsNameTag = new ArrayList<>(Arrays.asList(Pet0NameTag, Pet1NameTag, Pet2NameTag));
+    public static final List<Short> PETS_NAME_TAG = Collections.unmodifiableList(Arrays.asList(Pet0NameTag, Pet1NameTag, Pet2NameTag));
+
+    public static boolean isValidPetIndex(byte petIndex) {
+        return petIndex >= 0 && petIndex < 3;
+    }
 }

--- a/gms-server/src/main/java/org/gms/constants/inventory/ItemConstants.java
+++ b/gms-server/src/main/java/org/gms/constants/inventory/ItemConstants.java
@@ -25,6 +25,8 @@ import org.gms.client.inventory.InventoryType;
 import org.gms.config.GameConfig;
 import org.gms.constants.id.ItemId;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -325,4 +327,40 @@ public final class ItemConstants {
     public static boolean notValidHairColor(int hairColor) {
         return hairColor > 7 || hairColor < 0;
     }
+
+    // is_correct_bodypart
+    public final static short Pet0Equip = -114;
+    public final static short Pet1Equip = -130;
+    public final static short Pet2Equip = -138;
+
+    public final static short Pet0NameTag = -121;
+    public final static short Pet1NameTag = -131;
+    public final static short Pet2NameTag = -139;
+
+    public final static short Pet0ChatBalloon = -129;
+    public final static short Pet1ChatBalloon = -132;
+    public final static short Pet2ChatBalloon = -140;
+
+    // itemId = 1812000
+    public final static short Pet0MesoMagnet = -123;
+    public final static short Pet1MesoMagnet = -134;
+    public final static short Pet2MesoMagnet = -142;
+
+    // itemId = 1812001
+    public final static short Pet0ItemPouch = -122;
+    public final static short Pet1ItemPouch = -133;
+    public final static short Pet2ItemPouch = -141;
+
+    // itemId = 1812007
+    public final static short Pet0ItemIgnore = -146;
+    public final static short Pet1ItemIgnore = -147;
+    public final static short Pet2ItemIgnore = -148;
+
+    public static ArrayList<PetEquipSlot> PetEquipSlots = new ArrayList<>(Arrays.asList(
+        new PetEquipSlot(Pet0Equip, Pet0NameTag, Pet0ChatBalloon, Pet0MesoMagnet, Pet0ItemPouch, Pet0ItemIgnore),
+        new PetEquipSlot(Pet1Equip, Pet1NameTag, Pet1ChatBalloon, Pet1MesoMagnet, Pet1ItemPouch, Pet1ItemIgnore),
+        new PetEquipSlot(Pet2Equip, Pet2NameTag, Pet2ChatBalloon, Pet2MesoMagnet, Pet2ItemPouch, Pet2ItemIgnore)
+    ));
+
+    public static ArrayList<Short> PetsNameTag = new ArrayList<>(Arrays.asList(Pet0NameTag, Pet1NameTag, Pet2NameTag));
 }

--- a/gms-server/src/main/java/org/gms/constants/inventory/PetEquipSlot.java
+++ b/gms-server/src/main/java/org/gms/constants/inventory/PetEquipSlot.java
@@ -1,0 +1,5 @@
+package org.gms.constants.inventory;
+
+public record PetEquipSlot(short equip, short nameTag, short chatBalloon, short mesoMagnet, short itemPouch, short itemIgnore) {
+
+}

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/PetChatHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/PetChatHandler.java
@@ -50,7 +50,7 @@ public final class PetChatHandler extends AbstractPacketHandler {
             c.disconnect(true, false);
             return;
         }
-        c.getPlayer().getMap().broadcastMessage(c.getPlayer(), PacketCreator.petChat(c.getPlayer().getId(), pet, act, text, c.getPlayer().hasPetChatballoon(pet)), false);
+        c.getPlayer().getMap().broadcastMessage(c.getPlayer(), PacketCreator.petChat(c.getPlayer().getId(), pet, act, text, c.getPlayer().hasPetChatballoon(pet)), true);
         ChatLogger.log(c, "Pet", text);
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/PetChatHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/PetChatHandler.java
@@ -50,7 +50,7 @@ public final class PetChatHandler extends AbstractPacketHandler {
             c.disconnect(true, false);
             return;
         }
-        c.getPlayer().getMap().broadcastMessage(c.getPlayer(), PacketCreator.petChat(c.getPlayer().getId(), pet, act, text), true);
+        c.getPlayer().getMap().broadcastMessage(c.getPlayer(), PacketCreator.petChat(c.getPlayer().getId(), pet, act, text, c.getPlayer().hasPetChatballoon(pet)), false);
         ChatLogger.log(c, "Pet", text);
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/PetCommandHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/PetCommandHandler.java
@@ -54,9 +54,9 @@ public final class PetCommandHandler extends AbstractPacketHandler {
 
         if (Randomizer.nextInt(100) < petCommand.getProbability()) {
             pet.gainTamenessFullness(chr, petCommand.getIncrease(), 0, command);
-            chr.getMap().broadcastMessage(PacketCreator.commandResponse(chr.getId(), petIndex, false, command, false));
+            chr.getMap().broadcastMessage(PacketCreator.commandResponse(chr.getId(), petIndex, false, command, chr.hasPetChatballoon(petIndex)));
         } else {
-            chr.getMap().broadcastMessage(PacketCreator.commandResponse(chr.getId(), petIndex, true, command, false));
+            chr.getMap().broadcastMessage(PacketCreator.commandResponse(chr.getId(), petIndex, true, command, chr.hasPetChatballoon(petIndex)));
         }
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/PetLootHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/PetLootHandler.java
@@ -41,7 +41,7 @@ public final class PetLootHandler extends AbstractPacketHandler {
     public final void handlePacket(InPacket p, Client c) {
         Character chr = c.getPlayer();
 
-        int petIndex = chr.getPetIndex(p.readInt());
+        byte petIndex = chr.getPetIndex(p.readInt());
         Pet pet = chr.getPet(petIndex);
         if (pet == null || !pet.isSummoned()) {
             c.sendPacket(PacketCreator.enableActions());
@@ -54,12 +54,12 @@ public final class PetLootHandler extends AbstractPacketHandler {
         try {
             MapItem mapitem = (MapItem) ob;
             if (mapitem.getMeso() > 0) {
-                if (!chr.isEquippedMesoMagnet()) {
+                if (!chr.isEquippedMesoMagnet(petIndex)) {
                     c.sendPacket(PacketCreator.enableActions());
                     return;
                 }
 
-                if (chr.isEquippedPetItemIgnore()) {
+                if (chr.isEquippedPetItemIgnore(petIndex)) {
                     final Set<Integer> petIgnore = chr.getExcludedItems();
                     if (!petIgnore.isEmpty() && petIgnore.contains(Integer.MAX_VALUE)) {
                         c.sendPacket(PacketCreator.enableActions());
@@ -67,12 +67,12 @@ public final class PetLootHandler extends AbstractPacketHandler {
                     }
                 }
             } else {
-                if (!chr.isEquippedItemPouch()) {
+                if (!chr.isEquippedItemPouch(petIndex)) {
                     c.sendPacket(PacketCreator.enableActions());
                     return;
                 }
 
-                if (chr.isEquippedPetItemIgnore()) {
+                if (chr.isEquippedPetItemIgnore(petIndex)) {
                     final Set<Integer> petIgnore = chr.getExcludedItems();
                     if (!petIgnore.isEmpty() && petIgnore.contains(mapitem.getItem().getItemId())) {
                         c.sendPacket(PacketCreator.enableActions());

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/UseCashItemHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/UseCashItemHandler.java
@@ -420,7 +420,7 @@ public final class UseCashItemHandler extends AbstractPacketHandler {
                 player.forceUpdateItem(item);
             }
 
-            player.getMap().broadcastMessage(player, PacketCreator.changePetName(player, newName, 1), true);
+            player.getMap().broadcastMessage(player, PacketCreator.changePetName(player, newName, (byte)0), true);
             c.enableActions();
             remove(c, position, itemId);
         } else if (itemType == 520) {//钱袋子

--- a/gms-server/src/main/java/org/gms/util/PacketCreator.java
+++ b/gms-server/src/main/java/org/gms/util/PacketCreator.java
@@ -2729,6 +2729,7 @@ public class PacketCreator {
         p.writeString(allianceName);  // does not seem to work
         p.writeByte(0); // pMedalInfo, thanks to Arnah (Vertisy)
 
+        // CUIUserInfo::SetMultiPetInfo
         Pet[] pets = chr.getPets();
         for (byte i = 0; i < 3; i++) {
             if (pets[i] != null) {

--- a/gms-server/src/main/java/org/gms/util/PacketCreator.java
+++ b/gms-server/src/main/java/org/gms/util/PacketCreator.java
@@ -1975,9 +1975,9 @@ public class PacketCreator {
         p.writeShort(0);//chr.getFh()
         p.writeByte(0);
         Pet[] pet = chr.getPets();
-        for (int i = 0; i < 3; i++) {
+        for (byte i = 0; i < 3; i++) {
             if (pet[i] != null) {
-                addPetInfo(p, pet[i], false);
+                addPetInfo(p, pet[i], false, chr.hasPetNameTag(i), chr.hasPetChatballoon(i));
             }
         }
         p.writeByte(0); //end of pets
@@ -2730,17 +2730,16 @@ public class PacketCreator {
         p.writeByte(0); // pMedalInfo, thanks to Arnah (Vertisy)
 
         Pet[] pets = chr.getPets();
-        Item inv = chr.getInventory(InventoryType.EQUIPPED).getItem((short) -114);
-        for (int i = 0; i < 3; i++) {
+        for (byte i = 0; i < 3; i++) {
             if (pets[i] != null) {
-                p.writeByte(pets[i].getUniqueId());
+                p.writeBool(true);
                 p.writeInt(pets[i].getItemId()); // petid
                 p.writeString(pets[i].getName());
                 p.writeByte(pets[i].getLevel()); // pet level
                 p.writeShort(pets[i].getTameness()); // pet tameness
                 p.writeByte(pets[i].getFullness()); // pet fullness
                 p.writeShort(0);
-                p.writeInt(inv != null ? inv.getItemId() : 0);
+                p.writeInt(chr.getPetEquipItemId(i));
             }
         }
         p.writeByte(0); //end of pets
@@ -4422,7 +4421,7 @@ public class PacketCreator {
         return p;
     }
 
-    private static void addPetInfo(final OutPacket p, Pet pet, boolean showpet) {
+    private static void addPetInfo(final OutPacket p, Pet pet, boolean showpet, boolean hasNameTag, boolean hasChatBalloon) {
         p.writeByte(1);
         if (showpet) {
             p.writeByte(0);
@@ -4433,18 +4432,21 @@ public class PacketCreator {
         p.writeLong(pet.getUniqueId());
         p.writePos(pet.getPos());
         p.writeByte(pet.getStance());
-        p.writeInt(pet.getFh());
+        p.writeShort(pet.getFh());
+        p.writeBool(hasNameTag);
+        p.writeBool(hasChatBalloon);
     }
 
     public static Packet showPet(Character chr, Pet pet, boolean remove, boolean hunger) {
+        byte petIndex = chr.getPetIndex(pet);
         OutPacket p = OutPacket.create(SendOpcode.SPAWN_PET);
         p.writeInt(chr.getId());
-        p.writeByte(chr.getPetIndex(pet));
+        p.writeByte(petIndex);
         if (remove) {
             p.writeByte(0);
             p.writeBool(hunger);
         } else {
-            addPetInfo(p, pet, true);
+            addPetInfo(p, pet, true, chr.hasPetNameTag(petIndex), chr.hasPetChatballoon(petIndex));
         }
         return p;
     }
@@ -4458,24 +4460,32 @@ public class PacketCreator {
         return p;
     }
 
-    public static Packet petChat(int cid, byte index, int act, String text) {
+    public static Packet petChat(int cid, byte index, int act, String text, boolean hasChatBalloon) {
         final OutPacket p = OutPacket.create(SendOpcode.PET_CHAT);
         p.writeInt(cid);
         p.writeByte(index);
         p.writeByte(0);
         p.writeByte(act);
         p.writeString(text);
-        p.writeByte(0);
+        p.writeBool(hasChatBalloon);
         return p;
     }
 
-    public static Packet petFoodResponse(int cid, byte index, boolean success, boolean balloonType) {
+    public static Packet petFoodResponse(int cid, byte index, boolean success, boolean hasChatBalloon) {
         final OutPacket p = OutPacket.create(SendOpcode.PET_COMMAND);
         p.writeInt(cid);
         p.writeByte(index);
         p.writeByte(1);
         p.writeBool(success);
-        p.writeBool(balloonType);
+        p.writeBool(hasChatBalloon);
+        return p;
+    }
+
+    public static Packet petEatCashFoodFail() {
+        // CWvsContext::OnCashPetFoodResult
+        OutPacket p = OutPacket.create(SendOpcode.CASH_PET_FOOD_RESULT);
+        p.writeBool(true);
+        // SP_3793_YOUR_PET_CANNOT_CONSUME_THIS_FOOD_R_NPLEASE_CHECK_AGAIN
         return p;
     }
 
@@ -4507,12 +4517,12 @@ public class PacketCreator {
         return p;
     }
 
-    public static Packet changePetName(Character chr, String newname, int slot) {
+    public static Packet changePetName(Character chr, String newname, byte slot) {
         OutPacket p = OutPacket.create(SendOpcode.PET_NAMECHANGE);
         p.writeInt(chr.getId());
-        p.writeByte(0);
+        p.writeByte(slot);
         p.writeString(newname);
-        p.writeByte(0);
+        p.writeBool(chr.hasPetNameTag(slot));
         return p;
     }
 


### PR DESCRIPTION
- 宠物名片、聊天气泡对其他玩家的显示
- 群宠下，查看角色详细信息时宠物装备的正确显示
- 宠物拾取时，群宠状态宠物装备的验证