### PR TITLE
fix: 修复由美相关任务与商店街文本

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -17826,10 +17826,10 @@
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8028">
-        <string name="name" value=" 蔬菜，太好了~!"/>
-        <string name="0" value="听说最近昭和村里的蔬菜价格变得昂贵。为什么会这样?"/>
-        <string name="1" value="听由美讲， 因为#b#o8140500##k的捣乱，把菜园弄的一团糟。这次可不能视若无睹! \n#t4000080##b#c4000080##k/200"/>
-        <string name="2" value="清除#b#o8140500##k守住了昭和村人的菜园。 从现在起要多吃蔬菜。"/>
+        <string name="name" value="蔬菜真好！"/>
+        <string name="0" value="听说昭和村的蔬菜价格最近涨得很厉害。去问问#r#p9120005##k发生了什么事吧。"/>
+        <string name="1" value="听#r#p9120005##k说，菜园因为#b#o8140500##k到处捣乱而变得一团糟。为了让昭和村的蔬菜价格恢复正常，去收集#b200个#t4000080##k吧。\n\n#t4000080# #b#c4000080##k / 200"/>
+        <string name="2" value="我帮#r#p9120005##k解决了菜园的问题。以后也要多吃蔬菜，保持健康。"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8029">
@@ -18192,39 +18192,39 @@
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8079">
-        <string name="name" value="Umi Needs Money"/>
-        <string name="parent" value="Umi&apos;s Ambition"/>
+        <string name="name" value="由美需要钱"/>
+        <string name="parent" value="由美的野心"/>
         <int name="order" value="1"/>
-        <string name="0" value="I heard #r#p9120005##k of Showa Town is setting up a master plan. I better hear this."/>
-        <string name="1" value="She wanted to purchase a machine owned by #r#p2050002##k which is made out of the finest technology in the universe, but was short on money, so #r#p9120005##k asked me to pitch in for her. #n5,000,000 mesos is a LOT of money..."/>
-        <string name="2" value="I handed #r#p9120005##k 5,000,000 mesos. Can she buy it, though?"/>
+        <string name="0" value="听说昭和商店街的#r#p9120005##k正在筹划一个大计划。去听听她的想法吧。"/>
+        <string name="1" value="#r#p9120005##k想买下#r#p2050002##k手里的梦想机器。据说那台机器使用了宇宙中最先进的技术，可以把一种材料变成其他东西。可她还差一笔钱，于是希望我投资#b5,000,000金币#k。"/>
+        <string name="2" value="我把#b5,000,000金币#k交给了#r#p9120005##k。希望她真的能买到那台机器。"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8080">
-        <string name="name" value="Lazy Alien Grey"/>
-        <string name="parent" value="Umi&apos;s Ambition"/>
+        <string name="name" value="懒惰的外星人哥雷"/>
+        <string name="parent" value="由美的野心"/>
         <int name="order" value="2"/>
-        <string name="0" value="Apparently, #r#p9120005##k paid for the machine to #p2050002##k, only to keep waiting for the machine to come. #nIn any case, I better talk to #r#p9120005##k."/>
-        <string name="1" value="#r#p9120005##k asked me to convince #r#p2050002##k to send the machine to her. \nIn any case, I should meet up with  #r#p2050002##k."/>
-        <string name="2" value="I was able to meet #r#p2050002##k. This is it!"/>
+        <string name="0" value="#r#p9120005##k已经把钱付给了#r#p2050002##k，可机器迟迟没有送到昭和商店街。去问问#r#p9120005##k接下来怎么办。"/>
+        <string name="1" value="#r#p9120005##k希望我去找#r#p2050002##k交涉，让他尽快把机器送来。先去地球防御本部找#r#p2050002##k吧。"/>
+        <string name="2" value="我找到了#r#p2050002##k。接下来得想办法让他把机器送到昭和商店街。"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8081">
-        <string name="name" value="The Arrogant Alien Gray"/>
-        <string name="parent" value="Umi&apos;s Ambition"/>
+        <string name="name" value="傲慢的外星人哥雷"/>
+        <string name="parent" value="由美的野心"/>
         <int name="order" value="3"/>
-        <string name="0" value="I better negotiate with #r#p2050002##k so the machine can be sent to Showa Town ASAP."/>
-        <string name="1" value="After eating lunch, #r#p2050002##k claims that he&apos;ll send the machine to Showa Town, no problem. \nThis really irritated me, but I&apos;ll have to gather up #b400#k #b#t4000117#s#k in order for that to happen.\r\n#t4000117# #b#c4000117##k/400"/>
-        <string name="2" value="Just as #r#p2050002##k demanded, I got him #b400 #t4000117#s#k."/>
+        <string name="0" value="为了让机器尽快送到昭和商店街，需要继续和#r#p2050002##k交涉。"/>
+        <string name="1" value="#r#p2050002##k说只要我帮他准备午餐，他就会把机器送到昭和商店街。虽然很让人生气，但现在只能先收集#b400个#t4000117##k。\n\n#t4000117# #b#c4000117##k / 400"/>
+        <string name="2" value="我按照#r#p2050002##k的要求带来了#b400个#t4000117##k。希望他这次真的会履行约定。"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8082">
-        <string name="name" value="Good Luck"/>
-        <string name="parent" value="Umi&apos;s Ambition"/>
+        <string name="name" value="祝你好运"/>
+        <string name="parent" value="由美的野心"/>
         <int name="order" value="4"/>
