### PR TITLE
fix: 修正飞侠技能中英文说明

### DIFF
--- a/gms-server/wz-zh-CN/String.wz/Skill.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Skill.img.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <imgdir name="Skill.img">
     <imgdir name="000">
         <string name="bookName" value="冒险家技能"/>
@@ -9783,7 +9783,7 @@
         <string name="h6" value="投射武器的射程距离增加150"/>
         <string name="h7" value="投射武器的射程距离增加175"/>
         <string name="h8" value="投射武器的射程距离增加200"/>
-        <string name="desc" value="[最高等级 : 8]\n增加拳套系武器的射程距离"/>
+        <string name="desc" value="[最高等级 : 8]\n增加飞镖等投掷武器的攻击射程。\n必要技能：#c集中术 Lv.3#"/>
     </imgdir>
     <imgdir name="4001002">
         <string name="name" value="诅咒术"/>
@@ -9807,79 +9807,79 @@
         <string name="h7" value="消耗MP6，怪物物理攻击力 -7，物理防御力 -7(持续22秒)"/>
         <string name="h8" value="消耗MP6，怪物物理攻击力 -8，物理防御力 -8(持续24秒)"/>
         <string name="h9" value="消耗MP7，怪物物理攻击力 -9，物理防御力 -9(持续29秒)"/>
-        <string name="desc" value="[最高等级 : 20]\n降低怪物的物理攻击力和物理防御力，而且\n怪物停止攻击，对一个怪物不能使用两次"/>
+        <string name="desc" value="[最高等级 : 20]\n降低1个敌人的物理攻击力和物理防御力；\n不能对已处于诅咒状态的敌人重复使用。"/>
     </imgdir>
     <imgdir name="4001003">
         <string name="name" value="隐身术"/>
-        <string name="h1" value="消耗MP24，隐身10秒，移动速度-18"/>
-        <string name="h10" value="消耗MP15，隐身100秒，移动速度不变"/>
-        <string name="h11" value="消耗MP14，隐身110秒，移动速度不变"/>
-        <string name="h12" value="消耗MP13，隐身120秒，移动速度不变"/>
-        <string name="h13" value="消耗MP12，隐身130秒，移动速度不变"/>
-        <string name="h14" value="消耗MP11，隐身140秒，移动速度不变"/>
-        <string name="h15" value="消耗MP10，隐身150秒，移动速度不变"/>
-        <string name="h16" value="消耗MP9，隐身160秒，移动速度不变"/>
-        <string name="h17" value="消耗MP8，隐身170秒，移动速度不变"/>
-        <string name="h18" value="消耗MP7，隐身180秒，移动速度不变"/>
-        <string name="h19" value="消耗MP6，隐身190秒，移动速度不变"/>
-        <string name="h2" value="消耗MP23，隐身20秒，移动速度-16"/>
+        <string name="h1" value="消耗MP24，隐身10秒，移动速度-30"/>
+        <string name="h10" value="消耗MP15，隐身100秒，移动速度-12"/>
+        <string name="h11" value="消耗MP14，隐身110秒，移动速度-10"/>
+        <string name="h12" value="消耗MP13，隐身120秒，移动速度-8"/>
+        <string name="h13" value="消耗MP12，隐身130秒，移动速度-7"/>
+        <string name="h14" value="消耗MP11，隐身140秒，移动速度-6"/>
+        <string name="h15" value="消耗MP10，隐身150秒，移动速度-5"/>
+        <string name="h16" value="消耗MP9，隐身160秒，移动速度-4"/>
+        <string name="h17" value="消耗MP8，隐身170秒，移动速度-3"/>
+        <string name="h18" value="消耗MP7，隐身180秒，移动速度-2"/>
+        <string name="h19" value="消耗MP6，隐身190秒，移动速度-1"/>
+        <string name="h2" value="消耗MP23，隐身20秒，移动速度-28"/>
         <string name="h20" value="消耗MP5，隐身200秒，移动速度不变"/>
-        <string name="h3" value="消耗MP22，隐身30秒，移动速度-14"/>
-        <string name="h4" value="消耗MP21，隐身40秒，移动速度-12"/>
-        <string name="h5" value="消耗MP20，隐身50秒，移动速度-10"/>
-        <string name="h6" value="消耗MP19，隐身60秒，移动速度-8"/>
-        <string name="h7" value="消耗MP18，隐身70秒，移动速度-6"/>
-        <string name="h8" value="消耗MP17，隐身80秒，移动速度-4"/>
-        <string name="h9" value="消耗MP16，隐身90秒，移动速度-2"/>
-        <string name="desc" value="[最高等级 : 20]\n消费MP，能够隐身，\n不会受到怪物的攻击但也无法攻击怪物.\n必需技能 : #c诅咒术等级3以上#"/>
+        <string name="h3" value="消耗MP22，隐身30秒，移动速度-26"/>
+        <string name="h4" value="消耗MP21，隐身40秒，移动速度-24"/>
+        <string name="h5" value="消耗MP20，隐身50秒，移动速度-22"/>
+        <string name="h6" value="消耗MP19，隐身60秒，移动速度-20"/>
+        <string name="h7" value="消耗MP18，隐身70秒，移动速度-18"/>
+        <string name="h8" value="消耗MP17，隐身80秒，移动速度-16"/>
+        <string name="h9" value="消耗MP16，隐身90秒，移动速度-14"/>
+        <string name="desc" value="[最高等级 : 20]\n消耗MP进入隐身状态，不会受到怪物攻击，\n但也无法攻击怪物。\n必要技能：#c诅咒术 Lv.3#"/>
     </imgdir>
     <imgdir name="4001334">
         <string name="name" value="二连击"/>
-        <string name="h1" value="消耗MP8，伤害102%"/>
-        <string name="h10" value="消耗MP10，伤害120%"/>
-        <string name="h11" value="消耗MP11，伤害122%"/>
-        <string name="h12" value="消耗MP11，伤害124%"/>
-        <string name="h13" value="消耗MP11，伤害126%"/>
-        <string name="h14" value="消耗MP12，伤害128%"/>
-        <string name="h15" value="消耗MP12，伤害130%"/>
-        <string name="h16" value="消耗MP12，伤害132%"/>
-        <string name="h17" value="消耗MP13，伤害134%"/>
-        <string name="h18" value="消耗MP13，伤害136%"/>
-        <string name="h19" value="消耗MP13，伤害138%"/>
-        <string name="h2" value="消耗MP8，伤害104%"/>
-        <string name="h20" value="消耗MP14，伤害140%"/>
-        <string name="h3" value="消耗MP8，伤害106%"/>
-        <string name="h4" value="消耗MP8，伤害108%"/>
-        <string name="h5" value="消耗MP9，伤害110%"/>
-        <string name="h6" value="消耗MP9，伤害112%"/>
-        <string name="h7" value="消耗MP9，伤害114%"/>
-        <string name="h8" value="消耗MP10，伤害116%"/>
-        <string name="h9" value="消耗MP10，伤害118%"/>
-        <string name="desc" value="[最高等级 : 20]\n用短刀连续攻击2只怪物两次"/>
+        <string name="h1" value="消耗MP8，伤害98%，攻击2次"/>
+        <string name="h10" value="消耗MP10，伤害116%，攻击2次"/>
+        <string name="h11" value="消耗MP11，伤害118%，攻击2次"/>
+        <string name="h12" value="消耗MP11，伤害120%，攻击2次"/>
+        <string name="h13" value="消耗MP11，伤害122%，攻击2次"/>
+        <string name="h14" value="消耗MP12，伤害124%，攻击2次"/>
+        <string name="h15" value="消耗MP12，伤害126%，攻击2次"/>
+        <string name="h16" value="消耗MP12，伤害128%，攻击2次"/>
+        <string name="h17" value="消耗MP13，伤害130%，攻击2次"/>
+        <string name="h18" value="消耗MP13，伤害132%，攻击2次"/>
+        <string name="h19" value="消耗MP13，伤害134%，攻击2次"/>
+        <string name="h2" value="消耗MP8，伤害100%，攻击2次"/>
+        <string name="h20" value="消耗MP14，伤害140%，攻击2次"/>
+        <string name="h3" value="消耗MP8，伤害102%，攻击2次"/>
+        <string name="h4" value="消耗MP8，伤害104%，攻击2次"/>
+        <string name="h5" value="消耗MP9，伤害106%，攻击2次"/>
+        <string name="h6" value="消耗MP9，伤害108%，攻击2次"/>
+        <string name="h7" value="消耗MP9，伤害110%，攻击2次"/>
+        <string name="h8" value="消耗MP10，伤害112%，攻击2次"/>
+        <string name="h9" value="消耗MP10，伤害114%，攻击2次"/>
+        <string name="desc" value="[最高等级 : 20]\n消耗MP，用短刀对1个敌人连续攻击2次。"/>
     </imgdir>
     <imgdir name="4001344">
         <string name="name" value="双飞斩"/>
-        <string name="h1" value="消耗MP8，伤害 94%"/>
-        <string name="h10" value="消耗MP11，伤害 130%"/>
-        <string name="h11" value="消耗MP11，伤害 134%"/>
-        <string name="h12" value="消耗MP12，伤害 138%"/>
-        <string name="h13" value="消耗MP12，伤害 142%"/>
-        <string name="h14" value="消耗MP13，伤害 146%"/>
-        <string name="h15" value="消耗MP13，伤害 150%"/>
-        <string name="h16" value="消耗MP14，伤害 154%"/>
-        <string name="h17" value="消耗MP14，伤害 158%"/>
-        <string name="h18" value="消耗MP15，伤害 162%"/>
-        <string name="h19" value="消耗MP15，伤害 166%"/>
-        <string name="h2" value="消耗MP8，伤害 98%"/>
-        <string name="h20" value="消耗MP16，伤害 170%"/>
-        <string name="h3" value="消耗MP8，伤害 102%"/>
-        <string name="h4" value="消耗MP8，伤害 106%"/>
-        <string name="h5" value="消耗MP9，伤害 110%"/>
-        <string name="h6" value="消耗MP9，伤害 114%"/>
-        <string name="h7" value="消耗MP9，伤害 118%"/>
-        <string name="h8" value="消耗MP10，伤害 122%"/>
-        <string name="h9" value="消耗MP10，伤害 126%"/>
-        <string name="desc" value="[最高等级 : 20]\n使用飞镖对怪物连续攻击2次，\n攻击力受LUK数值的影响"/>
+        <string name="h1" value="消耗MP8，伤害58%，投掷2枚飞镖"/>
+        <string name="h10" value="消耗MP11，伤害100%，投掷2枚飞镖"/>
+        <string name="h11" value="消耗MP11，伤害104%，投掷2枚飞镖"/>
+        <string name="h12" value="消耗MP12，伤害110%，投掷2枚飞镖"/>
+        <string name="h13" value="消耗MP12，伤害114%，投掷2枚飞镖"/>
+        <string name="h14" value="消耗MP13，伤害120%，投掷2枚飞镖"/>
+        <string name="h15" value="消耗MP13，伤害124%，投掷2枚飞镖"/>
+        <string name="h16" value="消耗MP14，伤害130%，投掷2枚飞镖"/>
+        <string name="h17" value="消耗MP14，伤害134%，投掷2枚飞镖"/>
+        <string name="h18" value="消耗MP15，伤害140%，投掷2枚飞镖"/>
+        <string name="h19" value="消耗MP15，伤害144%，投掷2枚飞镖"/>
+        <string name="h2" value="消耗MP8，伤害62%，投掷2枚飞镖"/>
+        <string name="h20" value="消耗MP16，伤害150%，投掷2枚飞镖"/>
+        <string name="h3" value="消耗MP8，伤害66%，投掷2枚飞镖"/>
+        <string name="h4" value="消耗MP8，伤害70%，投掷2枚飞镖"/>
+        <string name="h5" value="消耗MP9，伤害76%，投掷2枚飞镖"/>
+        <string name="h6" value="消耗MP9，伤害80%，投掷2枚飞镖"/>
+        <string name="h7" value="消耗MP9，伤害84%，投掷2枚飞镖"/>
+        <string name="h8" value="消耗MP10，伤害90%，投掷2枚飞镖"/>
+        <string name="h9" value="消耗MP10，伤害94%，投掷2枚飞镖"/>
+        <string name="desc" value="[最高等级 : 20]\n使用飞镖对1个敌人连续攻击2次，\n伤害受LUK影响，不受拳套熟练度影响。"/>
     </imgdir>
     <imgdir name="410">
         <string name="bookName" value="刺客技能"/>
@@ -10046,7 +10046,7 @@
         <string name="h7" value="消耗MP12，吸收受伤害的22%，攻击力114%"/>
         <string name="h8" value="消耗MP12，吸收受伤害的23%，攻击力116%"/>
         <string name="h9" value="消耗MP12，吸收受伤害的24%，攻击力118%"/>
-        <string name="desc" value="[最高等级 : 30]\n按对怪物的伤害值的一定比例恢复HP\n(吸收值以最大HP的50%为上限)\n必需技能 : #c恢复术等级3以上#"/>
+        <string name="desc" value="[最高等级 : 30]\n攻击敌人并按伤害的一定比例恢复HP；\n单次吸收量不超过自身最大HP的50%，且不超过敌人HP。\n必要技能：#c恢复术 Lv.3#"/>
     </imgdir>
     <imgdir name="411">
         <string name="bookName" value="无影人技能"/>
@@ -10073,7 +10073,7 @@
         <string name="h7" value="恢复量121%，增加适用时间121%"/>
         <string name="h8" value="恢复量124%，增加适用时间124%"/>
         <string name="h9" value="恢复量127%，增加适用时间127%"/>
-        <string name="desc" value="[最高等级:20]\n提升使用各种恢复药水的效果，\n对按百分比恢复的道具不适用"/>
+        <string name="desc" value="[最高等级:20]\n提高恢复类道具的恢复量和持续时间；\n对按百分比恢复的道具不适用。"/>
     </imgdir>
     <imgdir name="4111001">
         <string name="name" value="聚财术"/>
@@ -10097,7 +10097,7 @@
         <string name="h7" value="消费MP50，持续55秒，提高金币掉落量21%"/>
         <string name="h8" value="消费MP50，持续60秒，提高金币掉落量24%"/>
         <string name="h9" value="消费MP50，持续65秒，提高金币掉落量27%"/>
-        <string name="desc" value="[最高等级:20]\n一定时间内，全队获得更多金币"/>
+        <string name="desc" value="[最高等级:20]\n一定时间内，提高周围队员获得的金币掉落量。"/>
     </imgdir>
     <imgdir name="4111002">
         <string name="name" value="影分身"/>
@@ -10131,31 +10131,31 @@
         <string name="h7" value="消费MP170，召回石1个，持续60秒，分身普通攻击力为自身的40%，技术攻击力为自身的21%"/>
         <string name="h8" value="消费MP165，召回石1个，持续60秒，分身普通攻击力为自身的43%，技术攻击力为自身的22%"/>
         <string name="h9" value="消费MP160，召回石1个，持续60秒，分身普通攻击力为自身的46%，技术攻击力为自身的23%"/>
-        <string name="desc" value="[最高等级:30]\n召唤影分身，和角色做一样的动作，\n一定时间后会自动消失"/>
+        <string name="desc" value="[最高等级:30]\n消耗召唤石召唤影分身，分身会模仿角色攻击，\n一定时间后自动消失。"/>
     </imgdir>
     <imgdir name="4111003">
         <string name="name" value="影网术"/>
-        <string name="h1" value="消费MP10，持续5秒 以62%几率捕缚成功"/>
-        <string name="h10" value="消费MP14，持续6秒 以80%几率捕缚成功"/>
-        <string name="h11" value="消费MP18，持续7秒 以82%几率捕缚成功"/>
-        <string name="h12" value="消费MP18，持续7秒 以84%几率捕缚成功"/>
-        <string name="h13" value="消费MP18，持续7秒 以86%几率捕缚成功"/>
-        <string name="h14" value="消费MP18，持续7秒 以88%几率捕缚成功"/>
-        <string name="h15" value="消费MP18，持续7秒 以90%几率捕缚成功"/>
-        <string name="h16" value="消费MP22，持续8秒 以92%几率捕缚成功"/>
-        <string name="h17" value="消费MP22，持续8秒 以94%几率捕缚成功"/>
-        <string name="h18" value="消费MP22，持续8秒 以96%几率捕缚成功"/>
-        <string name="h19" value="消费MP22，持续8秒 以98%几率捕缚成功"/>
-        <string name="h2" value="消费MP10，持续5秒 以64%几率捕缚成功"/>
-        <string name="h20" value="消费MP22，持续8秒 以100%几率捕缚成功"/>
-        <string name="h3" value="消费MP10，持续5秒 以66%几率捕缚成功"/>
-        <string name="h4" value="消费MP10，持续5秒 以68%几率捕缚成功"/>
-        <string name="h5" value="消费MP10，持续5秒 以70%几率捕缚成功"/>
-        <string name="h6" value="消费MP14，持续6秒 以72%几率捕缚成功"/>
-        <string name="h7" value="消费MP14，持续6秒 以74%几率捕缚成功"/>
-        <string name="h8" value="消费MP14，持续6秒 以76%几率捕缚成功"/>
-        <string name="h9" value="消费MP14，持续6秒 以78%几率捕缚成功"/>
-        <string name="desc" value="[最高等级:20]\n以自身的影子做成蜘蛛网，缠住6个\n以下的多个怪物。被缠住的怪物无法动弹"/>
+        <string name="h1" value="消耗MP10，束缚最多6个敌人5秒，成功率42%"/>
+        <string name="h10" value="消耗MP14，束缚最多6个敌人6秒，成功率60%"/>
+        <string name="h11" value="消耗MP18，束缚最多6个敌人7秒，成功率62%"/>
+        <string name="h12" value="消耗MP18，束缚最多6个敌人7秒，成功率64%"/>
+        <string name="h13" value="消耗MP18，束缚最多6个敌人7秒，成功率66%"/>
+        <string name="h14" value="消耗MP18，束缚最多6个敌人7秒，成功率68%"/>
+        <string name="h15" value="消耗MP18，束缚最多6个敌人7秒，成功率70%"/>
+        <string name="h16" value="消耗MP22，束缚最多6个敌人8秒，成功率72%"/>
+        <string name="h17" value="消耗MP22，束缚最多6个敌人8秒，成功率74%"/>
+        <string name="h18" value="消耗MP22，束缚最多6个敌人8秒，成功率76%"/>
+        <string name="h19" value="消耗MP22，束缚最多6个敌人8秒，成功率78%"/>
+        <string name="h2" value="消耗MP10，束缚最多6个敌人5秒，成功率44%"/>
+        <string name="h20" value="消耗MP22，束缚最多6个敌人8秒，成功率80%"/>
+        <string name="h3" value="消耗MP10，束缚最多6个敌人5秒，成功率46%"/>
+        <string name="h4" value="消耗MP10，束缚最多6个敌人5秒，成功率48%"/>
+        <string name="h5" value="消耗MP10，束缚最多6个敌人5秒，成功率50%"/>
+        <string name="h6" value="消耗MP14，束缚最多6个敌人6秒，成功率52%"/>
+        <string name="h7" value="消耗MP14，束缚最多6个敌人6秒，成功率54%"/>
+        <string name="h8" value="消耗MP14，束缚最多6个敌人6秒，成功率56%"/>
+        <string name="h9" value="消耗MP14，束缚最多6个敌人6秒，成功率58%"/>
+        <string name="desc" value="[最高等级:20]\n用自身影子制造蛛网，束缚最多6个敌人，\n被束缚的敌人无法移动。"/>
     </imgdir>
     <imgdir name="4111004">
         <string name="name" value="金钱攻击"/>
@@ -10189,41 +10189,41 @@
         <string name="h7" value="消费最小110到最大340金币，以攻击3%几率出现伤害增加50%"/>
         <string name="h8" value="消费最小120到最大360金币，以攻击3%几率出现伤害增加50%"/>
         <string name="h9" value="消费最小130到最大380金币，以攻击3%几率出现伤害增加50%"/>
-        <string name="desc" value="[最高等级:30]\n使用金币进行攻击，按投掷金币的比例\n伤害怪物。无视物理防御和魔法防御。\n必需技能 : #c聚财术等级5以上#"/>
+        <string name="desc" value="[最高等级:30]\n使用金币攻击敌人，伤害取决于投掷的金币数量；\n无视怪物的物理防御提升和魔法防御提升。\n必要技能：#c聚财术 Lv.5#"/>
     </imgdir>
     <imgdir name="4111005">
         <string name="name" value="多重飞镖"/>
-        <string name="h1" value="消费MP16，三个飞镖，攻击最多6个人，攻击力154%"/>
-        <string name="h10" value="消费MP16，三个飞镖，攻击最多6个人，攻击力190%"/>
-        <string name="h11" value="消费MP23，三个飞镖，攻击最多6个人，攻击力193%"/>
-        <string name="h12" value="消费MP23，三个飞镖，攻击最多6个人，攻击力196%"/>
-        <string name="h13" value="消费MP23，三个飞镖，攻击最多6个人，攻击力199%"/>
-        <string name="h14" value="消费MP23，三个飞镖，攻击最多6个人，攻击力202%"/>
-        <string name="h15" value="消费MP23，三个飞镖，攻击最多6个人，攻击力205%"/>
-        <string name="h16" value="消费MP23，三个飞镖，攻击最多6个人，攻击力208%"/>
-        <string name="h17" value="消费MP23，三个飞镖，攻击最多6个人，攻击力211%"/>
-        <string name="h18" value="消费MP23，三个飞镖，攻击最多6个人，攻击力214%"/>
-        <string name="h19" value="消费MP23，三个飞镖，攻击最多6个人，攻击力217%"/>
-        <string name="h2" value="消费MP16，三个飞镖，攻击最多6个人，攻击力158%"/>
-        <string name="h20" value="消费MP23，三个飞镖，攻击最多6个人，攻击力220%"/>
-        <string name="h21" value="消费MP30，三个飞镖，攻击最多6个人，攻击力222%"/>
-        <string name="h22" value="消费MP30，三个飞镖，攻击最多6个人，攻击力224%"/>
-        <string name="h23" value="消费MP30，三个飞镖，攻击最多6个人，攻击力226%"/>
-        <string name="h24" value="消费MP30，三个飞镖，攻击最多6个人，攻击力228%"/>
-        <string name="h25" value="消费MP30，三个飞镖，攻击最多6个人，攻击力230%"/>
-        <string name="h26" value="消费MP30，三个飞镖，攻击最多6个人，攻击力232%"/>
-        <string name="h27" value="消费MP30，三个飞镖，攻击最多6个人，攻击力234%"/>
-        <string name="h28" value="消费MP30，三个飞镖，攻击最多6个人，攻击力236%"/>
-        <string name="h29" value="消费MP30，三个飞镖，攻击最多6个人，攻击力238%"/>
-        <string name="h3" value="消费MP16，三个飞镖，攻击最多6个人，攻击力162%"/>
-        <string name="h30" value="消费MP30，三个飞镖，攻击最多6个人，攻击力240%"/>
-        <string name="h4" value="消费MP16，三个飞镖，攻击最多6个人，攻击力166%"/>
-        <string name="h5" value="消费MP16，三个飞镖，攻击最多6个人，攻击力170%"/>
-        <string name="h6" value="消费MP16，三个飞镖，攻击最多6个人，攻击力174%"/>
-        <string name="h7" value="消费MP16，三个飞镖，攻击最多6个人，攻击力178%"/>
-        <string name="h8" value="消费MP16，三个飞镖，攻击最多6个人，攻击力182%"/>
-        <string name="h9" value="消费MP16，三个飞镖，攻击最多6个人，攻击力186%"/>
-        <string name="desc" value="[最高等级:30]\n消耗MP制作大飞镖，攻击怪物"/>
+        <string name="h1" value="消耗MP16，消耗3枚飞镖，最多攻击4个敌人，伤害65%"/>
+        <string name="h10" value="消耗MP16，消耗3枚飞镖，最多攻击4个敌人，伤害110%"/>
+        <string name="h11" value="消耗MP23，消耗3枚飞镖，最多攻击5个敌人，伤害114%"/>
+        <string name="h12" value="消耗MP23，消耗3枚飞镖，最多攻击5个敌人，伤害118%"/>
+        <string name="h13" value="消耗MP23，消耗3枚飞镖，最多攻击5个敌人，伤害122%"/>
+        <string name="h14" value="消耗MP23，消耗3枚飞镖，最多攻击5个敌人，伤害126%"/>
+        <string name="h15" value="消耗MP23，消耗3枚飞镖，最多攻击5个敌人，伤害130%"/>
+        <string name="h16" value="消耗MP23，消耗3枚飞镖，最多攻击5个敌人，伤害134%"/>
+        <string name="h17" value="消耗MP23，消耗3枚飞镖，最多攻击5个敌人，伤害138%"/>
+        <string name="h18" value="消耗MP23，消耗3枚飞镖，最多攻击5个敌人，伤害142%"/>
+        <string name="h19" value="消耗MP23，消耗3枚飞镖，最多攻击5个敌人，伤害146%"/>
+        <string name="h2" value="消耗MP16，消耗3枚飞镖，最多攻击4个敌人，伤害70%"/>
+        <string name="h20" value="消耗MP23，消耗3枚飞镖，最多攻击5个敌人，伤害150%"/>
+        <string name="h21" value="消耗MP30，消耗3枚飞镖，最多攻击6个敌人，伤害153%"/>
+        <string name="h22" value="消耗MP30，消耗3枚飞镖，最多攻击6个敌人，伤害156%"/>
+        <string name="h23" value="消耗MP30，消耗3枚飞镖，最多攻击6个敌人，伤害159%"/>
+        <string name="h24" value="消耗MP30，消耗3枚飞镖，最多攻击6个敌人，伤害162%"/>
+        <string name="h25" value="消耗MP30，消耗3枚飞镖，最多攻击6个敌人，伤害165%"/>
+        <string name="h26" value="消耗MP30，消耗3枚飞镖，最多攻击6个敌人，伤害168%"/>
+        <string name="h27" value="消耗MP30，消耗3枚飞镖，最多攻击6个敌人，伤害171%"/>
+        <string name="h28" value="消耗MP30，消耗3枚飞镖，最多攻击6个敌人，伤害174%"/>
+        <string name="h29" value="消耗MP30，消耗3枚飞镖，最多攻击6个敌人，伤害177%"/>
+        <string name="h3" value="消耗MP16，消耗3枚飞镖，最多攻击4个敌人，伤害75%"/>
+        <string name="h30" value="消耗MP30，消耗3枚飞镖，最多攻击6个敌人，伤害180%"/>
+        <string name="h4" value="消耗MP16，消耗3枚飞镖，最多攻击4个敌人，伤害80%"/>
+        <string name="h5" value="消耗MP16，消耗3枚飞镖，最多攻击4个敌人，伤害85%"/>
+        <string name="h6" value="消耗MP16，消耗3枚飞镖，最多攻击4个敌人，伤害90%"/>
+        <string name="h7" value="消耗MP16，消耗3枚飞镖，最多攻击4个敌人，伤害95%"/>
+        <string name="h8" value="消耗MP16，消耗3枚飞镖，最多攻击4个敌人，伤害100%"/>
+        <string name="h9" value="消耗MP16，消耗3枚飞镖，最多攻击4个敌人，伤害105%"/>
+        <string name="desc" value="[最高等级:30]\n消耗MP制造巨大飞镖，贯穿敌人并攻击后方敌人。"/>
     </imgdir>
     <imgdir name="4111006">
         <string name="name" value="二段跳"/>
