### PR TITLE
fix: 修正玛亚关切任务链中文文本

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -17867,93 +17867,90 @@
         <string name="2" value="I really doubt that those potions enable eternal youth. Oh well, she likes it anyways, and that&apos;s the bottom line. I&apos;ll just leave her be."/>
         <int name="area" value="48"/>
     </imgdir>
-    <imgdir name="8034">
-        <string name="name" value="玛雅的关切 1"/>
-        <string name="parent" value="玛雅的关切"/>
-        <int name="order" value="1"/>
-        <string name="0" value="对了，玛雅最近怎么样？我得去看看她！"/>
-        <string name="1" value="玛雅正在照顾一只重伤的小狮子。我知道这并不是大家希望我们做的事情，但玛雅坚持要这么做，我必须支持她。唉……为了处理伤口，她说需要 #b50 #t02050003#s#k, #b20 #t04000086#s#k 和 #b20 #t04000023#s#k。\n\n#t02050003# #b#c02050003##k/50\n#t04000086#  #b#c04000086##k/20\n#t04000023#  #b#c04000023##k/20"/>
-        <string name="2" value="伤口已经消毒，但小狮子需要休息。它似乎因为这一切而非常疲惫。"/>
-        <int name="area" value="30"/>
-    </imgdir>
-    <imgdir name="8035">
-        <string name="name" value="玛雅的关切 2"/>
-        <string name="parent" value="玛雅的关切"/>
-        <int name="order" value="2"/>
-        <string name="0" value="小狮子的情况让我很担心。我得去玛雅家看看。"/>
-        <string name="1" value="现在，小狮子中毒了！为了排毒，需要#b50 #t02050000##ks、#b30 #t04000076#s#k和#b30 #t04000058#s#k。快点！\n#t02050000#  #b#c02050000##k/50 \n#t04000076#  #b#c04000076##k/30 \n#t04000058#  #b#c04000058##k/30"/>
-        <string name="2" value="这药应该能在它好好睡一晚后排除体内的毒素。这样就可以了吗？我最好问问玛雅。"/>
-        <int name="area" value="30"/>
-    </imgdir>
-    <imgdir name="8036">
-        <string name="name" value="玛雅的关切 3"/>
-        <string name="parent" value="玛雅的关切"/>
-        <int name="order" value="3"/>
-        <string name="0" value="我觉得我们已经迎来了转机。这就能解决问题吗？我需要问问玛雅。"/>
-        <string name="1" value="为了加快小狮子的康复，玛雅让我帮忙收集一些鱼，必须是新鲜的。由于#b#o5400000##k喜欢吃新鲜鱼，我最好准备#b100 #t4000088#s#k。\n#t4000088#  #b#c4000088##k/100"/>
-        <string name="2" value="我在这里所能做的一切都已经完成。接下来就交给玛雅吧。希望小狮子能够早日康复！"/>
-        <int name="area" value="30"/>
-    </imgdir>
-    <imgdir name="8037">
-        <string name="name" value="小狮子的项链 1"/>
-        <string name="parent" value="小狮子的项链"/>
-        <int name="order" value="1"/>
-        <string name="0" value="对了，小狮子最近怎么样？我得去玛雅家看看。"/>
-        <string name="1" value="玛雅决定给小狮子打扮一下，用一条项链把它伪装成家猫。因为在当地商场买一条可能会暴露它的身份，所以她想让我去找明珠港的特奥帮忙。"/>
-        <string name="2" value="特奥决定帮助制作小狮子的项链。"/>
-        <int name="area" value="30"/>
-    </imgdir>
-    <imgdir name="8038">
-        <string name="name" value="小狮子的项链 2"/>
-        <string name="parent" value="小狮子的项链"/>
-        <int name="order" value="2"/>
-        <string name="0" value="特奥决定帮助制作小狮子的项链。我得赶紧问问他。"/>
-        <string name="1" value="特奥似乎很忙，于是我决定自己去收集材料。我需要准备#b50 #t04000033#s#k、#b50 #t04000030#s#k和#b7 #t04000061##k，然后交给特奥。\n\n#t04000033#  #b#c04000033##k/50\n#t04000030#  #b#c04000030##k/50\n#t04000061#  #b#c04000061##k/7"/>
-        <string name="2" value="把材料交给特奥后，他很快就送去珠宝商那里制作。制作出来的是一条美丽的项链，使用了黑鳄鱼皮和龙皮。现在我得把这个展示给玛雅看看。"/>
-        <int name="area" value="30"/>
-    </imgdir>
-    <imgdir name="8039">
-        <string name="name" value="小狮子的项链 3"/>
-        <string name="parent" value="小狮子的项链"/>
-        <int name="order" value="3"/>
-        <string name="1" value="把材料交给特奥后，他很快就送去珠宝商那里制作。这条美丽的项链由黑鳄鱼皮和龙皮制成。现在我得把它展示给玛雅看看。"/>
-        <string name="2" value="有了这条项链，小狮子现在可一点也不像个怪物了。真是太好了！"/>
-        <int name="area" value="30"/>
-    </imgdir>
-    <imgdir name="8040">
-        <string name="name" value="小狮子的旅程"/>
-        <string name="0" value="小狮子现在和玛雅在外面玩吗？我得去玛雅家看看他们。"/>
-        <string name="1" value="显然，给小狮子留下伤疤的是#b#o5130104##k，这也是它尽管戴着项链还是不敢离开家的原因。我需要准备#b100 #t04000051#s#k来增强它的信心。\n#t04000051#  #b#c04000051##k/100"/>
-        <string name="2" value="玛雅说小狮子的朋友们来过，并且和它一起离开了。至少小狮子不是一个人。虽然玛雅可能在哭，但我认为让小狮子去和朋友们生活是最好的选择。"/>
-        <int name="area" value="30"/>
-    </imgdir>
-    <imgdir name="8041">
-        <string name="name" value="怪物传闻坊"/>
-        <string name="parent" value="怪物传闻坊"/>
-        <int name="order" value="1"/>
-        <string name="0" value="我听说埃尔纳斯的斯卡杜尔被怪物袭击了。我得去找他聊聊。"/>
-        <string name="1" value="显然，狐狸，也就是珀斯上尉也遭遇了那个臭名昭著的怪物。我得去了解一下情况。"/>
-        <string name="2" value="为了收集有关这个怪物的信息，我得帮珀斯上尉一个忙。你在开玩笑吗？"/>
-        <int name="area" value="33"/>
-    </imgdir>
-    <imgdir name="8042">
-        <string name="name" value="狐狸真迷人"/>
-        <string name="parent" value="怪物传闻坊"/>
-        <int name="order" value="2"/>
-        <string name="0" value="为了收集有关这个怪物的信息，我得帮珀斯上尉一个忙。你在开玩笑吗？"/>
-        <string name="1" value="为了进一步了解这个怪物，我需要给珀斯上尉#b50 #t04000129#s#k。\n#t04000129#  #b#c04000129##k/50"/>
-        <string name="2" value="难怪……他提到，地球防御总部似乎也在着手对付这个怪物。他说我可以通过偷听 马斯特将军 来了解更多情况。这可不容易……"/>
-        <int name="area" value="48"/>
-    </imgdir>
-    <imgdir name="8043">
-        <string name="name" value="狼人"/>
-        <string name="parent" value="怪物传闻坊"/>
-        <int name="order" value="3"/>
-        <string name="0" value="难怪……他说，地球防御总部似乎也在积极行动以击败那个怪物。他提到我可以通过偷听 马斯特 将军 来了解更多情况。这可不容易……"/>
-        <string name="1" value="不可能……其中一个#b#o8140000#s#k可能正在策划什么阴险的事情……我不能让他们在这里对无辜的人造成破坏。虽然这可能不是玛雅想听到的，但我必须消灭这些#b#o8140000#s#k。\n#t04000054# #b#c04000054##k/50"/>
-        <string name="2" value="我没有找到戴着项链的#b#o8140000##k。我相信它肯定还活着某个地方。我知道这听起来有些奇怪，但我决定相信这个事实。"/>
-        <int name="area" value="10"/>
-    </imgdir>
+      <imgdir name="8034">
+    <string name="name" value="玛亚的关切 1"/>
+    <string name="parent" value="玛亚的关切"/>
+    <int name="order" value="1"/>
+    <string name="0" value="对了，玛亚最近怎么样？我得去看看她。"/>
+    <string name="1" value="玛亚正在照顾一只受重伤的幼年独角狮。虽然大家未必愿意帮助怪物，但玛亚坚持要救它，我也想帮她。为了给伤口消毒并包扎，需要#b50个#t02050003##k、#b20个#t04000086##k和#b20个#t04000023##k。\n\n#t02050003# #b#c02050003##k/50\n#t04000086#  #b#c04000086##k/20\n#t04000023#  #b#c04000023##k/20"/>
+    <string name="2" value="伤口已经消毒，但幼年独角狮还需要休息。经历了这一切，它看起来非常疲惫。"/>
+    <int name="area" value="30"/>
+  </imgdir>
+      <imgdir name="8035">
+    <string name="name" value="玛亚的关切 2"/>
+    <string name="parent" value="玛亚的关切"/>
+    <int name="order" value="2"/>
+    <string name="0" value="幼年独角狮的情况让我很担心。我得去玛亚家看看。"/>
+    <string name="1" value="幼年独角狮中毒了！为了制作解毒药，需要#b50个#t02050000##k、#b30个#t04000076##k和#b30个#t04000058##k。得快点。\n#t02050000#  #b#c02050000##k/50\n#t04000076#  #b#c04000076##k/30\n#t04000058#  #b#c04000058##k/30"/>
+    <string name="2" value="这份药应该能在它睡一晚后清除体内毒素。这样就可以了吗？我最好再问问玛亚。"/>
+    <int name="area" value="30"/>
+  </imgdir>
+      <imgdir name="8036">
+    <string name="name" value="玛亚的关切 3"/>
+    <string name="parent" value="玛亚的关切"/>
+    <int name="order" value="3"/>
+    <string name="0" value="我觉得情况已经开始好转了。这样就能解决问题吗？我需要问问玛亚。"/>
+    <string name="1" value="为了让幼年独角狮恢复体力，玛亚让我帮忙收集一些新鲜的鱼。#b#o5400000##k只吃最新鲜的鱼，我得准备#b100个#t4000088##k。\n#t4000088#  #b#c4000088##k/100"/>
+    <string name="2" value="我能做的都已经做完了。接下来就交给玛亚吧。希望莱昂内尔能够早日康复！"/>
+    <int name="area" value="30"/>
+  </imgdir>
+      <imgdir name="8037">
+    <string name="name" value="莱昂内尔的项链 1"/>
+    <string name="parent" value="莱昂内尔的项链"/>
+    <int name="order" value="1"/>
+    <string name="0" value="幼年独角狮最近怎么样了？我得去玛亚家看看。"/>
+    <string name="1" value="玛亚决定给它取名为莱昂内尔，并用项链把它伪装成家猫。为了避免在射手村买项链引起注意，她让我去明珠港找特奥帮忙。"/>
+    <string name="2" value="特奥答应帮忙制作莱昂内尔的项链。"/>
+    <int name="area" value="30"/>
+  </imgdir>
+      <imgdir name="8038">
+    <string name="name" value="莱昂内尔的项链 2"/>
+    <string name="parent" value="莱昂内尔的项链"/>
+    <int name="order" value="2"/>
+    <string name="0" value="特奥答应帮忙制作莱昂内尔的项链。我得赶紧问问他。"/>
+    <string name="1" value="特奥似乎很忙，于是我决定自己去收集材料。我需要准备#b50个#t04000033##k、#b50个#t04000030##k和#b7个#t04000061##k，然后交给特奥。\n\n#t04000033#  #b#c04000033##k/50\n#t04000030#  #b#c04000030##k/50\n#t04000061#  #b#c04000061##k/7"/>
+    <string name="2" value="把材料交给特奥后，他很快就送去珠宝店制作。做出来的是一条用黑鳄鱼皮和龙皮制成的漂亮项链。现在我要把它拿给玛亚。"/>
+    <int name="area" value="30"/>
+  </imgdir>
+      <imgdir name="8039">
+    <string name="name" value="莱昂内尔的项链 3"/>
+    <string name="parent" value="莱昂内尔的项链"/>
+    <int name="order" value="3"/>
+    <string name="1" value="特奥把材料送去珠宝店，很快做好了一条由黑鳄鱼皮和龙皮制成的漂亮项链。现在我要把它拿给玛亚。"/>
+    <string name="2" value="戴上项链后，莱昂内尔看起来一点也不像怪物了。太好了！"/>
+    <int name="area" value="30"/>
+  </imgdir>
+      <imgdir name="8040">
+    <string name="name" value="莱昂内尔的旅程"/>
+    <string name="0" value="莱昂内尔现在能和玛亚一起外出了吗？我得去玛亚家看看他们。"/>
+    <string name="1" value="原来让莱昂内尔留下伤痕的是#b#o5130104##k，所以即使戴上项链，它仍然害怕出门。我需要收集#b100个#t04000051##k，帮它克服对狼的恐惧。\n#t04000051#  #b#c04000051##k/100"/>
+    <string name="2" value="玛亚说莱昂内尔的朋友们来找它，并和它一起离开了。至少莱昂内尔不是孤单一人。玛亚虽然很难过，但让莱昂内尔回到朋友身边，或许才是最好的选择。"/>
+    <int name="area" value="30"/>
+  </imgdir>
+      <imgdir name="8041">
+    <string name="name" value="怪物传闻坊"/>
+    <string name="parent" value="怪物传闻坊"/>
+    <string name="0" value="听说冰封雪域的斯卡德被某只怪物袭击了。我得去找他了解情况。"/>
+    <string name="1" value="原来珀斯上尉也被那只臭名昭著的怪物袭击过。我得去问问他。"/>
+    <string name="2" value="为了打听那只怪物的情报，我得先帮珀斯上尉一个忙。真是的……"/>
+    <int name="area" value="30"/>
+  </imgdir>
+      <imgdir name="8042">
+    <string name="name" value="珀斯上尉的情报"/>
+    <string name="parent" value="怪物传闻坊"/>
+    <string name="0" value="为了打听那只怪物的情报，我得先帮珀斯上尉一个忙。真是的……"/>
+    <string name="1" value="为了进一步了解那只怪物，我需要交给珀斯上尉#b50个#t04000129##k。\n#t04000129#  #b#c04000129##k/50"/>
+    <string name="2" value="难怪……据珀斯上尉所说，地球防御本部似乎也在行动，准备对付那只怪物。他建议我去偷听马斯特将军，也许能知道更多内情。这可不容易……"/>
+    <int name="area" value="30"/>
+  </imgdir>
+      <imgdir name="8043">
+    <string name="name" value="白狼人"/>
+    <string name="parent" value="怪物传闻坊"/>
+    <string name="0" value="难怪……据珀斯上尉所说，地球防御本部似乎正在准备对付那只怪物。他说偷听马斯特将军的谈话，也许能知道更多内情。这可不容易……"/>
+    <string name="1" value="不可能……这些#b#o8140000##k可能正在策划什么阴谋。我不能让它们伤害无辜的人。虽然这可能不是玛亚想听到的，但我必须消灭这些#b#o8140000##k。\n#t04000054# #b#c04000054##k/50"/>
+    <string name="2" value="我没有找到戴着项链的#b#o8140000##k。我相信莱昂内尔一定还活在某个地方。虽然听起来有些奇怪，但我愿意相信这一点。"/>
+    <int name="area" value="30"/>
+  </imgdir>
     <imgdir name="8047">
         <string name="name" value="勇助与美食"/>
         <string name="0" value="来自昭和村的勇助显然要做一个“奇妙的美食”。真是有趣……"/>
