### PR TITLE
fix: 修正休咪钞票任务栏父级显示

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -3929,7 +3929,7 @@
     </imgdir>
     <imgdir name="2056">
         <string name="name" value="休咪丢失的钞票"/>
-        <null name="parent"/>
+        <string name="parent" value=""/>
         <string name="0" value="要去废弃都市见休咪"/>
         <string name="1" value="在废弃都市又见到了休咪。她在担心几天前她弄丢的房费。她说蝙蝠抢走那钞票后逃进地铁站了。怎么又去那里呢？不如我替她付房费吧...不过她拜托我像上次那样进#b工地B2里#k面找回她的钱沓... 我只好进去了…"/>
         <string name="2" value="我找回了休咪弄丢的钞票。她可以付房费了吧？她为了表示感谢，给了我#b100个魔法药水#k。她说在地铁#b工地B2#k里还有另外贵重的物品。以后有空的话，我要再次进去。"/>


### PR DESCRIPTION

[bd-v16.1-cnpatch-r10.zip](https://github.com/user-attachments/files/28846438/bd-v16.1-cnpatch-r10.zip)


## 改动点汇总

- 修正任务 2056「休咪丢失的钞票」的 `parent` 字段为空字符串。
- 避免该任务在任务栏中错误归类或显示为「麦吉的旧战剑」。
- 保持任务名称、NPC、任务流程、奖励等配置不变。

## 客户端影响

- 该改动会影响客户端任务栏的任务显示。
- 客户端需要同步 `QuestInfo` 数据后，任务栏显示才会生效。

## 验证

- 确认本分支相对上游 `master` 仅包含本次 1 个提交。
- 确认仅修改该任务的父级显示字段。