@@ -10247,44 +10247,44 @@
         <string name="h7" value="消费MP42  跳上一定距离"/>
         <string name="h8" value="消费MP39  跳上一定距离"/>
         <string name="h9" value="消费MP36  跳上一定距离"/>
-        <string name="desc" value="[最高等级:20]\n跳跃后在空中使用的话，能再一次跳跃。\n技能点上升跳跃力也会上升。\n必需技能 : #c多重飞镖等级5以上#"/>
+        <string name="desc" value="[最高等级:20]\n跳跃后在空中再次跳跃；\n等级越高，跳跃距离越远。\n必要技能：#c多重飞镖 Lv.5#"/>
     </imgdir>
     <imgdir name="412">
         <string name="bookName" value="隐之侠士"/>
     </imgdir>
     <imgdir name="4120002">
         <string name="name" value="假动作"/>
-        <string name="h1" value="11%的几率 回避敌人的攻击"/>
-        <string name="h10" value="20%的几率 回避敌人的攻击"/>
-        <string name="h11" value="21%的几率 回避敌人的攻击"/>
-        <string name="h12" value="22%的几率 回避敌人的攻击"/>
-        <string name="h13" value="23%的几率 回避敌人的攻击"/>
-        <string name="h14" value="24%的几率 回避敌人的攻击"/>
-        <string name="h15" value="25%的几率 回避敌人的攻击"/>
-        <string name="h16" value="26%的几率 回避敌人的攻击"/>
-        <string name="h17" value="27%的几率 回避敌人的攻击"/>
-        <string name="h18" value="28%的几率 回避敌人的攻击"/>
-        <string name="h19" value="29%的几率 回避敌人的攻击"/>
-        <string name="h2" value="12%的几率 回避敌人的攻击"/>
-        <string name="h20" value="30%的几率 回避敌人的攻击"/>
-        <string name="h21" value="31%的几率 回避敌人的攻击"/>
-        <string name="h22" value="32%的几率 回避敌人的攻击"/>
-        <string name="h23" value="33%的几率 回避敌人的攻击"/>
-        <string name="h24" value="34%的几率 回避敌人的攻击"/>
-        <string name="h25" value="35%的几率 回避敌人的攻击"/>
-        <string name="h26" value="36%的几率 回避敌人的攻击"/>
-        <string name="h27" value="37%的几率 回避敌人的攻击"/>
-        <string name="h28" value="38%的几率 回避敌人的攻击"/>
-        <string name="h29" value="39%的几率 回避敌人的攻击"/>
-        <string name="h3" value="13%的几率 回避敌人的攻击"/>
-        <string name="h30" value="40%的几率 回避敌人的攻击"/>
-        <string name="h4" value="14%的几率 回避敌人的攻击"/>
-        <string name="h5" value="15%的几率 回避敌人的攻击"/>
-        <string name="h6" value="16%的几率 回避敌人的攻击"/>
-        <string name="h7" value="17%的几率 回避敌人的攻击"/>
-        <string name="h8" value="18%的几率 回避敌人的攻击"/>
-        <string name="h9" value="19%的几率 回避敌人的攻击"/>
-        <string name="desc" value="以极快的反射神经躲避敌人的攻击"/>
+        <string name="h1" value="以1%几率回避敌人的攻击"/>
+        <string name="h10" value="以10%几率回避敌人的攻击"/>
+        <string name="h11" value="以11%几率回避敌人的攻击"/>
+        <string name="h12" value="以12%几率回避敌人的攻击"/>
+        <string name="h13" value="以13%几率回避敌人的攻击"/>
+        <string name="h14" value="以14%几率回避敌人的攻击"/>
+        <string name="h15" value="以15%几率回避敌人的攻击"/>
+        <string name="h16" value="以16%几率回避敌人的攻击"/>
+        <string name="h17" value="以17%几率回避敌人的攻击"/>
+        <string name="h18" value="以18%几率回避敌人的攻击"/>
+        <string name="h19" value="以19%几率回避敌人的攻击"/>
+        <string name="h2" value="以2%几率回避敌人的攻击"/>
+        <string name="h20" value="以20%几率回避敌人的攻击"/>
+        <string name="h21" value="以21%几率回避敌人的攻击"/>
+        <string name="h22" value="以22%几率回避敌人的攻击"/>
+        <string name="h23" value="以23%几率回避敌人的攻击"/>
+        <string name="h24" value="以24%几率回避敌人的攻击"/>
+        <string name="h25" value="以25%几率回避敌人的攻击"/>
+        <string name="h26" value="以26%几率回避敌人的攻击"/>
+        <string name="h27" value="以27%几率回避敌人的攻击"/>
+        <string name="h28" value="以28%几率回避敌人的攻击"/>
+        <string name="h29" value="以29%几率回避敌人的攻击"/>
+        <string name="h3" value="以3%几率回避敌人的攻击"/>
+        <string name="h30" value="以30%几率回避敌人的攻击"/>
+        <string name="h4" value="以4%几率回避敌人的攻击"/>
+        <string name="h5" value="以5%几率回避敌人的攻击"/>
+        <string name="h6" value="以6%几率回避敌人的攻击"/>
+        <string name="h7" value="以7%几率回避敌人的攻击"/>
+        <string name="h8" value="以8%几率回避敌人的攻击"/>
+        <string name="h9" value="以9%几率回避敌人的攻击"/>
+        <string name="desc" value="以极快的反射神经，有一定概率回避敌人的攻击。"/>
     </imgdir>
     <imgdir name="4120005">
         <string name="name" value="武器用毒液"/>
@@ -10318,7 +10318,7 @@
         <string name="h7" value="攻击力 37，持续时间 2秒，成功率 16%"/>
         <string name="h8" value="攻击力 38，持续时间 2秒，成功率 16%"/>
         <string name="h9" value="攻击力 39，持续时间 2秒，成功率 16%"/>
-        <string name="desc" value="在飞镖上涂抹毒药攻击敌人使它一定几率\n中毒受持续伤害.最多可重复3次,\n敌人的HP不会掉落1以下"/>
+        <string name="desc" value="在飞镖上涂抹毒药，攻击时有一定概率使敌人中毒并持续受到伤害；\n最多可对同一敌人叠加3次，且不会使敌人的HP降到1以下。"/>
     </imgdir>
     <imgdir name="4121000">
         <string name="name" value="冒险岛勇士"/>
@@ -10352,7 +10352,7 @@
         <string name="h7" value="消耗MP 20，210秒内所有的属性点提高 4%"/>
         <string name="h8" value="消耗MP 20，240秒内所有的属性点提高 4%"/>
         <string name="h9" value="消耗MP 20，270秒内所有的属性点提高 5%"/>
-        <string name="desc" value="一定时间内把组队成员的所有属性点提高\n一定的百分比"/>
+        <string name="desc" value="一定时间内按百分比提高组队成员的所有属性。"/>
     </imgdir>
     <imgdir name="4121003">
         <string name="name" value="挑衅"/>
@@ -10386,7 +10386,7 @@
         <string name="h7" value="消耗MP27，敌人防御上升时，得到的经验值，物品掉落率提高17%"/>
         <string name="h8" value="消耗MP28，敌人防御上升时，得到的经验值，物品掉落率提高18%"/>
         <string name="h9" value="消耗MP29，敌人防御上升时，得到的经验值，物品掉落率提高19%"/>
-        <string name="desc" value="最多可以把6只敌人陷入挑衅状态，随着敌人\n的防御力上升而提高其经验值和物品掉落率。\n必需技能: #c假动作等级10以上#"/>
+        <string name="desc" value="最多使6个敌人陷入挑衅状态；\n敌人物理防御和魔法防御提高，同时经验值和物品掉落率提高。\n必要技能：#c假动作 Lv.10#"/>
     </imgdir>
     <imgdir name="4121004">
         <string name="name" value="忍者伏击"/>
@@ -10420,7 +10420,7 @@
         <string name="h7" value="消耗MP 16，伤害 74%，持续时间 4秒，攻击范围 130%"/>
         <string name="h8" value="消耗MP 16，伤害 76%，持续时间 4秒，攻击范围 130%"/>
         <string name="h9" value="消耗MP 16，伤害 78%，持续时间 4秒，攻击范围 130%"/>
-        <string name="desc" value="躲藏的同伴突然出现,在一定时间内持续攻击敌人.\n一次无法攻击6只以上,HP不会掉到1以下.\n必要技能 : #c假动作等级5以上#"/>
+        <string name="desc" value="躲藏的同伴突然出现，在一定时间内持续攻击最多6个敌人；\n该伤害不会使敌人的HP降到1以下。\n必要技能：#c假动作 Lv.5#"/>
     </imgdir>
     <imgdir name="4121006">
         <string name="name" value="暗器伤人"/>
@@ -10454,41 +10454,41 @@
         <string name="h7" value="消耗MP 15，持续时间 74秒"/>
         <string name="h8" value="消耗MP 15，持续时间 76秒"/>
         <string name="h9" value="消耗MP 15，持续时间 78秒"/>
-        <string name="desc" value="一下子消耗飞镖200个后,\n一定时间内可以不消耗飞镖攻击敌人"/>
+        <string name="desc" value="一次消耗当前飞镖200个后，\n一定时间内攻击不再消耗飞镖。"/>
     </imgdir>
     <imgdir name="4121007">
         <string name="name" value="三连环光击破"/>
-        <string name="h1" value="消耗MP 11，伤害 102%"/>
-        <string name="h10" value="消耗MP 14，伤害 120%"/>
-        <string name="h11" value="消耗MP 14，伤害 121%"/>
-        <string name="h12" value="消耗MP 14，伤害 122%"/>
-        <string name="h13" value="消耗MP 15，伤害 123%"/>
-        <string name="h14" value="消耗MP 15，伤害 124%"/>
-        <string name="h15" value="消耗MP 15，伤害 125%"/>
-        <string name="h16" value="消耗MP 16，伤害 126%"/>
-        <string name="h17" value="消耗MP 16，伤害 127%"/>
-        <string name="h18" value="消耗MP 16，伤害 128%"/>
-        <string name="h19" value="消耗MP 17，伤害 129%"/>
-        <string name="h2" value="消耗MP 11，伤害 104%"/>
-        <string name="h20" value="消耗MP 17，伤害 130%"/>
-        <string name="h21" value="消耗MP 17，伤害 131%"/>
-        <string name="h22" value="消耗MP 18，伤害 132%"/>
-        <string name="h23" value="消耗MP 18，伤害 133%"/>
-        <string name="h24" value="消耗MP 18，伤害 134%"/>
-        <string name="h25" value="消耗MP 19，伤害 135%"/>
-        <string name="h26" value="消耗MP 19，伤害 136%"/>
-        <string name="h27" value="消耗MP 19，伤害 137%"/>
-        <string name="h28" value="消耗MP 20，伤害 138%"/>
-        <string name="h29" value="消耗MP 20，伤害 139%"/>
-        <string name="h3" value="消耗MP 11，伤害 106%"/>
-        <string name="h30" value="消耗MP 20，伤害 140%"/>
-        <string name="h4" value="消耗MP 12，伤害 108%"/>
-        <string name="h5" value="消耗MP 12，伤害 110%"/>
-        <string name="h6" value="消耗MP 12，伤害 112%"/>
-        <string name="h7" value="消耗MP 13，伤害 114%"/>
-        <string name="h8" value="消耗MP 13，伤害 116%"/>
-        <string name="h9" value="消耗MP 13，伤害 118%"/>
-        <string name="desc" value="一下子扔3个飞镖攻击"/>
+        <string name="h1" value="消耗MP 11，伤害 102%，投掷3枚飞镖"/>
+        <string name="h10" value="消耗MP 14，伤害 120%，投掷3枚飞镖"/>
+        <string name="h11" value="消耗MP 14，伤害 122%，投掷3枚飞镖"/>
+        <string name="h12" value="消耗MP 14，伤害 124%，投掷3枚飞镖"/>
+        <string name="h13" value="消耗MP 15，伤害 126%，投掷3枚飞镖"/>
+        <string name="h14" value="消耗MP 15，伤害 128%，投掷3枚飞镖"/>
+        <string name="h15" value="消耗MP 15，伤害 130%，投掷3枚飞镖"/>
+        <string name="h16" value="消耗MP 16，伤害 132%，投掷3枚飞镖"/>
+        <string name="h17" value="消耗MP 16，伤害 134%，投掷3枚飞镖"/>
+        <string name="h18" value="消耗MP 16，伤害 136%，投掷3枚飞镖"/>
+        <string name="h19" value="消耗MP 17，伤害 138%，投掷3枚飞镖"/>
+        <string name="h2" value="消耗MP 11，伤害 104%，投掷3枚飞镖"/>
+        <string name="h20" value="消耗MP 17，伤害 140%，投掷3枚飞镖"/>
+        <string name="h21" value="消耗MP 17，伤害 141%，投掷3枚飞镖"/>
+        <string name="h22" value="消耗MP 18，伤害 142%，投掷3枚飞镖"/>
+        <string name="h23" value="消耗MP 18，伤害 143%，投掷3枚飞镖"/>
+        <string name="h24" value="消耗MP 18，伤害 144%，投掷3枚飞镖"/>
+        <string name="h25" value="消耗MP 19，伤害 145%，投掷3枚飞镖"/>
+        <string name="h26" value="消耗MP 19，伤害 146%，投掷3枚飞镖"/>
+        <string name="h27" value="消耗MP 19，伤害 147%，投掷3枚飞镖"/>
+        <string name="h28" value="消耗MP 20，伤害 148%，投掷3枚飞镖"/>
+        <string name="h29" value="消耗MP 20，伤害 149%，投掷3枚飞镖"/>
+        <string name="h3" value="消耗MP 11，伤害 106%，投掷3枚飞镖"/>
+        <string name="h30" value="消耗MP 20，伤害 150%，投掷3枚飞镖"/>
+        <string name="h4" value="消耗MP 12，伤害 108%，投掷3枚飞镖"/>
+        <string name="h5" value="消耗MP 12，伤害 110%，投掷3枚飞镖"/>
+        <string name="h6" value="消耗MP 12，伤害 112%，投掷3枚飞镖"/>
+        <string name="h7" value="消耗MP 13，伤害 114%，投掷3枚飞镖"/>
+        <string name="h8" value="消耗MP 13，伤害 116%，投掷3枚飞镖"/>
+        <string name="h9" value="消耗MP 13，伤害 118%，投掷3枚飞镖"/>
+        <string name="desc" value="同时投掷3枚飞镖攻击1个敌人。"/>
     </imgdir>
     <imgdir name="4121008">
         <string name="name" value="忍者冲击"/>
@@ -10522,16 +10522,16 @@
         <string name="h7" value="消耗MP 16,伤害 54%，54%的几率 把敌人推开100"/>
         <string name="h8" value="消耗MP 16,伤害 56%，56%的几率 把敌人推开100"/>
         <string name="h9" value="消耗MP 16,伤害 58%，58%的几率 把敌人推开100"/>
-        <string name="desc" value="隐藏的忍者快速旋转使敌人左右推开"/>
+        <string name="desc" value="召唤忍者旋转攻击周围敌人，并有一定概率将敌人推开。"/>
     </imgdir>
     <imgdir name="4121009">
         <string name="name" value="勇士的意志"/>
-        <string name="h1" value="消耗MP 30，解除诱惑异常状态，冷却时间10分钟"/>
-        <string name="h2" value="消耗MP 30，解除诱惑异常状态，冷却时间9分钟"/>
-        <string name="h3" value="消耗MP 30，解除诱惑异常状态，冷却时间8分钟"/>
-        <string name="h4" value="消耗MP 30，解除诱惑异常状态，冷却时间7分钟"/>
-        <string name="h5" value="消耗MP 30，解除诱惑异常状态，冷却时间6分钟"/>
-        <string name="desc" value="从异常状态中恢复. \n随着等级的上升,冷却时间逐渐缩短"/>
+        <string name="h1" value="消耗MP 30，解除诱惑、僵尸、混乱等异常状态，冷却时间10分钟"/>
+        <string name="h2" value="消耗MP 30，解除诱惑、僵尸、混乱等异常状态，冷却时间9分钟"/>
+        <string name="h3" value="消耗MP 30，解除诱惑、僵尸、混乱等异常状态，冷却时间8分钟"/>
+        <string name="h4" value="消耗MP 30，解除诱惑、僵尸、混乱等异常状态，冷却时间7分钟"/>
+        <string name="h5" value="消耗MP 30，解除诱惑、僵尸、混乱等异常状态，冷却时间6分钟"/>
+        <string name="desc" value="解除诱惑、僵尸、混乱等异常状态；\n等级越高，冷却时间越短。"/>
     </imgdir>
     <imgdir name="420">
         <string name="bookName" value="侠客技能"/>
@@ -10664,136 +10664,136 @@
         <string name="h7" value="消耗MP12，成功率17%，攻击力54%"/>
         <string name="h8" value="消耗MP12，成功率18%，攻击力56%"/>
         <string name="h9" value="消耗MP12，成功率19%，攻击力58%"/>
-        <string name="desc" value="[最高等级 : 30]\n攻击时，根据一定概率获取怪物身上的道具。\n必需技能 : #c轻功等级5以上#"/>
+        <string name="desc" value="[最高等级 : 30]\n攻击时有一定概率偷取怪物身上的道具；\n同一怪物成功偷取后不能再次偷取。\n必要技能：#c轻功 Lv.5#"/>
     </imgdir>
     <imgdir name="4201005">
         <string name="name" value="回旋斩"/>
-        <string name="h1" value="消耗MP15，攻击力32%，攻击6次"/>
-        <string name="h10" value="消耗MP15，攻击力50%，攻击6次"/>
-        <string name="h11" value="消耗MP18，攻击力52%，攻击6次"/>
-        <string name="h12" value="消耗MP18，攻击力54%，攻击6次"/>
-        <string name="h13" value="消耗MP18，攻击力56%，攻击6次"/>
-        <string name="h14" value="消耗MP18，攻击力58%，攻击6次"/>
-        <string name="h15" value="消耗MP18，攻击力60%，攻击6次"/>
-        <string name="h16" value="消耗MP18，攻击力62%，攻击6次"/>
-        <string name="h17" value="消耗MP18，攻击力64%，攻击6次"/>
-        <string name="h18" value="消耗MP18，攻击力66%，攻击6次"/>
-        <string name="h19" value="消耗MP18，攻击力68%，攻击6次"/>
-        <string name="h2" value="消耗MP15，攻击力34%，攻击6次"/>
-        <string name="h20" value="消耗MP18，攻击力70%，攻击6次"/>
-        <string name="h21" value="消耗MP27，攻击力72%，攻击6次"/>
-        <string name="h22" value="消耗MP27，攻击力74%，攻击6次"/>
-        <string name="h23" value="消耗MP27，攻击力76%，攻击6次"/>
-        <string name="h24" value="消耗MP27，攻击力78%，攻击6次"/>
-        <string name="h25" value="消耗MP27，攻击力80%，攻击6次"/>
-        <string name="h26" value="消耗MP27，攻击力82%，攻击6次"/>
-        <string name="h27" value="消耗MP27，攻击力84%，攻击6次"/>
-        <string name="h28" value="消耗MP27，攻击力86%，攻击6次"/>
-        <string name="h29" value="消耗MP27，攻击力88%，攻击6次"/>
-        <string name="h3" value="消耗MP15，攻击力36%，攻击6次"/>
-        <string name="h30" value="消耗MP27，攻击力90%，攻击6次"/>
-        <string name="h4" value="消耗MP15，攻击力38%，攻击6次"/>
-        <string name="h5" value="消耗MP15，攻击力40%，攻击6次"/>
-        <string name="h6" value="消耗MP15，攻击力42%，攻击6次"/>
-        <string name="h7" value="消耗MP15，攻击力44%，攻击6次"/>
-        <string name="h8" value="消耗MP15，攻击力46%，攻击6次"/>
-        <string name="h9" value="消耗MP15，攻击力48%，攻击6次"/>
-        <string name="desc" value="[最高等级 : 30]\n消费MP，最多连续攻击6次"/>
+        <string name="h1" value="消耗MP15，以40%伤害攻击4次"/>
+        <string name="h10" value="消耗MP15，以74%伤害攻击4次"/>
+        <string name="h11" value="消耗MP18，以60%伤害攻击5次"/>
+        <string name="h12" value="消耗MP18，以62%伤害攻击5次"/>
+        <string name="h13" value="消耗MP18，以64%伤害攻击5次"/>
+        <string name="h14" value="消耗MP18，以66%伤害攻击5次"/>
+        <string name="h15" value="消耗MP18，以68%伤害攻击5次"/>
+        <string name="h16" value="消耗MP18，以70%伤害攻击5次"/>
+        <string name="h17" value="消耗MP18，以72%伤害攻击5次"/>
+        <string name="h18" value="消耗MP18，以74%伤害攻击5次"/>
+        <string name="h19" value="消耗MP18，以76%伤害攻击5次"/>
+        <string name="h2" value="消耗MP15，以44%伤害攻击4次"/>
+        <string name="h20" value="消耗MP18，以78%伤害攻击5次"/>
+        <string name="h21" value="消耗MP27，以71%伤害攻击6次"/>
+        <string name="h22" value="消耗MP27，以72%伤害攻击6次"/>
+        <string name="h23" value="消耗MP27，以73%伤害攻击6次"/>
+        <string name="h24" value="消耗MP27，以74%伤害攻击6次"/>
+        <string name="h25" value="消耗MP27，以75%伤害攻击6次"/>
+        <string name="h26" value="消耗MP27，以76%伤害攻击6次"/>
+        <string name="h27" value="消耗MP27，以77%伤害攻击6次"/>
+        <string name="h28" value="消耗MP27，以78%伤害攻击6次"/>
+        <string name="h29" value="消耗MP27，以79%伤害攻击6次"/>
+        <string name="h3" value="消耗MP15，以48%伤害攻击4次"/>
+        <string name="h30" value="消耗MP27，以80%伤害攻击6次"/>
+        <string name="h4" value="消耗MP15，以52%伤害攻击4次"/>
+        <string name="h5" value="消耗MP15，以56%伤害攻击4次"/>
+        <string name="h6" value="消耗MP15，以60%伤害攻击4次"/>
+        <string name="h7" value="消耗MP15，以64%伤害攻击4次"/>
+        <string name="h8" value="消耗MP15，以68%伤害攻击4次"/>
+        <string name="h9" value="消耗MP15，以72%伤害攻击4次"/>
+        <string name="desc" value="[最高等级 : 30]\n消耗MP，用短刀对1个敌人连续攻击。"/>
     </imgdir>
     <imgdir name="421">
         <string name="bookName" value="独行客技能"/>
     </imgdir>
     <imgdir name="4210000">
         <string name="name" value="强化盾"/>