@@ -22594,8 +22591,7 @@
         <string name="name" value="秘密食谱"/>
         <int name="area" value="30"/>
         <string name="0" value="#b东东#k本来说如果能接受他的委托，他就会欣然地为招待会做准备……但找到他之后，他冲我大声嚷嚷，说“还说什么宴会”……到底发生了什么事情？"/>
-        <string name="1" value="食谱弄丢了？在秘密泄露之前，赶快帮他找到食谱。
-打猎#r废都广场3～4层#k的吊娃娃机，应该就能找到了吧？"/>
+        <string name="1" value="食谱弄丢了？在秘密泄露之前，赶快帮他找到食谱。\n打猎#r废都广场3～4层#k的吊娃娃机，应该就能找到了吧？"/>
         <string name="2" value="终于说服了七星级厨师东东。把这个好消息告诉#b拉娜#k吧。"/>
         <string name="demandSummary" value="#i4032508:# #t4032508:# #c4032508# / 1 "/>
         <string name="rewardSummary" value="13,200 EXP\r\n"/>

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -17927,30 +17927,33 @@
     <string name="2" value="玛亚说莱昂内尔的朋友们来找它，并和它一起离开了。至少莱昂内尔不是孤单一人。玛亚虽然很难过，但让莱昂内尔回到朋友身边，或许才是最好的选择。"/>
     <int name="area" value="30"/>
   </imgdir>
