### PR TITLE
fix: 修正英雄之回声冷却时间

### DIFF
--- a/gms-server/wz-zh-CN/String.wz/Skill.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Skill.img.xml
@@ -68,7 +68,7 @@
     <imgdir name="0001005">
         <string name="name" value="英雄之回声"/>
         <string name="h1" value="消耗MP 30，持续 40分钟，增加物理和魔法攻击力4%"/>
-        <string name="desc" value="[最高等级 : 1]\n增加周边角色的物理攻击力和魔法攻击力。 \n#c冷却时间 : 2小时#"/>
+        <string name="desc" value="[最高等级 : 1]\n增加周边角色的物理攻击力和魔法攻击力。 \n#c冷却时间 : 300秒#"/>
     </imgdir>
     <imgdir name="0001006">
         <string name="name" value="向下跳跃"/>
@@ -270,7 +270,7 @@
     <imgdir name="10001005">
         <string name="name" value="英雄之回声"/>
         <string name="h1" value="消耗MP30，持续时间40分钟，增加物理和魔法攻击力2%"/>
-        <string name="desc" value="[最高等级：1]\n增加周边角色的物理攻击力和魔法攻击力。 \n#c冷却时间 : 2小时#"/>
+        <string name="desc" value="[最高等级：1]\n增加周边角色的物理攻击力和魔法攻击力。 \n#c冷却时间 : 300秒#"/>
     </imgdir>
     <imgdir name="10001006">
         <string name="name" value="向下跳跃"/>
@@ -5393,7 +5393,7 @@
     <imgdir name="20001005">
         <string name="name" value="英雄的回声"/>
         <string name="h1" value="消耗MP30，40分钟之内物理攻击力、魔法攻击力提高4%"/>
-        <string name="desc" value="[最高等级：1]\n增加周边角色的物理攻击力和魔法攻击力。 \n#c冷却时间：2小时#"/>
+        <string name="desc" value="[最高等级：1]\n增加周边角色的物理攻击力和魔法攻击力。 \n#c冷却时间：300秒#"/>
     </imgdir>
     <imgdir name="20001006">
         <string name="name" value="向下跳跃"/>

--- a/gms-server/wz/Skill.wz/000.img.xml
+++ b/gms-server/wz/Skill.wz/000.img.xml
@@ -184,7 +184,7 @@
           <int name="time" value="2400"/>
           <vector name="lt" x="-400" y="-300"/>
           <vector name="rb" x="400" y="300"/>
-          <int name="cooltime" value="7200"/>
+          <int name="cooltime" value="300"/>
         </imgdir>
       </imgdir>
       <imgdir name="effect">

--- a/gms-server/wz/Skill.wz/1000.img.xml
+++ b/gms-server/wz/Skill.wz/1000.img.xml
@@ -519,7 +519,7 @@
           <int name="time" value="2400"/>
           <vector name="lt" x="-400" y="-300"/>
           <vector name="rb" x="400" y="300"/>
-          <int name="cooltime" value="7200"/>
+          <int name="cooltime" value="300"/>
         </imgdir>
       </imgdir>
       <imgdir name="effect">

--- a/gms-server/wz/Skill.wz/2000.img.xml
+++ b/gms-server/wz/Skill.wz/2000.img.xml
@@ -519,7 +519,7 @@
           <int name="time" value="2400"/>
           <vector name="lt" x="-400" y="-300"/>
           <vector name="rb" x="400" y="300"/>
-          <int name="cooltime" value="7200"/>
+          <int name="cooltime" value="300"/>
         </imgdir>
       </imgdir>
       <imgdir name="effect">

--- a/gms-server/wz/String.wz/Skill.img.xml
+++ b/gms-server/wz/String.wz/Skill.img.xml
@@ -4810,7 +4810,7 @@
   </imgdir>
   <imgdir name="0001005">
     <string name="name" value="Echo of Hero"/>
-    <string name="desc" value="[Master Level : 1]\n Increase weapon attack and magic attack on all players around. \n#cTerms between skills : 2hours#"/>
+    <string name="desc" value="[Master Level : 1]\n Increase weapon attack and magic attack on all players around. \n#cTerms between skills : 300 seconds#"/>
     <string name="h1" value="MP -30 Weapon attack +4%, Magic attack +4%  for 40Minutes"/>
   </imgdir>
   <imgdir name="112">
@@ -11566,7 +11566,7 @@
   </imgdir>
   <imgdir name="10001005">
     <string name="name" value="Echo of Hero"/>
-    <string name="desc" value="[Master Lever : 1]\n Increase weapon attack and magic attack on all players around. \n#cTerms between skills : 2hours#"/>
+    <string name="desc" value="[Master Lever : 1]\n Increase weapon attack and magic attack on all players around. \n#cTerms between skills : 300 seconds#"/>
     <string name="h1" value="Consumes MP 30 and increases Weapon &amp; Magic Attack by 4% for 40Minutes."/>
   </imgdir>
   <imgdir name="10001006">
@@ -11749,7 +11749,7 @@
   </imgdir>
   <imgdir name="20001005">
     <string name="name" value="Echo of Hero"/>
-    <string name="desc" value="[Master Level : 1]\n Increase weapon attack and magic attack on all players around. \n#cTerms between skills : 2hours#"/>
+    <string name="desc" value="[Master Level : 1]\n Increase weapon attack and magic attack on all players around. \n#cTerms between skills : 300 seconds#"/>
     <string name="h1" value="MP -30 Weapon attack +2%, Magic attack +2%  for 40Minutes"/>
   </imgdir>
   <imgdir name="20001006">


### PR DESCRIPTION
## 关联 issue

关联 #666

## 改动点汇总

- 修正 200 级通用技能“英雄之回声”的服务端技能数据，将冒险家、骑士团、战神三类技能的 `cooltime` 从 7200 秒调整为 300 秒。
- 同步更新英文技能描述，将技能间隔描述从 2 小时调整为 300 秒，避免描述与实际冷却不一致。
- 同步更新中文技能描述，将“冷却时间：2小时”调整为“冷却时间：300秒”，避免中文客户端提示误导。
- 该改动会影响客户端资源显示：客户端 `Skill` 与 `String` 资源需要随服务端 WZ 数据同步，否则可能出现服务端实际冷却已为 300 秒、客户端描述仍显示旧冷却的情况。

## 原因说明

当前服务端 WZ 中“英雄之回声”的 `cooltime` 仍为 7200 秒，导致技能提示显示 300 秒附近的冷却信息时，服务端实际仍按数小时冷却处理。本次将服务端实际冷却值与技能提示统一为 300 秒。

## 测试说明

- 未重新构建 release 包；正式 release 时再进行打包。
- 已检查本次提交仅包含该问题相关的 WZ 技能数据与中英文技能描述调整。