-        <string name="0" value="As promised, #r#p9120005##k sent this to #r#p9120005##k. I better go see it right now."/>
-        <string name="1" value="In order to create a new item, it&apos;ll require #b10#k #b#t4011005#s#k. \nI&apos;ve gone through too much to give up on this. Let&apos;s go!\r\n#t4011005# #b#c4011005##k/10"/>
-        <string name="2" value="I was able to make the item, but was this investment really worth it?"/>
+        <string name="0" value="机器终于被送到了#r#p9120005##k那里。去昭和商店街看看这台梦想机器吧。"/>
+        <string name="1" value="要启动机器，需要准备#b10个#t4011005##k。已经走到这一步了，不能半途而废。\n\n#t4011005# #b#c4011005##k / 10"/>
+        <string name="2" value="机器成功运转了，但这笔投资到底值不值得，还真不好说。"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8083">
@@ -22516,10 +22516,10 @@
         <int name="autoStart" value="1"/>
     </imgdir>
     <imgdir name="8052">
-        <string name="name" value="Umi&apos;s Spiced Veggies"/>
-        <string name="0" value="Umi of Showa Town sounds like she&apos;s stuck in a tough spot. I should go talk to her."/>
-        <string name="1" value="She said she needed a solid rock to help her make spice vegetables. A solid rock...speaking of which, I remember hearing that #b#o6400100##k the monster collects them. \n#t04000131#  #b#c04000131##k/80"/>
-        <string name="2" value="Umi&apos;s spiced vegetables sure sound enticing. I should go get some later~!"/>
+        <string name="name" value="由美的腌制蔬菜"/>
+        <string name="0" value="听说昭和村的#r#p9120005##k想腌制蔬菜，却缺少合适的压菜石。去问问她需要什么帮助吧。"/>
+        <string name="1" value="为了腌制蔬菜，#r#p9120005##k需要沉甸甸的石片。听说#b#o6400100##k会带着这种石片，去收集#b80个#t4000131##k吧。\n\n#t4000131# #b#c4000131##k / 80"/>
+        <string name="2" value="#r#p9120005##k用我带回来的石片腌制了蔬菜。听起来很下饭，有机会再去尝尝吧。"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="2230">

--- a/gms-server/wz-zh-CN/String.wz/Npc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Npc.img.xml
@@ -6308,10 +6308,10 @@
     </imgdir>
     <imgdir name="9120005">
         <string name="name" value="由美"/>
-        <string name="d0" value="大特價喔！"/>
-        <string name="d1" value="今天是最好的機會～"/>
-        <string name="n0" value="大特價喔！"/>
-        <string name="n1" value="今天是最好的機會～"/>
+        <string name="d0" value="价格便宜得离谱哦！"/>
+        <string name="d1" value="今天可是最好的机会～"/>
+        <string name="n0" value="价格便宜得离谱哦！"/>
+        <string name="n1" value="今天可是最好的机会～"/>
     </imgdir>
     <imgdir name="9120006">
         <string name="name" value="繪里香"/>


### PR DESCRIPTION
## 主要调整
- 汉化并修正由美相关任务 `8079`、`8080`、`8081`、`8082` 的任务名、父任务名、任务说明与任务对话。
- 修正由美关联任务 `8028`、`8052` 的任务说明与对话，统一蔬菜、腌制蔬菜、材料数量和怪物提示的表达。
- 对齐任务文本中的实际需求数值：`8079` 需要 5,000,000 金币，`8081` 需要 400 个 `#t4000117#`，`8082` 需要 10 个 `#t4011005#`，`8028` 需要 200 个 `#t4000080#`，`8052` 需要 80 个 `#t4000131#`。
- 修正 `8082` 中机器递送对象的指代错误，明确机器由 `#p2050002#` 送到 `#p9120005#`。
- 统一由美 `9120005` 的 NPC 静态文本为简体中文，移除繁体与不统一表达。

## 客户端同步备注
- 本次修改包含任务 WZ 与 NPC 静态文本。
- 如果客户端读取本地 WZ，需要同步对应的 Quest.wz/QuestInfo.img、Quest.wz/Say.img 与 String.wz/Npc.img 后，任务列表、任务说明、任务对话和 NPC 静态文本显示才会更新。