-        <string name="h1" value="装备的盾牌的物理防御力增加20%"/>
-        <string name="h10" value="装备的盾牌的物理防御力增加200%"/>
-        <string name="h11" value="装备的盾牌的物理防御力增加210%"/>
-        <string name="h12" value="装备的盾牌的物理防御力增加220%"/>
-        <string name="h13" value="装备的盾牌的物理防御力增加230%"/>
-        <string name="h14" value="装备的盾牌的物理防御力增加240%"/>
-        <string name="h15" value="装备的盾牌的物理防御力增加250%"/>
-        <string name="h16" value="装备的盾牌的物理防御力增加260%"/>
-        <string name="h17" value="装备的盾牌的物理防御力增加270%"/>
-        <string name="h18" value="装备的盾牌的物理防御力增加280%"/>
-        <string name="h19" value="装备的盾牌的物理防御力增加290%"/>
-        <string name="h2" value="装备的盾牌的物理防御力增加40%"/>
-        <string name="h20" value="装备的盾牌的物理防御力增加300%"/>
-        <string name="h3" value="装备的盾牌的物理防御力增加60%"/>
-        <string name="h4" value="装备的盾牌的物理防御力增加80%"/>
-        <string name="h5" value="装备的盾牌的物理防御力增加100%"/>
-        <string name="h6" value="装备的盾牌的物理防御力增加120%"/>
-        <string name="h7" value="装备的盾牌的物理防御力增加140%"/>
-        <string name="h8" value="装备的盾牌的物理防御力增加160%"/>
-        <string name="h9" value="装备的盾牌的物理防御力增加180%"/>
-        <string name="desc" value="[最高等级:20]\n提高盾牌的物理防御力,必须装备盾牌"/>
+        <string name="h1" value="装备盾牌时，盾牌物理防御力增加5%"/>
+        <string name="h10" value="装备盾牌时，盾牌物理防御力增加50%"/>
+        <string name="h11" value="装备盾牌时，盾牌物理防御力增加55%"/>
+        <string name="h12" value="装备盾牌时，盾牌物理防御力增加60%"/>
+        <string name="h13" value="装备盾牌时，盾牌物理防御力增加65%"/>
+        <string name="h14" value="装备盾牌时，盾牌物理防御力增加70%"/>
+        <string name="h15" value="装备盾牌时，盾牌物理防御力增加75%"/>
+        <string name="h16" value="装备盾牌时，盾牌物理防御力增加80%"/>
+        <string name="h17" value="装备盾牌时，盾牌物理防御力增加85%"/>
+        <string name="h18" value="装备盾牌时，盾牌物理防御力增加90%"/>
+        <string name="h19" value="装备盾牌时，盾牌物理防御力增加95%"/>
+        <string name="h2" value="装备盾牌时，盾牌物理防御力增加10%"/>
+        <string name="h20" value="装备盾牌时，盾牌物理防御力增加100%"/>
+        <string name="h3" value="装备盾牌时，盾牌物理防御力增加15%"/>
+        <string name="h4" value="装备盾牌时，盾牌物理防御力增加20%"/>
+        <string name="h5" value="装备盾牌时，盾牌物理防御力增加25%"/>
+        <string name="h6" value="装备盾牌时，盾牌物理防御力增加30%"/>
+        <string name="h7" value="装备盾牌时，盾牌物理防御力增加35%"/>
+        <string name="h8" value="装备盾牌时，盾牌物理防御力增加40%"/>
+        <string name="h9" value="装备盾牌时，盾牌物理防御力增加45%"/>
+        <string name="desc" value="[最高等级:20]\n装备盾牌时，提高盾牌的物理防御力。"/>
     </imgdir>
     <imgdir name="4211001">
         <string name="name" value="转化术"/>
-        <string name="h1" value="消费MP15，恢复力68%，恢复中被怪物攻击伤害是99%"/>
-        <string name="h10" value="消费MP15，恢复力140%，恢复中被怪物攻击伤害是90%"/>
-        <string name="h11" value="消费MP21，恢复力148%，恢复中被怪物攻击伤害是89%"/>
-        <string name="h12" value="消费MP21，恢复力156%，恢复中被怪物攻击伤害是88%"/>
-        <string name="h13" value="消费MP21，恢复力164%，恢复中被怪物攻击伤害是87%"/>
-        <string name="h14" value="消费MP21，恢复力172%，恢复中被怪物攻击伤害是86%"/>
-        <string name="h15" value="消费MP21，恢复力180%，恢复中被怪物攻击伤害是85%"/>
-        <string name="h16" value="消费MP21，恢复力188%，恢复中被怪物攻击伤害是84%"/>
-        <string name="h17" value="消费MP21，恢复力196%，恢复中被怪物攻击伤害是83%"/>
-        <string name="h18" value="消费MP21，恢复力204%，恢复中被怪物攻击伤害是82%"/>
-        <string name="h19" value="消费MP21，恢复力212%，恢复中被怪物攻击伤害是81%"/>
-        <string name="h2" value="消费MP15，恢复力76%，恢复中被怪物攻击伤害是98%"/>
-        <string name="h20" value="消费MP21，恢复力220%，恢复中被怪物攻击伤害是80%"/>
-        <string name="h21" value="消费MP27，恢复力228%，恢复中被怪物攻击伤害是79%"/>
-        <string name="h22" value="消费MP27，恢复力236%，恢复中被怪物攻击伤害是78%"/>
-        <string name="h23" value="消费MP27，恢复力244%，恢复中被怪物攻击伤害是77%"/>
-        <string name="h24" value="消费MP27，恢复力252%，恢复中被怪物攻击伤害是76%"/>
-        <string name="h25" value="消费MP27，恢复力260%，恢复中被怪物攻击伤害是75%"/>
-        <string name="h26" value="消费MP27，恢复力268%，恢复中被怪物攻击伤害是74%"/>
-        <string name="h27" value="消费MP27，恢复力276%，恢复中被怪物攻击伤害是73%"/>
-        <string name="h28" value="消费MP27，恢复力284%，恢复中被怪物攻击伤害是72%"/>
-        <string name="h29" value="消费MP27，恢复力292%，恢复中被怪物攻击伤害是71%"/>
-        <string name="h3" value="消费MP15，恢复力84%，恢复中被怪物攻击伤害是97%"/>
-        <string name="h30" value="消费MP27，恢复力300%，恢复中被怪物攻击伤害是70%"/>
-        <string name="h4" value="消费MP15，恢复力92%，恢复中被怪物攻击伤害是96%"/>
-        <string name="h5" value="消费MP15，恢复力100%，恢复中被怪物攻击伤害95%"/>
-        <string name="h6" value="消费MP15，恢复力108%，恢复中被怪物攻击伤害是94%"/>
-        <string name="h7" value="消费MP15，恢复力116%，恢复中被怪物攻击伤害是93%"/>
-        <string name="h8" value="消费MP15，恢复力124%，恢复中被怪物攻击伤害是92%"/>
-        <string name="h9" value="消费MP15，恢复力132%，恢复中被怪物攻击伤害是91%"/>
-        <string name="desc" value="[最高等级:30]\n消耗MP恢复HP。只有HP在一半以下才可以\n使用，如果中途做动作或遭受攻击就停止"/>
+        <string name="h1" value="消耗MP15，恢复力68%，恢复中受到的伤害为99%"/>
+        <string name="h10" value="消耗MP15，恢复力140%，恢复中受到的伤害为90%"/>
+        <string name="h11" value="消耗MP21，恢复力148%，恢复中受到的伤害为89%"/>
+        <string name="h12" value="消耗MP21，恢复力156%，恢复中受到的伤害为88%"/>
+        <string name="h13" value="消耗MP21，恢复力164%，恢复中受到的伤害为87%"/>
+        <string name="h14" value="消耗MP21，恢复力172%，恢复中受到的伤害为86%"/>
+        <string name="h15" value="消耗MP21，恢复力180%，恢复中受到的伤害为85%"/>
+        <string name="h16" value="消耗MP21，恢复力188%，恢复中受到的伤害为84%"/>
+        <string name="h17" value="消耗MP21，恢复力196%，恢复中受到的伤害为83%"/>
+        <string name="h18" value="消耗MP21，恢复力204%，恢复中受到的伤害为82%"/>
+        <string name="h19" value="消耗MP21，恢复力212%，恢复中受到的伤害为81%"/>
+        <string name="h2" value="消耗MP15，恢复力76%，恢复中受到的伤害为98%"/>
+        <string name="h20" value="消耗MP21，恢复力220%，恢复中受到的伤害为80%"/>
+        <string name="h21" value="消耗MP27，恢复力228%，恢复中受到的伤害为79%"/>
+        <string name="h22" value="消耗MP27，恢复力236%，恢复中受到的伤害为78%"/>
+        <string name="h23" value="消耗MP27，恢复力244%，恢复中受到的伤害为77%"/>
+        <string name="h24" value="消耗MP27，恢复力252%，恢复中受到的伤害为76%"/>
+        <string name="h25" value="消耗MP27，恢复力260%，恢复中受到的伤害为75%"/>
+        <string name="h26" value="消耗MP27，恢复力268%，恢复中受到的伤害为74%"/>
+        <string name="h27" value="消耗MP27，恢复力276%，恢复中受到的伤害为73%"/>
+        <string name="h28" value="消耗MP27，恢复力284%，恢复中受到的伤害为72%"/>
+        <string name="h29" value="消耗MP27，恢复力292%，恢复中受到的伤害为71%"/>
+        <string name="h3" value="消耗MP15，恢复力84%，恢复中受到的伤害为97%"/>
+        <string name="h30" value="消耗MP27，恢复力300%，恢复中受到的伤害为70%"/>
+        <string name="h4" value="消耗MP15，恢复力92%，恢复中受到的伤害为96%"/>
+        <string name="h5" value="消耗MP15，恢复力100%，恢复中受到的伤害为95%"/>
+        <string name="h6" value="消耗MP15，恢复力108%，恢复中受到的伤害为94%"/>
+        <string name="h7" value="消耗MP15，恢复力116%，恢复中受到的伤害为93%"/>
+        <string name="h8" value="消耗MP15，恢复力124%，恢复中受到的伤害为92%"/>
+        <string name="h9" value="消耗MP15，恢复力132%，恢复中受到的伤害为91%"/>
+        <string name="desc" value="[最高等级:30]\n消耗MP恢复HP。只有HP低于50%时才能使用；\n移动或受到攻击时会中断。"/>
     </imgdir>
     <imgdir name="4211002">
         <string name="name" value="落叶斩"/>
-        <string name="h1" value="消费MP12，造成伤害210%，以22%几率出现昏迷攻击"/>
-        <string name="h10" value="消费MP12，造成伤害300%，以40%几率出现昏迷攻击"/>
-        <string name="h11" value="消费MP19，造成伤害310%，以42%几率出现昏迷攻击"/>
-        <string name="h12" value="消费MP19，造成伤害320%，以44%几率出现昏迷攻击"/>
-        <string name="h13" value="消费MP19，造成伤害330%，以46%几率出现昏迷攻击"/>
-        <string name="h14" value="消费MP19，造成伤害340%，以48%几率出现昏迷攻击"/>
-        <string name="h15" value="消费MP19，造成伤害350%，以50%几率出现昏迷攻击"/>
-        <string name="h16" value="消费MP19，造成伤害360%，以52%几率出现昏迷攻击"/>
-        <string name="h17" value="消费MP19，造成伤害370%，以54%几率出现昏迷攻击"/>
-        <string name="h18" value="消费MP19，造成伤害380%，以56%几率出现昏迷攻击"/>
-        <string name="h19" value="消费MP19，造成伤害390%，以58%几率出现昏迷攻击"/>
-        <string name="h2" value="消费MP12，造成伤害220%，以24%几率出现昏迷攻击"/>
-        <string name="h20" value="消费MP19，造成伤害400%，以60%几率出现昏迷攻击"/>
-        <string name="h21" value="消费MP26，造成伤害410%，以62%几率出现昏迷攻击"/>
-        <string name="h22" value="消费MP26，造成伤害420%，以64%几率出现昏迷攻击"/>
-        <string name="h23" value="消费MP26，造成伤害430%，以66%几率出现昏迷攻击"/>
-        <string name="h24" value="消费MP26，造成伤害440%，以68%几率出现昏迷攻击"/>
-        <string name="h25" value="消费MP26，造成伤害450%，以70%几率出现昏迷攻击"/>
-        <string name="h26" value="消费MP26，造成伤害460%，以72%几率出现昏迷攻击"/>
-        <string name="h27" value="消费MP26，造成伤害470%，以74%几率出现昏迷攻击"/>
-        <string name="h28" value="消费MP26，造成伤害480%，以76%几率出现昏迷攻击"/>
-        <string name="h29" value="消费MP26，造成伤害490%，以78%几率出现昏迷攻击"/>
-        <string name="h3" value="消费MP12，造成伤害230%，以26%几率出现昏迷攻击"/>
-        <string name="h30" value="消费MP26，造成伤害500%，以80%几率出现昏迷攻击"/>
-        <string name="h4" value="消费MP12，造成伤害240%，以28%几率出现昏迷攻击"/>
-        <string name="h5" value="消费MP12，造成伤害250%，以30%几率出现昏迷攻击"/>
-        <string name="h6" value="消费MP12，造成伤害260%，以32%几率出现昏迷攻击"/>
-        <string name="h7" value="消费MP12，造成伤害270%，以34%几率出现昏迷攻击"/>
-        <string name="h8" value="消费MP12，造成伤害280%，以36%几率出现昏迷攻击"/>
-        <string name="h9" value="消费MP12，造成伤害290%，以38%几率出现昏迷攻击"/>
-        <string name="desc" value="[最高等级:30]\n瞬间攻击单个怪物，一定几率使其昏迷"/>
+        <string name="h1" value="消耗MP12，伤害210%，以22%几率眩晕2秒"/>
+        <string name="h10" value="消耗MP12，伤害300%，以40%几率眩晕2秒"/>
+        <string name="h11" value="消耗MP19，伤害310%，以42%几率眩晕3秒"/>
+        <string name="h12" value="消耗MP19，伤害320%，以44%几率眩晕3秒"/>
+        <string name="h13" value="消耗MP19，伤害330%，以46%几率眩晕3秒"/>
+        <string name="h14" value="消耗MP19，伤害340%，以48%几率眩晕3秒"/>
+        <string name="h15" value="消耗MP19，伤害350%，以50%几率眩晕3秒"/>
+        <string name="h16" value="消耗MP19，伤害360%，以52%几率眩晕3秒"/>
+        <string name="h17" value="消耗MP19，伤害370%，以54%几率眩晕3秒"/>
+        <string name="h18" value="消耗MP19，伤害380%，以56%几率眩晕3秒"/>
+        <string name="h19" value="消耗MP19，伤害390%，以58%几率眩晕3秒"/>
+        <string name="h2" value="消耗MP12，伤害220%，以24%几率眩晕2秒"/>
+        <string name="h20" value="消耗MP19，伤害400%，以60%几率眩晕3秒"/>
+        <string name="h21" value="消耗MP26，伤害405%，以62%几率眩晕4秒"/>
+        <string name="h22" value="消耗MP26，伤害410%，以64%几率眩晕4秒"/>
+        <string name="h23" value="消耗MP26，伤害415%，以66%几率眩晕4秒"/>
+        <string name="h24" value="消耗MP26，伤害420%，以68%几率眩晕4秒"/>
+        <string name="h25" value="消耗MP26，伤害425%，以70%几率眩晕4秒"/>
+        <string name="h26" value="消耗MP26，伤害430%，以72%几率眩晕4秒"/>
+        <string name="h27" value="消耗MP26，伤害435%，以74%几率眩晕4秒"/>
+        <string name="h28" value="消耗MP26，伤害440%，以76%几率眩晕4秒"/>
+        <string name="h29" value="消耗MP26，伤害445%，以78%几率眩晕4秒"/>
+        <string name="h3" value="消耗MP12，伤害230%，以26%几率眩晕2秒"/>
+        <string name="h30" value="消耗MP26，伤害450%，以80%几率眩晕4秒"/>
+        <string name="h4" value="消耗MP12，伤害240%，以28%几率眩晕2秒"/>
+        <string name="h5" value="消耗MP12，伤害250%，以30%几率眩晕2秒"/>
+        <string name="h6" value="消耗MP12，伤害260%，以32%几率眩晕2秒"/>
+        <string name="h7" value="消耗MP12，伤害270%，以34%几率眩晕2秒"/>
+        <string name="h8" value="消耗MP12，伤害280%，以36%几率眩晕2秒"/>
+        <string name="h9" value="消耗MP12，伤害290%，以38%几率眩晕2秒"/>
+        <string name="desc" value="[最高等级:30]\n以极快速度攻击1个敌人，并有一定概率使其眩晕。"/>
     </imgdir>
     <imgdir name="4211003">
         <string name="name" value="敛财术"/>
@@ -10817,99 +10817,99 @@
         <string name="h7" value="消费MP37，持续120秒， 攻击时以34%几率使怪物掉落金币"/>
         <string name="h8" value="消费MP38，持续120秒， 攻击时以36%几率使怪物掉落金币"/>
         <string name="h9" value="消费MP39，持续120秒， 攻击时以38%几率使怪物掉落金币"/>
-        <string name="desc" value="[最高等级:20]\n攻击怪物时候让金币掉落。掉落金币数量\n随技能等级和伤害增加而增加。\n必需技能 : #c金钱炸弹等级3以上#"/>
+        <string name="desc" value="[最高等级:20]\n一定时间内，攻击敌人时有概率使其掉落金币；\n金币数量随技能等级和伤害增加。\n必要技能：#c金钱炸弹 Lv.3#"/>
     </imgdir>
     <imgdir name="4211004">
         <string name="name" value="分身术"/>
-        <string name="h1" value="消费MP10，造成伤害155%，制造五个分身攻击怪物"/>
-        <string name="h10" value="消费MP13 造成伤害200%，制造五个分身攻击怪物"/>
-        <string name="h11" value="消费MP16，造成伤害205%，制造五个分身攻击怪物"/>
-        <string name="h12" value="消费MP16，造成伤害210%，制造五个分身攻击怪物"/>
-        <string name="h13" value="消费MP16，造成伤害215%，制造五个分身攻击怪物"/>
-        <string name="h14" value="消费MP16，造成伤害220%，制造五个分身攻击怪物"/>
-        <string name="h15" value="消费MP16，造成伤害225%，制造五个分身攻击怪物"/>
-        <string name="h16" value="消费MP19，造成伤害230%，制造五个分身攻击怪物"/>
-        <string name="h17" value="消费MP19，造成伤害235%，制造五个分身攻击怪物"/>
-        <string name="h18" value="消费MP19，造成伤害240%，制造五个分身攻击怪物"/>
-        <string name="h19" value="消费MP19，造成伤害245%，制造五个分身攻击怪物"/>
-        <string name="h2" value="消费MP10，造成伤害160%，制造五个分身攻击怪物"/>
-        <string name="h20" value="消费MP19，造成伤害250%，制造五个分身攻击怪物"/>
-        <string name="h21" value="消费MP22，造成伤害255%，制造五个分身攻击怪物"/>
-        <string name="h22" value="消费MP22，造成伤害260%，制造五个分身攻击怪物"/>
-        <string name="h23" value="消费MP22，造成伤害265%，制造五个分身攻击怪物"/>
-        <string name="h24" value="消费MP22，造成伤害270%，制造五个分身攻击怪物"/>
-        <string name="h25" value="消费MP22，造成伤害275%，制造五个分身攻击怪物"/>
-        <string name="h26" value="消费MP25，造成伤害280%，制造五个分身攻击怪物"/>
-        <string name="h27" value="消费MP25，造成伤害285%，制造五个分身攻击怪物"/>
-        <string name="h28" value="消费MP25，造成伤害290%，制造五个分身攻击怪物"/>
-        <string name="h29" value="消费MP25，造成伤害295%，制造五个分身攻击怪物"/>
-        <string name="h3" value="消费MP10，造成伤害165%，制造五个分身攻击怪物"/>
-        <string name="h30" value="消费MP25，造成伤害300%，制造五个分身攻击怪物"/>
-        <string name="h4" value="消费MP10，造成伤害170%，制造五个分身攻击怪物"/>
-        <string name="h5" value="消费MP10，造成伤害175%，制造五个分身攻击怪物"/>
-        <string name="h6" value="消费MP13，造成伤害180%，制造五个分身攻击怪物"/>
-        <string name="h7" value="消费MP13，造成伤害185%，制造五个分身攻击怪物"/>
-        <string name="h8" value="消费MP13，造成伤害190%，制造五个分身攻击怪物"/>
-        <string name="h9" value="消费MP13，造成伤害195%，制造五个分身攻击怪物"/>
-        <string name="desc" value="[最高等级:30]\n召唤分身攻击怪物。最多攻击6个怪物"/>
+        <string name="h1" value="消耗MP10，伤害110%，召唤1个分身，最多攻击2个敌人"/>
+        <string name="h10" value="消耗MP13，伤害150%，召唤2个分身，最多攻击3个敌人"/>
+        <string name="h11" value="消耗MP16，伤害160%，召唤2个分身，最多攻击3个敌人"/>
+        <string name="h12" value="消耗MP16，伤害170%，召唤2个分身，最多攻击3个敌人"/>
+        <string name="h13" value="消耗MP16，伤害130%，召唤3个分身，最多攻击4个敌人"/>
+        <string name="h14" value="消耗MP16，伤害140%，召唤3个分身，最多攻击4个敌人"/>
+        <string name="h15" value="消耗MP16，伤害150%，召唤3个分身，最多攻击4个敌人"/>
+        <string name="h16" value="消耗MP19，伤害160%，召唤3个分身，最多攻击4个敌人"/>
+        <string name="h17" value="消耗MP19，伤害170%，召唤3个分身，最多攻击4个敌人"/>
+        <string name="h18" value="消耗MP19，伤害180%，召唤3个分身，最多攻击4个敌人"/>
+        <string name="h19" value="消耗MP19，伤害140%，召唤4个分身，最多攻击5个敌人"/>
+        <string name="h2" value="消耗MP10，伤害120%，召唤1个分身，最多攻击2个敌人"/>
+        <string name="h20" value="消耗MP19，伤害150%，召唤4个分身，最多攻击5个敌人"/>
+        <string name="h21" value="消耗MP22，伤害160%，召唤4个分身，最多攻击5个敌人"/>
+        <string name="h22" value="消耗MP22，伤害170%，召唤4个分身，最多攻击5个敌人"/>
+        <string name="h23" value="消耗MP22，伤害180%，召唤4个分身，最多攻击5个敌人"/>
+        <string name="h24" value="消耗MP22，伤害190%，召唤4个分身，最多攻击5个敌人"/>
+        <string name="h25" value="消耗MP22，伤害160%，召唤5个分身，最多攻击6个敌人"/>
+        <string name="h26" value="消耗MP25，伤害170%，召唤5个分身，最多攻击6个敌人"/>
+        <string name="h27" value="消耗MP25，伤害180%，召唤5个分身，最多攻击6个敌人"/>
+        <string name="h28" value="消耗MP25，伤害190%，召唤5个分身，最多攻击6个敌人"/>
+        <string name="h29" value="消耗MP25，伤害200%，召唤5个分身，最多攻击6个敌人"/>
+        <string name="h3" value="消耗MP10，伤害130%，召唤1个分身，最多攻击2个敌人"/>
+        <string name="h30" value="消耗MP25，伤害210%，召唤5个分身，最多攻击6个敌人"/>
+        <string name="h4" value="消耗MP10，伤害140%，召唤1个分身，最多攻击2个敌人"/>
+        <string name="h5" value="消耗MP10，伤害150%，召唤1个分身，最多攻击2个敌人"/>
+        <string name="h6" value="消耗MP13，伤害160%，召唤1个分身，最多攻击2个敌人"/>
+        <string name="h7" value="消耗MP13，伤害120%，召唤2个分身，最多攻击3个敌人"/>
+        <string name="h8" value="消耗MP13，伤害130%，召唤2个分身，最多攻击3个敌人"/>
+        <string name="h9" value="消耗MP13，伤害140%，召唤2个分身，最多攻击3个敌人"/>
+        <string name="desc" value="[最高等级:30]\n召唤分身攻击周围敌人，最多攻击6个敌人。"/>
     </imgdir>
     <imgdir name="4211005">
         <string name="name" value="金钱护盾"/>