-      <imgdir name="8041">
-    <string name="name" value="怪物传闻坊"/>
-    <string name="parent" value="怪物传闻坊"/>
-    <string name="0" value="听说冰封雪域的斯卡德被某只怪物袭击了。我得去找他了解情况。"/>
-    <string name="1" value="原来珀斯上尉也被那只臭名昭著的怪物袭击过。我得去问问他。"/>
-    <string name="2" value="为了打听那只怪物的情报，我得先帮珀斯上尉一个忙。真是的……"/>
-    <int name="area" value="30"/>
-  </imgdir>
-      <imgdir name="8042">
-    <string name="name" value="珀斯上尉的情报"/>
-    <string name="parent" value="怪物传闻坊"/>
-    <string name="0" value="为了打听那只怪物的情报，我得先帮珀斯上尉一个忙。真是的……"/>
-    <string name="1" value="为了进一步了解那只怪物，我需要交给珀斯上尉#b50个#t04000129##k。\n#t04000129#  #b#c04000129##k/50"/>
-    <string name="2" value="难怪……据珀斯上尉所说，地球防御本部似乎也在行动，准备对付那只怪物。他建议我去偷听马斯特将军，也许能知道更多内情。这可不容易……"/>
-    <int name="area" value="30"/>
-  </imgdir>
-      <imgdir name="8043">
-    <string name="name" value="白狼人"/>
-    <string name="parent" value="怪物传闻坊"/>
-    <string name="0" value="难怪……据珀斯上尉所说，地球防御本部似乎正在准备对付那只怪物。他说偷听马斯特将军的谈话，也许能知道更多内情。这可不容易……"/>
-    <string name="1" value="不可能……这些#b#o8140000##k可能正在策划什么阴谋。我不能让它们伤害无辜的人。虽然这可能不是玛亚想听到的，但我必须消灭这些#b#o8140000##k。\n#t04000054# #b#c04000054##k/50"/>
-    <string name="2" value="我没有找到戴着项链的#b#o8140000##k。我相信莱昂内尔一定还活在某个地方。虽然听起来有些奇怪，但我愿意相信这一点。"/>
-    <int name="area" value="30"/>
-  </imgdir>
+    <imgdir name="8041">
+        <string name="name" value="怪物传闻坊"/>
+        <string name="parent" value="怪物传闻坊"/>
+        <int name="order" value="1"/>
+        <string name="0" value="听说冰封雪域的斯卡德被某只怪物袭击了。我得去找他了解情况。"/>
+        <string name="1" value="原来珀斯上尉也被那只臭名昭著的怪物袭击过。我得去问问他。"/>
+        <string name="2" value="为了打听那只怪物的情报，我得先帮珀斯上尉一个忙。真是的……"/>
+        <int name="area" value="33"/>
+    </imgdir>
+    <imgdir name="8042">
+        <string name="name" value="珀斯上尉的情报"/>
+        <string name="parent" value="怪物传闻坊"/>
+        <int name="order" value="2"/>
+        <string name="0" value="为了打听那只怪物的情报，我得先帮珀斯上尉一个忙。真是的……"/>
+        <string name="1" value="为了进一步了解那只怪物，我需要交给珀斯上尉#b50个#t04000129##k。\n#t04000129#  #b#c04000129##k/50"/>
+        <string name="2" value="难怪……据珀斯上尉所说，地球防御本部似乎也在行动，准备对付那只怪物。他建议我去偷听马斯特将军，也许能知道更多内情。这可不容易……"/>
+        <int name="area" value="48"/>
+    </imgdir>
+    <imgdir name="8043">
+        <string name="name" value="白狼人"/>
+        <string name="parent" value="怪物传闻坊"/>
+        <int name="order" value="3"/>
+        <string name="0" value="难怪……据珀斯上尉所说，地球防御本部似乎正在准备对付那只怪物。他说偷听马斯特将军的谈话，也许能知道更多内情。这可不容易……"/>
+        <string name="1" value="不可能……这些#b#o8140000##k可能正在策划什么阴谋。我不能让它们伤害无辜的人。虽然这可能不是玛亚想听到的，但我必须消灭这些#b#o8140000##k。\n#t04000054# #b#c04000054##k/50"/>
+        <string name="2" value="我没有找到戴着项链的#b#o8140000##k。我相信莱昂内尔一定还活在某个地方。虽然听起来有些奇怪，但我愿意相信这一点。"/>
+        <int name="area" value="10"/>
+    </imgdir>
     <imgdir name="8047">
         <string name="name" value="勇助与美食"/>
         <string name="0" value="来自昭和村的勇助显然要做一个“奇妙的美食”。真是有趣……"/>


