### PR TITLE
fix: 修复幸福村 NPC 交互与传送点问题

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2001000.js
+++ b/gms-server/scripts-zh-CN/npc/2001000.js
@@ -20,13 +20,13 @@ function action(mode, type, selection) {
         }
     }
     if (status == 0) {
-        cm.sendNext("你看到那边站着一群雪人吗？去和他们中的一个交谈，它会带你去这里著名的巨大圣诞树。这棵树可以用各种装饰品来装饰。你觉得怎么样？听起来很有趣，对吧？");
+        cm.sendNext("看到那边的雪人了吗？和他们对话，就能前往幸福村著名的巨大圣诞树房间。你可以把各种装饰品挂在树上，亲手布置属于自己的圣诞树。");
     } else if (status == 1) {
-        cm.sendNextPrev("只有6个人可以同时在树所在的地方，你不能在那里进行交易或者开设商店。你丢下的饰品只能由你自己捡起来，所以不用担心在这里丢失你的饰品。");
+        cm.sendNextPrev("每个圣诞树房间最多容纳6个人，而且不能交易或开设商店。你丢下的装饰品只有你自己能捡回，所以不用担心被别人拿走。");
     } else if (status == 2) {
-        cm.sendNextPrev("当然，掉落在那里的物品永远不会消失。一旦你通过里面的雪人离开那里，你在那张地图上掉落的所有物品都会回到你身边，所以你离开那个地方之前不必捡起所有这些物品。是不是很方便呢？");
+        cm.sendNextPrev("掉在圣诞树房间里的装饰品不会消失。离开房间时，系统会把你放下的物品归还给你，不需要临走前一件件捡起来。");
     } else if (status == 3) {
-        cm.sendPrev("Well then, go see #p2002001#, buy some Christmas ornaments there, and then decorate the tree with those~ Oh yeah! The biggest, the most beautiful ornament cannot be bought from him. It's probably ... taken by a monster ... huh huh ..");
+        cm.sendPrev("想装饰圣诞树的话，先去找#p2002001#购买装饰品吧。对了，最大也最漂亮的装饰品可买不到，听说它被怪物拿走了……");
         cm.dispose();
     }
 }

