### PR TITLE
fix: 汉化光之祭典(Festival of Lights)任务文本(8829/8830/8843)

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -5070,7 +5070,7 @@
         <string name="name" value="新手飞侠的第一次修炼"/>
         <string name="0" value="你已经成功转职成为飞侠. 但对于如何修炼却一无所知... 去向飞侠转职教官 #b#p1052001##k寻求帮助吧. "/>
         <string name="1" value="#p1052001#认为透过简单的怪物狩猎任务可以进行基础修炼，他要你捕捉#r#o210100# 16只#k. #o210100#多出现在 #m103000000# 周边地区，并不难找... \n\n#o210100# #r#a21401##k"/>
-        <string name="2" value="捕捉到#o130100# 16只并向 #p1052001#报告. 嗯... 任务很简单吧?"/>
+        <string name="2" value="捕捉到#o210100# 16只并向 #p1052001#报告. 嗯... 任务很简单吧?"/>
         <int name="area" value="10"/>
         <int name="autoStart" value="1"/>
         <int name="autoComplete" value="1"/>
@@ -18913,21 +18913,21 @@
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="8829">
-        <string name="name" value="Festival of Lights - Building the Altar"/>
-        <string name="parent" value="Festival of Lights"/>
+        <string name="name" value="光之祭典：建造祭坛"/>
+        <string name="parent" value="光之祭典"/>
         <int name="order" value="1"/>
-        <string name="0" value="Hmm, that woman looks like she&apos;s preparing some sort of celebration... I should check it out."/>
-        <string name="1" value="I spoke with Hannah, and she&apos;s preparing a Festival of Lights. I&apos;ve agreed to help her build the Altar by gathering 25 Altar Pieces. She mentioned that the monsters would already have an axe stuck in them, so I should hunt those."/>
-        <string name="2" value="I collected the 25 Altar Pieces and returned to Hannah. She was happy, and began building the Altar. She also mentioned that I could come back for more work when I have a chance"/>
+        <string name="0" value="嗯，那个女人看起来好像在准备什么庆祝活动……我去看看是怎么回事。"/>
+        <string name="1" value="我和汉娜聊了聊，她正在筹备光之祭典。我答应帮她收集#b25个祭坛碎片#k来搭建祭坛。她说身上插着斧头的怪物会掉落碎片，让我去狩猎那些怪物。"/>
+        <string name="2" value="我收集齐了25个祭坛碎片并交给了汉娜。她很高兴，开始搭建祭坛。她还说以后有空可以再去找她接更多工作。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8830">
-        <string name="name" value="Festival of Lights - Blessing the Festival "/>
-        <string name="parent" value="Festival of Lights"/>
+        <string name="name" value="光之祭典：点亮祭坛"/>
+        <string name="parent" value="光之祭典"/>
         <int name="order" value="2"/>
-        <string name="0" value="I promised Hannah I&apos;d return to her once I was rested up. I should head back soon."/>
-        <string name="1" value="Upon my return, Hannah was joyous, having finished the Altar. She now needs candles to signal the start of the ceremony. I&apos;ll have to get 9 candles (she mentioned Horned Mushrooms) and bring them back so the Festival of Lights can begin. "/>
-        <string name="2" value="I acquired the nine candles and gave them to Hannah. The Festival of Lights has begun!"/>
+        <string name="0" value="我答应汉娜，休息好了就回去找她。该出发了。"/>
+        <string name="1" value="回去之后，汉娜已经搭建好了祭坛，非常开心。现在她需要蜡烛来点燃祭坛，宣告仪式开始。我得收集#b9根蜡烛#k（她说角蘑菇怪会掉落），带回去给汉娜，这样光之祭典就可以开始了。\n\n#t4031444# #b#c4031444##k/9"/>
+        <string name="2" value="我收集了9根蜡烛交给汉娜。光之祭典开始了！"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8832">
@@ -18965,12 +18965,12 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8843">
-        <string name="name" value="Festival of Lights - Blessing the Festival reward"/>
-        <string name="parent" value="Festival of Lights"/>
+        <string name="name" value="光之祭典：领取奖励"/>
+        <string name="parent" value="光之祭典"/>
         <int name="order" value="3"/>
-        <string name="0" value="Now that I have the Hanukkah Present Box, I&apos;ll need to get this opened to see what&apos;s inside. Better go talk to Hannah."/>
-        <string name="1" value="Hannah promised to open the box for me. The box seems heavy though, so I may get something nice in return..."/>
-        <string name="2" value="Hannah helped open up the box, and I got to receive what&apos;s inside it. Not bad!"/>
+        <string name="0" value="我拿到了光明节礼物盒，得找汉娜打开看看里面有什么。"/>
+        <string name="1" value="汉娜答应帮我打开礼物盒。盒子看起来沉甸甸的，应该能开出好东西……"/>
+        <string name="2" value="汉娜帮我打开了礼物盒，我拿到了里面的东西。还不错！"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8848">


### PR DESCRIPTION

[bd-v16.1-cnpatch-r3.zip](https://github.com/user-attachments/files/28738866/bd-v16.1-cnpatch-r3.zip)
## 变更内容
- 汉化光之祭典任务文本：8829 / 8830 / 8843
- 仅修改 `gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml`

## 说明
- 勤奋冒险家勋章任务（29400）不包含在本 PR 中，将单独处理。
