### PR TITLE
fix: 汉化阿多尼斯迷失的灵魂任务

### DIFF
--- a/gms-server/scripts-zh-CN/npc/9201106.js
+++ b/gms-server/scripts-zh-CN/npc/9201106.js
@@ -40,7 +40,7 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            cm.sendOk("我来自遥远的地方，寻找足够强大的人加入我的远征队，对抗肆虐这片土地的邪恶。你，碰巧是其中之一吗？");
+            cm.sendOk("我从遥远的地方而来，寻找足够强大的人加入我的远征队，对抗肆虐这片土地的邪恶。你是否就是其中之一？");
             cm.dispose();
         }
     }

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -18513,21 +18513,21 @@
         <int name="autoStart" value="1"/>
     </imgdir>
     <imgdir name="8255">
-        <string name="name" value="Lost Spirits"/>
-        <string name="parent" value="Lost Spirits"/>
+        <string name="name" value="迷失的灵魂"/>
+        <string name="parent" value="迷失的灵魂"/>
         <int name="order" value="1"/>
-        <string name="0" value="A new traveler is in the town of El Nath, I wonder what his story is...perhaps something to do with Zakum? I should pay him a visit; I heard his name is Adonis."/>
-        <string name="1" value="I visited El Nath, and found Adonis. He&apos;s speaking to me now..."/>
-        <string name="2" value="Adonis and I had an enlightening conversation about Zakum, and the residents of the former town. It appears that Zakum gains additional power from what Adonis calls &quot;Zakum Diamonds&quot;.  They are souls of those who fell in battle against the mighty Zakum.  As they were fellow warriors and adventurers like me, their souls must be released.  If I can find a relic of the old town, such as a Crystal Blade, Miner&apos;s Hat, El Nathian Cape or Cloak of Corruption and combine it with a Zakum Diamond, I can perform a &apos;Liberation Ritual&quot; that will free the soul by transferring their power into that item.  I can then wear the enchanted item for extra strength in battle!  Only thing is, Zakum Diamonds only come from one place, Zakum himself.  This won&apos;t be easy..."/>
+        <string name="0" value="冰封雪域来了一位新的旅行者。我很好奇他的故事……也许和扎昆有关？我应该去拜访他，听说他的名字叫阿多尼斯。"/>
+        <string name="1" value="我去了冰封雪域，找到了阿多尼斯。他正在和我说话……"/>
+        <string name="2" value="我和阿多尼斯谈了许多关于扎昆，以及过去那座村庄居民的事情。看来扎昆会从阿多尼斯所说的“扎昆钻石”中获得额外力量。那些钻石其实是与强大的扎昆战斗时倒下的人们的灵魂。他们和我一样曾是战士与冒险家，必须让他们的灵魂得到解放。如果我能找到旧村庄的遗物，例如水晶刃、矿工帽、冰封雪域披风或腐败斗篷，并将它与扎昆钻石结合，就能举行“解放仪式”，把灵魂的力量转移到那件物品中，使灵魂获得自由。之后我还能穿戴附魔后的物品，在战斗中获得更强的力量！问题是，扎昆钻石只有一个来源——扎昆本身。这可不容易……"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="8256">
-        <string name="name" value="Lost Spirits."/>
-        <string name="parent" value="Lost Spirits"/>
+        <string name="name" value="迷失的灵魂。"/>
+        <string name="parent" value="迷失的灵魂"/>
         <int name="order" value="2"/>
-        <string name="0" value="A new traveler is in the town of El Nath, I wonder what his story is...perhaps something to do with Zakum? I should pay him a visit; I heard his name is Adonis. "/>
-        <string name="1" value="I visited El Nath, and found Adonis. He&apos;s speaking to me now..."/>
-        <string name="2" value="Adonis and I had an enlightening conversation about Zakum, and the residents of the former town. It appears that Zakum gains additional power from what Adonis calls &quot;Zakum Diamonds&quot;.  They are souls of those who fell in battle against the mighty Zakum.  As they were fellow warriors and adventurers like me, their souls must be released.  If I can find a relic of the old town, such as a Crystal Blade, Miner&apos;s Hat, El Nathian Cape or Cloak of Corruption and combine it with a Zakum Diamond, I can perform a &apos;Liberation Ritual&quot; that will free the soul by transferring their power into that item.  I can then wear the enchanted item for extra strength in battle!  Only thing is, Zakum Diamonds only come from one place, Zakum himself.  This won&apos;t be easy..."/>
+        <string name="0" value="冰封雪域来了一位新的旅行者。我很好奇他的故事……也许和扎昆有关？我应该去拜访他，听说他的名字叫阿多尼斯。"/>
+        <string name="1" value="我去了冰封雪域，找到了阿多尼斯。他正在和我说话……"/>
+        <string name="2" value="我和阿多尼斯谈了许多关于扎昆，以及过去那座村庄居民的事情。看来扎昆会从阿多尼斯所说的“扎昆钻石”中获得额外力量。那些钻石其实是与强大的扎昆战斗时倒下的人们的灵魂。他们和我一样曾是战士与冒险家，必须让他们的灵魂得到解放。如果我能找到旧村庄的遗物，例如水晶刃、矿工帽、冰封雪域披风或腐败斗篷，并将它与扎昆钻石结合，就能举行“解放仪式”，把灵魂的力量转移到那件物品中，使灵魂获得自由。之后我还能穿戴附魔后的物品，在战斗中获得更强的力量！问题是，扎昆钻石只有一个来源——扎昆本身。这可不容易……"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="8257">


### PR DESCRIPTION
## 改动内容
- 汉化阿多尼斯 NPC 的默认对话文本。
- 汉化任务 `Lost Spirits` / `Lost Spirits.` 的任务面板名称、分组与任务说明。

## 测试说明
- 已检查修改后的 XML 能正常解析。
- 任务面板文本来自客户端 `QuestInfo.img`，如果客户端使用内置 WZ，需要同步对应任务的 `QuestInfo.img` 后才能在快捷键 Q 面板显示中文。