### PR TITLE
fix: 修复阿里安特高级整形券对话无响应

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2100008.js
+++ b/gms-server/scripts-zh-CN/npc/2100008.js
@@ -58,8 +58,8 @@ function action(mode, type, selection) {
                     }
                 }
                 if (cm.getChar().getGender() == 1) {
-                    for (var i = 0; i < fface.length; i++) {
-                        pushIfItemExists(facenew, fface[i] + cm.getChar().getFace()
+                    for (var i = 0; i < fface_v.length; i++) {
+                        pushIfItemExists(facenew, fface_v[i] + cm.getChar().getFace()
                             % 1000 - (cm.getChar().getFace()
                                 % 100));
                     }

--- a/gms-server/scripts/npc/2100008.js
+++ b/gms-server/scripts/npc/2100008.js
@@ -58,8 +58,8 @@ function action(mode, type, selection) {
                     }
                 }
                 if (cm.getChar().getGender() == 1) {
-                    for (var i = 0; i < fface.length; i++) {
-                        pushIfItemExists(facenew, fface[i] + cm.getChar().getFace()
+                    for (var i = 0; i < fface_v.length; i++) {
+                        pushIfItemExists(facenew, fface_v[i] + cm.getChar().getFace()
                             % 1000 - (cm.getChar().getFace()
                                 % 100));
                     }


### PR DESCRIPTION
## 问题
女性角色在八德乐处选择阿里安特整形手术高级会员卡时，NPC 脚本会引用未定义的 `fface` 变量，导致后续对话中断。

## 修复
- 将女性高级整形脸型列表引用从 `fface` 改为已定义的 `fface_v`。
- 同步修复英文和中文 NPC 脚本，避免不同语言脚本表现不一致。

## 影响
- 仅修复服务端 NPC 脚本逻辑。
- 不依赖客户端资源更新。