### PR TITLE
fix: 修复多重飞镖命中多个怪物时可能不扣血的问题

### DIFF
--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -1129,7 +1129,9 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
      * 仅对明确不是“空间攻击框”语义的技能做豁免，避免误伤正常近战技能。
      */
     private static boolean shouldSkipDistanceHackCheck(int skillId, StatEffect attackEffect) {
-        return isFullScreenDistanceExempt(skillId) || isNonSpatialAttackSkill(skillId, attackEffect);
+        return isFullScreenDistanceExempt(skillId)
+                || isNonSpatialAttackSkill(skillId, attackEffect)
+                || isPiercingProjectileWithoutAttackBox(skillId, attackEffect);
     }
 
     /**
@@ -1143,6 +1145,19 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
 
         return skillId == Marauder.ENERGY_CHARGE
                 || skillId == ThunderBreaker.ENERGY_CHARGE;
+    }
+
+    /**
+     * Avenger has no level/lt or level/rb in Skill.wz; the client sends hits from its piercing projectile path.
+     * The generic distance check can skip valid hits when both the skill attack box and monster bbox are unavailable.
+     */
+    private static boolean isPiercingProjectileWithoutAttackBox(int skillId, StatEffect attackEffect) {
+        if (attackEffect != null && attackEffect.hasBoundingBox()) {
+            return false;
+        }
+
+        return skillId == Hermit.AVENGER
+                || skillId == NightWalker.AVENGER;
     }
 
     /**


### PR DESCRIPTION
## 改动点汇总

- 为隐士多重飞镖和夜行者多重飞镖增加专门的距离检测豁免判断。
- 修复这类穿透型飞镖技能缺少 `Skill.wz` 攻击范围框时，通用距离检测依赖怪物 bbox 导致正常命中被跳过的问题。
- 保留原有全屏技能、蓄能类技能的距离检测豁免逻辑，仅追加多重飞镖相关判断，降低对其他技能的影响。

## 客户端影响

- 本次改动仅调整服务端伤害结算前的距离校验逻辑。
- 不涉及 WZ/XML、客户端资源或补丁内容，客户端无需更新。

## 验证

- 已确认分支相对 `upstream/master` 只有本次 1 个提交。
- 已确认 diff 只包含本次服务端修复文件。
- 已完成服务端编译验证。
- 已完成乱码校验，未发现异常字符。