-        <string name="h1" value="使用MP20，持续33秒，消耗金币比率90%"/>
-        <string name="h10" value="使用MP25，持续70秒，消耗金币比率86%"/>
-        <string name="h11" value="使用MP25，持续83秒，消耗金币比率85%"/>
-        <string name="h12" value="使用MP25，持续86秒，消耗金币比率85%"/>
-        <string name="h13" value="使用MP30，持续89秒，消耗金币比率84%"/>
-        <string name="h14" value="使用MP30，持续92秒，消耗金币比率84%"/>
-        <string name="h15" value="使用MP30，持续95秒，消耗金币比率83%"/>
-        <string name="h16" value="使用MP35，持续108秒，消耗金币比率82%"/>
-        <string name="h17" value="使用MP35，持续111秒，消耗金币比率81%"/>
-        <string name="h18" value="使用MP35，持续114秒，消耗金币比率80%"/>
-        <string name="h19" value="使用MP35，持续117秒，消耗金币比率79%"/>
-        <string name="h2" value="使用MP20，持续36秒，消耗金币比率90%"/>
-        <string name="h20" value="使用MP35，持续120秒，消耗金币比率78%"/>
-        <string name="h3" value="使用MP20，持续39秒，消耗金币比率89%"/>
-        <string name="h4" value="使用MP20，持续42秒，消耗金币比率89%"/>
-        <string name="h5" value="使用MP20，持续45秒，消耗金币比率88%"/>
-        <string name="h6" value="使用MP25，持续58秒，消耗金币比率88%"/>
-        <string name="h7" value="使用MP25，持续61秒，消耗金币比率87%"/>
-        <string name="h8" value="使用MP25，持续64秒，消耗金币比率87%"/>
-        <string name="h9" value="使用MP25，持续67秒，消耗金币比率86%"/>
-        <string name="desc" value="[最高等级:20]\n用金币代替伤害的50%。\n每次收到伤害时根据比例消耗金币。\n必需技能 : #c转化术等级3以上#"/>
+        <string name="h1" value="消耗MP20，持续33秒，伤害减半，按减免后伤害的90%消耗金币"/>
+        <string name="h10" value="消耗MP25，持续70秒，伤害减半，按减免后伤害的86%消耗金币"/>
+        <string name="h11" value="消耗MP30，持续83秒，伤害减半，按减免后伤害的85%消耗金币"/>
+        <string name="h12" value="消耗MP30，持续86秒，伤害减半，按减免后伤害的85%消耗金币"/>
+        <string name="h13" value="消耗MP30，持续89秒，伤害减半，按减免后伤害的84%消耗金币"/>
+        <string name="h14" value="消耗MP30，持续92秒，伤害减半，按减免后伤害的84%消耗金币"/>
+        <string name="h15" value="消耗MP30，持续95秒，伤害减半，按减免后伤害的83%消耗金币"/>
+        <string name="h16" value="消耗MP35，持续108秒，伤害减半，按减免后伤害的82%消耗金币"/>
+        <string name="h17" value="消耗MP35，持续111秒，伤害减半，按减免后伤害的81%消耗金币"/>
+        <string name="h18" value="消耗MP35，持续114秒，伤害减半，按减免后伤害的80%消耗金币"/>
+        <string name="h19" value="消耗MP35，持续117秒，伤害减半，按减免后伤害的79%消耗金币"/>
+        <string name="h2" value="消耗MP20，持续36秒，伤害减半，按减免后伤害的90%消耗金币"/>
+        <string name="h20" value="消耗MP35，持续120秒，伤害减半，按减免后伤害的78%消耗金币"/>
+        <string name="h3" value="消耗MP20，持续39秒，伤害减半，按减免后伤害的89%消耗金币"/>
+        <string name="h4" value="消耗MP20，持续42秒，伤害减半，按减免后伤害的89%消耗金币"/>
+        <string name="h5" value="消耗MP20，持续45秒，伤害减半，按减免后伤害的88%消耗金币"/>
+        <string name="h6" value="消耗MP25，持续58秒，伤害减半，按减免后伤害的88%消耗金币"/>
+        <string name="h7" value="消耗MP25，持续61秒，伤害减半，按减免后伤害的87%消耗金币"/>
+        <string name="h8" value="消耗MP25，持续64秒，伤害减半，按减免后伤害的87%消耗金币"/>
+        <string name="h9" value="消耗MP25，持续67秒，伤害减半，按减免后伤害的86%消耗金币"/>
+        <string name="desc" value="[最高等级:20]\n用金币抵消受到伤害的一半；\n每次受到伤害时按比例消耗金币。\n必要技能：#c转化术 Lv.3#"/>
     </imgdir>
     <imgdir name="4211006">
         <string name="name" value="金钱炸弹"/>
-        <string name="h1" value="消费MP18，熟练度50%，10个引爆可能"/>
-        <string name="h10" value="消费MP18，熟练度68%，12个引爆可能"/>
-        <string name="h11" value="消费MP24，熟练度70%，14个引爆可能"/>
-        <string name="h12" value="消费MP24，熟练度72%，14个引爆可能"/>
-        <string name="h13" value="消费MP24，熟练度74%，14个引爆可能"/>
-        <string name="h14" value="消费MP24，熟练度76%，14个引爆可能"/>
-        <string name="h15" value="消费MP24，熟练度78%，14个引爆可能"/>
-        <string name="h16" value="消费MP24，熟练度80%，16个引爆可能"/>
-        <string name="h17" value="消费MP24，熟练度82%，16个引爆可能"/>
-        <string name="h18" value="消费MP24，熟练度84%，16个引爆可能"/>
-        <string name="h19" value="消费MP24，熟练度86%，16个引爆可能"/>
-        <string name="h2" value="消费MP18，熟练度52%，10个引爆可能"/>
-        <string name="h20" value="消费MP24，熟练度88%，16个引爆可能"/>
-        <string name="h21" value="消费MP30，熟练度90%，18个引爆可能"/>
-        <string name="h22" value="消费MP30 熟练度92%，18个引爆可能"/>
-        <string name="h23" value="消费MP30 熟练度93%，18个引爆可能"/>
-        <string name="h24" value="消费MP30 熟练度94%，18个引爆可能"/>
-        <string name="h25" value="消费MP30 熟练度95%，18个引爆可能"/>
-        <string name="h26" value="消费MP30 熟练度96%，20个引爆可能"/>
-        <string name="h27" value="消费MP30 熟练度97%，20个引爆可能"/>
-        <string name="h28" value="消费MP30 熟练度98%，20个引爆可能"/>
-        <string name="h29" value="消费MP30 熟练度99%，20个引爆可能"/>
-        <string name="h3" value="消费MP18，熟练度54%，10个引爆可能"/>
-        <string name="h30" value="消费MP30 熟练度100%，20个引爆可能"/>
-        <string name="h4" value="消费MP18，熟练度56%，10个引爆可能"/>
-        <string name="h5" value="消费MP18，熟练度58%，10个引爆可能"/>
-        <string name="h6" value="消费MP18，熟练度60%，12个引爆可能"/>
-        <string name="h7" value="消费MP18，熟练度62%，12个引爆可能"/>
-        <string name="h8" value="消费MP18，熟练度64%，12个引爆可能"/>
-        <string name="h9" value="消费MP18，熟练度66%，12个引爆可能"/>
-        <string name="desc" value="[最高等级:30]\n引爆前方掉落在地上的金币来攻击怪物，\n只能引爆属于自己的金币"/>
+        <string name="h1" value="消耗MP18，熟练度50%，最多引爆10个金币，最多攻击6个敌人"/>
+        <string name="h10" value="消耗MP18，熟练度68%，最多引爆12个金币，最多攻击6个敌人"/>
+        <string name="h11" value="消耗MP24，熟练度70%，最多引爆14个金币，最多攻击6个敌人"/>
+        <string name="h12" value="消耗MP24，熟练度72%，最多引爆14个金币，最多攻击6个敌人"/>
+        <string name="h13" value="消耗MP24，熟练度74%，最多引爆14个金币，最多攻击6个敌人"/>
+        <string name="h14" value="消耗MP24，熟练度76%，最多引爆14个金币，最多攻击6个敌人"/>
+        <string name="h15" value="消耗MP24，熟练度78%，最多引爆14个金币，最多攻击6个敌人"/>
+        <string name="h16" value="消耗MP24，熟练度80%，最多引爆16个金币，最多攻击6个敌人"/>
+        <string name="h17" value="消耗MP24，熟练度82%，最多引爆16个金币，最多攻击6个敌人"/>
+        <string name="h18" value="消耗MP24，熟练度84%，最多引爆16个金币，最多攻击6个敌人"/>
+        <string name="h19" value="消耗MP24，熟练度86%，最多引爆16个金币，最多攻击6个敌人"/>
+        <string name="h2" value="消耗MP18，熟练度52%，最多引爆10个金币，最多攻击6个敌人"/>
+        <string name="h20" value="消耗MP24，熟练度88%，最多引爆16个金币，最多攻击6个敌人"/>
+        <string name="h21" value="消耗MP30，熟练度90%，最多引爆18个金币，最多攻击6个敌人"/>
+        <string name="h22" value="消耗MP30，熟练度92%，最多引爆18个金币，最多攻击6个敌人"/>
+        <string name="h23" value="消耗MP30，熟练度93%，最多引爆18个金币，最多攻击6个敌人"/>
+        <string name="h24" value="消耗MP30，熟练度94%，最多引爆18个金币，最多攻击6个敌人"/>
+        <string name="h25" value="消耗MP30，熟练度95%，最多引爆18个金币，最多攻击6个敌人"/>
+        <string name="h26" value="消耗MP30，熟练度96%，最多引爆20个金币，最多攻击6个敌人"/>
+        <string name="h27" value="消耗MP30，熟练度97%，最多引爆20个金币，最多攻击6个敌人"/>
+        <string name="h28" value="消耗MP30，熟练度98%，最多引爆20个金币，最多攻击6个敌人"/>
+        <string name="h29" value="消耗MP30，熟练度99%，最多引爆20个金币，最多攻击6个敌人"/>
+        <string name="h3" value="消耗MP18，熟练度54%，最多引爆10个金币，最多攻击6个敌人"/>
+        <string name="h30" value="消耗MP30，熟练度100%，最多引爆20个金币，最多攻击6个敌人"/>
+        <string name="h4" value="消耗MP18，熟练度56%，最多引爆10个金币，最多攻击6个敌人"/>
+        <string name="h5" value="消耗MP18，熟练度58%，最多引爆10个金币，最多攻击6个敌人"/>
+        <string name="h6" value="消耗MP18，熟练度60%，最多引爆12个金币，最多攻击6个敌人"/>
+        <string name="h7" value="消耗MP18，熟练度62%，最多引爆12个金币，最多攻击6个敌人"/>
+        <string name="h8" value="消耗MP18，熟练度64%，最多引爆12个金币，最多攻击6个敌人"/>
+        <string name="h9" value="消耗MP18，熟练度66%，最多引爆12个金币，最多攻击6个敌人"/>
+        <string name="desc" value="[最高等级:30]\n引爆前方掉落在地上的金币攻击敌人；\n只能引爆属于自己的金币。"/>
     </imgdir>
     <imgdir name="422">
         <string name="bookName" value="盗之侠客"/>
@@ -10946,7 +10946,7 @@
         <string name="h7" value="17%的几率 回避敌人的攻击"/>
         <string name="h8" value="18%的几率 回避敌人的攻击"/>
         <string name="h9" value="19%的几率 回避敌人的攻击"/>
-        <string name="desc" value="以极快的反射神经躲避敌人的攻击"/>
+        <string name="desc" value="以极快的反射神经，有一定概率回避敌人的攻击。"/>
     </imgdir>
     <imgdir name="4220005">
         <string name="name" value="武器用毒液"/>
@@ -10980,7 +10980,7 @@
         <string name="h7" value="攻击力 37，持续时间 2秒，成功率 16%"/>
         <string name="h8" value="攻击力 38，持续时间 2秒，成功率 16%"/>
         <string name="h9" value="攻击力 39，持续时间 2秒，成功率 16%"/>
-        <string name="desc" value="在短刀上涂抹毒药攻击敌人使它一定几率\n中毒受持续伤害.最多可重复3次,\n敌人的HP不会掉落1以下"/>
+        <string name="desc" value="在短刀上涂抹毒药，攻击时有一定概率使敌人中毒并持续受到伤害；\n最多可对同一敌人叠加3次，且不会使敌人的HP降到1以下。"/>
     </imgdir>
     <imgdir name="4221000">
         <string name="name" value="冒险岛勇士"/>
@@ -11014,41 +11014,41 @@
         <string name="h7" value="消耗MP 20，210秒内所有的属性点提高 4%"/>
         <string name="h8" value="消耗MP 20，240秒内所有的属性点提高 4%"/>
         <string name="h9" value="消耗MP 20，270秒内所有的属性点提高 5%"/>
-        <string name="desc" value="一定时间内把组队成员的所有属性点提高\n一定的百分比"/>
+        <string name="desc" value="一定时间内按百分比提高组队成员的所有属性。"/>
     </imgdir>
     <imgdir name="4221001">
         <string name="name" value="暗杀"/>
-        <string name="h1" value="消耗MP 21, 攻击力 34%, 6秒间累计伤害, 必杀伤害 105%, 几率 32%"/>
-        <string name="h2" value="消耗MP 22, 攻击力 38%, 6秒间累计伤害, 必杀伤害 110%, 几率 34%"/>
-        <string name="h3" value="消耗MP 23, 攻击力 42%, 6秒间累计伤害, 必杀伤害 115%, 几率 36%"/>
-        <string name="h4" value="消耗MP 24, 攻击力 46%, 6秒间累计伤害, 必杀伤害 120%, 几率 38%"/>
-        <string name="h5" value="消耗MP 25, 攻击力 50%, 6秒间累计伤害, 必杀伤害 125%, 几率 40%"/>
-        <string name="h6" value="消耗MP 26, 攻击力 54%, 6秒间累计伤害, 必杀伤害 130%, 几率 42%"/>
-        <string name="h7" value="消耗MP 27, 攻击力 58%, 6秒间累计伤害, 必杀伤害 135%, 几率 44%"/>
-        <string name="h8" value="消耗MP 28, 攻击力 62%, 6秒间累计伤害, 必杀伤害 140%, 几率 46%"/>
-        <string name="h9" value="消耗MP 29, 攻击力 66%, 6秒间累计伤害, 必杀伤害 145%, 几率 48%"/>
-        <string name="h10" value="消耗MP 30, 攻击力 70%, 6秒间累计伤害, 必杀伤害 150%, 几率 50%"/>
-        <string name="h11" value="消耗MP 31, 攻击力 73%, 9秒间累计伤害, 必杀伤害 155%, 几率 52%"/>
-        <string name="h12" value="消耗MP 32, 攻击力 76%, 9秒间累计伤害, 必杀伤害 160%, 几率 54%"/>
-        <string name="h13" value="消耗MP 33, 攻击力 79%, 9秒间累计伤害, 必杀伤害 165%, 几率 56%"/>
-        <string name="h14" value="消耗MP 34, 攻击力 82%, 9秒间累计伤害, 必杀伤害 170%, 几率 58%"/>
-        <string name="h15" value="消耗MP 35, 攻击力 85%, 9秒间累计伤害, 必杀伤害 175%, 几率 60%"/>
-        <string name="h16" value="消耗MP 36, 攻击力 88%, 9秒间累计伤害, 必杀伤害 180%, 几率 62%"/>
-        <string name="h17" value="消耗MP 37, 攻击力 91%, 9秒间累计伤害, 必杀伤害 185%, 几率 64%"/>
-        <string name="h18" value="消耗MP 38, 攻击力 94%, 9秒间累计伤害, 必杀伤害 190%, 几率 66%"/>
-        <string name="h19" value="消耗MP 39, 攻击力 97%, 9秒间累计伤害, 必杀伤害 195%, 几率 68%"/>
-        <string name="h20" value="消耗MP 40, 攻击力 100%, 9秒间累计伤害, 必杀伤害 200%, 几率 70%"/>
-        <string name="h21" value="消耗MP 41, 攻击力 102%, 12秒间累计伤害, 必杀伤害 205%, 几率 72%"/>
-        <string name="h22" value="消耗MP 42, 攻击力 104%, 12秒间累计伤害, 必杀伤害 210%, 几率 74%"/>
-        <string name="h23" value="消耗MP 43, 攻击力 106%, 12秒间累计伤害, 必杀伤害 215%, 几率 76%"/>
-        <string name="h24" value="消耗MP 44, 攻击力 108%, 12秒间累计伤害, 必杀伤害 220%, 几率 78%"/>
-        <string name="h25" value="消耗MP 45, 攻击力 110%, 12秒间累计伤害, 必杀伤害 225%, 几率 80%"/>
-        <string name="h26" value="消耗MP 44, 攻击力 112%, 12秒间累计伤害, 必杀伤害 230%, 几率 82%"/>
-        <string name="h27" value="消耗MP 43, 攻击力 114%, 12秒间累计伤害, 必杀伤害 235%, 几率 84%"/>
-        <string name="h28" value="消耗MP 42, 攻击力 116%, 12秒间累计伤害, 必杀伤害 240%, 几率 86%"/>
-        <string name="h29" value="消耗MP 41, 攻击力 118%, 12秒间累计伤害, 必杀伤害 245%, 几率 88%"/>
-        <string name="h30" value="消耗MP 40, 攻击力 120%, 12秒间累计伤害, 必杀伤害 250%, 几率 90%"/>
-        <string name="desc" value="用隐身悄悄地靠近敌人附近后，突然攻击4次敌人的要害.\n最后一击以一定几率给敌人致命伤"/>
+        <string name="h1" value="消耗MP 21，伤害 170%，攻击3次，6秒内累计伤害，最后一击必杀伤害 105%，成功率 32%"/>
+        <string name="h2" value="消耗MP 22，伤害 190%，攻击3次，6秒内累计伤害，最后一击必杀伤害 110%，成功率 34%"/>
+        <string name="h3" value="消耗MP 23，伤害 210%，攻击3次，6秒内累计伤害，最后一击必杀伤害 115%，成功率 36%"/>
+        <string name="h4" value="消耗MP 24，伤害 230%，攻击3次，6秒内累计伤害，最后一击必杀伤害 120%，成功率 38%"/>
+        <string name="h5" value="消耗MP 25，伤害 250%，攻击3次，6秒内累计伤害，最后一击必杀伤害 125%，成功率 40%"/>
+        <string name="h6" value="消耗MP 26，伤害 270%，攻击3次，6秒内累计伤害，最后一击必杀伤害 130%，成功率 42%"/>
+        <string name="h7" value="消耗MP 27，伤害 290%，攻击3次，6秒内累计伤害，最后一击必杀伤害 135%，成功率 44%"/>
+        <string name="h8" value="消耗MP 28，伤害 310%，攻击3次，6秒内累计伤害，最后一击必杀伤害 140%，成功率 46%"/>
+        <string name="h9" value="消耗MP 29，伤害 330%，攻击3次，6秒内累计伤害，最后一击必杀伤害 145%，成功率 48%"/>
+        <string name="h10" value="消耗MP 30，伤害 350%，攻击3次，6秒内累计伤害，最后一击必杀伤害 150%，成功率 50%"/>
+        <string name="h11" value="消耗MP 31，伤害 365%，攻击3次，9秒内累计伤害，最后一击必杀伤害 155%，成功率 52%"/>
+        <string name="h12" value="消耗MP 32，伤害 380%，攻击3次，9秒内累计伤害，最后一击必杀伤害 160%，成功率 54%"/>
+        <string name="h13" value="消耗MP 33，伤害 395%，攻击3次，9秒内累计伤害，最后一击必杀伤害 165%，成功率 56%"/>
+        <string name="h14" value="消耗MP 34，伤害 410%，攻击3次，9秒内累计伤害，最后一击必杀伤害 170%，成功率 58%"/>
+        <string name="h15" value="消耗MP 35，伤害 425%，攻击3次，9秒内累计伤害，最后一击必杀伤害 175%，成功率 60%"/>
+        <string name="h16" value="消耗MP 36，伤害 440%，攻击3次，9秒内累计伤害，最后一击必杀伤害 180%，成功率 62%"/>
+        <string name="h17" value="消耗MP 37，伤害 455%，攻击3次，9秒内累计伤害，最后一击必杀伤害 185%，成功率 64%"/>
+        <string name="h18" value="消耗MP 38，伤害 470%，攻击3次，9秒内累计伤害，最后一击必杀伤害 190%，成功率 66%"/>
+        <string name="h19" value="消耗MP 39，伤害 485%，攻击3次，9秒内累计伤害，最后一击必杀伤害 195%，成功率 68%"/>
+        <string name="h20" value="消耗MP 40，伤害 500%，攻击3次，9秒内累计伤害，最后一击必杀伤害 200%，成功率 70%"/>
+        <string name="h21" value="消耗MP 41，伤害 510%，攻击3次，12秒内累计伤害，最后一击必杀伤害 205%，成功率 72%"/>
+        <string name="h22" value="消耗MP 42，伤害 520%，攻击3次，12秒内累计伤害，最后一击必杀伤害 210%，成功率 74%"/>
+        <string name="h23" value="消耗MP 43，伤害 530%，攻击3次，12秒内累计伤害，最后一击必杀伤害 215%，成功率 76%"/>
+        <string name="h24" value="消耗MP 44，伤害 540%，攻击3次，12秒内累计伤害，最后一击必杀伤害 220%，成功率 78%"/>
+        <string name="h25" value="消耗MP 45，伤害 550%，攻击3次，12秒内累计伤害，最后一击必杀伤害 225%，成功率 80%"/>
+        <string name="h26" value="消耗MP 44，伤害 560%，攻击3次，12秒内累计伤害，最后一击必杀伤害 230%，成功率 82%"/>
+        <string name="h27" value="消耗MP 43，伤害 570%，攻击3次，12秒内累计伤害，最后一击必杀伤害 235%，成功率 84%"/>
+        <string name="h28" value="消耗MP 42，伤害 580%，攻击3次，12秒内累计伤害，最后一击必杀伤害 240%，成功率 86%"/>
+        <string name="h29" value="消耗MP 41，伤害 590%，攻击3次，12秒内累计伤害，最后一击必杀伤害 245%，成功率 88%"/>
+        <string name="h30" value="消耗MP 40，伤害 600%，攻击3次，12秒内累计伤害，最后一击必杀伤害 250%，成功率 90%"/>
+        <string name="desc" value="隐身状态下靠近敌人并攻击要害；\n进行3次攻击后，最后一击有一定概率造成必杀伤害。"/>
     </imgdir>
     <imgdir name="4221003">
         <string name="name" value="挑衅"/>
@@ -11082,7 +11082,7 @@
         <string name="h7" value="消耗MP27，敌人防御上升时，得到的经验值，物品掉落率提高17%"/>
         <string name="h8" value="消耗MP28，敌人防御上升时，得到的经验值，物品掉落率提高18%"/>
         <string name="h9" value="消耗MP29，敌人防御上升时，得到的经验值，物品掉落率提高19%"/>
-        <string name="desc" value="最多可以把6只敌人陷入挑衅状态，随着敌人\n的防御力上升而提高其经验值和物品掉落率。\n必需技能: #c假动作等级10以上#"/>
+        <string name="desc" value="最多使6个敌人陷入挑衅状态；\n敌人物理防御和魔法防御提高，同时经验值和物品掉落率提高。\n必要技能：#c假动作 Lv.10#"/>
     </imgdir>
     <imgdir name="4221004">
         <string name="name" value="忍者伏击"/>
@@ -11116,7 +11116,7 @@
         <string name="h7" value="消耗MP 16，伤害 74%，持续时间 4秒，攻击范围 130%"/>
         <string name="h8" value="消耗MP 16，伤害 76%，持续时间 4秒，攻击范围 130%"/>
         <string name="h9" value="消耗MP 16，伤害 78%，持续时间 4秒，攻击范围 130%"/>
-        <string name="desc" value="躲藏的同伴突然出现,在一定时间内持续攻击敌人.\n一次无法攻击6只以上,HP不会掉到1以下.\n必要技能 : #c假动作等级5以上#"/>
+        <string name="desc" value="躲藏的同伴突然出现，在一定时间内持续攻击最多6个敌人；\n该伤害不会使敌人的HP降到1以下。\n必要技能：#c假动作 Lv.5#"/>
     </imgdir>
     <imgdir name="4221006">
         <string name="name" value="烟雾弹"/>
@@ -11188,12 +11188,12 @@
     </imgdir>
     <imgdir name="4221008">
         <string name="name" value="勇士的意志"/>
