### PR TITLE
fix: 保持角色特殊效果重登后生效

### DIFF
--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -164,6 +164,19 @@ public class Character extends AbstractCharacterObject {
     @Setter
     @Getter
     private int itemEffect;
+
+    public boolean hasItemEffectItem(int itemId) {
+        if (itemId == 0) {
+            return true;
+        }
+
+        InventoryType inventoryType = (itemId == ItemId.BUMMER_EFFECT || itemId == ItemId.GOLDEN_CHICKEN_EFFECT)
+                ? InventoryType.ETC
+                : InventoryType.CASH;
+        Item item = getInventory(inventoryType).findById(itemId);
+        return item != null && item.getQuantity() > 0;
+    }
+
     @Setter
     @Getter
     private int guildId;
@@ -6470,6 +6483,10 @@ public class Character extends AbstractCharacterObject {
         if ((sandboxCheck & ItemConstants.SANDBOX) == ItemConstants.SANDBOX) {
             chr.setHasSandboxItem();
         }
+        Integer itemEffect = charactersDO.getItemEffect();
+        if (itemEffect != null && chr.hasItemEffectItem(itemEffect)) {
+            chr.setItemEffect(itemEffect);
+        }
         chr.setPartnerId(charactersDO.getPartnerId());
         chr.setMarriageItemId(charactersDO.getMarriageItemId());
         World world = Server.getInstance().getWorld(charactersDO.getWorld());
@@ -6627,6 +6644,7 @@ public class Character extends AbstractCharacterObject {
         cdo.setUseslots((int) chr.getSlots(1));
         cdo.setSetupslots((int) chr.getSlots(2));
         cdo.setEtcslots((int) chr.getSlots(3));
+        cdo.setItemEffect(chr.getItemEffect());
         // todo 未完成
         return cdo;
     }
@@ -7540,7 +7558,7 @@ public class Character extends AbstractCharacterObject {
             con.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
 
             try {
-                try (PreparedStatement ps = con.prepareStatement("UPDATE characters SET level = ?, fame = ?, str = ?, dex = ?, luk = ?, `int` = ?, exp = ?, gachaexp = ?, hp = ?, mp = ?, maxhp = ?, maxmp = ?, sp = ?, ap = ?, gm = ?, skincolor = ?, gender = ?, job = ?, hair = ?, face = ?, map = ?, meso = ?, hpMpUsed = ?, spawnpoint = ?, party = ?, buddyCapacity = ?, messengerid = ?, messengerposition = ?, mountlevel = ?, mountexp = ?, mounttiredness= ?, equipslots = ?, useslots = ?, setupslots = ?, etcslots = ?,  monsterbookcover = ?, vanquisherStage = ?, dojoPoints = ?, lastDojoStage = ?, finishedDojoTutorial = ?, vanquisherKills = ?, matchcardwins = ?, matchcardlosses = ?, matchcardties = ?, omokwins = ?, omoklosses = ?, omokties = ?, dataString = ?, fquest = ?, jailexpire = ?, partnerId = ?, marriageItemId = ?, lastExpGainTime = ?, ariantPoints = ?, partySearch = ? WHERE id = ?", Statement.RETURN_GENERATED_KEYS)) {
+                try (PreparedStatement ps = con.prepareStatement("UPDATE characters SET level = ?, fame = ?, str = ?, dex = ?, luk = ?, `int` = ?, exp = ?, gachaexp = ?, hp = ?, mp = ?, maxhp = ?, maxmp = ?, sp = ?, ap = ?, gm = ?, skincolor = ?, gender = ?, job = ?, hair = ?, face = ?, map = ?, meso = ?, hpMpUsed = ?, spawnpoint = ?, party = ?, buddyCapacity = ?, messengerid = ?, messengerposition = ?, mountlevel = ?, mountexp = ?, mounttiredness= ?, equipslots = ?, useslots = ?, setupslots = ?, etcslots = ?,  monsterbookcover = ?, vanquisherStage = ?, dojoPoints = ?, lastDojoStage = ?, finishedDojoTutorial = ?, vanquisherKills = ?, matchcardwins = ?, matchcardlosses = ?, matchcardties = ?, omokwins = ?, omoklosses = ?, omokties = ?, dataString = ?, fquest = ?, jailexpire = ?, partnerId = ?, marriageItemId = ?, lastExpGainTime = ?, ariantPoints = ?, partySearch = ?, itemEffect = ? WHERE id = ?", Statement.RETURN_GENERATED_KEYS)) {
                     ps.setInt(1, level);    // thanks CanIGetaPR for noticing an unnecessary "level" limitation when persisting DB data
                     ps.setInt(2, fame);
 
@@ -7654,7 +7672,8 @@ public class Character extends AbstractCharacterObject {
                     ps.setTimestamp(53, new Timestamp(lastExpGainTime));
                     ps.setInt(54, ariantPoints);
                     ps.setBoolean(55, canRecvPartySearchInvite);
-                    ps.setInt(56, id);
+                    ps.setInt(56, itemEffect);
+                    ps.setInt(57, id);
 
                     int updateRows = ps.executeUpdate();
                     if (updateRows < 1) {

--- a/gms-server/src/main/java/org/gms/dao/entity/CharactersDO.java
+++ b/gms-server/src/main/java/org/gms/dao/entity/CharactersDO.java
@@ -200,6 +200,9 @@ public class CharactersDO implements Serializable {
     @Column("partySearch")
     private Boolean partySearch;
 
+    @Column("itemEffect")
+    private Integer itemEffect;
+
     private Long jailexpire;
 
 }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/PlayerLoggedinHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/PlayerLoggedinHandler.java
@@ -270,6 +270,9 @@ public final class PlayerLoggedinHandler extends AbstractPacketHandler {
             player.sendPacket(PacketCreator.sendAutoMpPot(autompPot != null ? autompPot.getAction() : 0));
 
             player.getMap().addPlayer(player);
+            if (player.getItemEffect() != 0) {
+                player.sendPacket(PacketCreator.itemEffect(player.getId(), player.getItemEffect()));
+            }
             player.visitMap(player.getMap());
 
             BuddyList bl = player.getBuddylist();

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/UseItemEffectHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/UseItemEffectHandler.java
@@ -22,9 +22,6 @@
 package org.gms.net.server.channel.handlers;
 
 import org.gms.client.Client;
-import org.gms.client.inventory.InventoryType;
-import org.gms.client.inventory.Item;
-import org.gms.constants.id.ItemId;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
 import org.gms.util.PacketCreator;
@@ -32,17 +29,9 @@ import org.gms.util.PacketCreator;
 public final class UseItemEffectHandler extends AbstractPacketHandler {
     @Override
     public final void handlePacket(InPacket p, Client c) {
-        Item toUse;
         int itemId = p.readInt();
-        if (itemId == ItemId.BUMMER_EFFECT || itemId == ItemId.GOLDEN_CHICKEN_EFFECT) {
-            toUse = c.getPlayer().getInventory(InventoryType.ETC).findById(itemId);
-        } else {
-            toUse = c.getPlayer().getInventory(InventoryType.CASH).findById(itemId);
-        }
-        if (toUse == null || toUse.getQuantity() < 1) {
-            if (itemId != 0) {
-                return;
-            }
+        if (!c.getPlayer().hasItemEffectItem(itemId)) {
+            return;
         }
         c.getPlayer().setItemEffect(itemId);
         c.getPlayer().getMap().broadcastMessage(c.getPlayer(), PacketCreator.itemEffect(c.getPlayer().getId(), itemId), false);

--- a/gms-server/src/main/resources/db/migration/V1.11.2__add_character_item_effect.sql
+++ b/gms-server/src/main/resources/db/migration/V1.11.2__add_character_item_effect.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `characters`
+    ADD COLUMN `itemEffect` INT(11) NOT NULL DEFAULT '0' AFTER `partySearch`;


### PR DESCRIPTION
## 改动点汇总

- 将角色当前启用的特殊道具效果持久化到角色数据中，避免重新登录后效果丢失。
- 角色加载背包后恢复已保存的效果，并校验角色仍持有对应效果道具，防止恢复无效或已失去的效果。
- 保留 `itemId = 0` 的关闭效果逻辑，并让使用效果道具时复用统一校验。
- 角色进入地图后，如果存在已恢复的效果，会向本人补发效果包，确保本人和其他玩家都能立即看到效果。
- 新增数据库迁移，为角色表补充 `itemEffect` 字段，默认值为 `0`。

## 客户端影响

- 不涉及客户端代码或 WZ/IMG 改动。
- 服务端复用已有 `itemEffect` 协议包完成恢复展示，客户端无需更新。

## 验证

- 已执行 `mvn -pl gms-server -DskipTests compile`，编译通过。