### PR TITLE
fix: 统一地狱大公防毒面具中文名称

### DIFF
--- a/gms-server/scripts-zh-CN/npc/9201133.js
+++ b/gms-server/scripts-zh-CN/npc/9201133.js
@@ -19,7 +19,7 @@ function action(mode, type, selection) {
         if (!inHuntingGround) {
             if (cm.isQuestStarted(quest)) {
                 if (!cm.getPlayer().haveItemEquipped(1003036)) {
-                    cm.sendOk("前方的道路有一股奇怪的气味... 进入之前装备 #rgas mask#k。");
+                    cm.sendOk("前方的道路有一股奇怪的气味……进入之前请先装备#r狂野之眼的防毒面具#k。");
                     cm.dispose();
                     return;
                 }

--- a/gms-server/wz-zh-CN/String.wz/Eqp.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Eqp.img.xml
@@ -4280,7 +4280,7 @@
                 <string name="name" value="雪之猫女头" />
             </imgdir>
             <imgdir name="1003036">
-                <string name="name" value="符咒独眼野猪头" />
+                <string name="name" value="狂野之眼的防毒面具" />
             </imgdir>
             <imgdir name="1003038">
                 <string name="name" value="娃娃头" />


### PR DESCRIPTION
**变更内容**

- 将装备 `1003036` 的中文名从 `符咒独眼野猪头` 修正为 `狂野之眼的防毒面具`。
- 将地狱大公入口 NPC 的提示文本从英文 `gas mask` 统一为中文道具名。
- 保持任务 `28282/28283` 中已有的“狂野之眼的防毒面具”表述一致。

**影响范围**

- 仅涉及 `zh-CN` 本地化文本和 NPC 提示。
- 不涉及任务逻辑、奖励配置或入口判定逻辑。

**客户端同步说明**

- 本 PR 已修正服务端 `zh-CN` WZ 文本和 NPC 提示；入口判定仍按道具 ID `1003036`，不依赖客户端文本。
- 如果需要客户端背包、装备提示、任务奖励展示等 UI 中的道具名也显示为 `狂野之眼的防毒面具`，还需要同步修改客户端资源 `Data/String/Eqp.img` 中 `1003036` 的名称。
- 本次 PR 不包含客户端资源改动。