### PR TITLE
保留法师魔力恢复服务端修正

### DIFF
--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/HealOvertimeHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/HealOvertimeHandler.java
@@ -23,8 +23,11 @@ package org.gms.net.server.channel.handlers;
 
 import org.gms.client.Character;
 import org.gms.client.Client;
+import org.gms.client.Skill;
+import org.gms.client.SkillFactory;
 import org.gms.client.autoban.AutobanFactory;
 import org.gms.client.autoban.AutobanManager;
+import org.gms.constants.skills.Magician;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
 import org.gms.net.server.Server;
@@ -61,15 +64,28 @@ public final class HealOvertimeHandler extends AbstractPacketHandler {
             chr.getMap().broadcastMessage(chr, PacketCreator.showHpHealed(chr.getId(), healHP), false);
             abm.spam(0, timestamp);
         }
-        short healMP = p.readShort();
+        int healMP = p.readShort();
         if (healMP != 0 && healMP < 1000) {
             abm.setTimestamp(9, timestamp, 28);
             if ((abm.getLastSpam(1) + 1500) > timestamp) {
                 AutobanFactory.FAST_MP_HEALING.addPoint(abm, "Fast mp healing");
                 return;     // thanks resinate for noticing mp being gained even after detection
             }
+            healMP = applyImprovedMpRecovery(chr, healMP);
             chr.addMP(healMP);
             abm.spam(1, timestamp);
         }
+    }
+
+    private static int applyImprovedMpRecovery(Character chr, int healMP) {
+        Skill improvedRecovery = SkillFactory.getSkill(Magician.IMPROVED_MP_RECOVERY);
+        int skillLevel = chr.getSkillLevel(improvedRecovery);
+        if (skillLevel <= 0) {
+            return healMP;
+        }
+
+        // Keep this as a server-side floor so clients that already include the bonus are not doubled.
+        int expectedRecovery = skillLevel * (chr.getLevel() / 10) + 3;
+        return Math.max(healMP, expectedRecovery);
     }
 }


### PR DESCRIPTION
## 主要调整
- 仅保留 `2000000 魔力恢复 / Improved MP Recovery` 的服务端恢复量下限修正。
- 在处理自然 MP 恢复时，根据技能等级和角色等级计算应有恢复量，避免客户端上报值低于技能应生效的恢复量。
- 不再修改 `2210000 冰雷抗性 / Partial Resistance` 的服务端受击逻辑，避免与客户端受击伤害计算重复叠加，导致头顶伤害数字与实际扣血不一致。

## 客户端同步备注
- 本次 PR 只修改服务端 Java 逻辑，不依赖客户端 WZ 同步。
- 冰雷抗性的客户端技能数值与显示文本属于独立的客户端文本一致性问题，本次不混入处理。