### PR TITLE
fix: 汉化怪物嘉年华2休彼德蔓相关任务与对话

### DIFF
--- a/gms-server/scripts/npc/2042005.js
+++ b/gms-server/scripts/npc/2042005.js
@@ -31,10 +31,10 @@ function action(mode, type, selection) {
         if (status == 0) {
             if (cm.getParty() == null) {
                 status = 10;
-                cm.sendOk("You need to create a party before you can participate in Monster Carnival!");
+                cm.sendOk("你需要先创建一个队伍，才能参加怪物嘉年华！");
             } else if (!cm.isLeader()) {
                 status = 10;
-                cm.sendOk("If you want to start the battle, let the #bleader#k come and speak to me.");
+                cm.sendOk("如果想开始战斗，请让#b队长#k来和我对话。");
             } else {
                 var leaderMapid = cm.getMapId();
                 var party = cm.getParty().getMembers();
@@ -53,16 +53,16 @@ function action(mode, type, selection) {
 
                 if (party >= 1) {
                     status = 10;
-                    cm.sendOk("You do not have enough people in your party. You need a party with #b" + cpqMinAmt + "#k - #r" + cpqMaxAmt + "#k members and they should be on the map with you.");
+                    cm.sendOk("你的队伍人数不足。队伍需要有#b" + cpqMinAmt + "#k - #r" + cpqMaxAmt + "#k名成员，而且所有成员都必须和你在同一张地图。");
                 } else if (lvlOk != inMap) {
                     status = 10;
-                    cm.sendOk("Make sure everyone in your party is among the correct levels (" + cpqMinLvl + "~" + cpqMaxLvl + ")!");
+                    cm.sendOk("请确认队伍中的所有成员等级都在正确范围内（" + cpqMinLvl + "~" + cpqMaxLvl + "）！");
                 } else if (isOutMap > 0) {
                     status = 10;
-                    cm.sendOk("There are some of the party members that is not on the map!");
+                    cm.sendOk("队伍中有成员不在当前地图！");
                 } else {
                     if (!cm.sendCPQMapLists2()) {
-                        cm.sendOk("All Monster Carnival fields are currently in use! Try again later.");
+                        cm.sendOk("所有怪物嘉年华场地目前都在使用中！请稍后再试。");
                         cm.dispose();
                     }
                 }
@@ -73,16 +73,16 @@ function action(mode, type, selection) {
                     cm.challengeParty2(selection);
                     cm.dispose();
                 } else {
-                    cm.sendOk("The room is currently full.");
+                    cm.sendOk("这个房间目前已经满员。");
                     cm.dispose();
                 }
             } else {
                 var party = cm.getParty().getMembers();
                 const GameConfig = Java.type('org.gms.config.GameConfig');
                 if ((selection === 0 || selection === 1) && party.size() < (GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : 2)) {
-                    cm.sendOk("You need at least 2 players to participate in the battle!");
+                    cm.sendOk("至少需要2名玩家才能参加战斗！");
                 } else if ((selection === 2) && party.size() < (GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : 3)) {
-                    cm.sendOk("You need at least 3 players to participate in the battle!");
+                    cm.sendOk("至少需要3名玩家才能参加战斗！");
                 } else {
                     cm.cpqLobby2(selection);
                 }

--- a/gms-server/scripts/npc/2042007.js
+++ b/gms-server/scripts/npc/2042007.js
@@ -18,7 +18,7 @@ function action(mode, type, selection) {
         cm.dispose();
     } else {
         if (status >= 0 && mode == 0) {
-            cm.sendOk("Alright then, I hope we can chat later next time.");
+            cm.sendOk("好吧，希望下次还能再聊。");
             cm.dispose();
             return;
         }
@@ -30,7 +30,7 @@ function action(mode, type, selection) {
 
         if (cm.getPlayer().getMapId() == 980030010) {
             if (status == 0) {
-                cm.sendNext("I hope you had fun at the Monster Carnival!");
+                cm.sendNext("希望你在怪物嘉年华中玩得开心！");
             } else if (status > 0) {
                 cm.warp(980030000, 0);
                 cm.dispose();
@@ -41,20 +41,20 @@ function action(mode, type, selection) {
                     var shiu = "";
                     if (cm.getPlayer().getFestivalPoints() >= 300) {
                         shiu += "#rA#k";
-                        cm.sendOk("Unfortunately, you either drew or lost the battle despite your excellent performance. Victory can be yours next time! \r\n\r\n#bYour result: " + shiu);
+                        cm.sendOk("很遗憾，虽然你表现非常出色，但这场战斗还是平局或失败了。下次胜利一定会属于你！ \r\n\r\n#b你的结果：" + shiu);
                         rnk = 10;
                     } else if (cm.getPlayer().getFestivalPoints() >= 100) {
                         shiu += "#rB#k";
                         rnk = 20;
-                        cm.sendOk("Unfortunately, you either drew or lost the battle, even with your ultimate performance. Just a little bit, and the victory could have been yours! \r\n\r\n#bYour result: " + shiu);
+                        cm.sendOk("很遗憾，虽然你展现了极限般的表现，但这场战斗还是平局或失败了。只差一点点，胜利就会属于你！ \r\n\r\n#b你的结果：" + shiu);
                     } else if (cm.getPlayer().getFestivalPoints() >= 50) {
                         shiu += "#rC#k";
                         rnk = 30;
-                        cm.sendOk("Unfortunately, you either drew or lost the battle. Victory is for those who strive. I see your efforts, so victory is not far from your reach. Keep it up!\r\n\r\n#bYour result: " + shiu);
+                        cm.sendOk("很遗憾，这场战斗最终平局或失败了。胜利属于不断努力的人。我看到了你的努力，所以胜利离你并不遥远。继续加油！\r\n\r\n#b你的结果：" + shiu);
                     } else {
                         shiu += "#rD#k";
                         rnk = 40;
-                        cm.sendOk("Unfortunately, you either equalized or lost the battle, and your performance clearly reflects on it. I expect more from you next time. \r\n\r\n#bYour result: " + shiu);
+                        cm.sendOk("很遗憾，这场战斗最终平局或失败了，你的表现也确实反映了这一点。下次我期待你有更好的表现。 \r\n\r\n#b你的结果：" + shiu);
                     }
                 } else {
                     cm.warp(980030000, 0);
@@ -95,19 +95,19 @@ function action(mode, type, selection) {
                     if (cm.getPlayer().getFestivalPoints() >= 300) {
                         shi += "#rA#k";
                         rnk = 1;
-                        cm.sendOk("Congratulations on your victory!!! What a performance! The opposite group could not do anything! I hope the same good work next time! \r\n\r\n#bYour result: " + shi);
+                        cm.sendOk("恭喜你获得胜利！！！多么精彩的表现！对方队伍完全无计可施！希望下次也能保持这样的好表现！ \r\n\r\n#b你的结果：" + shi);
                     } else if (cm.getPlayer().getFestivalPoints() >= 100) {
                         shi += "#rB#k";
                         rnk = 2;
-                        cm.sendOk("Congratulations on your victory! That was awesome! You did a good job against the opposing group! Just a little longer, and you'll definitely get an A next time! \r\n\r\n#bYour result: " + shi);
+                        cm.sendOk("恭喜你获得胜利！太棒了！你在对抗对方队伍时表现得很好！只要再努力一点，下次一定能拿到A！ \r\n\r\n#b你的结果：" + shi);
                     } else if (cm.getPlayer().getFestivalPoints() >= 50) {
                         shi += "#rC#k";
                         rnk = 3;
-                        cm.sendOk("Congratulations on your victory. You did some things here and there, but that can not be considered a good victory. I expect more from you next time. \r\n\r\n#bYour result: " + shi);
+                        cm.sendOk("恭喜你获得胜利。你确实做了一些贡献，不过还称不上漂亮的胜利。下次我期待你有更好的表现。 \r\n\r\n#b你的结果：" + shi);
                     } else {
                         shi += "#rD#k";
                         rnk = 4;
-                        cm.sendOk("Congratulations on your victory, though your performance did not quite reflect that. Be more active in your next participation in the Monster Carnival! \r\n\r\n#bYour result: " + shi);
+                        cm.sendOk("恭喜你获得胜利，虽然你的表现还不太配得上这场胜利。下次参加怪物嘉年华时，请更积极一些！ \r\n\r\n#b你的结果：" + shi);
                     }
                 } else {
                     cm.warp(980030000, 0);

--- a/gms-server/scripts/npc/cpqchallenge2.js
+++ b/gms-server/scripts/npc/cpqchallenge2.js
@@ -43,9 +43,9 @@ function action(mode, type, selection) {
                 const GameConstants = Java.type('org.gms.constants.game.GameConstants');
                 var snd = "";
                 for (var i = 0; i < party.size(); i++) {
-                    snd += "#bName: " + party.get(i).getName() + " / (Level: " + party.get(i).getLevel() + ") / " + GameConstants.getJobName(party.get(i).getJobId()) + "#k\r\n\r\n";
+                    snd += "#b角色名：" + party.get(i).getName() + " / （等级：" + party.get(i).getLevel() + "） / " + GameConstants.getJobName(party.get(i).getJobId()) + "#k\r\n\r\n";
                 }
-                cm.sendAcceptDecline(snd + "Would you like to fight this party at the Monster Carnival?");
+                cm.sendAcceptDecline(snd + "你想在怪物嘉年华中挑战这个队伍吗？");
             } else {
                 cm.answerCPQChallenge(false);
                 cm.getChar().setChallenged(false);
@@ -57,7 +57,7 @@ function action(mode, type, selection) {
             } else {
                 cm.answerCPQChallenge(false);
                 cm.getChar().setChallenged(false);
-                cm.sendOk("The number of players between the teams is not the same.");
+                cm.sendOk("双方队伍人数不一致。");
             }
             cm.dispose();
         }

--- a/gms-server/wz-zh-CN/Quest.wz/PQuest.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/PQuest.img.xml
@@ -650,7 +650,7 @@
         </imgdir>
     </imgdir>
     <imgdir name="1302">
-        <string name="The 2nd Monster Carnival" value=""/>
+        <string name="怪物嘉年华2" value=""/>
         <string name="mark" value="Map/MapHelper/mark/Carnival"/>
         <imgdir name="rank">
             <imgdir name="S">

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9640,20 +9640,20 @@
         <int name="viewMedalItem" value="1142014"/>
     </imgdir>
     <imgdir name="29505">
-        <string name="name" value="The Carnivalian of Absolute Victory"/>
+        <string name="name" value="嘉年华百战百胜者"/>
         <int name="area" value="10"/>
-        <string name="0" value="If you think you have the most wins under your belt in the 2nd Monster Carnival, acquire the #bAbsolute Victory Carnivalian Medal#k from Spiegelmann!"/>
-        <string name="1" value="If you think you have the most wins under your belt in the 2nd Monster Carnival, acquire the #bAbsolute Victory Carnivalian Medal#k from Spiegelmann!"/>
-        <string name="2" value="You have acquired the #bAbsolute Victory Carnivalian Medal#k for having the most wins in the 2nd Monster Carnival."/>
+        <string name="0" value="如果你认为自己在怪物嘉年华2中拥有最多胜场，就去找休彼德蔓领取#b#t1142077##k吧！"/>
+        <string name="1" value="如果你认为自己在怪物嘉年华2中拥有最多胜场，就去找休彼德蔓领取#b#t1142077##k吧！"/>
+        <string name="2" value="已因在怪物嘉年华2中拥有最多胜场而获得#b#t1142077##k。"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142077"/>
     </imgdir>
     <imgdir name="29506">
-        <string name="name" value="The Gifted Carnivalian"/>
+        <string name="name" value="嘉年华天才"/>
         <int name="area" value="10"/>
-        <string name="0" value="If you think you have the highest victory rate in the 2nd Monster Carnival, acquire the #bGifted Carnivalian Medal#k from Spiegelmann!"/>
-        <string name="1" value="If you think you have the highest victory rate in the 2nd Monster Carnival, acquire the #bGifted Carnivalian Medal#k from Spiegelmann!"/>
-        <string name="2" value="You have acquired the #Gifted Carnivalian Medal#k for having the highest victory rate in the 2nd Monster Carnival."/>
+        <string name="0" value="如果你认为自己在怪物嘉年华2中拥有最高胜率，就去找休彼德蔓领取#b#t1142078##k吧！"/>
+        <string name="1" value="如果你认为自己在怪物嘉年华2中拥有最高胜率，就去找休彼德蔓领取#b#t1142078##k吧！"/>
+        <string name="2" value="已因在怪物嘉年华2中拥有最高胜率而获得#b#t1142078##k。"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142078"/>
     </imgdir>


### PR DESCRIPTION
## 改动汇总
- 汉化怪物嘉年华2休彼德蔓关联的勋章任务标题与任务说明，包括「嘉年华百战百胜者」和「嘉年华天才」。
- 补充这两个勋章任务的接取、拒绝、完成和条件不足提示，避免任务对话为空或继续显示英文。
- 汉化怪物嘉年华2休彼德蔓相关 NPC 脚本对白，包括入场条件、房间状态、胜负结算和挑战确认提示。
- 汉化怪物嘉年华2组队任务显示名，避免仍显示英文名称。

## 客户端影响
- 本次改动包含 Quest.wz 相关文本资源，客户端发布或测试时需要同步对应的 Quest 数据文件，确保任务标题、任务描述和任务对话在客户端侧显示为中文。

## 验证
- 已确认本分支仅包含本次怪物嘉年华2休彼德蔓汉化相关改动。
- 已检查修改后的 XML 可正常解析。
- 已检查修改后的 NPC 脚本语法。
- 未重新构建 jar，jar 包应在后续正式 release 时统一打包。