### PR TITLE
fix:修正露妮与幸福村相关文本汉化不一致问题

### DIFF
--- a/gms-server/scripts-zh-CN/npc/1022101.js
+++ b/gms-server/scripts-zh-CN/npc/1022101.js
@@ -45,7 +45,7 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            cm.sendYesNo("圣诞老人告诉我来到这里，只是他没有告诉我什么时候……我希望我来的时间对了！哦！顺便说一下，我是鲁尼，我可以带你去#b快乐村#k。你准备好了吗？");
+            cm.sendYesNo("圣诞老人让我来到这里，只是没有告诉我具体是什么时候……希望我来得正是时候！哦！顺便说一下，我是露妮，我可以带你去#b幸福村#k。你准备好了吗？");
         } else {
             cm.getPlayer().saveLocation("HAPPYVILLE");
             cm.warp(209000000, 0);

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -14865,119 +14865,119 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="4437">
-        <string name="name" value="Rooney&apos;s Breaking News"/>
-        <string name="0" value="#b#p9250052##k is apparently handing out flyers that contain the breaking news..."/>
-        <string name="1" value="Just received a flyer from #b#p9250052##k. The flyer stated that Happyville is in a state of emergency, and for more details, I have to visit #p1022101#."/>
-        <string name="2" value="I asked #b#p1022101##k to inquire more on the stuff written on the flyer."/>
+        <string name="name" value="露妮的突发新闻"/>
+        <string name="0" value="#b#p9250052##k好像正在发放写有突发新闻的传单……"/>
+        <string name="1" value="刚从#b#p9250052##k那里拿到一张传单。传单上说幸福村正处于紧急状态，想了解详情的话，需要去找#p1022101#。"/>
+        <string name="2" value="我向#b#p1022101##k询问了传单上写的事情。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4477">
-        <string name="name" value="News Special Report"/>
-        <string name="0" value="People are saying that there is shocking news on the front page of the Maple Herald. What could it be?"/>
-        <string name="1" value="You were unable to buy the newspaper because it was already sold out.  However, you were able to read from the newspaper clippings behind the sales clerk. They say that Santa Claus will not be coming to Maple World this year. Is it true that he&apos;s not coming to town because Maplers stopped believing in Santa Claus? There must be some other reason. #bRooney#k is from Happyville and should know about what&apos;s happening. You should go ask."/>
-        <string name="2" value="You wished Rooney a Merry Christmas! Now, you should ask about Santa Claus."/>
+        <string name="name" value="新闻特别报道"/>
+        <string name="0" value="听说《枫叶先驱报》的头版刊登了令人震惊的新闻。会是什么事呢？"/>
+        <string name="1" value="报纸已经卖光了，没能买到。不过，我从报刊亭后面的剪报上看到了消息：圣诞老人今年不会来到冒险岛世界。难道真的是因为冒险家们不再相信圣诞老人，所以他才不来了吗？一定还有别的原因。#b#p1022101##k来自幸福村，应该知道发生了什么。去问问她吧。"/>
+        <string name="2" value="你向露妮送上了圣诞祝福。接下来，问问她有关圣诞老人的事吧。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4478">
-        <string name="name" value="Disappeared Santa Encyclopedia  "/>
-        <string name="0" value="You should ask Rooney about the article on Santa Claus."/>
-        <string name="1" value="Rooney felt bad that most Maplers don&apos;t believe in Santa Claus anymore. She also mentioned that this is caused by the loss of #bSanta Encyclopedias#k in the town library. She asked that you gather all 6 Santa Encyclopedias that the monsters have stolen. Remember, not only is it meaningful to gather all 6 Santa Encyclopedias, but also something good will happen while searching for those books.\n\n#t4161043# #b#c4161043##k/1 \n#t4161038# #b#c4161038##k/1 \n#t4161039# #b#c4161039##k/1 \n#t4161040# #b#c4161040##k/1 \n#t4161041# #b#c4161041##k/1 \n#t4161042# #b#c4161042##k/1"/>
-        <string name="2" value="Just like Rooney had mentioned, a lot of good things happened to you while searching for the 6 Santa Encyclopedias. Since you did all those good deeds, Santa is certainly coming to town. More importantly, Maplers will now believe in Santa Claus!"/>
+        <string name="name" value="消失的圣诞老人百科全书"/>
+        <string name="0" value="去向露妮询问有关圣诞老人的报道吧。"/>
+        <string name="1" value="露妮对许多冒险家不再相信圣诞老人感到难过。她还提到，这是因为村子图书馆里的#b圣诞老人百科全书#k遗失了。她拜托你找回被怪物偷走的6本圣诞老人百科全书。记住，找齐这6本书本身就很有意义，而且在寻找的过程中也会有好事发生。\n\n#t4161043# #b#c4161043##k/1 \n#t4161038# #b#c4161038##k/1 \n#t4161039# #b#c4161039##k/1 \n#t4161040# #b#c4161040##k/1 \n#t4161041# #b#c4161041##k/1 \n#t4161042# #b#c4161042##k/1"/>
+        <string name="2" value="正如露妮所说，在寻找6本圣诞老人百科全书的过程中，你遇到了许多好事。既然你做了这么多善事，圣诞老人一定会来到这里。更重要的是，冒险家们也会重新相信圣诞老人！"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4479">
-        <string name="name" value="Santa Grandmother Finding"/>
-        <string name="0" value="You&apos;ve found Santa Encyclopedia No.2, regarding Santa&apos;s Family History.  Santa Encyclopedia No.2 has stories about the lovely wife of Santa Claus, Mrs. Claus. You should visit her by tracing the information written in Santa Encyclopedia No.2."/>
-        <string name="1" value="Mrs. Claus was precisely at the location mentioned in the book. You asked Mrs. Claus about Santa Claus."/>
-        <string name="2" value="You asked Mrs. Claus about Santa Claus, but she pretended as if she didn&apos;t know who he was. How will you get her to warm up to you?"/>
+        <string name="name" value="寻找圣诞老人夫人"/>
+        <string name="0" value="你找到了记载圣诞老人家族故事的《圣诞老人百科全书》第2卷。书里提到了圣诞老人亲爱的妻子——圣诞老人夫人。根据书中记录的线索，去拜访她吧。"/>
+        <string name="1" value="圣诞老人夫人果然就在书中提到的地方。你向她询问了圣诞老人的事情。"/>
+        <string name="2" value="你向圣诞老人夫人询问圣诞老人的事情，但她却装作不认识他。要怎样才能让她愿意开口呢？"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4480">
-        <string name="name" value="Common Sense Of Santa "/>
-        <string name="0" value="You made a visit to Mrs. Claus wondering about Santa Claus&apos;s condition, but she wouldn&apos;t tell you anything. Maybe you should go find #bSanta Encyclopedia No.1#k, the one that contains the history of Santa Claus, and read up a bit first.  Then you should go visit her again."/>
-        <string name="1" value="Thanks to #bSanta Encyclopedia No.1#k, she finally opened up and started talking to you."/>
-        <string name="2" value="Truth always prospers! You were able to discover the real reason why Santa Claus disappeared."/>
+        <string name="name" value="圣诞老人的常识"/>
+        <string name="0" value="你为了打听圣诞老人的近况去拜访圣诞老人夫人，但她什么也不肯说。也许应该先找到记载圣诞老人历史的#b《圣诞老人百科全书》第1卷#k，读一读之后再去找她。"/>
+        <string name="1" value="多亏了#b《圣诞老人百科全书》第1卷#k，她终于敞开心扉，开始和你交谈。"/>
+        <string name="2" value="真相终会浮现！你终于知道了圣诞老人消失的真正原因。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4481">
-        <string name="name" value="Socks Creation Recipes"/>
-        <string name="0" value="Mrs. Claus, who previously wouldn&apos;t open up about Santa Claus, finally started talking to you after realizing you had read up on Santa Claus. As you expected, there was another reason behind Santa Claus leaving."/>
-        <string name="1" value="Mrs. Claus told you about the importance of the Christmas Socks. However, she also said that making quality socks is not an easy task. The sock factory ceased its production due to a case of robbery, but she&apos;ll be able to make them again with a little bit of your help.\n\n#t4161039# #b#c4161039##k/1"/>
-        <string name="2" value="You brought #bSanta Encyclopedia No.3#k to Mrs. Claus who was having a hard time remembering how to make Christmas Socks. But it all came back to her after reading the book. You should wait a while until she finds the frame for the socks."/>
+        <string name="name" value="圣诞袜制作配方"/>
+        <string name="0" value="原本不愿谈起圣诞老人的圣诞老人夫人，在发现你了解过圣诞老人的事情后，终于开始和你交谈。果然，圣诞老人离开还有别的原因。"/>
+        <string name="1" value="圣诞老人夫人告诉你圣诞袜非常重要。不过，她也说制作合格的袜子并不容易。袜子工厂因为遭到抢劫而停产了，但只要你稍微帮帮忙，她就能重新制作圣诞袜。\n\n#t4161039# #b#c4161039##k/1"/>
+        <string name="2" value="你把#b《圣诞老人百科全书》第3卷#k交给了想不起圣诞袜制作方法的圣诞老人夫人。她读完后终于想起来了。等她找到制作袜子的框架后，再去找她吧。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4482">
-        <string name="name" value="Socks Actual Creation Action"/>
-        <string name="0" value="Mrs. Claus has finally discovered the frame for the socks. You should ask her again."/>
-        <string name="1" value="Mrs. Claus gladly lent you a frame necessary for making Christmas Socks. She also said that yarn with good flexibility is a must. These yarns seem to have been taken by the #bSnowman#k who is highly suspected as the culprit behind the robbery. You can make socks by collecting the yarn and attaching them to the sock frame.\n\n#t4220022# #b#c4220022##k/1"/>
-        <string name="2" value="Finally, you made the Socks by getting the necessary amount of yarn. Of course, don&apos;t forget to thank Mrs. Claus who taught you the craft."/>
+        <string name="name" value="正式制作圣诞袜"/>
+        <string name="0" value="圣诞老人夫人终于找到了制作袜子的框架。再去问问她吧。"/>
+        <string name="1" value="圣诞老人夫人很爽快地把制作圣诞袜所需的框架借给了你。她还说，必须使用弹性良好的毛线。这些毛线似乎被很可能是抢劫案犯人的#b雪人#k拿走了。收集毛线并固定在袜子框架上，就能制作圣诞袜。\n\n#t4220022# #b#c4220022##k/1"/>
+        <string name="2" value="你终于收集到足够的毛线，完成了圣诞袜。当然，别忘了感谢教你制作方法的圣诞老人夫人。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4483">
-        <string name="name" value="Socks Hanging"/>
-        <string name="0" value="You&apos;ve successfully completed the Socks. Mrs. Claus thinks that Santa Claus will be satisfied with them. Now, you must hang the socks in a good location so that it will be seen easily by Santa Claus."/>
-        <string name="1" value="You&apos;ve found a Christmas tree where you can hang the socks. This tree must be the one that Santa Claus used to visit whenever he was worried. Obviously, this is not a normal tree since it can talk! The tree tells you that doing good deeds will allow you to receive better gifts from Santa. You should go around town to see if there is anything you can do to help.\n\n#t4031885# #b#c4031885##k/4"/>
-        <string name="2" value="You&apos;ve helped the people in Happyville and also received a present from Santa Claus. Here&apos;s hoping that everyone will have a Merry Christmas!"/>
+        <string name="name" value="挂起圣诞袜"/>
+        <string name="0" value="你成功完成了圣诞袜。圣诞老人夫人认为圣诞老人一定会满意。现在，需要把袜子挂在一个容易被圣诞老人看到的好位置。"/>
+        <string name="1" value="你找到了一棵可以挂圣诞袜的圣诞树。这棵树应该就是圣诞老人烦恼时常来的地方。它居然会说话，显然不是普通的树！圣诞树告诉你，多做好事就能从圣诞老人那里收到更好的礼物。到村子里看看有没有需要帮忙的人吧。\n\n#t4031885# #b#c4031885##k/4"/>
+        <string name="2" value="你帮助了幸福村的人们，也收到了圣诞老人送来的礼物。希望大家都能度过一个快乐的圣诞节！"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4484">
-        <string name="name" value="Cliff&apos;s Request"/>
-        <string name="parent" value="Cliff&apos;s Rudolph"/>
+        <string name="name" value="克里夫的请求"/>
+        <string name="parent" value="克里夫的鲁道夫"/>
         <int name="order" value="1"/>
-        <string name="0" value="There is an old man looking sad on the 2nd floor of center tower in Happyville. It must be hard to just pass him by, knowing that he is sad. Go find him and offer him some help."/>
-        <string name="1" value="#bCliff#k has been feeling lonely ever since Torr left to help Santa Claus. You will need to go to the highest point in town to take a picture of #bTorr#k pulling Santa&apos;s sleigh.\n\n#t4031881# #b#c4031881##k/1"/>
-        <string name="2" value="What?! #bTorr#k is not in the sleigh formation. Rumor has it that there is a Reindeer crying around the corner of town. Could it be #bTorr#k?"/>
+        <string name="0" value="幸福村中央塔2层有一位看起来很难过的老人。既然知道他正在伤心，应该很难就这样无视他。去找他，看看能不能帮上忙吧。"/>
+        <string name="1" value="#b克里夫#k自从托尔离开去帮助圣诞老人后，就一直感到很孤单。你需要前往村子最高的地方，拍下#b托尔#k拉着圣诞老人雪橇的照片。\n\n#t4031881# #b#c4031881##k/1"/>
+        <string name="2" value="什么？！#b托尔#k不在雪橇队伍里。听说村子角落有一只正在哭泣的驯鹿。难道那就是#b托尔#k吗？"/>
         <int name="area" value="50"/>
         <int name="selectedMob" value="1"/>
     </imgdir>
     <imgdir name="4485">
-        <string name="name" value="Torr&apos;s Whereabouts"/>
-        <string name="parent" value="Cliff&apos;s Rudolph"/>
+        <string name="name" value="托尔的下落"/>
+        <string name="parent" value="克里夫的鲁道夫"/>
         <int name="order" value="2"/>
-        <string name="0" value="You took the picture as Cliff had requested, but Torr was not there! Cliff began to worry greatly about Torr. Let&apos;s listen to his unfinished story."/>
-        <string name="1" value="Cliff asked you to check if the reindeer crying around the corner of Happyville is Torr. And if it is, he asked you to #btell Torr#k that he will be waiting on the 2nd floor at the Center Tower of Happyville."/>
-        <string name="2" value="You&apos;ve sent Torr back to lonely old man Cliff. It will be a warm and happy holiday, at least for those two."/>
+        <string name="0" value="你按照克里夫的请求拍了照片，但托尔并不在那里！克里夫开始非常担心托尔。听听他还没说完的故事吧。"/>
+        <string name="1" value="克里夫拜托你确认幸福村角落里哭泣的驯鹿是不是托尔。如果是的话，他希望你#b告诉托尔#k，他会在幸福村中央塔2层等着它。"/>
+        <string name="2" value="你让托尔回到了孤单的克里夫老人身边。至少对他们两个来说，这会是一个温暖又幸福的节日。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4486">
-        <string name="name" value="Santa Cat&apos;s request"/>
-        <string name="parent" value="Helping to Clean Chimney "/>
+        <string name="name" value="圣诞猫的请求"/>
+        <string name="parent" value="帮忙清扫烟囱"/>
         <int name="order" value="1"/>
-        <string name="0" value="#b#p9201030##k, who is planning on extensive chimney cleaning, needs some help. #b#p9201030##k should be somewhere around the Chimney in Happyville.  You should find out."/>
-        <string name="1" value="You met Santa Kitty #b#p9201030##k in Happyville, who asked you to find Rina#b#p1010100##k in Henesys in order to borrow a Chimney Sweep and a Flashlight to be used for cleaning the Chimney."/>
-        <string name="2" value="You&apos;ve successfully borrowed a Chimney Sweep and a Flashlight from Rina#p1010100#k in Henesys."/>
+        <string name="0" value="正在准备大扫除烟囱的#b#p9201030##k需要帮忙。#b#p9201030##k应该就在幸福村烟囱附近，去找找看吧。"/>
+        <string name="1" value="你在幸福村见到了圣诞猫#b#p9201030##k。它拜托你去射手村找丽娜#b#p1010100##k，借来清扫烟囱用的扫帚和手电筒。"/>
+        <string name="2" value="你成功从射手村的丽娜#p1010100#k那里借到了烟囱扫帚和手电筒。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4487">
-        <string name="name" value="Delivery of Rina cleaning device"/>
-        <string name="parent" value="Helping to Clean Chimney "/>
+        <string name="name" value="递送丽娜的清扫工具"/>
+        <string name="parent" value="帮忙清扫烟囱"/>
         <int name="order" value="2"/>
-        <string name="1" value="You&apos;ve successfully borrowed a Chimney Sweep and Flashlight from #p1010100#k. Let&apos;s take them to #b#p9201030##k in Happyville.\n\n#t4031882# #b#c4031882##k/1 \n#t4031883# #b#c4031883##k/1"/>
-        <string name="2" value="You brought #b#p9201030##k a Chimney Sweep and a Flashlight. He thanked you and asked for permission to clean the Chimney."/>
+        <string name="1" value="你成功从#p1010100#k那里借到了烟囱扫帚和手电筒。把它们带给幸福村的#b#p9201030##k吧。\n\n#t4031882# #b#c4031882##k/1 \n#t4031883# #b#c4031883##k/1"/>
+        <string name="2" value="你把烟囱扫帚和手电筒交给了#b#p9201030##k。它向你道谢，并请求允许开始清扫烟囱。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4488">
-        <string name="name" value="Warm Milk Delivery"/>
-        <string name="parent" value="To sleep Icarus"/>
+        <string name="name" value="递送温牛奶"/>
+        <string name="parent" value="让伊卡路斯入睡"/>
         <int name="order" value="1"/>
-        <string name="0" value="Dalphs#b#9220005##k in Happyville has a favor to ask of you."/>
-        <string name="1" value="You met with Dalphs#b#p9220005##k in Happyville. He asked if you could bring a glass of warm milk to #bIcarus in Kerning City#.\n\n#t4031884# #b#c4031884##k/1"/>
-        <string name="2" value="You delivered a glass of warm milk to Icarus#b#p1010100##k in Kerning City."/>
+        <string name="0" value="幸福村的达尔夫#b#p9220005##k有事想拜托你。"/>
+        <string name="1" value="你在幸福村见到了达尔夫#b#p9220005##k。他想请你把一杯温牛奶送给#b废弃都市的伊卡路斯#k。\n\n#t4031884# #b#c4031884##k/1"/>
+        <string name="2" value="你把一杯温牛奶送给了废弃都市的伊卡路斯#b#p1052106##k。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4489">
-        <string name="name" value="Delivery the word Thank "/>
-        <string name="parent" value="To sleep Icarus"/>
+        <string name="name" value="转达谢意"/>
+        <string name="parent" value="让伊卡路斯入睡"/>
         <int name="order" value="2"/>
-        <string name="1" value="You delivered a glass of warm milk to #b#p1052106##k. Hope he can go to bed early from now on. You should tell #b#p9220005##k in Happyville about this delivery, as he was worried."/>
-        <string name="2" value="You told Dalphs#b#p9220005##k that the glass of warm milk was successfully delivered to Icarus."/>
+        <string name="1" value="你把一杯温牛奶送给了#b#p1052106##k。希望他以后能早点睡。#b#p9220005##k一直很担心这件事，回幸福村告诉他已经送到了吧。"/>
+        <string name="2" value="你告诉达尔夫#b#p9220005##k，温牛奶已经成功送到了伊卡路斯手里。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4490">
-        <string name="name" value="Bicho&apos;s snowman"/>
-        <string name="0" value="Bicho in Happyville looks too weak to make a snowman all by himself, but he is doing quite well so far. But it seems like he is looking for someone."/>
-        <string name="1" value="Bicho asked you to find the person who helped him make the snowman. He said that the person is somewhere in Maple World.\n\nHis friend&apos;s name is #b#Q4490##k"/>
-        <string name="2" value="Due to Bicho&apos;s misunderstanding, you were not able to find the Mapler who had helped him earlier. Wait, Bicho is thinking of another name now? You should go visit him!"/>
+        <string name="name" value="比丘的雪人"/>
+        <string name="0" value="幸福村的比丘看起来没办法独自堆好雪人，不过目前做得还不错。只是，他好像在寻找某个人。"/>
+        <string name="1" value="比丘拜托你寻找曾经帮他堆雪人的人。他说那个人就在冒险岛世界的某处。\n\n他的朋友名字是#b#Q4490##k"/>
+        <string name="2" value="因为比丘记错了名字，你没能找到曾经帮过他的冒险家。等等，比丘好像又想起了另一个名字？去找他看看吧！"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4503">
@@ -16082,7 +16082,7 @@
     </imgdir>
     <imgdir name="4995">
         <string name="name" value="The Spirit of Maplemas"/>
-        <string name="0" value="To help her decide between Maplemas and Versalmas, Little Suzy wants me to go talk to Maple Claws.  I&apos;m sure she&apos;s back in town now in Happyville."/>
+        <string name="0" value="为了帮小苏西在Maplemas和Versalmas之间做出选择，她希望我去和Maple Claws谈谈。她现在应该已经回到幸福村了。"/>
         <string name="1" value="To help Little Suzy decide between Maplemas and Versalmas, I spoke to Maple Claws about Suzy&apos;s dilemma.  Maple Claws listened and asked me to deliver a message to Suzy.  I should talk to her in a bit."/>
         <string name="2" value="Maple Claws gave me a message for Suzy: that as long as she remembers the essence of the Maplemas Spirit, it doesn&apos;t really matter what holiday traditions she chooses to follow this year.  I should return to Suzy with Maple Claws&apos; message once I&apos;ve also spoken to O-Pongo."/>
         <int name="area" value="50"/>
@@ -16096,7 +16096,7 @@
     </imgdir>
     <imgdir name="4997">
         <string name="name" value="A Very Merry Maplemas"/>
-        <string name="0" value="Now that I have Little Suzy&apos;s Wishlist, I need to give it to either Maple Claws or O-Pongo.  I&apos;m thinking I should give it to Maple Claws; I should go see her in Happyville."/>
+        <string name="0" value="现在我拿到了小苏西的愿望清单，需要把它交给Maple Claws或O-Pongo。我想还是交给Maple Claws吧，去幸福村找她。"/>
         <string name="1" value="I can give Little Suzy&apos;s Wishlist to Maple Claws.  In doing so, she&apos;ll be counting on me to help me recover her presents for her this year.  All I have to do now is to give Maple Claws the list to cement my decision. Yes... it&apos;s going to be a very Merry Maplemas this year!"/>
         <string name="2" value="I thought that Maplemas was the better holiday so I gave #bLittle Suzy&apos;s Wishlist#k to Maple Claws.  In return, she gave me a red #bMaplemas Hat#k that I can wear proudly to show my Maplemas Spirit!  Every time I help Maple Claws recover the presents stolen by monsters, she&apos;ll reward me; I&apos;ll now be able to redeem presents with her in batches of #b10, 20, 30, 40, 60, 90, or 100#k.  I&apos;ll get different rewards at different tiers; the more presents I bring at one time, the better the rewards!  I&apos;ll need to bring her presents appropriate to my level though.\r\nBringing Maple Claws more presents will also help me earn #bMaplemas Spirit#k!  If the total amount of #bMaplemas Spirit#k accumulated on my world beats out the total amount of #bVersalmas Cheer#k, Maple Claws will have a special something for me at the end of the event!a"/>
         <int name="area" value="50"/>
@@ -18756,7 +18756,7 @@
     </imgdir>
     <imgdir name="8290">
         <string name="name" value="The Spirit of Maplemas"/>
-        <string name="0" value="To help her decide between Maplemas and Versalmas, Little Suzy wants me to go talk to Maple Claws.  I&apos;m sure she&apos;s back in town now in Happyville."/>
+        <string name="0" value="为了帮小苏西在Maplemas和Versalmas之间做出选择，她希望我去和Maple Claws谈谈。她现在应该已经回到幸福村了。"/>
         <string name="1" value="To help Little Suzy decide between Maplemas and Versalmas, I spoke to Maple Claws about Suzy&apos;s dilemma.  Maple Claws listened and asked me to deliver a message to Suzy.  I should talk to her in a bit."/>
         <string name="2" value="Maple Claws gave me a message for Suzy: that as long as she remembers the essence of the Maplemas Spirit, it doesn&apos;t really matter what holiday traditions she chooses to follow this year.  I should return to Suzy with Maple Claws&apos; message once I&apos;ve also spoken to O-Pongo."/>
         <int name="area" value="50"/>
@@ -18770,7 +18770,7 @@
     </imgdir>
     <imgdir name="8292">
         <string name="name" value="A Very Merry Maplemas"/>
-        <string name="0" value="Now that I have Little Suzy&apos;s Wishlist, I need to give it to either Maple Claws or O-Pongo.  I&apos;m thinking I should give it to Maple Claws; I should go see her in Happyville."/>
+        <string name="0" value="现在我拿到了小苏西的愿望清单，需要把它交给Maple Claws或O-Pongo。我想还是交给Maple Claws吧，去幸福村找她。"/>
         <string name="1" value="I can give Little Suzy&apos;s Wishlist to Maple Claws.  In doing so, she&apos;ll be counting on me to help me recover her presents for her this year.  All I have to do now is to give Maple Claws the list to cement my decision. Yes... it&apos;s going to be a very Merry Maplemas this year!"/>
         <string name="2" value="I thought that Maplemas was the better holiday so I gave #bLittle Suzy&apos;s Wishlist#k to Maple Claws.  In return, she gave me a red #bMaplemas Hat#k that I can wear proudly to show my Maplemas Spirit!  Every time I help Maple Claws recover the presents stolen by monsters, she&apos;ll reward me; I&apos;ll now be able to redeem presents with her in batches of #b10, 20, 30, 40, 60, 90, or 100#k.  I&apos;ll get different rewards at different tiers; the more presents I bring at one time, the better the rewards!  I&apos;ll need to bring her presents appropriate to my level though.\r\nBringing Maple Claws more presents will also help me earn #bMaplemas Spirit#k!  If the total amount of #bMaplemas Spirit#k accumulated on my world beats out the total amount of #bVersalmas Cheer#k, Maple Claws will have a special something for me at the end of the event!a"/>
         <int name="area" value="50"/>

--- a/gms-server/wz-zh-CN/String.wz/Npc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Npc.img.xml
@@ -521,10 +521,10 @@
     </imgdir>
     <imgdir name="1022101">
         <string name="name" value="露妮"/>
-        <string name="d0" value="你好 我叫鲁尼。"/>
-        <string name="d1" value="有事情发生在圣诞村了!"/>
-        <string name="n0" value="你听说过魔法密林附近有白雪覆盖着的村落吗?"/>
-        <string name="n1" value="你不想去白雪覆盖着的村落吗?"/>
+        <string name="d0" value="你好，我叫露妮。"/>
+        <string name="d1" value="幸福村出事了！"/>
+        <string name="n0" value="你听说过那个被白雪覆盖的幸福村吗？"/>
+        <string name="n1" value="你不想去幸福村看看吗？"/>
     </imgdir>
     <imgdir name="1022102">
         <string name="name" value="遗迹发掘队布告栏"/>


### PR DESCRIPTION
## 主要调整

### NPC 1022101 露妮

- 修正 NPC 自我介绍与传送对话中的姓名不一致问题。
- 将玩家可见文本中的“鲁尼”统一为“露妮”。
- 将传送目标相关文本中的“快乐村 / 圣诞村”统一为“幸福村”。
- 对齐实际传送地图 `209000000 幸福村`。

### 任务 4437 露妮的突发新闻

- 汉化任务名 `Rooney's Breaking News` 为“露妮的突发新闻”。
- 汉化传单与紧急事件相关任务说明。
- 统一 `Rooney / Happyville` 为 `露妮 / 幸福村`。
- 保留 `#p1022101#` NPC 引用，确保客户端按当前汉化名称显示。

### 任务 4477 新闻特别报道

- 汉化任务名 `News Special Report` 为“新闻特别报道”。
- 汉化《枫叶先驱报》头版新闻相关任务说明。
- 修正玩家指引文本，让玩家明确去找 `#p1022101#` 露妮。

### 任务 4478 消失的圣诞老人百科全书

- 汉化任务名 `Disappeared Santa Encyclopedia` 为“消失的圣诞老人百科全书”。
- 修正 `Rooney` 未汉化问题。
- 优化圣诞老人百科全书相关任务说明，使目标更清晰。

### 任务 4479 至 4490 幸福村圣诞任务链

- 汉化圣诞老人夫人、圣诞老人常识、圣诞袜制作、克里夫、托尔、圣诞猫、达尔夫、比丘等相关任务描述。
- 统一任务链中的 `Happyville` 为“幸福村”。
- 对齐幸福村中央塔、烟囱、圣诞袜、圣诞老人百科全书等任务语境。
- 修正部分 NPC 与地点引用，减少任务栏英文残留。

### 任务对话修正

- 修正报刊亭对话中 `Rooney / 快乐村` 未对齐问题。
- 修正圣诞老人百科全书说明中的明显机翻错误。
- 修正小苏西相关对话中 `Happyville / Rooney` 未汉化问题。
- 修正圣诞袜任务对话中的 `Happyville` 未汉化问题。

## 变更文件

- `gms-server/scripts-zh-CN/npc/1022101.js`
- `gms-server/wz-zh-CN/String.wz/Npc.img.xml`
- `gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml`
- `gms-server/wz-zh-CN/Quest.wz/Say.img.xml`

## 验证结果

- 已确认 `1022101` 的显示名称为“露妮”。
- 已确认 `1022101` 实际传送地图为 `209000000 幸福村`。
- 已确认修改文件中面向玩家文本不再残留：`鲁尼`、`快乐村`、`圣诞村`、`美国人`、`Rooney`、`Happyville`。
- 已通过 XML 解析检查。
- 已通过 `git diff --check` 检查。
## 客户端同步说明

- 服务端 NPC 脚本对话由服务端发送，脚本文本修改随服务端资源更新后即可生效。
- NPC 名称、任务栏文本、任务说明等来自客户端 WZ 显示资源；如果需要在游戏客户端界面中看到本次汉化修正，需要同步对应客户端 WZ 资源。
- 本 PR 只提交服务端仓库中的源资源变更，不包含客户端文件或本地测试环境内容。