### PR TITLE
fix: 修复最佳公民勋章任务判定

### DIFF
--- a/gms-server/scripts-zh-CN/quest/29508.js
+++ b/gms-server/scripts-zh-CN/quest/29508.js
@@ -1,0 +1,70 @@
+var OutstandingCitizenMedal = Java.type('org.gms.server.quest.medal.OutstandingCitizenMedal');
+var medalId = OutstandingCitizenMedal.MEDAL_ID;
+
+function getMissingRequirements() {
+    var missing = [];
+    var player = qm.getPlayer();
+    var familyEntry = player.getFamilyEntry();
+
+    if (!player.isMarried()) {
+        missing.push("完成结婚：与另一名角色完成婚礼，并佩戴有效婚戒");
+    }
+    if (player.getGuildId() <= 0) {
+        missing.push("加入公会：角色当前必须属于任意公会");
+    }
+    if (familyEntry == null || familyEntry.getJuniorCount() < 1) {
+        missing.push("拥有后辈：家族系统中至少登记 1 名后辈");
+    }
+
+    return missing;
+}
+
+function formatMissingRequirements(missing) {
+    var text = "你还没有满足全部条件。领取#b最佳公民勋章#k需要同时完成以下 3 项：\r\n";
+    text += "#b- 完成结婚#k：与另一名角色完成婚礼，并佩戴有效婚戒。\r\n";
+    text += "#b- 加入公会#k：角色当前必须属于任意公会。\r\n";
+    text += "#b- 拥有后辈#k：家族系统中至少登记 1 名后辈。\r\n\r\n";
+    text += "目前还缺少：\r\n#r- " + missing.join("\r\n- ") + "#k\r\n\r\n";
+    text += "请补齐缺少的条件后再来找我领取勋章。";
+    return text;
+}
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    OutstandingCitizenMedal.refreshEligibility(qm.getPlayer());
+
+    var missing = getMissingRequirements();
+    if (missing.length > 0) {
+        qm.sendOk(formatMissingRequirements(missing));
+    } else {
+        qm.sendOk("你已经同时满足结婚、公会和后辈条件。请再次和我对话领取#b最佳公民勋章#k。");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    OutstandingCitizenMedal.refreshEligibility(qm.getPlayer());
+
+    var missing = getMissingRequirements();
+    if (missing.length > 0) {
+        qm.sendOk(formatMissingRequirements(missing));
+        qm.dispose();
+        return;
+    }
+
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏中空出 1 个位置后再来领取勋章。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    var medalname = qm.getMedalName();
+    qm.message("<" + medalname + "> 奖励已获得。");
+    qm.earnTitle(medalname);
+    qm.forceCompleteQuest();
+    OutstandingCitizenMedal.clearEligibility(qm.getPlayer());
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29508.js
+++ b/gms-server/scripts/quest/29508.js
@@ -1,0 +1,70 @@
+var OutstandingCitizenMedal = Java.type('org.gms.server.quest.medal.OutstandingCitizenMedal');
+var medalId = OutstandingCitizenMedal.MEDAL_ID;
+
+function getMissingRequirements() {
+    var missing = [];
+    var player = qm.getPlayer();
+    var familyEntry = player.getFamilyEntry();
+
+    if (!player.isMarried()) {
+        missing.push("get married: complete a wedding with another character and wear a valid wedding ring");
+    }
+    if (player.getGuildId() <= 0) {
+        missing.push("join a guild: the character must currently belong to a guild");
+    }
+    if (familyEntry == null || familyEntry.getJuniorCount() < 1) {
+        missing.push("register a Junior: have at least 1 Junior in the Family system");
+    }
+
+    return missing;
+}
+
+function formatMissingRequirements(missing) {
+    var text = "You have not met all requirements yet. The #bOutstanding Citizen#k medal requires all 3 conditions:\r\n";
+    text += "#b- Get married#k: complete a wedding with another character and wear a valid wedding ring.\r\n";
+    text += "#b- Join a guild#k: this character must currently belong to a guild.\r\n";
+    text += "#b- Register a Junior#k: have at least 1 Junior in the Family system.\r\n\r\n";
+    text += "Still missing:\r\n#r- " + missing.join("\r\n- ") + "#k\r\n\r\n";
+    text += "Please come back after all missing conditions are complete.";
+    return text;
+}
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    OutstandingCitizenMedal.refreshEligibility(qm.getPlayer());
+
+    var missing = getMissingRequirements();
+    if (missing.length > 0) {
+        qm.sendOk(formatMissingRequirements(missing));
+    } else {
+        qm.sendOk("You meet the marriage, guild, and Junior requirements. Talk to me again to receive the #bOutstanding Citizen#k medal.");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    OutstandingCitizenMedal.refreshEligibility(qm.getPlayer());
+
+    var missing = getMissingRequirements();
+    if (missing.length > 0) {
+        qm.sendOk(formatMissingRequirements(missing));
+        qm.dispose();
+        return;
+    }
+
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your Equip inventory before receiving the medal.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    var medalname = qm.getMedalName();
+    qm.message("<" + medalname + "> has been awarded.");
+    qm.earnTitle(medalname);
+    qm.forceCompleteQuest();
+    OutstandingCitizenMedal.clearEligibility(qm.getPlayer());
+    qm.dispose();
+}

--- a/gms-server/src/main/java/org/gms/client/FamilyEntry.java
+++ b/gms-server/src/main/java/org/gms/client/FamilyEntry.java
@@ -435,6 +435,10 @@ public class FamilyEntry {
                 juniors[i] = newJunior;
                 addJuniorCount(1);
                 getFamily().addEntry(newJunior);
+                Character chr = getChr();
+                if (chr != null) {
+                    org.gms.server.quest.medal.OutstandingCitizenMedal.refreshEligibility(chr);
+                }
                 return true;
             }
         }
