### PR TITLE
﻿Fix: 少林寺任务8538寻找师兄链无法完成

### DIFF
--- a/gms-server/scripts-zh-CN/npc/9310040.js
+++ b/gms-server/scripts-zh-CN/npc/9310040.js
@@ -1,0 +1,47 @@
+/*
+	NPC Name: 		国清
+	Map(s): 		Mount Song: Mountainside (702030000)
+	Description: 	Quest NPC - 寻找师兄 chain
+	Quest: 			8538 (寻找师兄1), 8539 (寻找师兄2)
+*/
+
+var status = 0;
+
+function start() {
+    status = -1;
+    action(1, 0, 0);
+}
+
+function action(mode, type, selection) {
+    if (mode == -1) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 0) {
+        cm.dispose();
+        return;
+    }
+    status++;
+
+    if (status == 0) {
+        if (cm.isQuestStarted(8538) && cm.haveItem(4031786, 1)) {
+            cm.sendYesNo("阿弥陀佛，贫僧有礼了。不知施主找贫僧，所为何事。");
+        } else if (cm.isQuestStarted(8539)) {
+            cm.sendNext("请施主早日将书信送与我那小师弟，免得他挂念，于修行不利。");
+            cm.dispose();
+        } else {
+            cm.sendNext("修行啊修行");
+            cm.dispose();
+        }
+    } else if (status == 1) {
+        cm.completeQuest(8538);
+        cm.sendNext("太谢谢你了，出来这么久让师弟担心了啊~等会再来找我。");
+    } else if (status == 2) {
+        cm.startQuest(8539);
+        cm.sendNextPrev("原来是#b#p9310052##k师弟所托，贫僧入世修行未满，还不能回寺。这里有书信一封，请施主带给我的小师弟。");
+    } else if (status == 3) {
+        cm.sendNextPrev("如此多谢施主了。");
+    } else {
+        cm.dispose();
+    }
+}

--- a/gms-server/scripts-zh-CN/npc/9310052.js
+++ b/gms-server/scripts-zh-CN/npc/9310052.js
@@ -1,0 +1,59 @@
+/*
+	NPC Name: 		虚竹
+	Map(s): 		Mount Song: Mahavira Hall (702100000)
+	Description: 	Quest NPC - 寻找师兄 chain
+	Quest: 			8538 (寻找师兄1), 8539 (寻找师兄2)
+*/
+
+var status = 0;
+var questAction = "";
+
+function start() {
+    status = -1;
+    questAction = "";
+    action(1, 0, 0);
+}
+
+function action(mode, type, selection) {
+    if (mode == -1) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 0) {
+        cm.dispose();
+        return;
+    }
+    status++;
+
+    if (status == 0) {
+        if (cm.isQuestCompleted(8538) && cm.isQuestStarted(8539) && cm.haveItem(4031787, 1)) {
+            questAction = "complete8539";
+            cm.sendNext("啊，师兄的信！原来师兄正在精修禅宗，多谢施主带来师兄的音信。小僧无以为报，些许物件，还请施主笑纳。");
+        } else if (cm.isQuestCompleted(8539)) {
+            cm.sendNext("多谢施主带来师兄的音信。");
+            cm.dispose();
+        } else if (cm.isQuestStarted(8538)) {
+            cm.sendNext("施主找到我师兄了吗？他在山腰苦修，就在#b#m702030000##k。");
+            cm.dispose();
+        } else if (!cm.isQuestStarted(8538) && !cm.isQuestCompleted(8538)) {
+            questAction = "start8538";
+            cm.sendYesNo("这位施主，小僧有事相求，万望施主不吝相助。");
+        } else {
+            cm.sendNext("今天也要好好修炼啊");
+            cm.dispose();
+        }
+    } else if (status == 1) {
+        if (questAction == "complete8539") {
+            cm.completeQuest(8539);
+            cm.sendNext("小僧无以为报，些许物件，还请施主笑纳。");
+            cm.dispose();
+        } else {
+            cm.startQuest(8538);
+            cm.sendNext("小僧有个师兄早年外出苦修，时日已久却不见音信，小僧好不挂念，还请施主代为寻找。小僧的师兄法号#b#p9310040##k。");
+        }
+    } else if (status == 2) {
+        cm.sendNextPrev("请施主去#b#m702030000##k寻找我的师兄。");
+    } else {
+        cm.dispose();
+    }
+}

