### PR TITLE
fix: 汉化阿里安特拉尔拉护肤对话

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2100007.js
+++ b/gms-server/scripts-zh-CN/npc/2100007.js
@@ -1,7 +1,7 @@
 /* Author: aaroncsn <MapleSea Like, Incomplete, Needs skin id>
-	NPC Name: 		Laila
-	Map(s): 		The Burning Road: Ariant(2600000000)
-	Description: 	Skin Care Specialist
+    NPC Name:       Laila
+    Map(s):         The Burning Road: Ariant(2600000000)
+    Description:    Skin Care Specialist
 */
 
 var status = 0;
@@ -22,17 +22,17 @@ function action(mode, type, selection) {
             status--;
         }
         if (status == 0) {
-            cm.sendNext("Hohoh~ 欢迎欢迎。欢迎来到阿里安特护肤中心。你已经踏入了一家著名的护肤店，甚至连女王本人都经常光顾这个地方。如果你带着 #b阿里安特护肤优惠券#k，我们会照顾好你的其余事项。今天让我们来护理一下你的肌肤吧？");
+            cm.sendNext("呵呵呵~ 欢迎，欢迎。欢迎来到阿里安特护肤中心。你来到的是一家知名护肤店，就连王妃本人也经常光顾这里。如果你带着#b阿里安特护肤券#k，剩下的事就交给我们吧。今天要不要让我们帮你护理一下肌肤呢？");
         } else if (status == 1) {
-            cm.sendStyle("With our specialized machine, you can see yourself after the treatment in advance. What kind of skin-treatment would you like to do? Choose the style of your liking...", skin);
+            cm.sendStyle("通过我们的专业机器，你可以提前看到护理后的效果。你想做哪一种护肤护理呢？请选择你喜欢的肤色。", skin);
         } else if (status == 2) {
             cm.dispose();
             if (cm.haveItem(5153007) == true) {
                 cm.gainItem(5153007, -1);
                 cm.setSkin(skin[selection]);
-                cm.sendOk("享受你的新肤色吧！");
+                cm.sendOk("好好享受你焕然一新的肌肤吧！");
             } else {
-                cm.sendNext("嗯...我觉得你没有我们的护肤券。没有券，我就不能给你护理服务。");
+                cm.sendNext("嗯……你身上好像没有我们的护肤券。没有护肤券的话，我不能为你提供护理服务。");
             }
         }
     }


### PR DESCRIPTION
## 变更内容
- 汉化阿里安特护肤中心 NPC 拉尔拉的对话文本。
- 补全护肤券不足、护理成功、肤色选择等流程中的中文提示。
- 清理该脚本中残留的英文对话，避免中文环境下显示英文文本。

## 客户端影响
- 本次只修改服务端 NPC 脚本，不依赖客户端 WZ 改动。

## 测试
- 已确认修改范围仅包含拉尔拉对应 NPC 脚本。
- 已在中文脚本中检查无乱码和残留英文提示。