-        <string name="h1" value="消耗MP 30，解除诱惑异常状态，冷却时间10分钟"/>
-        <string name="h2" value="消耗MP 30，解除诱惑异常状态，冷却时间9分钟"/>
-        <string name="h3" value="消耗MP 30，解除诱惑异常状态，冷却时间8分钟"/>
-        <string name="h4" value="消耗MP 30，解除诱惑异常状态，冷却时间7分钟"/>
-        <string name="h5" value="消耗MP 30，解除诱惑异常状态，冷却时间6分钟"/>
-        <string name="desc" value="从异常状态中恢复. \n随着等级的上升,冷却时间逐渐缩短"/>
+        <string name="h1" value="消耗MP 30，解除诱惑、僵尸、混乱等异常状态，冷却时间10分钟"/>
+        <string name="h2" value="消耗MP 30，解除诱惑、僵尸、混乱等异常状态，冷却时间9分钟"/>
+        <string name="h3" value="消耗MP 30，解除诱惑、僵尸、混乱等异常状态，冷却时间8分钟"/>
+        <string name="h4" value="消耗MP 30，解除诱惑、僵尸、混乱等异常状态，冷却时间7分钟"/>
+        <string name="h5" value="消耗MP 30，解除诱惑、僵尸、混乱等异常状态，冷却时间6分钟"/>
+        <string name="desc" value="解除诱惑、僵尸、混乱等异常状态；\n等级越高，冷却时间越短。"/>
     </imgdir>
     <imgdir name="500">
         <string name="bookName" value="海盗入门书"/>

--- a/gms-server/wz/String.wz/Skill.img.xml
+++ b/gms-server/wz/String.wz/Skill.img.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <imgdir name="Skill.img">
   <imgdir name="000">
     <string name="bookName" value="Beginner&apos;s Basics"/>
@@ -464,7 +464,7 @@
   </imgdir>
   <imgdir name="4000001">
     <string name="name" value="Keen Eyes"/>
-    <string name="desc" value="[Master Level : 8]\nIncreases the range of attack using throwing weapons such as throwing stars &amp; knives.\nRequired Skill : #cAt least Level 3 on Nimble Body#"/>
+    <string name="desc" value="[Master Level : 8]\nIncreases the attack range of throwing weapons such as throwing stars and knives.\nRequired Skill : #cAt least Level 3 on Nimble Body#"/>
     <string name="h1" value="Range of attack for the throwing weapon: +25"/>
     <string name="h2" value="Range of attack for the throwing weapon: +50"/>
     <string name="h3" value="Range of attack for the throwing weapon: +75"/>
@@ -476,7 +476,7 @@
   </imgdir>
   <imgdir name="4001002">
     <string name="name" value="Disorder"/>
-    <string name="desc" value="[Master Level : 20]\nTemporarily decreases the weapon def. and attacking abilities of the affected, even stunting the ongoing attacks. Can&apos;t use this skill on a monster that&apos;s already in &quot;disorder.&quot;"/>
+    <string name="desc" value="[Master Level : 20]\nTemporarily decreases one enemy&apos;s weapon attack and weapon defense. Cannot be used on an enemy already affected by Disorder."/>
     <string name="h1" value="MP -5; enemy&apos;s weapon attack -1, weapon def. -1 for 7 sec."/>
     <string name="h2" value="MP -5; enemy&apos;s weapon attack -2, weapon def. -2 for 9 sec."/>
     <string name="h3" value="MP -5; enemy&apos;s weapon attack -3, weapon def. -3 for 11 sec."/>
@@ -500,75 +500,75 @@
   </imgdir>
   <imgdir name="4001003">
     <string name="name" value="Dark Sight"/>
-    <string name="desc" value="[Master Level : 20]\nUse MP to hide behind the shadows. Can&apos;t be attacked, and can&apos;t attack either.\nRequired Skill : #cAt least Level 3 on Disorder#"/>
-    <string name="h1" value="MP -24; disappear for 10 sec., speed -30"/>
-    <string name="h2" value="MP -23; disappear for 20 sec., speed -28"/>
-    <string name="h3" value="MP -22; disappear for 30 sec., speed -26"/>
-    <string name="h4" value="MP -21; disappear for 40 sec., speed -24"/>
-    <string name="h5" value="MP -20; disappear for 50 sec., speed -22"/>
-    <string name="h6" value="MP -19; disappear for 60 sec., speed -20"/>
-    <string name="h7" value="MP -18; disappear for 70 sec., speed -18"/>
-    <string name="h8" value="MP -17; disappear for 80 sec., speed -16"/>
-    <string name="h9" value="MP -16; disappear for 90 sec., speed -14"/>
-    <string name="h10" value="MP -15; disappear for 100 sec., speed -12"/>
-    <string name="h11" value="MP -14; disappear for 110 sec., speed -10"/>
-    <string name="h12" value="MP -13; disappear for 120 sec., speed -8"/>
-    <string name="h13" value="MP -12; disappear for 130 sec., speed -7"/>
-    <string name="h14" value="MP -11; disappear for 140 sec., speed -6"/>
-    <string name="h15" value="MP -10; disappear for 150 sec., speed -5"/>
-    <string name="h16" value="MP -9; disappear for 160 sec., speed -4"/>
-    <string name="h17" value="MP -8; disappear for 170 sec., speed -3"/>
-    <string name="h18" value="MP -7; disappear for 180 sec., speed -2"/>
-    <string name="h19" value="MP -6; disappear for 190 sec., speed -1"/>
-    <string name="h20" value="MP -5; disappear for 200 sec., regular moving speed"/>
+    <string name="desc" value="[Master Level : 20]\nUses MP to hide in the shadows. You cannot be attacked by monsters, but you cannot attack either.\nRequired Skill : #cAt least Level 3 on Disorder#"/>
+    <string name="h1" value="MP -24. Disappear for 10 sec. speed -30."/>
+    <string name="h2" value="MP -23. Disappear for 20 sec. speed -28."/>
+    <string name="h3" value="MP -22. Disappear for 30 sec. speed -26."/>
+    <string name="h4" value="MP -21. Disappear for 40 sec. speed -24."/>
+    <string name="h5" value="MP -20. Disappear for 50 sec. speed -22."/>
+    <string name="h6" value="MP -19. Disappear for 60 sec. speed -20."/>
+    <string name="h7" value="MP -18. Disappear for 70 sec. speed -18."/>
+    <string name="h8" value="MP -17. Disappear for 80 sec. speed -16."/>
+    <string name="h9" value="MP -16. Disappear for 90 sec. speed -14."/>
+    <string name="h10" value="MP -15. Disappear for 100 sec. speed -12."/>
+    <string name="h11" value="MP -14. Disappear for 110 sec. speed -10."/>
+    <string name="h12" value="MP -13. Disappear for 120 sec. speed -8."/>
+    <string name="h13" value="MP -12. Disappear for 130 sec. speed -7."/>
+    <string name="h14" value="MP -11. Disappear for 140 sec. speed -6."/>
+    <string name="h15" value="MP -10. Disappear for 150 sec. speed -5."/>
+    <string name="h16" value="MP -9. Disappear for 160 sec. speed -4."/>
+    <string name="h17" value="MP -8. Disappear for 170 sec. speed -3."/>
+    <string name="h18" value="MP -7. Disappear for 180 sec. speed -2."/>
+    <string name="h19" value="MP -6. Disappear for 190 sec. speed -1."/>
+    <string name="h20" value="MP -5. Disappear for 200 sec. regular moving speed"/>
   </imgdir>
   <imgdir name="4001334">
     <string name="name" value="Double Stab"/>
-    <string name="desc" value="[Master Level : 20]\nUse MP to quickly stab a monster twice in one turn using a dagger."/>
-    <string name="h1" value="MP -6; damage 65%"/>
-    <string name="h2" value="MP -6; damage 68%"/>
-    <string name="h3" value="MP -6; damage 71%"/>
-    <string name="h4" value="MP -6; damage 74%"/>
-    <string name="h5" value="MP -7; damage 78%"/>
-    <string name="h6" value="MP -7; damage 81%"/>
-    <string name="h7" value="MP -7; damage 84%"/>
-    <string name="h8" value="MP -8; damage 88%"/>
-    <string name="h9" value="MP -8; damage 91%"/>
-    <string name="h10" value="MP -9; damage 95%"/>
-    <string name="h11" value="MP -9; damage 98%"/>
-    <string name="h12" value="MP -10; damage 102%"/>
-    <string name="h13" value="MP -10; damage 105%"/>
-    <string name="h14" value="MP -11; damage 109%"/>
-    <string name="h15" value="MP -11; damage 112%"/>
-    <string name="h16" value="MP -12; damage 116%"/>
-    <string name="h17" value="MP -12; damage 119%"/>
-    <string name="h18" value="MP -13; damage 123%"/>
-    <string name="h19" value="MP -13; damage 126%"/>
-    <string name="h20" value="MP -14; damage 130%"/>
+    <string name="desc" value="[Master Level : 20]\nUses MP to quickly stab one enemy twice with a dagger."/>
+    <string name="h1" value="MP -8. Damage 98%, attacks 2 times."/>
+    <string name="h2" value="MP -8. Damage 100%, attacks 2 times."/>
+    <string name="h3" value="MP -8. Damage 102%, attacks 2 times."/>
+    <string name="h4" value="MP -8. Damage 104%, attacks 2 times."/>
+    <string name="h5" value="MP -9. Damage 106%, attacks 2 times."/>
+    <string name="h6" value="MP -9. Damage 108%, attacks 2 times."/>
+    <string name="h7" value="MP -9. Damage 110%, attacks 2 times."/>
+    <string name="h8" value="MP -10. Damage 112%, attacks 2 times."/>
+    <string name="h9" value="MP -10. Damage 114%, attacks 2 times."/>
+    <string name="h10" value="MP -10. Damage 116%, attacks 2 times."/>
+    <string name="h11" value="MP -11. Damage 118%, attacks 2 times."/>
+    <string name="h12" value="MP -11. Damage 120%, attacks 2 times."/>
+    <string name="h13" value="MP -11. Damage 122%, attacks 2 times."/>
+    <string name="h14" value="MP -12. Damage 124%, attacks 2 times."/>
+    <string name="h15" value="MP -12. Damage 126%, attacks 2 times."/>
+    <string name="h16" value="MP -12. Damage 128%, attacks 2 times."/>
+    <string name="h17" value="MP -13. Damage 130%, attacks 2 times."/>
+    <string name="h18" value="MP -13. Damage 132%, attacks 2 times."/>
+    <string name="h19" value="MP -13. Damage 134%, attacks 2 times."/>
+    <string name="h20" value="MP -14. Damage 140%, attacks 2 times."/>
   </imgdir>
   <imgdir name="4001344">
     <string name="name" value="Lucky Seven"/>
-    <string name="desc" value="[Master Level : 20]\nUse MP to throw 2 throwing stars and apply damage based on LUK, regardless of the rate of Claw Mastery."/>
-    <string name="h1" value="MP -8; damage 58%"/>
-    <string name="h2" value="MP -8; damage 62%"/>
-    <string name="h3" value="MP -8; damage 66%"/>
-    <string name="h4" value="MP -8; damage 70%"/>
-    <string name="h5" value="MP -9; damage 76%"/>
-    <string name="h6" value="MP -9; damage 80%"/>
-    <string name="h7" value="MP -9; damage 84%"/>
-    <string name="h8" value="MP -10; damage 90%"/>
-    <string name="h9" value="MP -10; damage 94%"/>
-    <string name="h10" value="MP -11; damage 100%"/>
-    <string name="h11" value="MP -11; damage 104%"/>
-    <string name="h12" value="MP -12; damage 110%"/>
-    <string name="h13" value="MP -12; damage 114%"/>
-    <string name="h14" value="MP -13; damage 120%"/>
-    <string name="h15" value="MP -13; damage 124%"/>
-    <string name="h16" value="MP -14; damage 130%"/>
-    <string name="h17" value="MP -14; damage 134%"/>
-    <string name="h18" value="MP -15; damage 140%"/>
-    <string name="h19" value="MP -15; damage 144%"/>
-    <string name="h20" value="MP -16; damage 150%"/>
+    <string name="desc" value="[Master Level : 20]\nThrows 2 stars at one enemy. Damage is based on LUK and ignores Claw Mastery."/>
+    <string name="h1" value="MP -8. Damage 58%, throws 2 stars."/>
+    <string name="h2" value="MP -8. Damage 62%, throws 2 stars."/>
+    <string name="h3" value="MP -8. Damage 66%, throws 2 stars."/>
+    <string name="h4" value="MP -8. Damage 70%, throws 2 stars."/>
+    <string name="h5" value="MP -9. Damage 76%, throws 2 stars."/>
+    <string name="h6" value="MP -9. Damage 80%, throws 2 stars."/>
+    <string name="h7" value="MP -9. Damage 84%, throws 2 stars."/>
+    <string name="h8" value="MP -10. Damage 90%, throws 2 stars."/>
+    <string name="h9" value="MP -10. Damage 94%, throws 2 stars."/>
+    <string name="h10" value="MP -11. Damage 100%, throws 2 stars."/>
+    <string name="h11" value="MP -11. Damage 104%, throws 2 stars."/>
+    <string name="h12" value="MP -12. Damage 110%, throws 2 stars."/>
+    <string name="h13" value="MP -12. Damage 114%, throws 2 stars."/>
+    <string name="h14" value="MP -13. Damage 120%, throws 2 stars."/>
+    <string name="h15" value="MP -13. Damage 124%, throws 2 stars."/>
+    <string name="h16" value="MP -14. Damage 130%, throws 2 stars."/>
+    <string name="h17" value="MP -14. Damage 134%, throws 2 stars."/>
+    <string name="h18" value="MP -15. Damage 140%, throws 2 stars."/>
+    <string name="h19" value="MP -15. Damage 144%, throws 2 stars."/>
+    <string name="h20" value="MP -16. Damage 150%, throws 2 stars."/>
   </imgdir>
   <imgdir name="110">
     <string name="bookName" value="Fighter Techniques"/>
@@ -2382,37 +2382,37 @@
   </imgdir>
   <imgdir name="4201005">
     <string name="name" value="Savage Blow"/>
-    <string name="desc" value="[Master Level : 30]\nUse MP to attack an enemy up to 6 times in a row with a dagger."/>
-    <string name="h1" value="MP -15; attack 4x with 40% damage."/>
-    <string name="h2" value="MP -15; attack 4x with 44% damage."/>
-    <string name="h3" value="MP -15; attack 4x with 48% damage."/>
-    <string name="h4" value="MP -15; attack 4x with 52% damage."/>
-    <string name="h5" value="MP -15; attack 4x with 56% damage."/>
-    <string name="h6" value="MP -15; attack 4x with 60% damage."/>
-    <string name="h7" value="MP -15; attack 4x with 64% damage."/>
-    <string name="h8" value="MP -15; attack 4x with 68% damage."/>
-    <string name="h9" value="MP -15; attack 4x with 72% damage."/>
-    <string name="h10" value="MP -15; attack 4x with 74% damage."/>
-    <string name="h11" value="MP -18; attack 5x with 60% damage."/>
-    <string name="h12" value="MP -18; attack 5x with 62% damage."/>
-    <string name="h13" value="MP -18; attack 5x with 64% damage."/>
-    <string name="h14" value="MP -18; attack 5x with 66% damage."/>
-    <string name="h15" value="MP -18; attack 5x with 68% damage."/>
-    <string name="h16" value="MP -18; attack 5x with 70% damage."/>
-    <string name="h17" value="MP -18; attack 5x with 72% damage."/>
-    <string name="h18" value="MP -18; attack 5x with 74% damage."/>
-    <string name="h19" value="MP -18; attack 5x with 76% damage."/>
-    <string name="h20" value="MP -18; attack 5x with 78% damage."/>
-    <string name="h21" value="MP -27; attack 6x with 71% damage."/>
-    <string name="h22" value="MP -27; attack 6x with 72% damage."/>
-    <string name="h23" value="MP -27; attack 6x with 73% damage."/>
-    <string name="h24" value="MP -27; attack 6x with 74% damage."/>
-    <string name="h25" value="MP -27; attack 6x with 75% damage."/>
-    <string name="h26" value="MP -27; attack 6x with 76% damage."/>
-    <string name="h27" value="MP -27; attack 6x with 77% damage."/>
-    <string name="h28" value="MP -27; attack 6x with 78% damage."/>
-    <string name="h29" value="MP -27; attack 6x with 79% damage."/>
-    <string name="h30" value="MP -27; attack 6x with 80% damage."/>
+    <string name="desc" value="[Master Level : 30]\nUses MP to attack one enemy several times in a row with a dagger."/>
+    <string name="h1" value="MP -15. Attacks 4 times with 40% damage."/>
+    <string name="h2" value="MP -15. Attacks 4 times with 44% damage."/>
+    <string name="h3" value="MP -15. Attacks 4 times with 48% damage."/>
+    <string name="h4" value="MP -15. Attacks 4 times with 52% damage."/>
+    <string name="h5" value="MP -15. Attacks 4 times with 56% damage."/>
+    <string name="h6" value="MP -15. Attacks 4 times with 60% damage."/>
+    <string name="h7" value="MP -15. Attacks 4 times with 64% damage."/>
+    <string name="h8" value="MP -15. Attacks 4 times with 68% damage."/>
+    <string name="h9" value="MP -15. Attacks 4 times with 72% damage."/>
+    <string name="h10" value="MP -15. Attacks 4 times with 74% damage."/>
+    <string name="h11" value="MP -18. Attacks 5 times with 60% damage."/>
+    <string name="h12" value="MP -18. Attacks 5 times with 62% damage."/>
+    <string name="h13" value="MP -18. Attacks 5 times with 64% damage."/>
+    <string name="h14" value="MP -18. Attacks 5 times with 66% damage."/>
+    <string name="h15" value="MP -18. Attacks 5 times with 68% damage."/>
+    <string name="h16" value="MP -18. Attacks 5 times with 70% damage."/>
+    <string name="h17" value="MP -18. Attacks 5 times with 72% damage."/>
+    <string name="h18" value="MP -18. Attacks 5 times with 74% damage."/>
+    <string name="h19" value="MP -18. Attacks 5 times with 76% damage."/>
+    <string name="h20" value="MP -18. Attacks 5 times with 78% damage."/>
+    <string name="h21" value="MP -27. Attacks 6 times with 71% damage."/>
+    <string name="h22" value="MP -27. Attacks 6 times with 72% damage."/>
+    <string name="h23" value="MP -27. Attacks 6 times with 73% damage."/>
+    <string name="h24" value="MP -27. Attacks 6 times with 74% damage."/>
+    <string name="h25" value="MP -27. Attacks 6 times with 75% damage."/>
+    <string name="h26" value="MP -27. Attacks 6 times with 76% damage."/>
+    <string name="h27" value="MP -27. Attacks 6 times with 77% damage."/>
+    <string name="h28" value="MP -27. Attacks 6 times with 78% damage."/>
+    <string name="h29" value="MP -27. Attacks 6 times with 79% damage."/>
+    <string name="h30" value="MP -27. Attacks 6 times with 80% damage."/>
   </imgdir>
   <imgdir name="111">
     <string name="bookName" value="Crusader&apos;s Guide"/>
@@ -4427,27 +4427,27 @@
   </imgdir>
   <imgdir name="4111003">
     <string name="name" value="Shadow Web"/>
-    <string name="desc" value="[Spider Web : 20]\nCreates a web of shadow of oneself to hold up to 6 monsters. Once stuck, the monsters held in the spiderweb will be unable to move."/>
-    <string name="h1" value="MP - 10; For 5 sec., holds the enemies with 42% success rate"/>
-    <string name="h2" value="MP - 10; For 5 sec., holds the enemies with 44% success rate"/>
-    <string name="h3" value="MP - 10; For 5 sec., holds the enemies with 46% success rate"/>
-    <string name="h4" value="MP - 10; For 5 sec., holds the enemies with 48% success rate"/>
-    <string name="h5" value="MP - 10; For 5 sec., holds the enemies with 50% success rate"/>
-    <string name="h6" value="MP - 14; For 6 sec., holds the enemies with 52% success rate"/>
-    <string name="h7" value="MP - 14; For 6 sec., holds the enemies with 54% success rate"/>
-    <string name="h8" value="MP - 14; For 6 sec., holds the enemies with 56% success rate"/>
-    <string name="h9" value="MP - 14; For 6 sec., holds the enemies with 58% success rate"/>
-    <string name="h10" value="MP - 14; For 6 sec., holds the enemies with 60% success rate"/>
-    <string name="h11" value="MP - 18; For 7 sec., holds the enemies with 62% success rate"/>
-    <string name="h12" value="MP - 18; For 7 sec., holds the enemies with 64% success rate"/>
-    <string name="h13" value="MP - 18; For 7 sec., holds the enemies with 66% success rate"/>
-    <string name="h14" value="MP - 18; For 7 sec., holds the enemies with 68% success rate"/>
-    <string name="h15" value="MP - 18; For 7 sec., holds the enemies with 70% success rate"/>
-    <string name="h16" value="MP - 22; For 8 sec., holds the enemies with 72% success rate"/>
-    <string name="h17" value="MP - 22; For 8 sec., holds the enemies with 74% success rate"/>
-    <string name="h18" value="MP - 22; For 8 sec., holds the enemies with 76% success rate"/>
-    <string name="h19" value="MP - 22; For 8 sec., holds the enemies with 78% success rate"/>
-    <string name="h20" value="MP - 22; For 8 sec., holds the enemies with 80% success rate"/>
+    <string name="desc" value="[Master Level : 20]\nCreates a web of shadow to hold up to 6 enemies. Enemies caught in the web cannot move."/>
+    <string name="h1" value="MP - 10. Holds up to 6 enemies for 5 sec. Success rate 42%."/>
+    <string name="h2" value="MP - 10. Holds up to 6 enemies for 5 sec. Success rate 44%."/>
+    <string name="h3" value="MP - 10. Holds up to 6 enemies for 5 sec. Success rate 46%."/>
+    <string name="h4" value="MP - 10. Holds up to 6 enemies for 5 sec. Success rate 48%."/>
+    <string name="h5" value="MP - 10. Holds up to 6 enemies for 5 sec. Success rate 50%."/>
+    <string name="h6" value="MP - 14. Holds up to 6 enemies for 6 sec. Success rate 52%."/>
+    <string name="h7" value="MP - 14. Holds up to 6 enemies for 6 sec. Success rate 54%."/>
+    <string name="h8" value="MP - 14. Holds up to 6 enemies for 6 sec. Success rate 56%."/>
+    <string name="h9" value="MP - 14. Holds up to 6 enemies for 6 sec. Success rate 58%."/>
+    <string name="h10" value="MP - 14. Holds up to 6 enemies for 6 sec. Success rate 60%."/>
+    <string name="h11" value="MP - 18. Holds up to 6 enemies for 7 sec. Success rate 62%."/>
+    <string name="h12" value="MP - 18. Holds up to 6 enemies for 7 sec. Success rate 64%."/>
+    <string name="h13" value="MP - 18. Holds up to 6 enemies for 7 sec. Success rate 66%."/>
+    <string name="h14" value="MP - 18. Holds up to 6 enemies for 7 sec. Success rate 68%."/>
+    <string name="h15" value="MP - 18. Holds up to 6 enemies for 7 sec. Success rate 70%."/>
+    <string name="h16" value="MP - 22. Holds up to 6 enemies for 8 sec. Success rate 72%."/>
+    <string name="h17" value="MP - 22. Holds up to 6 enemies for 8 sec. Success rate 74%."/>
+    <string name="h18" value="MP - 22. Holds up to 6 enemies for 8 sec. Success rate 76%."/>
+    <string name="h19" value="MP - 22. Holds up to 6 enemies for 8 sec. Success rate 78%."/>
+    <string name="h20" value="MP - 22. Holds up to 6 enemies for 8 sec. Success rate 80%."/>
   </imgdir>
   <imgdir name="4111004">
     <string name="name" value="Shadow Meso"/>
@@ -4485,37 +4485,37 @@
   </imgdir>
   <imgdir name="4111005">
     <string name="name" value="Avenger"/>