--- a/gms-server/scripts/npc/9310040.js
+++ b/gms-server/scripts/npc/9310040.js
@@ -1,0 +1,47 @@
+/*
+	NPC Name: 		Guoqing
+	Map(s): 		Mount Song: Mountainside (702030000)
+	Description: 	Quest NPC - Searching for Senior Brother chain
+	Quest: 			8538, 8539
+*/
+
+var status = 0;
+
+function start() {
+    status = -1;
+    action(1, 0, 0);
+}
+
+function action(mode, type, selection) {
+    if (mode == -1) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 0) {
+        cm.dispose();
+        return;
+    }
+    status++;
+
+    if (status == 0) {
+        if (cm.isQuestStarted(8538) && cm.haveItem(4031786, 1)) {
+            cm.sendYesNo("Amitabha. Greetings, traveler. What brings you to seek me out?");
+        } else if (cm.isQuestStarted(8539)) {
+            cm.sendNext("Please deliver the letter to my junior as soon as possible, so he may cease worrying.");
+            cm.dispose();
+        } else {
+            cm.sendNext("Practice, practice...");
+            cm.dispose();
+        }
+    } else if (status == 1) {
+        cm.completeQuest(8538);
+        cm.sendNext("Thank you very much. I've been out so long that my junior must have been worried. Come find me again later.");
+    } else if (status == 2) {
+        cm.startQuest(8539);
+        cm.sendNextPrev("My junior sent you? I see... I have not yet completed my ascetic training, so I cannot return to the temple. May I trouble you to deliver this letter to my junior?");
+    } else if (status == 3) {
+        cm.sendNextPrev("Thank you kindly.");
+    } else {
+        cm.dispose();
+    }
+}

--- a/gms-server/scripts/npc/9310052.js
+++ b/gms-server/scripts/npc/9310052.js
@@ -1,0 +1,59 @@
+/*
+	NPC Name: 		Xuzhu
+	Map(s): 		Mount Song: Mahavira Hall (702100000)
+	Description: 	Quest NPC - Searching for Senior Brother chain
+	Quest: 			8538, 8539
+*/
+
+var status = 0;
+var questAction = "";
+
+function start() {
+    status = -1;
+    questAction = "";
+    action(1, 0, 0);
+}
+
+function action(mode, type, selection) {
+    if (mode == -1) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 0) {
+        cm.dispose();
+        return;
+    }
+    status++;
+
+    if (status == 0) {
+        if (cm.isQuestCompleted(8538) && cm.isQuestStarted(8539) && cm.haveItem(4031787, 1)) {
+            questAction = "complete8539";
+            cm.sendNext("Ah, a letter from my senior! He is in deep meditation. Thank you for bringing me his news. I have little to offer, but please accept these humble gifts.");
+        } else if (cm.isQuestCompleted(8539)) {
+            cm.sendNext("Thank you for bringing word from my senior.");
+            cm.dispose();
+        } else if (cm.isQuestStarted(8538)) {
+            cm.sendNext("Have you found my senior brother? He is cultivating on the mountainside at #b#m702030000##k.");
+            cm.dispose();
+        } else if (!cm.isQuestStarted(8538) && !cm.isQuestCompleted(8538)) {
+            questAction = "start8538";
+            cm.sendYesNo("Greetings, traveler. This humble monk has a favor to ask. Would you be willing to help?");
+        } else {
+            cm.sendNext("I must train hard today too.");
+            cm.dispose();
+        }
+    } else if (status == 1) {
+        if (questAction == "complete8539") {
+            cm.completeQuest(8539);
+            cm.sendNext("I have little to offer, but please accept these humble gifts.");
+            cm.dispose();
+        } else {
+            cm.startQuest(8538);
+            cm.sendNext("My senior brother left long ago for ascetic training, but has not returned for a long time. I am worried about him. Please help me find him. His dharma name is #b#p9310040##k.");
+        }
+    } else if (status == 2) {
+        cm.sendNextPrev("Please look for my senior brother at #b#m702030000##k.");
+    } else {
+        cm.dispose();
+    }
+}

--- a/gms-server/wz/Item.wz/Etc/0403.img.xml
+++ b/gms-server/wz/Item.wz/Etc/0403.img.xml
@@ -8450,6 +8450,16 @@
       <int name="quest" value="1"/>
     </imgdir>
   </imgdir>
+  <imgdir name="04031786">
+    <imgdir name="info">
+      <int name="quest" value="1"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="04031787">
+    <imgdir name="info">
+      <int name="quest" value="1"/>
+    </imgdir>
+  </imgdir>
   <imgdir name="04031788">
     <imgdir name="info">
       <canvas name="icon" width="29" height="28">


### PR DESCRIPTION
问题：点击NPC国清(9310040)无反应，任务链中断

根因：
- NPC 9310040/9310052 缺少对话脚本导致NPCTalkHandler无响应
- 任务道具4031786/4031787未在Item.wz中定义，slotMax=0致道具无法创建

修复：
1. 新增 scripts/npc/9310040.js - 国清英文NPC对话(完成8538+接8539)
2. 新增 scripts/npc/9310052.js - 虚竹英文NPC对话(接8538+完成8539)
3. 新增 scripts-zh-CN/npc/9310040.js - 国清中文NPC对话
4. 新增 scripts-zh-CN/npc/9310052.js - 虚竹中文NPC对话
5. 修改 wz/Item.wz/Etc/0403.img.xml - 补全4031786/4031787最小化条目