### PR DESCRIPTION
## 主要调整
- 修正任务 `8034 玛亚的关切 1`：统一 NPC 名称为“玛亚”，重写救助幼年独角狮的任务说明和对话，清理机翻残留与错误换行符。
- 修正任务 `8035 玛亚的关切 2`：重写中毒、解毒药材收集和材料不足提示，修复 `##ks`、多余英文复数等格式问题。
- 修正任务 `8036 玛亚的关切 3`：重写恢复体力、收集新鲜鱼、命名莱昂内尔等剧情文本，统一“幼年独角狮 / 莱昂内尔”称呼。
- 修正任务 `8037 莱昂内尔的项链 1`：统一 `Lionel's Necklace` 为“莱昂内尔的项链”，修正“生命港 / 泰欧”为“明珠港 / 特奥”。
- 修正任务 `8038 莱昂内尔的项链 2`：重写特奥制作项链、收集材料、珠宝店制作等对话，清理生硬机翻。
- 修正任务 `8039 莱昂内尔的项链 3`：重写玛亚收到项链、给莱昂内尔戴上项链、感谢玩家的文本。
- 修正任务 `8040 莱昂内尔的旅程`：重写莱昂内尔害怕野狼、朋友来接它离开、玛亚送别等剧情文本。
- 修正任务 `8041 怪物传闻坊`、`8042 珀斯上尉的情报`、`8043 白狼人`：补齐下游关联剧情翻译，统一地球防御本部、马斯特将军、珀斯上尉、白狼人等名称。