-    <string name="desc" value="[Master Level : 30]\nUses MP to make an enormous throwing star for attack. The throwing star will go through an enemy, and attack the ones behind it, too."/>
-    <string name="h1" value="MP - 16; Uses 3 throwing stars to attack upto 4 enemies, Damage 65%"/>
-    <string name="h2" value="MP - 16; Uses 3 throwing stars to attack upto 4 enemies, Damage 70%"/>
-    <string name="h3" value="MP - 16; Uses 3 throwing stars to attack upto 4 enemies, Damage 75%"/>
-    <string name="h4" value="MP - 16; Uses 3 throwing stars to attack upto 4 enemies, Damage 80%"/>
-    <string name="h5" value="MP - 16; Uses 3 throwing stars to attack upto 4 enemies, Damage 85%"/>
-    <string name="h6" value="MP - 16; Uses 3 throwing stars to attack upto 4 enemies, Damage 90%"/>
-    <string name="h7" value="MP - 16; Uses 3 throwing stars to attack upto 4 enemies, Damage 95%"/>
-    <string name="h8" value="MP - 16; Uses 3 throwing stars to attack upto 4 enemies, Damage 100%"/>
-    <string name="h9" value="MP - 16; Uses 3 throwing stars to attack upto 4 enemies, Damage 105%"/>
-    <string name="h10" value="MP - 16; Uses 3 throwing stars to attack upto 4 enemies, Damage 110%"/>
-    <string name="h11" value="MP - 23; Uses 3 throwing stars to attack upto 5 enemies, Damage 114%"/>
-    <string name="h12" value="MP - 23; Uses 3 throwing stars to attack upto 5 enemies, Damage 118%"/>
-    <string name="h13" value="MP - 23; Uses 3 throwing stars to attack upto 5 enemies, Damage 122%"/>
-    <string name="h14" value="MP - 23; Uses 3 throwing stars to attack upto 5 enemies, Damage 126%"/>
-    <string name="h15" value="MP - 23; Uses 3 throwing stars to attack upto 5 enemies, Damage 130%"/>
-    <string name="h16" value="MP - 23; Uses 3 throwing stars to attack upto 5 enemies, Damage 134%"/>
-    <string name="h17" value="MP - 23; Uses 3 throwing stars to attack upto 5 enemies, Damage 138%"/>
-    <string name="h18" value="MP - 23; Uses 3 throwing stars to attack upto 5 enemies, Damage 142%"/>
-    <string name="h19" value="MP - 23; Uses 3 throwing stars to attack upto 5 enemies, Damage 146%"/>
-    <string name="h20" value="MP - 23; Uses 3 throwing stars to attack upto 5 enemies, Damage 150%"/>
-    <string name="h21" value="MP - 30; Uses 3 throwing stars to attack upto 6 enemies, Damage 153%"/>
-    <string name="h22" value="MP - 30; Uses 3 throwing stars to attack upto 6 enemies, Damage 156%"/>
-    <string name="h23" value="MP - 30; Uses 3 throwing stars to attack upto 6 enemies, Damage 159%"/>
-    <string name="h24" value="MP - 30; Uses 3 throwing stars to attack upto 6 enemies, Damage 162%"/>
-    <string name="h25" value="MP - 30; Uses 3 throwing stars to attack upto 6 enemies, Damage 165%"/>
-    <string name="h26" value="MP - 30; Uses 3 throwing stars to attack upto 6 enemies, Damage 168%"/>
-    <string name="h27" value="MP - 30; Uses 3 throwing stars to attack upto 6 enemies, Damage 171%"/>
-    <string name="h28" value="MP - 30; Uses 3 throwing stars to attack upto 6 enemies, Damage 174%"/>
-    <string name="h29" value="MP - 30; Uses 3 throwing stars to attack upto 6 enemies, Damage 177%"/>
-    <string name="h30" value="MP - 30; Uses 3 throwing stars to attack upto 6 enemies, Damage 180%"/>
+    <string name="desc" value="[Master Level : 30]\nUses MP to create a giant throwing star that pierces enemies and attacks enemies behind them."/>
+    <string name="h1" value="MP -16. Uses 3 throwing stars to attack up to 4 enemies. Damage 65%."/>
+    <string name="h2" value="MP -16. Uses 3 throwing stars to attack up to 4 enemies. Damage 70%."/>
+    <string name="h3" value="MP -16. Uses 3 throwing stars to attack up to 4 enemies. Damage 75%."/>
+    <string name="h4" value="MP -16. Uses 3 throwing stars to attack up to 4 enemies. Damage 80%."/>
+    <string name="h5" value="MP -16. Uses 3 throwing stars to attack up to 4 enemies. Damage 85%."/>
+    <string name="h6" value="MP -16. Uses 3 throwing stars to attack up to 4 enemies. Damage 90%."/>
+    <string name="h7" value="MP -16. Uses 3 throwing stars to attack up to 4 enemies. Damage 95%."/>
+    <string name="h8" value="MP -16. Uses 3 throwing stars to attack up to 4 enemies. Damage 100%."/>
+    <string name="h9" value="MP -16. Uses 3 throwing stars to attack up to 4 enemies. Damage 105%."/>
+    <string name="h10" value="MP -16. Uses 3 throwing stars to attack up to 4 enemies. Damage 110%."/>
+    <string name="h11" value="MP -23. Uses 3 throwing stars to attack up to 5 enemies. Damage 114%."/>
+    <string name="h12" value="MP -23. Uses 3 throwing stars to attack up to 5 enemies. Damage 118%."/>
+    <string name="h13" value="MP -23. Uses 3 throwing stars to attack up to 5 enemies. Damage 122%."/>
+    <string name="h14" value="MP -23. Uses 3 throwing stars to attack up to 5 enemies. Damage 126%."/>
+    <string name="h15" value="MP -23. Uses 3 throwing stars to attack up to 5 enemies. Damage 130%."/>
+    <string name="h16" value="MP -23. Uses 3 throwing stars to attack up to 5 enemies. Damage 134%."/>
+    <string name="h17" value="MP -23. Uses 3 throwing stars to attack up to 5 enemies. Damage 138%."/>
+    <string name="h18" value="MP -23. Uses 3 throwing stars to attack up to 5 enemies. Damage 142%."/>
+    <string name="h19" value="MP -23. Uses 3 throwing stars to attack up to 5 enemies. Damage 146%."/>
+    <string name="h20" value="MP -23. Uses 3 throwing stars to attack up to 5 enemies. Damage 150%."/>
+    <string name="h21" value="MP -30. Uses 3 throwing stars to attack up to 6 enemies. Damage 153%."/>
+    <string name="h22" value="MP -30. Uses 3 throwing stars to attack up to 6 enemies. Damage 156%."/>
+    <string name="h23" value="MP -30. Uses 3 throwing stars to attack up to 6 enemies. Damage 159%."/>
+    <string name="h24" value="MP -30. Uses 3 throwing stars to attack up to 6 enemies. Damage 162%."/>
+    <string name="h25" value="MP -30. Uses 3 throwing stars to attack up to 6 enemies. Damage 165%."/>
+    <string name="h26" value="MP -30. Uses 3 throwing stars to attack up to 6 enemies. Damage 168%."/>
+    <string name="h27" value="MP -30. Uses 3 throwing stars to attack up to 6 enemies. Damage 171%."/>
+    <string name="h28" value="MP -30. Uses 3 throwing stars to attack up to 6 enemies. Damage 174%."/>
+    <string name="h29" value="MP -30. Uses 3 throwing stars to attack up to 6 enemies. Damage 177%."/>
+    <string name="h30" value="MP -30. Uses 3 throwing stars to attack up to 6 enemies. Damage 180%."/>
   </imgdir>
   <imgdir name="4111006">
     <string name="name" value="Flash Jump"/>
@@ -4546,95 +4546,95 @@
   </imgdir>
   <imgdir name="4210000">
     <string name="name" value="Shield Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the def. of the equipped shield. Only works when the shield is equipped."/>
-    <string name="h1" value="Shield def. + 5%; Has to be equipped"/>
-    <string name="h2" value="Shield def. + 10%; Has to be equipped"/>
-    <string name="h3" value="Shield def. + 15%; Has to be equipped"/>
-    <string name="h4" value="Shield def. + 20%; Has to be equipped"/>
-    <string name="h5" value="Shield def. + 25%; Has to be equipped"/>
-    <string name="h6" value="Shield def. + 30%; Has to be equipped"/>
-    <string name="h7" value="Shield def. + 35%; Has to be equipped"/>
-    <string name="h8" value="Shield def. + 40%; Has to be equipped"/>
-    <string name="h9" value="Shield def. + 45%; Has to be equipped"/>
-    <string name="h10" value="Shield def. + 50%; Has to be equipped"/>
-    <string name="h11" value="Shield def. + 55%; Has to be equipped"/>
-    <string name="h12" value="Shield def. + 60%; Has to be equipped"/>
-    <string name="h13" value="Shield def. + 65%; Has to be equipped"/>
-    <string name="h14" value="Shield def. + 70%; Has to be equipped"/>
-    <string name="h15" value="Shield def. + 75%; Has to be equipped"/>
-    <string name="h16" value="Shield def. + 80%; Has to be equipped"/>
-    <string name="h17" value="Shield def. + 85%; Has to be equipped"/>
-    <string name="h18" value="Shield def. + 90%; Has to be equipped"/>
-    <string name="h19" value="Shield def. + 95%; Has to be equipped"/>
-    <string name="h20" value="Shield def. + 100%; Has to be equipped"/>
+    <string name="desc" value="[Master Level : 20]\nIncreases the weapon defense of the equipped shield. Only works when a shield is equipped."/>
+    <string name="h1" value="Shield def. + 5%. Has to be equipped."/>
+    <string name="h2" value="Shield def. + 10%. Has to be equipped."/>
+    <string name="h3" value="Shield def. + 15%. Has to be equipped."/>
+    <string name="h4" value="Shield def. + 20%. Has to be equipped."/>
+    <string name="h5" value="Shield def. + 25%. Has to be equipped."/>
+    <string name="h6" value="Shield def. + 30%. Has to be equipped."/>
+    <string name="h7" value="Shield def. + 35%. Has to be equipped."/>
+    <string name="h8" value="Shield def. + 40%. Has to be equipped."/>
+    <string name="h9" value="Shield def. + 45%. Has to be equipped."/>
+    <string name="h10" value="Shield def. + 50%. Has to be equipped."/>
+    <string name="h11" value="Shield def. + 55%. Has to be equipped."/>
+    <string name="h12" value="Shield def. + 60%. Has to be equipped."/>
+    <string name="h13" value="Shield def. + 65%. Has to be equipped."/>
+    <string name="h14" value="Shield def. + 70%. Has to be equipped."/>
+    <string name="h15" value="Shield def. + 75%. Has to be equipped."/>
+    <string name="h16" value="Shield def. + 80%. Has to be equipped."/>
+    <string name="h17" value="Shield def. + 85%. Has to be equipped."/>
+    <string name="h18" value="Shield def. + 90%. Has to be equipped."/>
+    <string name="h19" value="Shield def. + 95%. Has to be equipped."/>
+    <string name="h20" value="Shield def. + 100%. Has to be equipped."/>
   </imgdir>
   <imgdir name="4211001">
     <string name="name" value="Chakra"/>
-    <string name="desc" value="[Master Level : 30]\nUses MP to recover HP. Only works when the HP is less than 50%, and it&apos;ll stop if either attacked or moved."/>
-    <string name="h1" value="MP - 15, Recovery rate 9%; Damage during the recovery if hit: 200%"/>
-    <string name="h2" value="MP - 15, Recovery rate 18%; Damage during the recovery if hit: 196%"/>
-    <string name="h3" value="MP - 15, Recovery rate 27%; Damage during the recovery if hit: 192%"/>
-    <string name="h4" value="MP - 15, Recovery rate 36%; Damage during the recovery if hit: 188%"/>
-    <string name="h5" value="MP - 15, Recovery rate 45%; Damage during the recovery if hit: 184%"/>
-    <string name="h6" value="MP - 15, Recovery rate 54%; Damage during the recovery if hit: 180%"/>
-    <string name="h7" value="MP - 15, Recovery rate 62%; Damage during the recovery if hit: 176%"/>
-    <string name="h8" value="MP - 15, Recovery rate 70%; Damage during the recovery if hit: 172%"/>
-    <string name="h9" value="MP - 15, Recovery rate 78%; Damage during the recovery if hit: 168%"/>
-    <string name="h10" value="MP - 15, Recovery rate 86%; Damage during the recovery if hit: 164%"/>
-    <string name="h11" value="MP - 21, Recovery rate 94%; Damage during the recovery if hit: 160%"/>
-    <string name="h12" value="MP - 21, Recovery rate 101%; Damage during the recovery if hit: 157%"/>
-    <string name="h13" value="MP - 21, Recovery rate 108%; Damage during the recovery if hit: 154%"/>
-    <string name="h14" value="MP - 21, Recovery rate 115%; Damage during the recovery if hit: 151%"/>
-    <string name="h15" value="MP - 21, Recovery rate 122%; Damage during the recovery if hit: 148%"/>
-    <string name="h16" value="MP - 21, Recovery rate 129%; Damage during the recovery if hit: 145%"/>
-    <string name="h17" value="MP - 21, Recovery rate 135%; Damage during the recovery if hit: 142%"/>
-    <string name="h18" value="MP - 21, Recovery rate 141%; Damage during the recovery if hit: 139%"/>
-    <string name="h19" value="MP - 21, Recovery rate 147%; Damage during the recovery if hit: 136%"/>
-    <string name="h20" value="MP - 21, Recovery rate 153%; Damage during the recovery if hit: 133%"/>
-    <string name="h21" value="MP - 27, Recovery rate 159%; Damage during the recovery if hit: 130%"/>
-    <string name="h22" value="MP - 27, Recovery rate 164%; Damage during the recovery if hit: 128%"/>
-    <string name="h23" value="MP - 27, Recovery rate 169%; Damage during the recovery if hit: 126%"/>
-    <string name="h24" value="MP - 27, Recovery rate 174%; Damage during the recovery if hit: 124%"/>
-    <string name="h25" value="MP - 27, Recovery rate 179%; Damage during the recovery if hit: 122%"/>
-    <string name="h26" value="MP - 27, Recovery rate 184%; Damage during the recovery if hit: 120%"/>
-    <string name="h27" value="MP - 27, Recovery rate 188%; Damage during the recovery if hit: 118%"/>
-    <string name="h28" value="MP - 27, Recovery rate 192%; Damage during the recovery if hit: 116%"/>
-    <string name="h29" value="MP - 27, Recovery rate 196%; Damage during the recovery if hit: 114%"/>
-    <string name="h30" value="MP - 27, Recovery rate 200%; Damage during the recovery if hit: 112%"/>
+    <string name="desc" value="[Master Level : 30]\nUses MP to recover HP. Only works when HP is below 50%, and stops if you move or are attacked."/>
+    <string name="h1" value="MP - 15. Recovery rate 68%. Damage received during recovery 99%."/>
+    <string name="h2" value="MP - 15. Recovery rate 76%. Damage received during recovery 98%."/>
+    <string name="h3" value="MP - 15. Recovery rate 84%. Damage received during recovery 97%."/>
+    <string name="h4" value="MP - 15. Recovery rate 92%. Damage received during recovery 96%."/>
+    <string name="h5" value="MP - 15. Recovery rate 100%. Damage received during recovery 95%."/>
+    <string name="h6" value="MP - 15. Recovery rate 108%. Damage received during recovery 94%."/>
+    <string name="h7" value="MP - 15. Recovery rate 116%. Damage received during recovery 93%."/>
+    <string name="h8" value="MP - 15. Recovery rate 124%. Damage received during recovery 92%."/>
+    <string name="h9" value="MP - 15. Recovery rate 132%. Damage received during recovery 91%."/>
+    <string name="h10" value="MP - 15. Recovery rate 140%. Damage received during recovery 90%."/>
+    <string name="h11" value="MP - 21. Recovery rate 148%. Damage received during recovery 89%."/>
+    <string name="h12" value="MP - 21. Recovery rate 156%. Damage received during recovery 88%."/>
+    <string name="h13" value="MP - 21. Recovery rate 164%. Damage received during recovery 87%."/>
+    <string name="h14" value="MP - 21. Recovery rate 172%. Damage received during recovery 86%."/>
+    <string name="h15" value="MP - 21. Recovery rate 180%. Damage received during recovery 85%."/>
+    <string name="h16" value="MP - 21. Recovery rate 188%. Damage received during recovery 84%."/>
+    <string name="h17" value="MP - 21. Recovery rate 196%. Damage received during recovery 83%."/>
+    <string name="h18" value="MP - 21. Recovery rate 204%. Damage received during recovery 82%."/>
+    <string name="h19" value="MP - 21. Recovery rate 212%. Damage received during recovery 81%."/>
+    <string name="h20" value="MP - 21. Recovery rate 220%. Damage received during recovery 80%."/>
+    <string name="h21" value="MP - 27. Recovery rate 228%. Damage received during recovery 79%."/>
+    <string name="h22" value="MP - 27. Recovery rate 236%. Damage received during recovery 78%."/>
+    <string name="h23" value="MP - 27. Recovery rate 244%. Damage received during recovery 77%."/>
+    <string name="h24" value="MP - 27. Recovery rate 252%. Damage received during recovery 76%."/>
+    <string name="h25" value="MP - 27. Recovery rate 260%. Damage received during recovery 75%."/>
+    <string name="h26" value="MP - 27. Recovery rate 268%. Damage received during recovery 74%."/>
+    <string name="h27" value="MP - 27. Recovery rate 276%. Damage received during recovery 73%."/>
+    <string name="h28" value="MP - 27. Recovery rate 284%. Damage received during recovery 72%."/>
+    <string name="h29" value="MP - 27. Recovery rate 292%. Damage received during recovery 71%."/>
+    <string name="h30" value="MP - 27. Recovery rate 300%. Damage received during recovery 70%."/>
   </imgdir>
   <imgdir name="4211002">
     <string name="name" value="Assaulter"/>
-    <string name="desc" value="[Master Level : 30]\nAttacks a single monster with incredible power and speed. The attacked may even be stunned on a low succcess rate."/>
-    <string name="h1" value="MP - 12, Damage 210%, Stunner 22%"/>
-    <string name="h2" value="MP - 12, Damage 220%, Stunner 24%"/>
-    <string name="h3" value="MP - 12, Damage 230%, Stunner 26%"/>
-    <string name="h4" value="MP - 12, Damage 240%, Stunner 28%"/>
-    <string name="h5" value="MP - 12, Damage 250%, Stunner 30%"/>
-    <string name="h6" value="MP - 12, Damage 260%, Stunner 32%"/>
-    <string name="h7" value="MP - 12, Damage 270%, Stunner 34%"/>
-    <string name="h8" value="MP - 12, Damage 280%, Stunner 36%"/>
-    <string name="h9" value="MP - 12, Damage 290%, Stunner 38%"/>
-    <string name="h10" value="MP - 12, Damage 300%, Stunner 40%"/>
-    <string name="h11" value="MP - 19, Damage 310%, Stunner 42%"/>
-    <string name="h12" value="MP - 19, Damage 320%, Stunner 44%"/>
-    <string name="h13" value="MP - 19, Damage 330%, Stunner 46%"/>
-    <string name="h14" value="MP - 19, Damage 340%, Stunner 48%"/>
-    <string name="h15" value="MP - 19, Damage 350%, Stunner 50%"/>
-    <string name="h16" value="MP - 19, Damage 360%, Stunner 52%"/>
-    <string name="h17" value="MP - 19, Damage 370%, Stunner 54%"/>
-    <string name="h18" value="MP - 19, Damage 380%, Stunner 56%"/>
-    <string name="h19" value="MP - 19, Damage 390%, Stunner 58%"/>
-    <string name="h20" value="MP - 19, Damage 400%, Stunner 60%"/>
-    <string name="h21" value="MP - 26, Damage 405%, Stunner 62%"/>
-    <string name="h22" value="MP - 26, Damage 410%, Stunner 64%"/>
-    <string name="h23" value="MP - 26, Damage 415%, Stunner 66%"/>
-    <string name="h24" value="MP - 26, Damage 420%, Stunner 68%"/>
-    <string name="h25" value="MP - 26, Damage 425%, Stunner 70%"/>
-    <string name="h26" value="MP - 26, Damage 430%, Stunner 72%"/>
-    <string name="h27" value="MP - 26, Damage 435%, Stunner 74%"/>
-    <string name="h28" value="MP - 26, Damage 440%, Stunner 76%"/>
-    <string name="h29" value="MP - 26, Damage 445%, Stunner 78%"/>
-    <string name="h30" value="MP - 26, Damage 450%, Stunner 80%"/>
+    <string name="desc" value="[Master Level : 30]\nAttacks one enemy with incredible power and speed. The enemy may be stunned."/>
+    <string name="h1" value="MP - 12. Damage 210%. Stuns for 2 sec with 22% success rate."/>
+    <string name="h2" value="MP - 12. Damage 220%. Stuns for 2 sec with 24% success rate."/>
+    <string name="h3" value="MP - 12. Damage 230%. Stuns for 2 sec with 26% success rate."/>
+    <string name="h4" value="MP - 12. Damage 240%. Stuns for 2 sec with 28% success rate."/>
+    <string name="h5" value="MP - 12. Damage 250%. Stuns for 2 sec with 30% success rate."/>
+    <string name="h6" value="MP - 12. Damage 260%. Stuns for 2 sec with 32% success rate."/>
+    <string name="h7" value="MP - 12. Damage 270%. Stuns for 2 sec with 34% success rate."/>
+    <string name="h8" value="MP - 12. Damage 280%. Stuns for 2 sec with 36% success rate."/>
+    <string name="h9" value="MP - 12. Damage 290%. Stuns for 2 sec with 38% success rate."/>
+    <string name="h10" value="MP - 12. Damage 300%. Stuns for 2 sec with 40% success rate."/>
+    <string name="h11" value="MP - 19. Damage 310%. Stuns for 3 sec with 42% success rate."/>
+    <string name="h12" value="MP - 19. Damage 320%. Stuns for 3 sec with 44% success rate."/>
+    <string name="h13" value="MP - 19. Damage 330%. Stuns for 3 sec with 46% success rate."/>
+    <string name="h14" value="MP - 19. Damage 340%. Stuns for 3 sec with 48% success rate."/>
+    <string name="h15" value="MP - 19. Damage 350%. Stuns for 3 sec with 50% success rate."/>
+    <string name="h16" value="MP - 19. Damage 360%. Stuns for 3 sec with 52% success rate."/>
+    <string name="h17" value="MP - 19. Damage 370%. Stuns for 3 sec with 54% success rate."/>
+    <string name="h18" value="MP - 19. Damage 380%. Stuns for 3 sec with 56% success rate."/>
+    <string name="h19" value="MP - 19. Damage 390%. Stuns for 3 sec with 58% success rate."/>
+    <string name="h20" value="MP - 19. Damage 400%. Stuns for 3 sec with 60% success rate."/>
+    <string name="h21" value="MP - 26. Damage 405%. Stuns for 4 sec with 62% success rate."/>
+    <string name="h22" value="MP - 26. Damage 410%. Stuns for 4 sec with 64% success rate."/>
+    <string name="h23" value="MP - 26. Damage 415%. Stuns for 4 sec with 66% success rate."/>
+    <string name="h24" value="MP - 26. Damage 420%. Stuns for 4 sec with 68% success rate."/>
+    <string name="h25" value="MP - 26. Damage 425%. Stuns for 4 sec with 70% success rate."/>
+    <string name="h26" value="MP - 26. Damage 430%. Stuns for 4 sec with 72% success rate."/>
+    <string name="h27" value="MP - 26. Damage 435%. Stuns for 4 sec with 74% success rate."/>
+    <string name="h28" value="MP - 26. Damage 440%. Stuns for 4 sec with 76% success rate."/>
+    <string name="h29" value="MP - 26. Damage 445%. Stuns for 4 sec with 78% success rate."/>
+    <string name="h30" value="MP - 26. Damage 450%. Stuns for 4 sec with 80% success rate."/>
   </imgdir>
   <imgdir name="4211003">
     <string name="name" value="Pickpocket"/>
@@ -4662,95 +4662,95 @@
   </imgdir>
   <imgdir name="4211004">
     <string name="name" value="Band of Thieves"/>