@@ -453,6 +457,10 @@ public class FamilyEntry {
         for (int i = 0; i < juniors.length; i++) {
             if (juniors[i] == junior) {
                 juniors[i] = null;
+                Character chr = getChr();
+                if (chr != null) {
+                    org.gms.server.quest.medal.OutstandingCitizenMedal.refreshEligibility(chr);
+                }
                 return true;
             }
         }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/PlayerLoggedinHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/PlayerLoggedinHandler.java
@@ -338,6 +338,7 @@ public final class PlayerLoggedinHandler extends AbstractPacketHandler {
                 }
             }
             //展示服务信息
+            org.gms.server.quest.medal.OutstandingCitizenMedal.refreshEligibility(player);
             noteService.show(player);
             //异常地图掉线信息提示
             c.getSysRescue().showMapChangeMessage(player);

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/RingActionHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/RingActionHandler.java
@@ -210,6 +210,7 @@ public final class RingActionHandler extends AbstractPacketHandler {
             partner.setPartnerId(-1);
             partner.setMarriageItemId(-1);
             partner.setMarriageRing(null);
+            org.gms.server.quest.medal.OutstandingCitizenMedal.refreshEligibility(partner);
         }
 
         chr.dropMessage(5, "You have successfully break the marriage with " + Character.getNameById(partnerid) + ".");