## 结构修复
- 恢复 `Say.img.xml` 中第二组 `8034`、`8035`、`8036` 的原始 WZ 层级结构。
- 保留新的中文文本，但将 `yes`、`no`、`stop` 放回对应的 `0` / `1` 对话状态节点下。
- 解决 `yes` / `no` / `stop` 被提升到任务节点同级后可能导致的接受、拒绝、材料不足和完成对话读取异常。
- 已确认 `8041`、`8042`、`8043` 没有同类结构问题，`order` 字段仍保留。

## 一致性处理
- `Maya` 统一为“玛亚”，对齐 NPC 名称与既有任务翻译。
- `Teo` 统一为“特奥”，`Lith Harbor` 统一为“明珠港”。
- `baby Lioner` 统一为“幼年独角狮”，命名后的 `Lionel` 统一为“莱昂内尔”。
- 清理目标任务链内的英文残留、错误控制符、错误空格和中英文混排格式。
- 同步修复 `Say.img.xml` 中 `8034-8036` 的重复文本块，避免部分流程仍显示旧文案。

## 客户端同步备注
- 本次改动包含任务说明和任务对话相关 WZ 文本，服务端中文 WZ 会随本 PR 生效。
- 如果运行环境的客户端仍使用独立客户端 WZ，需要同步客户端 `Quest/Say.img` 和 `Quest/QuestInfo.img`，否则任务列表或部分对话仍可能显示旧文本。
- 客户端资源同步不包含在本 PR 提交范围内。

## 验证结果
- 已通过 XML 解析校验。
- 已通过 UTF-8 严格解码与常见乱码标记检查。
- 已通过 `git diff --check` 校验。
- 已对比 `Say.img.xml` 的子节点结构，确认 `8034`、`8035`、`8036` 已恢复为原有层级。
- 已检查 `8034-8043` 目标任务块，未发现本次清理范围内的错误名称、机翻残留或坏格式。