-    <string name="desc" value="[Master Level : 30]\nSummons fellow bandits to attack up to 6 monsters around the area."/>
-    <string name="h1" value="MP - 10, Damage 110%, 1 &quot;other self&quot; will attack enemies"/>
-    <string name="h2" value="MP - 10, Damage 120%, 1 &quot;other self&quot; will attack enemies"/>
-    <string name="h3" value="MP - 10, Damage 130%, 1 &quot;other self&quot; will attack enemies"/>
-    <string name="h4" value="MP - 10, Damage 140%, 1 &quot;other self&quot; will attack enemies"/>
-    <string name="h5" value="MP - 10, Damage 150%, 1 &quot;other self&quot; will attack enemies"/>
-    <string name="h6" value="MP - 10, Damage 160%, 1 &quot;other self&quot; will attack enemies"/>
-    <string name="h7" value="MP - 20, Damage 120%, 2 &quot;other selves&quot; will attack enemies"/>
-    <string name="h8" value="MP - 20, Damage 130%, 2 &quot;other selves&quot; will attack enemies"/>
-    <string name="h9" value="MP - 20, Damage 140%, 2 &quot;other selves&quot; will attack enemies"/>
-    <string name="h10" value="MP - 20, Damage 150%, 2 &quot;other selves&quot; will attack enemies"/>
-    <string name="h11" value="MP - 20, Damage 160%, 2 &quot;other selves&quot; will attack enemies"/>
-    <string name="h12" value="MP - 20, Damage 170%, 2 &quot;other selves&quot; will attack enemies"/>
-    <string name="h13" value="MP - 30, Damage 130%, 3 &quot;other selves&quot; will attack enemies"/>
-    <string name="h14" value="MP - 30, Damage 140%, 3 &quot;other selves&quot; will attack enemies"/>
-    <string name="h15" value="MP - 30, Damage 150%, 3 &quot;other selves&quot; will attack enemies"/>
-    <string name="h16" value="MP - 30, Damage 160%, 3 &quot;other selves&quot; will attack enemies"/>
-    <string name="h17" value="MP - 30, Damage 170%, 3 &quot;other selves&quot; will attack enemies"/>
-    <string name="h18" value="MP - 30, Damage 180%, 3 &quot;other selves&quot; will attack enemies"/>
-    <string name="h19" value="MP - 40, Damage 140%, 4 &quot;other selves&quot; will attack enemies"/>
-    <string name="h20" value="MP - 40, Damage 150%, 4 &quot;other selves&quot; will attack enemies"/>
-    <string name="h21" value="MP - 40, Damage 160%, 4 &quot;other selves&quot; will attack enemies"/>
-    <string name="h22" value="MP - 40, Damage 170%, 4 &quot;other selves&quot; will attack enemies"/>
-    <string name="h23" value="MP - 40, Damage 180%, 4 &quot;other selves&quot; will attack enemies"/>
-    <string name="h24" value="MP - 40, Damage 190%, 4 &quot;other selves&quot; will attack enemies"/>
-    <string name="h25" value="MP - 25, Damage 160%, 5 &quot;other selves&quot; will attack enemies"/>
-    <string name="h26" value="MP - 25, Damage 170%, 5 &quot;other selves&quot; will attack enemies"/>
-    <string name="h27" value="MP - 25, Damage 180%, 5 &quot;other selves&quot; will attack enemies"/>
-    <string name="h28" value="MP - 25, Damage 190%, 5 &quot;other selves&quot; will attack enemies"/>
-    <string name="h29" value="MP - 25, Damage 200%, 5 &quot;other selves&quot; will attack enemies"/>
-    <string name="h30" value="MP - 25, Damage 210%, 5 &quot;other selves&quot; will attack enemies"/>
+    <string name="desc" value="[Master Level : 30]\nSummons fellow bandits to attack nearby enemies, up to 6 enemies at once."/>
+    <string name="h1" value="MP - 10. Damage 110%. 1 bandit(s) attack up to 2 enemies."/>
+    <string name="h2" value="MP - 10. Damage 120%. 1 bandit(s) attack up to 2 enemies."/>
+    <string name="h3" value="MP - 10. Damage 130%. 1 bandit(s) attack up to 2 enemies."/>
+    <string name="h4" value="MP - 10. Damage 140%. 1 bandit(s) attack up to 2 enemies."/>
+    <string name="h5" value="MP - 10. Damage 150%. 1 bandit(s) attack up to 2 enemies."/>
+    <string name="h6" value="MP - 13. Damage 160%. 1 bandit(s) attack up to 2 enemies."/>
+    <string name="h7" value="MP - 13. Damage 120%. 2 bandit(s) attack up to 3 enemies."/>
+    <string name="h8" value="MP - 13. Damage 130%. 2 bandit(s) attack up to 3 enemies."/>
+    <string name="h9" value="MP - 13. Damage 140%. 2 bandit(s) attack up to 3 enemies."/>
+    <string name="h10" value="MP - 13. Damage 150%. 2 bandit(s) attack up to 3 enemies."/>
+    <string name="h11" value="MP - 16. Damage 160%. 2 bandit(s) attack up to 3 enemies."/>
+    <string name="h12" value="MP - 16. Damage 170%. 2 bandit(s) attack up to 3 enemies."/>
+    <string name="h13" value="MP - 16. Damage 130%. 3 bandit(s) attack up to 4 enemies."/>
+    <string name="h14" value="MP - 16. Damage 140%. 3 bandit(s) attack up to 4 enemies."/>
+    <string name="h15" value="MP - 16. Damage 150%. 3 bandit(s) attack up to 4 enemies."/>
+    <string name="h16" value="MP - 19. Damage 160%. 3 bandit(s) attack up to 4 enemies."/>
+    <string name="h17" value="MP - 19. Damage 170%. 3 bandit(s) attack up to 4 enemies."/>
+    <string name="h18" value="MP - 19. Damage 180%. 3 bandit(s) attack up to 4 enemies."/>
+    <string name="h19" value="MP - 19. Damage 140%. 4 bandit(s) attack up to 5 enemies."/>
+    <string name="h20" value="MP - 19. Damage 150%. 4 bandit(s) attack up to 5 enemies."/>
+    <string name="h21" value="MP - 22. Damage 160%. 4 bandit(s) attack up to 5 enemies."/>
+    <string name="h22" value="MP - 22. Damage 170%. 4 bandit(s) attack up to 5 enemies."/>
+    <string name="h23" value="MP - 22. Damage 180%. 4 bandit(s) attack up to 5 enemies."/>
+    <string name="h24" value="MP - 22. Damage 190%. 4 bandit(s) attack up to 5 enemies."/>
+    <string name="h25" value="MP - 22. Damage 160%. 5 bandit(s) attack up to 6 enemies."/>
+    <string name="h26" value="MP - 25. Damage 170%. 5 bandit(s) attack up to 6 enemies."/>
+    <string name="h27" value="MP - 25. Damage 180%. 5 bandit(s) attack up to 6 enemies."/>
+    <string name="h28" value="MP - 25. Damage 190%. 5 bandit(s) attack up to 6 enemies."/>
+    <string name="h29" value="MP - 25. Damage 200%. 5 bandit(s) attack up to 6 enemies."/>
+    <string name="h30" value="MP - 25. Damage 210%. 5 bandit(s) attack up to 6 enemies."/>
   </imgdir>
   <imgdir name="4211005">
     <string name="name" value="Meso Guard"/>
-    <string name="desc" value="[Master Level : 20]\nUses mesos to guard 50% of the damage received. Once the skill is used, it saves up a certain amount of mesos, and once damaged from then on out, the mesos will be used based on the damage received. The skill will be turned off when the saved mesos are used up.\nRequired Skill : #cAt least Level 3 on Chakra#"/>
-    <string name="h1" value="MP - 20, Save up 200 mesos, 90% of the guarded damage replaced with mesos"/>
-    <string name="h2" value="MP - 20, Save up 400 mesos, 90% of the guarded damage replaced with mesos"/>
-    <string name="h3" value="MP - 20, Save up 600 mesos, 89% of the guarded damage replaced with mesos"/>
-    <string name="h4" value="MP - 20, Save up 800 mesos, 89% of the guarded damage replaced with mesos"/>
-    <string name="h5" value="MP - 20, Save up 1000 mesos, 88% of the guarded damage replaced with mesos"/>
-    <string name="h6" value="MP - 25, Save up 1200 mesos, 88% of the guarded damage replaced with mesos"/>
-    <string name="h7" value="MP - 25, Save up 1400 mesos, 87% of the guarded damage replaced with mesos"/>
-    <string name="h8" value="MP - 25, Save up 1600 mesos, 87% of the guarded damage replaced with mesos"/>
-    <string name="h9" value="MP - 25, Save up 1800 mesos, 86% of the guarded damage replaced with mesos"/>
-    <string name="h10" value="MP - 25, Save up 2000 mesos, 86% of the guarded damage replaced with mesos"/>
-    <string name="h11" value="MP - 30, Save up 2100 mesos, 85% of the guarded damage replaced with mesos"/>
-    <string name="h12" value="MP - 30, Save up 2200 mesos, 85% of the guarded damage replaced with mesos"/>
-    <string name="h13" value="MP - 30, Save up 2300 mesos, 84% of the guarded damage replaced with mesos"/>
-    <string name="h14" value="MP - 30, Save up 2400 mesos, 84% of the guarded damage replaced with mesos"/>
-    <string name="h15" value="MP - 30, Save up 2500 mesos, 83% of the guarded damage replaced with mesos"/>
-    <string name="h16" value="MP - 35, Save up 2500 mesos, 82% of the guarded damage replaced with mesos"/>
-    <string name="h17" value="MP - 35, Save up 2500 mesos, 81% of the guarded damage replaced with mesos"/>
-    <string name="h18" value="MP - 35, Save up 2500 mesos, 80% of the guarded damage replaced with mesos"/>
-    <string name="h19" value="MP - 35, Save up 2500 mesos, 79% of the guarded damage replaced with mesos"/>
-    <string name="h20" value="MP - 35, Save up 2500 mesos, 78% of the guarded damage replaced with mesos"/>
+    <string name="desc" value="[Master Level : 20]\nUses mesos to reduce incoming damage by 50%. Mesos are consumed based on the guarded damage. The skill ends when you run out of mesos.\nRequired Skill : #cAt least Level 3 on Chakra#"/>
+    <string name="h1" value="MP - 20. For 33 sec. Reduces damage by 50%; mesos consumed at 90% of guarded damage."/>
+    <string name="h2" value="MP - 20. For 36 sec. Reduces damage by 50%; mesos consumed at 90% of guarded damage."/>
+    <string name="h3" value="MP - 20. For 39 sec. Reduces damage by 50%; mesos consumed at 89% of guarded damage."/>
+    <string name="h4" value="MP - 20. For 42 sec. Reduces damage by 50%; mesos consumed at 89% of guarded damage."/>
+    <string name="h5" value="MP - 20. For 45 sec. Reduces damage by 50%; mesos consumed at 88% of guarded damage."/>
+    <string name="h6" value="MP - 25. For 58 sec. Reduces damage by 50%; mesos consumed at 88% of guarded damage."/>
+    <string name="h7" value="MP - 25. For 61 sec. Reduces damage by 50%; mesos consumed at 87% of guarded damage."/>
+    <string name="h8" value="MP - 25. For 64 sec. Reduces damage by 50%; mesos consumed at 87% of guarded damage."/>
+    <string name="h9" value="MP - 25. For 67 sec. Reduces damage by 50%; mesos consumed at 86% of guarded damage."/>
+    <string name="h10" value="MP - 25. For 70 sec. Reduces damage by 50%; mesos consumed at 86% of guarded damage."/>
+    <string name="h11" value="MP - 30. For 83 sec. Reduces damage by 50%; mesos consumed at 85% of guarded damage."/>
+    <string name="h12" value="MP - 30. For 86 sec. Reduces damage by 50%; mesos consumed at 85% of guarded damage."/>
+    <string name="h13" value="MP - 30. For 89 sec. Reduces damage by 50%; mesos consumed at 84% of guarded damage."/>
+    <string name="h14" value="MP - 30. For 92 sec. Reduces damage by 50%; mesos consumed at 84% of guarded damage."/>
+    <string name="h15" value="MP - 30. For 95 sec. Reduces damage by 50%; mesos consumed at 83% of guarded damage."/>
+    <string name="h16" value="MP - 35. For 108 sec. Reduces damage by 50%; mesos consumed at 82% of guarded damage."/>
+    <string name="h17" value="MP - 35. For 111 sec. Reduces damage by 50%; mesos consumed at 81% of guarded damage."/>
+    <string name="h18" value="MP - 35. For 114 sec. Reduces damage by 50%; mesos consumed at 80% of guarded damage."/>
+    <string name="h19" value="MP - 35. For 117 sec. Reduces damage by 50%; mesos consumed at 79% of guarded damage."/>
+    <string name="h20" value="MP - 35. For 120 sec. Reduces damage by 50%; mesos consumed at 78% of guarded damage."/>
   </imgdir>
   <imgdir name="4211006">
     <string name="name" value="Meso Explosion"/>
-    <string name="desc" value="[Master Level : 30]\nExplodes the mesos dropped on the ground around you to attack monsters. The mesos from the monsters killed by someone else will not be able to be used for this."/>
-    <string name="h1" value="MP - 18, Mastery 50%, Explode upto 10"/>
-    <string name="h2" value="MP - 18, Mastery 52%, Explode upto 10"/>
-    <string name="h3" value="MP - 18, Mastery 54%, Explode upto 10"/>
-    <string name="h4" value="MP - 18, Mastery 56%, Explode upto 10"/>
-    <string name="h5" value="MP - 18, Mastery 58%, Explode upto 10"/>
-    <string name="h6" value="MP - 18, Mastery 60%, Explode upto 12"/>
-    <string name="h7" value="MP - 18, Mastery 62%, Explode upto 12"/>
-    <string name="h8" value="MP - 18, Mastery 64%, Explode upto 12"/>
-    <string name="h9" value="MP - 18, Mastery 66%, Explode upto 12"/>
-    <string name="h10" value="MP - 18, Mastery 68%, Explode upto 12"/>
-    <string name="h11" value="MP - 24, Mastery 70%, Explode upto 14"/>
-    <string name="h12" value="MP - 24, Mastery 72%, Explode upto 14"/>
-    <string name="h13" value="MP - 24, Mastery 74%, Explode upto 14"/>
-    <string name="h14" value="MP - 24, Mastery 76%, Explode upto 14"/>
-    <string name="h15" value="MP - 24, Mastery 78%, Explode upto 14"/>
-    <string name="h16" value="MP - 24, Mastery 80%, Explode upto 16"/>
-    <string name="h17" value="MP - 24, Mastery 82%, Explode upto 16"/>
-    <string name="h18" value="MP - 24, Mastery 84%, Explode upto 16"/>
-    <string name="h19" value="MP - 24, Mastery 86%, Explode upto 16"/>
-    <string name="h20" value="MP - 24, Mastery 88%, Explode upto 16"/>
-    <string name="h21" value="MP - 30, Mastery 90%, Explode upto 18"/>
-    <string name="h22" value="MP - 30, Mastery 92%, Explode upto 18"/>
-    <string name="h23" value="MP - 30, Mastery 93%, Explode upto 18"/>
-    <string name="h24" value="MP - 30, Mastery 94%, Explode upto 18"/>
-    <string name="h25" value="MP - 30, Mastery 95%, Explode upto 18"/>
-    <string name="h26" value="MP - 30, Mastery 96%, Explode upto 20"/>
-    <string name="h27" value="MP - 30, Mastery 97%, Explode upto 20"/>
-    <string name="h28" value="MP - 30, Mastery 98%, Explode upto 20"/>
-    <string name="h29" value="MP - 30, Mastery 99%, Explode upto 20"/>
-    <string name="h30" value="MP - 30, Mastery 100%, Explode upto 20"/>
+    <string name="desc" value="[Master Level : 30]\nExplodes mesos dropped on the ground to attack enemies. Mesos dropped by monsters killed by someone else cannot be used."/>
+    <string name="h1" value="MP - 18. Mastery 50%. Explodes up to 10 mesos and attacks up to 6 enemies."/>
+    <string name="h2" value="MP - 18. Mastery 52%. Explodes up to 10 mesos and attacks up to 6 enemies."/>
+    <string name="h3" value="MP - 18. Mastery 54%. Explodes up to 10 mesos and attacks up to 6 enemies."/>
+    <string name="h4" value="MP - 18. Mastery 56%. Explodes up to 10 mesos and attacks up to 6 enemies."/>
+    <string name="h5" value="MP - 18. Mastery 58%. Explodes up to 10 mesos and attacks up to 6 enemies."/>
+    <string name="h6" value="MP - 18. Mastery 60%. Explodes up to 12 mesos and attacks up to 6 enemies."/>
+    <string name="h7" value="MP - 18. Mastery 62%. Explodes up to 12 mesos and attacks up to 6 enemies."/>
+    <string name="h8" value="MP - 18. Mastery 64%. Explodes up to 12 mesos and attacks up to 6 enemies."/>
+    <string name="h9" value="MP - 18. Mastery 66%. Explodes up to 12 mesos and attacks up to 6 enemies."/>
+    <string name="h10" value="MP - 18. Mastery 68%. Explodes up to 12 mesos and attacks up to 6 enemies."/>
+    <string name="h11" value="MP - 24. Mastery 70%. Explodes up to 14 mesos and attacks up to 6 enemies."/>
+    <string name="h12" value="MP - 24. Mastery 72%. Explodes up to 14 mesos and attacks up to 6 enemies."/>
+    <string name="h13" value="MP - 24. Mastery 74%. Explodes up to 14 mesos and attacks up to 6 enemies."/>
+    <string name="h14" value="MP - 24. Mastery 76%. Explodes up to 14 mesos and attacks up to 6 enemies."/>
+    <string name="h15" value="MP - 24. Mastery 78%. Explodes up to 14 mesos and attacks up to 6 enemies."/>
+    <string name="h16" value="MP - 24. Mastery 80%. Explodes up to 16 mesos and attacks up to 6 enemies."/>
+    <string name="h17" value="MP - 24. Mastery 82%. Explodes up to 16 mesos and attacks up to 6 enemies."/>
+    <string name="h18" value="MP - 24. Mastery 84%. Explodes up to 16 mesos and attacks up to 6 enemies."/>
+    <string name="h19" value="MP - 24. Mastery 86%. Explodes up to 16 mesos and attacks up to 6 enemies."/>
+    <string name="h20" value="MP - 24. Mastery 88%. Explodes up to 16 mesos and attacks up to 6 enemies."/>
+    <string name="h21" value="MP - 30. Mastery 90%. Explodes up to 18 mesos and attacks up to 6 enemies."/>
+    <string name="h22" value="MP - 30. Mastery 92%. Explodes up to 18 mesos and attacks up to 6 enemies."/>
+    <string name="h23" value="MP - 30. Mastery 93%. Explodes up to 18 mesos and attacks up to 6 enemies."/>
+    <string name="h24" value="MP - 30. Mastery 94%. Explodes up to 18 mesos and attacks up to 6 enemies."/>
+    <string name="h25" value="MP - 30. Mastery 95%. Explodes up to 18 mesos and attacks up to 6 enemies."/>
+    <string name="h26" value="MP - 30. Mastery 96%. Explodes up to 20 mesos and attacks up to 6 enemies."/>
+    <string name="h27" value="MP - 30. Mastery 97%. Explodes up to 20 mesos and attacks up to 6 enemies."/>
+    <string name="h28" value="MP - 30. Mastery 98%. Explodes up to 20 mesos and attacks up to 6 enemies."/>
+    <string name="h29" value="MP - 30. Mastery 99%. Explodes up to 20 mesos and attacks up to 6 enemies."/>
+    <string name="h30" value="MP - 30. Mastery 100%. Explodes up to 20 mesos and attacks up to 6 enemies."/>
   </imgdir>
   <imgdir name="900">
     <string name="bookName" value="Admin. Skill Book (Normal)"/>
@@ -7204,7 +7204,7 @@
   </imgdir>
   <imgdir name="4121000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
+    <string name="desc" value="Increases all party members&apos; stats by a certain percentage for a set time."/>
     <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
     <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
     <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
@@ -7238,37 +7238,37 @@
   </imgdir>
   <imgdir name="4120002">
     <string name="name" value="Shadow Shifter"/>
-    <string name="desc" value="With great reflexes, enables one to avoid the monster&apos;s attack."/>
-    <string name="h1" value="Avoid enemy&apos;s attack with success rate 1%"/>
-    <string name="h2" value="Avoid enemy&apos;s attack with success rate 2%"/>
-    <string name="h3" value="Avoid enemy&apos;s attack with success rate 3%"/>
-    <string name="h4" value="Avoid enemy&apos;s attack with success rate 4%"/>
-    <string name="h5" value="Avoid enemy&apos;s attack with success rate 5%"/>
-    <string name="h6" value="Avoid enemy&apos;s attack with success rate 6%"/>
-    <string name="h7" value="Avoid enemy&apos;s attack with success rate 7%"/>
-    <string name="h8" value="Avoid enemy&apos;s attack with success rate 8%"/>
-    <string name="h9" value="Avoid enemy&apos;s attack with success rate 9%"/>
-    <string name="h10" value="Avoid enemy&apos;s attack with success rate 10%"/>
-    <string name="h11" value="Avoid enemy&apos;s attack with success rate 11%"/>
-    <string name="h12" value="Avoid enemy&apos;s attack with success rate 12%"/>
-    <string name="h13" value="Avoid enemy&apos;s attack with success rate 13%"/>
-    <string name="h14" value="Avoid enemy&apos;s attack with success rate 14%"/>
-    <string name="h15" value="Avoid enemy&apos;s attack with success rate 15%"/>
-    <string name="h16" value="Avoid enemy&apos;s attack with success rate 16%"/>
-    <string name="h17" value="Avoid enemy&apos;s attack with success rate 17%"/>
-    <string name="h18" value="Avoid enemy&apos;s attack with success rate 18%"/>
-    <string name="h19" value="Avoid enemy&apos;s attack with success rate 19%"/>
-    <string name="h20" value="Avoid enemy&apos;s attack with success rate 20%"/>
-    <string name="h21" value="Avoid enemy&apos;s attack with success rate 21%"/>
-    <string name="h22" value="Avoid enemy&apos;s attack with success rate 22%"/>
-    <string name="h23" value="Avoid enemy&apos;s attack with success rate 23%"/>
-    <string name="h24" value="Avoid enemy&apos;s attack with success rate 24%"/>
-    <string name="h25" value="Avoid enemy&apos;s attack with success rate 25%"/>
-    <string name="h26" value="Avoid enemy&apos;s attack with success rate 26%"/>
-    <string name="h27" value="Avoid enemy&apos;s attack with success rate 27%"/>
-    <string name="h28" value="Avoid enemy&apos;s attack with success rate 28%"/>
-    <string name="h29" value="Avoid enemy&apos;s attack with success rate 29%"/>
-    <string name="h30" value="Avoid enemy&apos;s attack with success rate 30%"/>
+    <string name="desc" value="With great reflexes, enables one to avoid enemy attacks."/>
+    <string name="h1" value="Avoid enemy attacks with 1% success rate."/>
+    <string name="h2" value="Avoid enemy attacks with 2% success rate."/>
+    <string name="h3" value="Avoid enemy attacks with 3% success rate."/>
+    <string name="h4" value="Avoid enemy attacks with 4% success rate."/>
+    <string name="h5" value="Avoid enemy attacks with 5% success rate."/>
+    <string name="h6" value="Avoid enemy attacks with 6% success rate."/>
+    <string name="h7" value="Avoid enemy attacks with 7% success rate."/>
+    <string name="h8" value="Avoid enemy attacks with 8% success rate."/>
+    <string name="h9" value="Avoid enemy attacks with 9% success rate."/>
+    <string name="h10" value="Avoid enemy attacks with 10% success rate."/>
+    <string name="h11" value="Avoid enemy attacks with 11% success rate."/>
+    <string name="h12" value="Avoid enemy attacks with 12% success rate."/>
+    <string name="h13" value="Avoid enemy attacks with 13% success rate."/>
+    <string name="h14" value="Avoid enemy attacks with 14% success rate."/>
+    <string name="h15" value="Avoid enemy attacks with 15% success rate."/>
+    <string name="h16" value="Avoid enemy attacks with 16% success rate."/>
+    <string name="h17" value="Avoid enemy attacks with 17% success rate."/>
+    <string name="h18" value="Avoid enemy attacks with 18% success rate."/>
+    <string name="h19" value="Avoid enemy attacks with 19% success rate."/>
+    <string name="h20" value="Avoid enemy attacks with 20% success rate."/>
+    <string name="h21" value="Avoid enemy attacks with 21% success rate."/>
+    <string name="h22" value="Avoid enemy attacks with 22% success rate."/>
+    <string name="h23" value="Avoid enemy attacks with 23% success rate."/>
+    <string name="h24" value="Avoid enemy attacks with 24% success rate."/>
+    <string name="h25" value="Avoid enemy attacks with 25% success rate."/>
+    <string name="h26" value="Avoid enemy attacks with 26% success rate."/>
+    <string name="h27" value="Avoid enemy attacks with 27% success rate."/>
+    <string name="h28" value="Avoid enemy attacks with 28% success rate."/>
+    <string name="h29" value="Avoid enemy attacks with 29% success rate."/>
+    <string name="h30" value="Avoid enemy attacks with 30% success rate."/>
   </imgdir>
   <imgdir name="4121003">
     <string name="name" value="Taunt"/>
@@ -7408,37 +7408,37 @@
   </imgdir>
   <imgdir name="4121007">
     <string name="name" value="Triple Throw"/>
