### PR TITLE
修复法师魔力恢复服务端效果

### DIFF
--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/HealOvertimeHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/HealOvertimeHandler.java
@@ -23,8 +23,11 @@ package org.gms.net.server.channel.handlers;
 
 import org.gms.client.Character;
 import org.gms.client.Client;
+import org.gms.client.Skill;
+import org.gms.client.SkillFactory;
 import org.gms.client.autoban.AutobanFactory;
 import org.gms.client.autoban.AutobanManager;
+import org.gms.constants.skills.Magician;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
 import org.gms.net.server.Server;
@@ -61,15 +64,28 @@ public final class HealOvertimeHandler extends AbstractPacketHandler {
             chr.getMap().broadcastMessage(chr, PacketCreator.showHpHealed(chr.getId(), healHP), false);
             abm.spam(0, timestamp);
         }
-        short healMP = p.readShort();
+        int healMP = p.readShort();
         if (healMP != 0 && healMP < 1000) {
             abm.setTimestamp(9, timestamp, 28);
             if ((abm.getLastSpam(1) + 1500) > timestamp) {
                 AutobanFactory.FAST_MP_HEALING.addPoint(abm, "Fast mp healing");
                 return;     // thanks resinate for noticing mp being gained even after detection
             }
+            healMP = applyImprovedMpRecovery(chr, healMP);
             chr.addMP(healMP);
             abm.spam(1, timestamp);
         }
+    }
+
+    private static int applyImprovedMpRecovery(Character chr, int healMP) {
+        Skill improvedRecovery = SkillFactory.getSkill(Magician.IMPROVED_MP_RECOVERY);
+        int skillLevel = chr.getSkillLevel(improvedRecovery);
+        if (skillLevel <= 0) {
+            return healMP;
+        }
+
+        // Keep this as a server-side floor so clients that already include the bonus are not doubled.
+        int expectedRecovery = skillLevel * (chr.getLevel() / 10) + 3;
+        return Math.max(healMP, expectedRecovery);
     }
 }


### PR DESCRIPTION
## 主要调整
- 修复 `2000000 魔力恢复 / Improved MP Recovery` 在服务端自然恢复 MP 时未体现技能加成的问题。
- 在处理角色自然 MP 恢复时，根据技能等级与角色等级计算魔力恢复应有的最低恢复量。
- 保留客户端上报恢复值较高时的结果，避免重复叠加恢复量；仅在上报值低于技能应有恢复量时进行服务端补足。
- 该处理用于保证角色已学习魔力恢复后，服务端实际 MP 变化与技能说明中的恢复效果保持一致。

## 客户端同步备注
- 本次修改只涉及服务端 Java 逻辑，不依赖客户端 WZ 同步。