### PR TITLE
fix: 汉化阿里安特玛兹拉美发对话

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2100006.js
+++ b/gms-server/scripts-zh-CN/npc/2100006.js
@@ -1,7 +1,7 @@
 /* Author: aaroncsn <MapleSea Like>
-	NPC Name: 		Mazra
-	Map(s): 		The Burning Road: Ariant(2600000000)
-	Description: 	Hair Salon Owner
+    NPC Name:       Mazra
+    Map(s):         The Burning Road: Ariant(2600000000)
+    Description:    Hair Salon Owner
 
         GMS-like revised by Ronan -- contents found thanks to Mitsune (GamerBewbs), Waltzing, AyumiLove
 */
@@ -33,7 +33,7 @@ function action(mode, type, selection) {
             status--;
         }
         if (status == 0) {
-            cm.sendSimple("“哈哈哈...在沙漠中，一个人要注意自己的发型，需要有很多的风格和魅力。像你这样的人...如果你有#b阿里安特发型券（VIP）#k或#b阿里安特染发券（VIP）#k，我会给你的头发一个全新的造型。\r\n#L0#理发：#i5150027##t5150027##l\r\n#L1#染发：#i5151022##t5151022##l");
+            cm.sendSimple("哈哈哈……在沙漠里还愿意打理发型的人，确实需要不少风格和魅力。像你这样的人……如果你有#b阿里安特美发券（VIP）#k或#b阿里安特染发券（VIP）#k，我可以让你的头发焕然一新。\r\n#L0#理发：#i5150027##t5150027##l\r\n#L1#染发：#i5151022##t5151022##l");
         } else if (status == 1) {
             if (selection == 0) {
                 beauty = 1;
@@ -50,7 +50,7 @@ function action(mode, type, selection) {
                             % 10));
                     }
                 }
-                cm.sendStyle("Hahaha~all you need is #bAriant hair style coupon(VIP)#k to change up your hairstyle. Choose the new style, and let me do the rest.", hairnew);
+                cm.sendStyle("哈哈哈~ 只要有#b阿里安特美发券（VIP）#k，就可以改变你的发型。选择你喜欢的新发型，剩下的就交给我吧。", hairnew);
             } else if (selection == 1) {
                 beauty = 2;
                 haircolor = Array();
@@ -59,7 +59,7 @@ function action(mode, type, selection) {
                 for (var i = 0; i < 8; i++) {
                     pushIfItemExists(haircolor, current + i);
                 }
-                cm.sendStyle("Every once in a while, it doesn't hurt to change up your hair color... it's fun. Allow me, the great Mazra, to dye your hair, so you just bring me #bAriant hair color coupon(VIP)#k, and choose your new hair color.", haircolor);
+                cm.sendStyle("偶尔换个发色也不错……这很有趣。带上#b阿里安特染发券（VIP）#k，选择你想要的新发色，就让我玛兹拉来为你染发吧。", haircolor);
             }
         } else if (status == 2) {
             cm.dispose();
@@ -67,18 +67,18 @@ function action(mode, type, selection) {
                 if (cm.haveItem(5150027) == true) {
                     cm.gainItem(5150027, -1);
                     cm.setHair(hairnew[selection]);
-                    cm.sendOk("享受你的新发型吧！");
+                    cm.sendOk("好好享受你焕然一新的发型吧！");
                 } else {
-                    cm.sendNext("我以为我告诉过你了，你需要优惠券我才能给你的头发做魔法，再检查一下。");
+                    cm.sendNext("我应该说过了，需要美发券我才能为你的头发施展魔法。再检查一下吧。");
                 }
             }
             if (beauty == 2) {
                 if (cm.haveItem(5151022) == true) {
                     cm.gainItem(5151022, -1);
                     cm.setHair(haircolor[selection]);
-                    cm.sendOk("享受你的新发色吧！");
+                    cm.sendOk("好好享受你焕然一新的发色吧！");
                 } else {
-                    cm.sendNext("我以为我告诉过你了，你需要优惠券才能让我为你的头发施展魔法，再检查一下。");
+                    cm.sendNext("我应该说过了，需要染发券我才能为你的头发施展魔法。再检查一下吧。");
                 }
             }
         }


### PR DESCRIPTION
## 变更内容
- 汉化阿里安特美发店 NPC 玛兹拉的对话文本。
- 补全美发券、染发券流程中的选择提示、成功提示和券不足提示。
- 清理该脚本中残留的英文对话，避免中文环境下显示英文文本。

## 客户端影响
- 本次只修改服务端 NPC 脚本，不依赖客户端 WZ 改动。

## 测试
- 已确认修改范围仅包含玛兹拉对应 NPC 脚本。
- 已在中文脚本中检查无乱码和残留英文提示。