### PR TITLE
fix: Ellin PQ NPC 2133000 移除错误的第三级阿尔泰耳环

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2133000.js
+++ b/gms-server/scripts-zh-CN/npc/2133000.js
@@ -87,7 +87,7 @@ function action(mode, type, selection) {
                 cm.sendOk("#e#b<组队任务：毒雾森林>#k#n\r\n在这个组队任务中，你的任务是逐步穿越森林，对抗路上的所有坏家伙，解决你遇到的许多谜题，并团结一致，充分发挥团队合作的优势，以克服时间限制和强大的生物。击败最终BOSS后，你的团队有机会获得一个大理石，#b当它被喷泉在出口地图上掉落时#k，将会确保团队获得额外的奖励。祝你好运。");
                 cm.dispose();
             } else {
-                cm.sendSimple("那么，你想要获得什么奖品？\r\n#b#L0#给我阿尔泰耳环。\r\n#L1#给我闪亮的阿尔泰耳环。\r\n#L2#给我闪耀的阿尔泰耳环。");
+                cm.sendSimple("那么，你想要获得什么奖品？\r\n#b#L0##t1032060#\r\n#L1##t1032061#");
             }
         } else if (status == 2) {
             if (selection == 0) {
@@ -96,7 +96,7 @@ function action(mode, type, selection) {
                     cm.gainItem(4001198, -10);
                     cm.dispose();
                 } else {
-                    cm.sendOk("你要么已经有了阿尔泰耳环，要么没有10个阿尔泰碎片。");
+                    cm.sendOk("你要么已经有了 #t1032060#，要么没有 10 个 #t4001198#。");
                     cm.dispose();
                 }
             } else if (selection == 1) {
@@ -106,17 +106,7 @@ function action(mode, type, selection) {
                     cm.gainItem(4001198, -10);
                     cm.dispose();
                 } else {
-                    cm.sendOk("你要么还没有阿尔泰耳环，要么没有10个阿尔泰碎片。");
-                    cm.dispose();
-                }
-            } else if (selection == 2) {
-                if (cm.haveItem(1032061) && !cm.haveItem(1032072) && cm.haveItem(4001198, 10)) {
-                    cm.gainItem(1032061, -1);
-                    cm.gainItem(1032072, 1);    // thanks yuxaij for noticing unexpected itemid here
-                    cm.gainItem(4001198, -10);
-                    cm.dispose();
-                } else {
-                    cm.sendOk("你要么还没有闪耀的阿尔泰尔耳环，要么没有10个阿尔泰尔碎片。");
+                    cm.sendOk("你要么还没有 #t1032060#，要么没有 10 个 #t4001198#。");
                     cm.dispose();
                 }
             }

--- a/gms-server/scripts/npc/2133000.js
+++ b/gms-server/scripts/npc/2133000.js
@@ -87,7 +87,7 @@ function action(mode, type, selection) {
                 cm.sendOk("#e#b<Party Quest: Forest of Poison Haze>#k#n\r\nIn this PQ, your mission is to progressively make your way through the woods, taking on all baddies in your path, solving many puzzles you encounter and rallying yourselves to take the best of teamwork to overcome time limits and powerful creatures. Clearing the final boss, your team have a chance to obtain a marble that, #bwhen dropped by the fountain at the exit map#k, will guarantee the team extra prizes. Good luck.");
                 cm.dispose();
             } else {
-                cm.sendSimple("So, what prize do you want to obtain?\r\n#b#L0#Give me Altaire Earrings.\r\n#L1#Give me Glittering Altaire Earrings.\r\n#L2#Give me Brilliant Altaire Earrings");
+                cm.sendSimple("So, what prize do you want to obtain?\r\n#b#L0##t1032060#\r\n#L1##t1032061#");
             }
         } else if (status == 2) {
             if (selection == 0) {
@@ -96,7 +96,7 @@ function action(mode, type, selection) {
                     cm.gainItem(4001198, -10);
                     cm.dispose();
                 } else {
-                    cm.sendOk("You either have Altair Earrings already or you do not have 10 Altair Fragments.");
+                    cm.sendOk("You either have #t1032060# already or you do not have 10 #t4001198#.");
                     cm.dispose();
                 }
             } else if (selection == 1) {
@@ -106,17 +106,7 @@ function action(mode, type, selection) {
                     cm.gainItem(4001198, -10);
                     cm.dispose();
                 } else {
-                    cm.sendOk("You either don't have Altair Earrings already or you do not have 10 Altair Fragments.");
-                    cm.dispose();
-                }
-            } else if (selection == 2) {
-                if (cm.haveItem(1032061) && !cm.haveItem(1032072) && cm.haveItem(4001198, 10)) {
-                    cm.gainItem(1032061, -1);
-                    cm.gainItem(1032072, 1);    // thanks yuxaij for noticing unexpected itemid here
-                    cm.gainItem(4001198, -10);
-                    cm.dispose();
-                } else {
-                    cm.sendOk("You either don't have Glittering Altair Earrings already or you do not have 10 Altair Fragments.");
+                    cm.sendOk("You either don't have #t1032060# already or you do not have 10 #t4001198#.");
                     cm.dispose();
                 }
             }


### PR DESCRIPTION
V83 原版 Ellin PQ 只有两级耳环：1032060（阿尔泰）→ 1032061（发光的阿尔泰）。
第三级原用 1032072（Shiny Altair Earrings）是 GMS 商城现金道具（2400 NX），
非 PQ 奖励。改动：移除 L2 分支，菜单和反馈文本改用 #t# 动态引用物品名，自动适配中英文