@@ -220,6 +221,7 @@ public final class RingActionHandler extends AbstractPacketHandler {
         chr.setPartnerId(-1);
         chr.setMarriageItemId(-1);
         chr.setMarriageRing(null);
+        org.gms.server.quest.medal.OutstandingCitizenMedal.refreshEligibility(chr);
     }
 
     private static void resetRingId(Character player) {
@@ -308,6 +310,8 @@ public final class RingActionHandler extends AbstractPacketHandler {
         partner.setMarriageRing(Ring.loadFromDb(rings.getRight()));
         InventoryManipulator.addFromDrop(partner.getClient(), ringEqp, false, -1);
         partner.broadcastMarriageMessage();
+        org.gms.server.quest.medal.OutstandingCitizenMedal.refreshEligibility(player);
+        org.gms.server.quest.medal.OutstandingCitizenMedal.refreshEligibility(partner);
     }
 
     @Override

--- a/gms-server/src/main/java/org/gms/net/server/guild/GuildCharacter.java
+++ b/gms-server/src/main/java/org/gms/net/server/guild/GuildCharacter.java
@@ -111,7 +111,10 @@ public class GuildCharacter {
 
     public void setGuildId(int gid) {
         guildid = gid;
-        character.setGuildId(gid);
+        if (character != null) {
+            character.setGuildId(gid);
+            org.gms.server.quest.medal.OutstandingCitizenMedal.refreshEligibility(character);
+        }
     }
 
     public int getGuildRank() {

--- a/gms-server/src/main/java/org/gms/server/quest/medal/OutstandingCitizenMedal.java
+++ b/gms-server/src/main/java/org/gms/server/quest/medal/OutstandingCitizenMedal.java
@@ -1,0 +1,48 @@
+package org.gms.server.quest.medal;
+
+import org.gms.client.Character;
+import org.gms.client.FamilyEntry;
+import org.gms.client.QuestStatus;
+import org.gms.server.quest.Quest;
+
+public final class OutstandingCitizenMedal {
+    public static final int QUEST_ID = 29508;
+    public static final int ELIGIBILITY_QUEST_ID = 29580;
+    public static final int MEDAL_ID = 1142081;
+
+    private OutstandingCitizenMedal() {
+    }
+
+    public static boolean isEligible(Character player) {
+        FamilyEntry familyEntry = player.getFamilyEntry();
+        return player.isMarried()
+                && player.getGuildId() > 0
+                && familyEntry != null
+                && familyEntry.getJuniorCount() >= 1;
+    }
+
+    public static void refreshEligibility(Character player) {
+        Quest mainQuest = Quest.getInstance(QUEST_ID);
+        Quest eligibilityQuest = Quest.getInstance(ELIGIBILITY_QUEST_ID);
+        QuestStatus.Status mainStatus = player.getQuest(mainQuest).getStatus();
+        QuestStatus.Status eligibilityStatus = player.getQuest(eligibilityQuest).getStatus();
+
+        if (mainStatus != QuestStatus.Status.STARTED || !isEligible(player)) {
+            if (eligibilityStatus != QuestStatus.Status.NOT_STARTED) {
+                eligibilityQuest.reset(player);
+            }
+            return;
+        }
+
+        if (eligibilityStatus != QuestStatus.Status.STARTED) {
+            eligibilityQuest.forceStart(player, 9000040);
+        }
+    }
+
+    public static void clearEligibility(Character player) {
+        Quest eligibilityQuest = Quest.getInstance(ELIGIBILITY_QUEST_ID);
+        if (player.getQuest(eligibilityQuest).getStatus() != QuestStatus.Status.NOT_STARTED) {
+            eligibilityQuest.reset(player);
+        }
+    }
+}

--- a/gms-server/wz-zh-CN/Quest.wz/Act.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/Act.img.xml
@@ -15920,6 +15920,10 @@
         <imgdir name="0"/>
         <imgdir name="1"/>
     </imgdir>
+    <imgdir name="29580">
+        <imgdir name="0"/>
+        <imgdir name="1"/>
+    </imgdir>
     <imgdir name="29509">
         <imgdir name="0"/>
         <imgdir name="1">

--- a/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
@@ -35780,7 +35780,17 @@
         <imgdir name="1">
             <int name="npc" value="9000040"/>
             <string name="endscript" value="q29508e"/>
+            <imgdir name="quest">
+                <imgdir name="0">
+                    <int name="id" value="29580"/>
+                    <int name="state" value="1"/>
+                </imgdir>
+            </imgdir>
         </imgdir>
+    </imgdir>
+    <imgdir name="29580">
+        <imgdir name="0"/>
+        <imgdir name="1"/>
     </imgdir>
     <imgdir name="29509">
         <imgdir name="0">

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9669,15 +9669,22 @@
         <int name="viewMedalItem" value="1142082"/>
     </imgdir>
     <imgdir name="29508">
-        <string name="name" value="挑战勋章-最佳公民勋章"/>
+        <string name="name" value="挑战勋章 - 最佳公民勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="#b#eTitle Challenge - Outstanding Citizen#n\nParticipate in #k#bMarriage, Guild, and Family#k activities! Dalair, on behalf of the God of Honor, is looking for active citizens. He says anyone who participates in a #bMarriage#k and a #bGuild#k, and #bhas at least 1 Junior#k, will receive the #e#bOutstanding Citizen#k#n title."/>
-        <string name="1" value="#b#eTitle Challenge - Outstanding Citizen#n#k\n Actively participate in Marriage, Guild, and Family activities."/>
-        <string name="2" value="#b#eTitle Challenge - Outstanding Citizen#n#k\n\nYou have acquired the #bOutstanding Citizen#k title and the associated medal."/>
-        <string name="demandSummary" value="Be part of a Marriage and a Guild, and register at least 1 Junior."/>
+        <string name="0" value="#b#e挑战勋章 - 最佳公民勋章#n\n积极参与#k#b结婚、公会和家族#k活动吧！达利尔代表荣誉之神寻找活跃的市民。只要你已经#b结婚#k、#b加入公会#k，并且#b拥有至少 1 名后辈#k，就能获得#e#b最佳公民勋章#k#n称号。"/>
+        <string name="1" value="#b#e挑战勋章 - 最佳公民勋章#n#k\n积极参与结婚、公会和家族活动。"/>
+        <string name="2" value="#b#e挑战勋章 - 最佳公民勋章#n#k\n\n你已经获得#b最佳公民勋章#k称号和对应勋章。"/>
+        <string name="demandSummary" value="完成结婚、加入公会，并拥有至少 1 名后辈。"/>
         <string name="rewardSummary" value="#Wbasic# #v1142081:##t1142081:# 1"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142081"/>
+    </imgdir>
+    <imgdir name="29580">
+        <string name="name" value="最佳公民勋章资格状态"/>
+        <int name="area" value="51"/>
+        <string name="0" value="最佳公民勋章挑战的内部资格状态。"/>
+        <string name="1" value="最佳公民勋章挑战的内部资格状态。"/>
+        <string name="2" value="最佳公民勋章挑战的内部资格状态。"/>
     </imgdir>
     <imgdir name="29509">
         <string name="name" value="坚强的挑战者"/>

--- a/gms-server/wz/Quest.wz/Act.img.xml
+++ b/gms-server/wz/Quest.wz/Act.img.xml
@@ -17271,7 +17271,11 @@
     <imgdir name="1">
     </imgdir>
   </imgdir>
-  <imgdir name="29509">
+  <imgdir name="29580">
+        <imgdir name="0"/>
+        <imgdir name="1"/>
+    </imgdir>
+    <imgdir name="29509">
     <imgdir name="0">
     </imgdir>
     <imgdir name="1">

--- a/gms-server/wz/Quest.wz/Check.img.xml
+++ b/gms-server/wz/Quest.wz/Check.img.xml
@@ -35863,7 +35863,17 @@
     <imgdir name="1">
       <int name="npc" value="9000040"/>
       <string name="endscript" value="q29508e"/>
+      <imgdir name="quest">
+        <imgdir name="0">
+          <int name="id" value="29580"/>
+          <int name="state" value="1"/>
+        </imgdir>
+      </imgdir>
     </imgdir>
+  </imgdir>
+  <imgdir name="29580">
+    <imgdir name="0"/>
+    <imgdir name="1"/>
   </imgdir>
   <imgdir name="29509">
     <imgdir name="0">

--- a/gms-server/wz/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz/Quest.wz/QuestInfo.img.xml
@@ -10663,6 +10663,13 @@ Able to proceed to &apos;For the peace of Victoria Island...&apos; as next quest
     <int name="medalCategory" value="2"/>
     <int name="viewMedalItem" value="1142081"/>
   </imgdir>
+  <imgdir name="29580">
+    <string name="name" value="Outstanding Citizen Eligibility"/>
+    <int name="area" value="51"/>
+    <string name="0" value="Internal eligibility state for the Outstanding Citizen medal challenge."/>
+    <string name="1" value="Internal eligibility state for the Outstanding Citizen medal challenge."/>
+    <string name="2" value="Internal eligibility state for the Outstanding Citizen medal challenge."/>
+  </imgdir>
   <imgdir name="29509">
     <string name="name" value="Persevering Challenger"/>
     <int name="area" value="51"/>


### PR DESCRIPTION

[bd-v16.1-cnpatch-r4.zip](https://github.com/user-attachments/files/28739025/bd-v16.1-cnpatch-r4.zip)
## 变更说明
- 为“最佳公民勋章”补充服务端资格判定：需要已结婚、已加入公会、并在家族系统中拥有至少 1 名后辈。
- 使用内部资格任务同步 Q 面板完成状态，避免玩家未满足条件时仍显示可完成。
- 补充中英文任务脚本、任务检查、奖励和任务信息文本。
- 为内部资格任务补充 QuestInfo 节点，避免客户端任务面板读取内部任务状态时缺少信息。 
- 优化未满足条件时的 NPC 提示，明确说明缺少结婚、公会或后辈条件。

## 测试
- 已执行 `mvn -pl gms-server -DskipTests package`，构建通过。
- 本任务涉及客户端 Quest WZ 文本；如果使用旧客户端，需要同步对应 QuestInfo/Say 资源后才能看到完整中文任务面板和提示文本。
## 客户端影响

- 本 PR 不修改客户端程序逻辑或 `BeiDou.exe`，主要客户端影响来自 Quest WZ 资源同步。
- 需要同步的客户端资源为 `Quest.wz` 相关节点：`Act.img`、`Check.img`、`QuestInfo.img`、`Say.img`，对应本 PR 新增/修改的任务 `29508` 和内部资格任务 `29580`。
- 如果客户端仍使用旧版 Quest WZ，服务端仍会执行新的资格判定，但客户端任务面板、NPC 对话、任务完成状态或任务说明可能显示不完整、显示旧文本，或因缺少 `29580` 的任务信息而表现异常。
- 本 PR 未新增客户端道具素材或客户端代码；勋章道具仍使用现有的 `1142081` 资源。

## 部署 / 生效说明

- `scripts/quest/29508.js` 和 WZ XML 属于服务端运行时资源，部署时需要随服务端发布包一起同步。
- `src/main/java` 下的修改不会通过替换 `.java` 源文件直接生效。Java 源码需要先编译成 `.class`，再打包进服务端启动使用的 `BeiDou.jar`。
- 因此合并本 PR 后，发布者需要重新执行 Maven 打包，例如 `mvn -pl gms-server -DskipTests package`，生成新的 `gms-server/target/BeiDou.jar`，并用新 jar 替换服务器/镜像/发布包中的 `BeiDou.jar` 后重启服务。
- 如果只同步脚本或 WZ，但没有替换重新打包后的 `BeiDou.jar`，新增的 `OutstandingCitizenMedal` 类以及登录、结婚、公会、家族变更时的资格刷新逻辑不会生效。