--- a/gms-server/scripts-zh-CN/npc/2001001.js
+++ b/gms-server/scripts-zh-CN/npc/2001001.js
@@ -31,17 +31,13 @@ function start() {
 }
 
 function action(mode, type, selection) {
-    if (mode < 0) {
+    if (mode <= 0) {
         cm.dispose();
     } else {
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
+        status++;
 
         if (status == 0) {
-            cm.sendYesNo("我们有一棵漂亮的圣诞树。你想看看/装饰它吗？");
+            cm.sendYesNo("这里有一间圣诞树房间，可以自由装饰。要进去看看吗？");
         } else if (status == 1) {
             cm.warp(209000001);
             cm.dispose();

--- a/gms-server/scripts-zh-CN/npc/2001002.js
+++ b/gms-server/scripts-zh-CN/npc/2001002.js
@@ -31,17 +31,13 @@ function start() {
 }
 
 function action(mode, type, selection) {
-    if (mode < 0) {
+    if (mode <= 0) {
         cm.dispose();
     } else {
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
+        status++;
 
         if (status == 0) {
-            cm.sendYesNo("我们有一棵漂亮的圣诞树。你想看看/装饰它吗？");
+            cm.sendYesNo("这里有一间圣诞树房间，可以自由装饰。要进去看看吗？");
         } else if (status == 1) {
             cm.warp(209000002);
             cm.dispose();

--- a/gms-server/scripts-zh-CN/npc/2001003.js
+++ b/gms-server/scripts-zh-CN/npc/2001003.js
@@ -31,17 +31,13 @@ function start() {
 }
 
 function action(mode, type, selection) {
-    if (mode < 0) {
+    if (mode <= 0) {
         cm.dispose();
     } else {
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
+        status++;
 
         if (status == 0) {
-            cm.sendYesNo("我们有一棵漂亮的圣诞树。你想看看/装饰它吗？");
+            cm.sendYesNo("这里有一间圣诞树房间，可以自由装饰。要进去看看吗？");
         } else if (status == 1) {
             cm.warp(209000003);
             cm.dispose();

--- a/gms-server/scripts-zh-CN/npc/2002001.js
+++ b/gms-server/scripts-zh-CN/npc/2002001.js
@@ -1,0 +1,25 @@
+/*
+ * 2002001 - Rudi, Tree Ornament Merchant
+ */
+
+var status = -1;
+
+function start() {
+    action(1, 0, 0);
+}
+
+function action(mode, type, selection) {
+    if (mode <= 0) {
+        cm.dispose();
+        return;
+    }
+
+    status++;
+
+    if (status == 0) {
+        cm.sendYesNo("想装饰圣诞树吗？我这里有各种装饰品，要看看吗？");
+    } else if (status == 1) {
+        cm.openShopNPC(2090003);
+        cm.dispose();
+    }
+}

--- a/gms-server/scripts-zh-CN/npc/2002002.js
+++ b/gms-server/scripts-zh-CN/npc/2002002.js
@@ -1,0 +1,8 @@
+/*
+ * 2002002 - Torr, lost reindeer in Happyville
+ */
+
+function start() {
+    cm.sendOk("呜呜……我的角不见了。那可是对驯鹿来说最重要的东西！如果你看见我的角，请一定要告诉我。");
+    cm.dispose();
+}

--- a/gms-server/scripts-zh-CN/npc/9209100.js
+++ b/gms-server/scripts-zh-CN/npc/9209100.js
@@ -29,9 +29,9 @@ function action(mode, type, selection) {
 
         if (status == 0) {
             if (playerNearby(cm.getPlayer().getPosition(), cm.getMap().getPortal("chimney01").getPosition())) {
-                cm.sendOk("嘿，嘿~~请不要未经允许潜入别人家里，你可不想今年在圣诞老人的名单上被列为调皮的吧？");
+                cm.sendOk("嘿嘿，不要偷偷钻进别人家的烟囱哦。要是被记在圣诞老人的淘气名单上，今年的礼物可就危险了。");
             } else {
-                cm.sendOk("嘿嘿嘿~~你有一个充满健康、实现和幸福的美好一年！");
+                cm.sendOk("呵呵呵，愿你在新的一年里健康、顺利，也收获满满的幸福。");
             }
         } else {
             cm.dispose();

--- a/gms-server/scripts-zh-CN/npc/9310058.js
+++ b/gms-server/scripts-zh-CN/npc/9310058.js
@@ -3,6 +3,6 @@
  **/
 
 function start() {
-    cm.sendOk("欢迎来到#b快乐小镇#k，年轻的旅行者。你有什么愿望吗？");
+    cm.sendOk("欢迎来到#b幸福村#k，年轻的旅行者。愿这个冬天带给你温暖和好运。");
     cm.dispose();
 } 

--- a/gms-server/wz-zh-CN/String.wz/Npc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Npc.img.xml
@@ -7706,11 +7706,11 @@
         <string name="n1" value="圣诞老人来到小镇〜 "/>
     </imgdir>
     <imgdir name="9250054">
-        <string name="name" value="Bicho"/>
-        <string name="d0" value="雪人！我喜欢它！什么是冬季喜欢雪人！"/>
-        <string name="d1" value="Ahhh ....~~~我的双手冻结...请帮我作出最大的雪人世界。 ^ ^ "/>
-        <string name="n0" value="辊〜辊辊雪〜 〜"/>
-        <string name="n1" value="我要作出最大的雪人在世界上！"/>
+        <string name="name" value="比乔"/>
+        <string name="d0" value="雪人！我最喜欢雪人了！没有什么比雪人更有冬天的感觉。"/>
+        <string name="d1" value="啊……我的手都冻僵了。请帮我一起堆出世界上最大的雪人吧！"/>
+        <string name="n0" value="滚呀滚，把雪滚成大雪球～"/>
+        <string name="n1" value="我要堆出世界上最大的雪人！"/>
     </imgdir>
     <imgdir name="9270000">
         <string name="name" value="枫叶电视"/>

--- a/gms-server/wz/Map.wz/Map/Map2/209000000.img.xml
+++ b/gms-server/wz/Map.wz/Map/Map2/209000000.img.xml
@@ -2054,8 +2054,8 @@
       <int name="x" value="2469"/>
       <int name="y" value="-192"/>
       <int name="pt" value="1"/>
-      <int name="tm" value="999999999"/>
-      <string name="tn" value=""/>
+      <int name="tm" value="209000000"/>
+      <string name="tn" value="h003_1"/>
       <string name="pn" value="h003"/>
     </imgdir>
     <imgdir name="13">


### PR DESCRIPTION

[bd-v16.1-cnpatch-r12.zip](https://github.com/user-attachments/files/28847793/bd-v16.1-cnpatch-r12.zip)


## 改动汇总

- 修复幸福村部分 NPC 点击无反应的问题：补充鲁迪与麋鹿托尔的中文 NPC 脚本，并修正圣诞树房间雪人的取消交互流程。
- 优化克里夫、圣诞树相关 NPC、圣诞老人等中文对话，去除英文残留与生硬机翻，使对话更连贯。
- 修复幸福村克里夫房顶传送点目标配置错误的问题，使其可以正确传送到对应出口。
- 修正 NPC Bicho 的中文名称与台词，将名称改为“比乔”，并润色雪人相关文本。

## 客户端影响

- 本次改动包含 WZ/XML 数据变更，会影响客户端资源：需要同步地图 `Map/Map2/209000000.img` 与字符串 `String/Npc.img`，否则客户端可能仍显示旧名称/旧台词，或传送点表现与服务端配置不一致。

## 测试说明

- 已检查 XML 可解析。
- 已检查本次新增/修改的 NPC 脚本语法。
- 未重新构建 jar 包，正式 release 时再统一打包。