-    <string name="desc" value="Attacks one monster by simultaneously throwing 3 stars."/>
-    <string name="h1" value="MP - 11, Damage 102%"/>
-    <string name="h2" value="MP - 11, Damage 104%"/>
-    <string name="h3" value="MP - 11, Damage 106%"/>
-    <string name="h4" value="MP - 12, Damage 108%"/>
-    <string name="h5" value="MP - 12, Damage 110%"/>
-    <string name="h6" value="MP - 12, Damage 112%"/>
-    <string name="h7" value="MP - 13, Damage 114%"/>
-    <string name="h8" value="MP - 13, Damage 116%"/>
-    <string name="h9" value="MP - 13, Damage 118%"/>
-    <string name="h10" value="MP - 14, Damage 120%"/>
-    <string name="h11" value="MP - 14, Damage 122%"/>
-    <string name="h12" value="MP - 14, Damage 124%"/>
-    <string name="h13" value="MP - 15, Damage 126%"/>
-    <string name="h14" value="MP - 15, Damage 128%"/>
-    <string name="h15" value="MP - 15, Damage 130%"/>
-    <string name="h16" value="MP - 16, Damage 132%"/>
-    <string name="h17" value="MP - 16, Damage 134%"/>
-    <string name="h18" value="MP - 16, Damage 136%"/>
-    <string name="h19" value="MP - 17, Damage 138%"/>
-    <string name="h20" value="MP - 17, Damage 140%"/>
-    <string name="h21" value="MP - 17, Damage 141%"/>
-    <string name="h22" value="MP - 18, Damage 142%"/>
-    <string name="h23" value="MP - 18, Damage 143%"/>
-    <string name="h24" value="MP - 18, Damage 144%"/>
-    <string name="h25" value="MP - 19, Damage 145%"/>
-    <string name="h26" value="MP - 19, Damage 146%"/>
-    <string name="h27" value="MP - 19, Damage 147%"/>
-    <string name="h28" value="MP - 20, Damage 148%"/>
-    <string name="h29" value="MP - 20, Damage 149%"/>
-    <string name="h30" value="MP - 20, Damage 150%"/>
+    <string name="desc" value="Attacks one enemy by simultaneously throwing 3 stars."/>
+    <string name="h1" value="MP -11. Damage 102%, throws 3 stars."/>
+    <string name="h2" value="MP -11. Damage 104%, throws 3 stars."/>
+    <string name="h3" value="MP -11. Damage 106%, throws 3 stars."/>
+    <string name="h4" value="MP -12. Damage 108%, throws 3 stars."/>
+    <string name="h5" value="MP -12. Damage 110%, throws 3 stars."/>
+    <string name="h6" value="MP -12. Damage 112%, throws 3 stars."/>
+    <string name="h7" value="MP -13. Damage 114%, throws 3 stars."/>
+    <string name="h8" value="MP -13. Damage 116%, throws 3 stars."/>
+    <string name="h9" value="MP -13. Damage 118%, throws 3 stars."/>
+    <string name="h10" value="MP -14. Damage 120%, throws 3 stars."/>
+    <string name="h11" value="MP -14. Damage 122%, throws 3 stars."/>
+    <string name="h12" value="MP -14. Damage 124%, throws 3 stars."/>
+    <string name="h13" value="MP -15. Damage 126%, throws 3 stars."/>
+    <string name="h14" value="MP -15. Damage 128%, throws 3 stars."/>
+    <string name="h15" value="MP -15. Damage 130%, throws 3 stars."/>
+    <string name="h16" value="MP -16. Damage 132%, throws 3 stars."/>
+    <string name="h17" value="MP -16. Damage 134%, throws 3 stars."/>
+    <string name="h18" value="MP -16. Damage 136%, throws 3 stars."/>
+    <string name="h19" value="MP -17. Damage 138%, throws 3 stars."/>
+    <string name="h20" value="MP -17. Damage 140%, throws 3 stars."/>
+    <string name="h21" value="MP -17. Damage 141%, throws 3 stars."/>
+    <string name="h22" value="MP -18. Damage 142%, throws 3 stars."/>
+    <string name="h23" value="MP -18. Damage 143%, throws 3 stars."/>
+    <string name="h24" value="MP -18. Damage 144%, throws 3 stars."/>
+    <string name="h25" value="MP -19. Damage 145%, throws 3 stars."/>
+    <string name="h26" value="MP -19. Damage 146%, throws 3 stars."/>
+    <string name="h27" value="MP -19. Damage 147%, throws 3 stars."/>
+    <string name="h28" value="MP -20. Damage 148%, throws 3 stars."/>
+    <string name="h29" value="MP -20. Damage 149%, throws 3 stars."/>
+    <string name="h30" value="MP -20. Damage 150%, throws 3 stars."/>
   </imgdir>
   <imgdir name="4121008">
     <string name="name" value="Ninja Storm"/>
@@ -7476,19 +7476,19 @@
   </imgdir>
   <imgdir name="4121009">
     <string name="name" value="Hero&apos;s Will"/>
-    <string name="desc" value="Enables one to shrug off abnormal conditions. The higher the skill level, the more types of abnormal conditions one can nullify."/>
-    <string name="h1" value="MP - 30 escape from abnormal condition, Terms between skills 600secs"/>
-    <string name="h2" value="MP - 30 escape from abnormal condition, Terms between skills 540secs"/>
-    <string name="h3" value="MP - 30 escape from abnormal condition, Terms between skills 480secs"/>
-    <string name="h4" value="MP - 30 escape from abnormal condition, Terms between skills 420secs"/>
-    <string name="h5" value="MP - 30 escape from abnormal condition, Terms between skills 360secs"/>
+    <string name="desc" value="Removes abnormal conditions such as seduce, zombify, and confusion. The higher the skill level, the shorter the cooldown."/>
+    <string name="h1" value="MP - 30. Escape from abnormal conditions. Cooldown 10 min."/>
+    <string name="h2" value="MP - 30. Escape from abnormal conditions. Cooldown 9 min."/>
+    <string name="h3" value="MP - 30. Escape from abnormal conditions. Cooldown 8 min."/>
+    <string name="h4" value="MP - 30. Escape from abnormal conditions. Cooldown 7 min."/>
+    <string name="h5" value="MP - 30. Escape from abnormal conditions. Cooldown 6 min."/>
   </imgdir>
   <imgdir name="422">
     <string name="bookName" value="Secret Skills of Shadower"/>
   </imgdir>
   <imgdir name="4221000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
+    <string name="desc" value="Increases all party members&apos; stats by a certain percentage for a set time."/>
     <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
     <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
     <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
@@ -7522,37 +7522,37 @@
   </imgdir>
   <imgdir name="4221001">
     <string name="name" value="Assassinate"/>
-    <string name="desc" value="Strikes an unsuspecting monster at its vital spots 4 times. The last strike can be lethal with a given success rate.  Only works with Dark Sight enabled."/>
-    <string name="h1" value="MP - 21, Attack 34%, for 6secs, accumulative damage, Critical Damage 105%, for success rate 32%"/>
-    <string name="h2" value="MP - 22, Attack 38%, for 6secs, accumulative damage, Critical Damage 110%, for success rate 34%"/>
-    <string name="h3" value="MP - 23, Attack 42%, for 6secs, accumulative damage, Critical Damage 115%, for success rate 36%"/>
-    <string name="h4" value="MP - 24, Attack 46%, for 6secs, accumulative damage, Critical Damage 120%, for success rate 38%"/>
-    <string name="h5" value="MP - 25, Attack 50%, for 6secs, accumulative damage, Critical Damage 125%, for success rate 40%"/>
-    <string name="h6" value="MP - 26, Attack 54%, for 6secs, accumulative damage, Critical Damage 130%, for success rate 42%"/>
-    <string name="h7" value="MP - 27, Attack 58%, for 6secs, accumulative damage, Critical Damage 135%, for success rate 44%"/>
-    <string name="h8" value="MP - 28, Attack 62%, for 6secs, accumulative damage, Critical Damage 140%, for success rate 46%"/>
-    <string name="h9" value="MP - 29, Attack 66%, for 6secs, accumulative damage, Critical Damage 145%, for success rate 48%"/>
-    <string name="h10" value="MP - 30, Attack 70%, for 6secs, accumulative damage, Critical Damage 150%, for success rate 50%"/>
-    <string name="h11" value="MP - 31, Attack 73%, for 9secs, accumulative damage, Critical Damage 155%, for success rate 52%"/>
-    <string name="h12" value="MP - 32, Attack 76%, for 9secs, accumulative damage, Critical Damage 160%, for success rate 54%"/>
-    <string name="h13" value="MP - 33, Attack 79%, for 9secs, accumulative damage, Critical Damage 165%, for success rate 56%"/>
-    <string name="h14" value="MP - 34, Attack 82%, for 9secs, accumulative damage, Critical Damage 170%, for success rate 58%"/>
-    <string name="h15" value="MP - 35, Attack 85%, for 9secs, accumulative damage, Critical Damage 175%, for success rate 60%"/>
-    <string name="h16" value="MP - 36, Attack 88%, for 9secs, accumulative damage, Critical Damage 180%, for success rate 62%"/>
-    <string name="h17" value="MP - 37, Attack 91%, for 9secs, accumulative damage, Critical Damage 185%, for success rate 64%"/>
-    <string name="h18" value="MP - 38, Attack 94%, for 9secs, accumulative damage, Critical Damage 190%, for success rate 66%"/>
-    <string name="h19" value="MP - 39, Attack 97%, for 9secs, accumulative damage, Critical Damage 195%, for success rate 68%"/>
-    <string name="h20" value="MP - 40, Attack 100%, for 9secs, accumulative damage, Critical Damage 200%, for success rate 70%"/>
-    <string name="h21" value="MP - 41, Attack 102%, for 12secs, accumulative damage, Critical Damage 205%, for success rate 72%"/>
-    <string name="h22" value="MP - 42, Attack 104%, for 12secs, accumulative damage, Critical Damage 210%, for success rate 74%"/>
-    <string name="h23" value="MP - 43, Attack 106%, for 12secs, accumulative damage, Critical Damage 215%, for success rate 76%"/>
-    <string name="h24" value="MP - 44, Attack 108%, for 12secs, accumulative damage, Critical Damage 220%, for success rate 78%"/>
-    <string name="h25" value="MP - 45, Attack 110%, for 12secs, accumulative damage, Critical Damage 225%, for success rate 80%"/>
-    <string name="h26" value="MP - 44, Attack 112%, for 12secs, accumulative damage, Critical Damage 230%, for success rate 82%"/>
-    <string name="h27" value="MP - 43, Attack 114%, for 12secs, accumulative damage, Critical Damage 235%, for success rate 84%"/>
-    <string name="h28" value="MP - 42, Attack 116%, for 12secs, accumulative damage, Critical Damage 240%, for success rate 86%"/>
-    <string name="h29" value="MP - 41, Attack 118%, for 12secs, accumulative damage, Critical Damage 245%, for success rate 88%"/>
-    <string name="h30" value="MP - 40, Attack 120%, for 12secs, accumulative damage, Critical Damage 250%, for success rate 90%"/>
+    <string name="desc" value="Strikes an unsuspecting enemy from Dark Sight. Attacks 3 times, then the final strike can deal critical damage with a given success rate."/>
+    <string name="h1" value="MP - 21. Damage 170%, attacks 3 times. Accumulates damage for 6 sec. Final strike critical damage 105% with 32% success rate."/>
+    <string name="h2" value="MP - 22. Damage 190%, attacks 3 times. Accumulates damage for 6 sec. Final strike critical damage 110% with 34% success rate."/>
+    <string name="h3" value="MP - 23. Damage 210%, attacks 3 times. Accumulates damage for 6 sec. Final strike critical damage 115% with 36% success rate."/>
+    <string name="h4" value="MP - 24. Damage 230%, attacks 3 times. Accumulates damage for 6 sec. Final strike critical damage 120% with 38% success rate."/>
+    <string name="h5" value="MP - 25. Damage 250%, attacks 3 times. Accumulates damage for 6 sec. Final strike critical damage 125% with 40% success rate."/>
+    <string name="h6" value="MP - 26. Damage 270%, attacks 3 times. Accumulates damage for 6 sec. Final strike critical damage 130% with 42% success rate."/>
+    <string name="h7" value="MP - 27. Damage 290%, attacks 3 times. Accumulates damage for 6 sec. Final strike critical damage 135% with 44% success rate."/>
+    <string name="h8" value="MP - 28. Damage 310%, attacks 3 times. Accumulates damage for 6 sec. Final strike critical damage 140% with 46% success rate."/>
+    <string name="h9" value="MP - 29. Damage 330%, attacks 3 times. Accumulates damage for 6 sec. Final strike critical damage 145% with 48% success rate."/>
+    <string name="h10" value="MP - 30. Damage 350%, attacks 3 times. Accumulates damage for 6 sec. Final strike critical damage 150% with 50% success rate."/>
+    <string name="h11" value="MP - 31. Damage 365%, attacks 3 times. Accumulates damage for 9 sec. Final strike critical damage 155% with 52% success rate."/>
+    <string name="h12" value="MP - 32. Damage 380%, attacks 3 times. Accumulates damage for 9 sec. Final strike critical damage 160% with 54% success rate."/>
+    <string name="h13" value="MP - 33. Damage 395%, attacks 3 times. Accumulates damage for 9 sec. Final strike critical damage 165% with 56% success rate."/>
+    <string name="h14" value="MP - 34. Damage 410%, attacks 3 times. Accumulates damage for 9 sec. Final strike critical damage 170% with 58% success rate."/>
+    <string name="h15" value="MP - 35. Damage 425%, attacks 3 times. Accumulates damage for 9 sec. Final strike critical damage 175% with 60% success rate."/>
+    <string name="h16" value="MP - 36. Damage 440%, attacks 3 times. Accumulates damage for 9 sec. Final strike critical damage 180% with 62% success rate."/>
+    <string name="h17" value="MP - 37. Damage 455%, attacks 3 times. Accumulates damage for 9 sec. Final strike critical damage 185% with 64% success rate."/>
+    <string name="h18" value="MP - 38. Damage 470%, attacks 3 times. Accumulates damage for 9 sec. Final strike critical damage 190% with 66% success rate."/>
+    <string name="h19" value="MP - 39. Damage 485%, attacks 3 times. Accumulates damage for 9 sec. Final strike critical damage 195% with 68% success rate."/>
+    <string name="h20" value="MP - 40. Damage 500%, attacks 3 times. Accumulates damage for 9 sec. Final strike critical damage 200% with 70% success rate."/>
+    <string name="h21" value="MP - 41. Damage 510%, attacks 3 times. Accumulates damage for 12 sec. Final strike critical damage 205% with 72% success rate."/>
+    <string name="h22" value="MP - 42. Damage 520%, attacks 3 times. Accumulates damage for 12 sec. Final strike critical damage 210% with 74% success rate."/>
+    <string name="h23" value="MP - 43. Damage 530%, attacks 3 times. Accumulates damage for 12 sec. Final strike critical damage 215% with 76% success rate."/>
+    <string name="h24" value="MP - 44. Damage 540%, attacks 3 times. Accumulates damage for 12 sec. Final strike critical damage 220% with 78% success rate."/>
+    <string name="h25" value="MP - 45. Damage 550%, attacks 3 times. Accumulates damage for 12 sec. Final strike critical damage 225% with 80% success rate."/>
+    <string name="h26" value="MP - 44. Damage 560%, attacks 3 times. Accumulates damage for 12 sec. Final strike critical damage 230% with 82% success rate."/>
+    <string name="h27" value="MP - 43. Damage 570%, attacks 3 times. Accumulates damage for 12 sec. Final strike critical damage 235% with 84% success rate."/>
+    <string name="h28" value="MP - 42. Damage 580%, attacks 3 times. Accumulates damage for 12 sec. Final strike critical damage 240% with 86% success rate."/>
+    <string name="h29" value="MP - 41. Damage 590%, attacks 3 times. Accumulates damage for 12 sec. Final strike critical damage 245% with 88% success rate."/>
+    <string name="h30" value="MP - 40. Damage 600%, attacks 3 times. Accumulates damage for 12 sec. Final strike critical damage 250% with 90% success rate."/>
   </imgdir>
   <imgdir name="4220002">
     <string name="name" value="Shadow Shifter"/>
@@ -7760,12 +7760,12 @@
   </imgdir>
   <imgdir name="4221008">
     <string name="name" value="Hero&apos;s Will"/>
-    <string name="desc" value="Enables one to shrug off abnormal conditions. The higher the skill level, the more types of abnormal conditions one can nullify."/>
-    <string name="h1" value="MP - 30 escape from abnormal condition, Terms between skills 600secs"/>
-    <string name="h2" value="MP - 30 escape from abnormal condition, Terms between skills 540secs"/>
-    <string name="h3" value="MP - 30 escape from abnormal condition, Terms between skills 480secs"/>
-    <string name="h4" value="MP - 30 escape from abnormal condition, Terms between skills 420secs"/>
-    <string name="h5" value="MP - 30 escape from abnormal condition, Terms between skills 360secs"/>
+    <string name="desc" value="Removes abnormal conditions such as seduce, zombify, and confusion. The higher the skill level, the shorter the cooldown."/>
+    <string name="h1" value="MP - 30. Escape from abnormal conditions. Cooldown 10 min."/>
+    <string name="h2" value="MP - 30. Escape from abnormal conditions. Cooldown 9 min."/>
+    <string name="h3" value="MP - 30. Escape from abnormal conditions. Cooldown 8 min."/>
+    <string name="h4" value="MP - 30. Escape from abnormal conditions. Cooldown 7 min."/>
+    <string name="h5" value="MP - 30. Escape from abnormal conditions. Cooldown 6 min."/>
   </imgdir>
   <imgdir name="0001006">
     <string name="name" value="Jump Down"/>


### PR DESCRIPTION

[bd-v16.1-cnpatch-r6.zip](https://github.com/user-attachments/files/28774845/bd-v16.1-cnpatch-r6.zip)
## 主要调整

本次针对飞侠一转至后续分支四转职业技能说明进行中英文整理，修正 `Skill.img.xml` 中与服务端实际技能数值或生效逻辑不一致的描述。

本次仅调整文本说明，不修改服务端 Java 技能逻辑，不修改 `Skill.wz` 技能数值，不重新构建发布用 jar。

职业名对齐：
- `Night Lord` 按「隐士」处理
- `Shadower` 按「侠盗」处理

## 变更明细

### 一转飞侠

- `4000001 远程暗器 / Keen Eyes`
  - 调整中英文描述，明确提升飞镖等投掷武器的攻击射程。
- `4001002 诅咒术 / Disorder`
  - 调整中英文描述，按实际效果描述为降低物理攻击力和物理防御力，不再描述为停止攻击。
- `4001003 隐身术 / Dark Sight`
  - 修正中文等级说明移动速度数值，按实际 `speed=-30 -> 0` 显示。
  - 英文等级说明同步整理。
- `4001334 二连击 / Double Stab`
  - 修正中英文等级说明 MP、伤害和攻击次数，按实际 `damage=98 -> 140`、攻击 2 次显示。
- `4001344 双飞斩 / Lucky Seven`
  - 修正中文等级说明伤害，按实际 `damage=58 -> 150` 显示。
  - 英文说明同步整理，明确伤害受 LUK 影响且不受拳套熟练度影响。

### 二转刺客

- `4101005 生命吸收 / Drain`
  - 优化中文描述，补充单次吸收上限不超过自身最大 HP 的 50%，且不超过敌人 HP。

### 二转侠客

- `4201004 神通术 / Steal`
  - 优化中文描述，补充同一怪物成功偷取后不能再次偷取。
- `4201005 回旋斩 / Savage Blow`
  - 修正中文等级说明攻击次数和伤害数值：Lv.1-Lv.10 攻击 4 次，Lv.11-Lv.20 攻击 5 次，Lv.21-Lv.30 攻击 6 次。
  - 英文等级说明同步整理。

### 三转无影人

- `4110000 药剂精通 / Alchemist`
  - 优化中文描述，明确对百分比恢复道具不适用。
- `4111001 聚财术 / Meso Up`
  - 优化中文描述，明确提高队员获得的金币掉落量。
- `4111002 影分身 / Shadow Partner`
  - 优化中文描述，明确消耗召唤石并召唤影分身模仿攻击。
- `4111003 影网术 / Shadow Web`
  - 修正中文成功率等级说明，按实际 `prop=42 -> 80` 显示。
  - 英文等级说明同步整理。
- `4111004 金钱攻击 / Shadow Meso`
  - 优化中文描述，明确伤害取决于投掷金币数量，并无视怪物物理防御提升和魔法防御提升。
- `4111005 多重飞镖 / Avenger`
  - 修正中文等级说明目标数和伤害，按实际最多攻击 `4 -> 6` 个敌人、`damage=65 -> 180` 显示。
  - 英文等级说明同步整理。
- `4111006 二段跳 / Flash Jump`
  - 优化中文描述，明确空中再次跳跃且等级越高距离越远。

### 三转独行客

- `4210000 强化盾 / Shield Mastery`
  - 修正中文等级说明盾牌防御提升数值，按实际 `+5% -> +100%` 显示。
  - 英文等级说明同步整理。
- `4211001 转化术 / Chakra`
  - 优化中英文描述和等级说明，按实际恢复力与恢复中受击伤害比例显示。
- `4211002 落叶斩 / Assaulter`
  - 修正中文 Lv.30 伤害，按实际 `450%` 显示。
  - 英文等级说明同步整理。
- `4211003 敛财术 / Pickpocket`
  - 优化中文描述，明确攻击时概率掉落金币，金币数量随技能等级和伤害增加。
- `4211004 分身术 / Band of Thieves`
  - 修正中文等级说明分身数、目标数、伤害和 MP 消耗，按实际 `x=1 -> 5`、最多目标 `2 -> 6`、`damage=110 -> 210` 显示。
  - 英文等级说明同步整理。
- `4211005 金钱护盾 / Meso Guard`
  - 优化中英文描述，按实际逻辑说明伤害减半，并按减免后伤害比例消耗金币。
- `4211006 金钱炸弹 / Meso Explosion`
  - 优化中英文等级说明，明确熟练度、最多引爆金币数和最多攻击目标数。

### 四转隐士

- `4121000 冒险岛勇士 / Maple Warrior`
  - 优化中英文描述，统一为按百分比提高组队成员所有属性。
- `4120002 假动作 / Shadow Shifter`
  - 修正中文等级说明，按隐士实际 `prop=1 -> 30` 显示，避免误用侠盗同名技能数值。
  - 英文等级说明同步整理。
- `4121003 挑衅 / Taunt`
  - 优化中文描述，明确提高敌人物理防御和魔法防御，同时提高经验值和物品掉落率。
- `4121004 忍者伏击 / Ninja Ambush`
  - 优化中文描述，明确最多攻击 6 个敌人，且伤害不会使敌人 HP 降到 1 以下。
- `4120005 武器用毒液 / Venomous Star`
  - 优化中文描述，明确最多叠加 3 次且不会使敌人 HP 降到 1 以下。
- `4121006 暗器伤人 / Shadow Stars`
  - 优化中文描述，明确消耗当前飞镖 200 个后，一定时间内攻击不再消耗飞镖。
- `4121007 三连环光击破 / Triple Throw`
  - 修正中文 Lv.30 伤害，按实际 `150%` 显示。
  - 英文等级说明同步整理。
- `4121008 忍者冲击 / Ninja Storm`
  - 优化中文描述，明确召唤忍者攻击周围敌人并概率击退。
- `4121009 勇士的意志 / Hero's Will`
  - 修正中英文描述和等级说明，明确解除诱惑、僵尸、混乱等异常状态，冷却时间随等级降低。

### 四转侠盗

- `4221000 冒险岛勇士 / Maple Warrior`
  - 优化中英文描述，统一为按百分比提高组队成员所有属性。
- `4221001 暗杀 / Assassinate`
  - 修正中英文等级说明，按实际 `damage=170 -> 600`、攻击 3 次、累计伤害时间、最后一击必杀伤害和成功率显示。
- `4220002 假动作 / Shadow Shifter`
  - 优化中文描述，保留侠盗实际 `prop=11 -> 40` 的等级说明。
- `4221003 挑衅 / Taunt`
  - 优化中文描述，明确提高敌人物理防御和魔法防御，同时提高经验值和物品掉落率。
- `4221004 忍者伏击 / Ninja Ambush`
  - 优化中文描述，明确最多攻击 6 个敌人，且伤害不会使敌人 HP 降到 1 以下。
- `4220005 武器用毒液 / Venomous Stab`
  - 优化中文描述，明确最多叠加 3 次且不会使敌人 HP 降到 1 以下。
- `4221008 勇士的意志 / Hero's Will`
  - 修正中英文描述和等级说明，明确解除诱惑、僵尸、混乱等异常状态，冷却时间随等级降低。

## 客户端影响

本次修改的是服务端 WZ XML 文本资源。若需要游戏客户端技能窗口同步显示这些文本，需要在客户端同步更新 `String/Skill.img` 资源。

## 校验

- 已确认 `wz/String.wz/Skill.img.xml` 可以正常 XML 解析。
- 已确认 `wz-zh-CN/String.wz/Skill.img.xml` 可以正常 XML 解析。
- 已检查中文文本未出现 `??` 乱码残留。