### PR TITLE
fix(NPE): 解决数据为空时getInt方法的空指针异常

### DIFF
--- a/gms-server/src/main/java/org/gms/provider/DataTool.java
+++ b/gms-server/src/main/java/org/gms/provider/DataTool.java
@@ -117,6 +117,9 @@ public class DataTool {
     }
 
     public static int getInt(String path, Data data, int def) {
+        if (data==null) {
+            return def;
+        }
         return getInt(data.getChildByPath(path), def);
     }
 


### PR DESCRIPTION
- 添加了对data参数为null的检查
- 当data为null时直接返回默认值def
- 避免了getChildByPath方法调用时可能出现的空指针异常