### PR TITLE
fix: 修复最佳公民勋章任务

### DIFF
--- a/gms-server/scripts-zh-CN/quest/29508.js
+++ b/gms-server/scripts-zh-CN/quest/29508.js
@@ -1,4 +1,5 @@
 var medalId = 1142081;
+var Quest = Java.type('org.gms.server.quest.Quest');
 
 function getMissingRequirements() {
     var missing = [];
@@ -18,25 +19,20 @@ function getMissingRequirements() {
     return missing;
 }
 
-function start(mode, type, selection) {
-    qm.forceStartQuest();
-    qm.sendOk("请完成结婚、加入公会，并拥有至少 1 名后辈。满足全部条件后再来找我领取勋章。");
-    qm.dispose();
-}
-
-function end(mode, type, selection) {
+function tryAwardMedal() {
     var missing = getMissingRequirements();
     if (missing.length > 0) {
         qm.sendOk("你还没有满足全部条件，请先：" + missing.join("、") + "。");
+        Quest.getInstance(29508).reset(qm.getPlayer());
         qm.dispose();
-        return;
+        return false;
     }
 
     if (!qm.haveItem(medalId)) {
         if (!qm.canHold(medalId)) {
             qm.sendOk("请在装备栏中空出 1 个位置后再来领取勋章。");
             qm.dispose();
-            return;
+            return false;
         }
         qm.gainItem(medalId, 1);
     }
@@ -46,4 +42,13 @@ function end(mode, type, selection) {
     qm.earnTitle(medalname);
     qm.forceCompleteQuest();
     qm.dispose();
+    return true;
+}
+
+function start(mode, type, selection) {
+    tryAwardMedal();
+}
+
+function end(mode, type, selection) {
+    tryAwardMedal();
 }

--- a/gms-server/scripts-zh-CN/quest/29508.js
+++ b/gms-server/scripts-zh-CN/quest/29508.js
@@ -1,0 +1,49 @@
+var medalId = 1142081;
+
+function getMissingRequirements() {
+    var missing = [];
+    var player = qm.getPlayer();
+    var familyEntry = player.getFamilyEntry();
+
+    if (!player.isMarried()) {
+        missing.push("完成结婚");
+    }
+    if (player.getGuildId() <= 0) {
+        missing.push("加入公会");
+    }
+    if (familyEntry == null || familyEntry.getJuniorCount() < 1) {
+        missing.push("拥有至少 1 名后辈");
+    }
+
+    return missing;
+}
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("请完成结婚、加入公会，并拥有至少 1 名后辈。满足全部条件后再来找我领取勋章。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var missing = getMissingRequirements();
+    if (missing.length > 0) {
+        qm.sendOk("你还没有满足全部条件，请先：" + missing.join("、") + "。");
+        qm.dispose();
+        return;
+    }
+
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏中空出 1 个位置后再来领取勋章。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    var medalname = qm.getMedalName();
+    qm.message("<" + medalname + "> 奖励已获得。");
+    qm.earnTitle("<" + medalname + "> 奖励已获得。");
+    qm.forceCompleteQuest();
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29508.js
+++ b/gms-server/scripts-zh-CN/quest/29508.js
@@ -43,7 +43,7 @@ function end(mode, type, selection) {
 
     var medalname = qm.getMedalName();
     qm.message("<" + medalname + "> 奖励已获得。");
-    qm.earnTitle("<" + medalname + "> 奖励已获得。");
+    qm.earnTitle(medalname);
     qm.forceCompleteQuest();
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29508.js
+++ b/gms-server/scripts/quest/29508.js
@@ -43,7 +43,7 @@ function end(mode, type, selection) {
 
     var medalname = qm.getMedalName();
     qm.message("<" + medalname + "> has been awarded.");
-    qm.earnTitle("<" + medalname + "> has been awarded.");
+    qm.earnTitle(medalname);
     qm.forceCompleteQuest();
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29508.js
+++ b/gms-server/scripts/quest/29508.js
@@ -1,0 +1,49 @@
+var medalId = 1142081;
+
+function getMissingRequirements() {
+    var missing = [];
+    var player = qm.getPlayer();
+    var familyEntry = player.getFamilyEntry();
+
+    if (!player.isMarried()) {
+        missing.push("get married");
+    }
+    if (player.getGuildId() <= 0) {
+        missing.push("join a guild");
+    }
+    if (familyEntry == null || familyEntry.getJuniorCount() < 1) {
+        missing.push("register at least 1 Junior");
+    }
+
+    return missing;
+}
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Join a marriage, a guild, and register at least 1 Junior. Come back once you meet all three requirements.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var missing = getMissingRequirements();
+    if (missing.length > 0) {
+        qm.sendOk("You have not met all the requirements yet. Please " + missing.join(", ") + ".");
+        qm.dispose();
+        return;
+    }
+
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your Equip inventory before receiving the medal.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    var medalname = qm.getMedalName();
+    qm.message("<" + medalname + "> has been awarded.");
+    qm.earnTitle("<" + medalname + "> has been awarded.");
+    qm.forceCompleteQuest();
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29508.js
+++ b/gms-server/scripts/quest/29508.js
@@ -1,4 +1,5 @@
 var medalId = 1142081;
+var Quest = Java.type('org.gms.server.quest.Quest');
 
 function getMissingRequirements() {
     var missing = [];
@@ -18,25 +19,20 @@ function getMissingRequirements() {
     return missing;
 }
 
-function start(mode, type, selection) {
-    qm.forceStartQuest();
-    qm.sendOk("Join a marriage, a guild, and register at least 1 Junior. Come back once you meet all three requirements.");
-    qm.dispose();
-}
-
-function end(mode, type, selection) {
+function tryAwardMedal() {
     var missing = getMissingRequirements();
     if (missing.length > 0) {
         qm.sendOk("You have not met all the requirements yet. Please " + missing.join(", ") + ".");
+        Quest.getInstance(29508).reset(qm.getPlayer());
         qm.dispose();
-        return;
+        return false;
     }
 
     if (!qm.haveItem(medalId)) {
         if (!qm.canHold(medalId)) {
             qm.sendOk("Please make room in your Equip inventory before receiving the medal.");
             qm.dispose();
-            return;
+            return false;
         }
         qm.gainItem(medalId, 1);
     }
@@ -46,4 +42,13 @@ function end(mode, type, selection) {
     qm.earnTitle(medalname);
     qm.forceCompleteQuest();
     qm.dispose();
+    return true;
+}
+
+function start(mode, type, selection) {
+    tryAwardMedal();
+}
+
+function end(mode, type, selection) {
+    tryAwardMedal();
 }

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9669,12 +9669,12 @@
         <int name="viewMedalItem" value="1142082"/>
     </imgdir>
     <imgdir name="29508">
-        <string name="name" value="挑战勋章-最佳公民勋章"/>
+        <string name="name" value="挑战勋章 - 最佳公民勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="#b#eTitle Challenge - Outstanding Citizen#n\nParticipate in #k#bMarriage, Guild, and Family#k activities! Dalair, on behalf of the God of Honor, is looking for active citizens. He says anyone who participates in a #bMarriage#k and a #bGuild#k, and #bhas at least 1 Junior#k, will receive the #e#bOutstanding Citizen#k#n title."/>
-        <string name="1" value="#b#eTitle Challenge - Outstanding Citizen#n#k\n Actively participate in Marriage, Guild, and Family activities."/>
-        <string name="2" value="#b#eTitle Challenge - Outstanding Citizen#n#k\n\nYou have acquired the #bOutstanding Citizen#k title and the associated medal."/>
-        <string name="demandSummary" value="Be part of a Marriage and a Guild, and register at least 1 Junior."/>
+        <string name="0" value="#b#e挑战勋章 - 最佳公民勋章#n\n积极参与#k#b结婚、公会和家族#k活动吧！达利尔代表荣誉之神寻找活跃的市民。只要你已经#b结婚#k、#b加入公会#k，并且#b拥有至少 1 名后辈#k，就能获得#e#b最佳公民勋章#k#n称号。"/>
+        <string name="1" value="#b#e挑战勋章 - 最佳公民勋章#n#k\n积极参与结婚、公会和家族活动。"/>
+        <string name="2" value="#b#e挑战勋章 - 最佳公民勋章#n#k\n\n你已经获得#b最佳公民勋章#k称号和对应勋章。"/>
+        <string name="demandSummary" value="完成结婚、加入公会，并拥有至少 1 名后辈。"/>
         <string name="rewardSummary" value="#Wbasic# #v1142081:##t1142081:# 1"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142081"/>


### PR DESCRIPTION
## 修改内容

- 为任务 29508（最佳公民勋章）新增专用任务脚本，避免回退到通用未实现勋章脚本并提示“没有找到”。
- 完成结婚、加入公会、拥有至少 1 名后辈后，发放最佳公民勋章道具 1142081 并完成任务。
- 补充中文任务面板和接任务说明，明确三个完成条件。

## 客户端影响

本次修改包含 QuestInfo 和 Say 文本更新。若客户端使用本地 WZ 显示任务面板或任务说明，需要同步以下客户端资源后才能看到完整中文文本：

- Quest/QuestInfo.img
- Quest/Say.img

## 验证

- 已验证新增脚本语法。
- 已验证修改后的 QuestInfo.img.xml 和 Say.img.xml 可以正常解析。