### PR TITLE
feat: 副本关卡谜题支持单人跳过 增加配置

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2013001.js
+++ b/gms-server/scripts-zh-CN/npc/2013001.js
@@ -155,7 +155,7 @@ function action(mode, type, selection) {
                     }
                     if (total != 3) {
                         const GameConfig = Java.type('org.gms.config.GameConfig');
-                        if(GameConfig.getServerBoolean("use_enable_solo_expeditions") && eim.getPlayerCount() == 1){
+                        if(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1){
                             cm.getMap().getReactorByName("stone4").forceHitReactor(1);
                             eim.giveEventPlayersExp(3500);
                             clearStage(4, eim);

--- a/gms-server/scripts-zh-CN/npc/9020001.js
+++ b/gms-server/scripts-zh-CN/npc/9020001.js
@@ -69,7 +69,7 @@ function clearStage(stage, eim, curMap) {
 
 function rectangleStages(eim, property, areaCombos, areaRects) {
     const GameConfig = Java.type('org.gms.config.GameConfig');
-    if(GameConfig.getServerBoolean("use_enable_solo_expeditions") && eim.getPlayerCount() == 1){
+    if(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1){
         return true;
     }
     var c = eim.getProperty(property);
@@ -139,6 +139,12 @@ function action(mode, type, selection) {
                     cm.sendNext("太棒了！你通过了所有的关卡来到了这一点。这是为了你出色的表现而给予的小奖品。在接受之前，请确保你的使用和其他物品栏有空位可用。");
                 }
             } else if (curMap == 103000800) {   // stage 1
+                const GameConfig = Java.type('org.gms.config.GameConfig');
+                if (eim.getPlayerCount() == 1 && !GameConfig.getServerBoolean("use_enable_stage_skip")) {
+                    cm.sendOk("这里的机关需要多人配合才能解开，一个人恐怕难以应付。等你找到了可靠的伙伴，再一起回来挑战吧！");
+                    cm.dispose();
+                    return;
+                }
                 if (cm.isEventLeader()) {
                     var numpasses = eim.getPlayerCount() - 1;     // minus leader
 

--- a/gms-server/scripts/npc/2013001.js
+++ b/gms-server/scripts/npc/2013001.js
@@ -154,7 +154,14 @@ function action(mode, type, selection) {
                         total += z;
                     }
                     if (total != 3) {
-                        cm.sendOk("There needs to be exactly 3 players on these platforms.");
+                        const GameConfig = Java.type('org.gms.config.GameConfig');
+                        if(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1){
+                            cm.getMap().getReactorByName("stone4").forceHitReactor(1);
+                            eim.giveEventPlayersExp(3500);
+                            clearStage(4, eim);
+                        }else{
+                            cm.sendOk("There needs to be exactly 3 players on these platforms.");
+                        }
                     } else {
                         var num_correct = 0;
                         for (var i = 0; i < 3; i++) {

--- a/gms-server/scripts/npc/9020001.js
+++ b/gms-server/scripts/npc/9020001.js
@@ -67,6 +67,10 @@ function clearStage(stage, eim, curMap) {
 }
 
 function rectangleStages(eim, property, areaCombos, areaRects) {
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1){
+        return true;
+    }
     var c = eim.getProperty(property);
     if (c == null) {
         c = Math.floor(Math.random() * areaCombos.length);
@@ -134,6 +138,12 @@ function action(mode, type, selection) {
                     cm.sendNext("Incredible! You cleared all the stages to get to this point. Here's a small prize for your job well done. Before you accept it, however, please make sure your use and etc. inventories have empty slots available.");
                 }
             } else if (curMap == 103000800) {   // stage 1
+                const GameConfig = Java.type('org.gms.config.GameConfig');
+                if (eim.getPlayerCount() == 1 && !GameConfig.getServerBoolean("use_enable_stage_skip")) {
+                    cm.sendOk("The mechanisms here require teamwork to solve. It will be difficult to face alone. Find reliable companions and come back to challenge it together!");
+                    cm.dispose();
+                    return;
+                }
                 if (cm.isEventLeader()) {
                     var numpasses = eim.getPlayerCount() - 1;     // minus leader
 

--- a/gms-server/src/main/resources/db/migration/V1.11.2__insert_game_config_stage_skip.sql
+++ b/gms-server/src/main/resources/db/migration/V1.11.2__insert_game_config_stage_skip.sql
@@ -1,0 +1,20 @@
+-- 是否允许跳过副本关卡谜题
+INSERT INTO `game_config`(`config_type`, `config_sub_type`, `config_clazz`, `config_code`, `config_value`, `config_desc`, `update_time`)
+SELECT 'server', 'Game Mechanics', 'java.lang.Boolean', 'use_enable_stage_skip', 'false', 'use_enable_stage_skip', '2026-06-09 14:00:00'
+WHERE NOT EXISTS (
+    SELECT 1 FROM `game_config` WHERE `config_code` = 'use_enable_stage_skip'
+);
+
+-- 中文
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'zh-CN', 'game_config', 'use_enable_stage_skip', '是否允许跳过副本关卡谜题', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'zh-CN' AND `lang_code` = 'use_enable_stage_skip'
+);
+
+-- 英文
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'en-US', 'game_config', 'use_enable_stage_skip', 'Allow skipping stage puzzles in expeditions', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'en-US' AND `lang_code` = 'use_enable_stage_skip'
+);


### PR DESCRIPTION
- 新增 game_config 配置项 use_enable_stage_skip（Boolean/false），
- 控制是否允许单人跳过副本中需多人合作的关卡谜题
- 废弃都市组队任务(KPQ)：第1关增加单人拦截提示；第2/3/4关绳索、平台、木桶站位支持单人自动通关
- 女神之塔副本(OPQ)：第4关封印平台支持单人自动通关
- 同步更新 EN/ZH 双语脚本