### PR TITLE
fix: 简化女神之塔组队任务流程

### DIFF
--- a/gms-server/scripts-zh-CN/event/OrbisPQ.js
+++ b/gms-server/scripts-zh-CN/event/OrbisPQ.js
@@ -194,9 +194,14 @@ function respawnStages(eim) {}
 
 function playerEntry(eim, player) {
     var map = eim.getMapInstance(entryMap);
+    if (eim.getProperty("stage0NpcSpawned") != "1") {
+        const Point = Java.type('java.awt.Point');
+        eim.spawnNpc(2013001, new Point(377, 66), map);
+        eim.setProperty("stage0NpcSpawned", "1");
+    }
     player.changeMap(map, map.getPortal(0));
 
-    var texttt = "你好，我是女神的内侍官#e#b帮佣易克#n#k。\r\n别紧张，你现在还看不到我。\r\n当女神石化时，我也同时失去了力量，所以现在你只能看到我微弱的闪光。\r\n如果你能收集到魔法云的力量，我就能恢复形体变回原样。\r\n请帮我收集 #b#e20#n#k 朵 #b#e#v4001063##t4001063##k#n 带回来。";
+    var texttt = "你好，我是女神的内侍官#e#b帮佣易克#n#k。\r\n别紧张，第一阶段的魔法云收集已经简化。\r\n请让#b队长#k直接和我对话，我会带大家继续前进。";
     player.getAbstractPlayerInteraction().npcTalk(2013001, texttt);
 }
 

--- a/gms-server/scripts-zh-CN/npc/2013001.js
+++ b/gms-server/scripts-zh-CN/npc/2013001.js
@@ -75,43 +75,63 @@ function action(mode, type, selection) {
                 cm.dispose();
                 break;
             case 920010100:
-                if (isStatueComplete()) {
+                if (eim.getIntProperty("statusStg1") != 1) {
+                    cm.sendOk("第二阶段已完成！现在将带大家进入下一个阶段。");
+                    cm.removeAll(4001050);
+                    cm.gainItem(4001044, 1); //first piece
+                    eim.giveEventPlayersExp(3500);
+                    clearStage(1, eim);
+                    eim.warpEventTeam(920010300);
+                } else if (cm.haveItem(4001055, 1)) {
+                    cm.sendOk("生命草已经带回！我会直接召唤雅典娜女神，请和她对话领取奖励。");
+                    cm.removeAll(4001055);
+                    eim.clearPQ();
+                    eim.setProperty("statusStg8", "1");
+                    eim.giveEventPlayersExp(3500);
+                    eim.showClearEffect(true);
+                    eim.startEventTimer(5 * 60000);
+                    if (cm.getMap().getNPCById(2013002) == null) {
+                        cm.spawnNpc(2013002, new java.awt.Point(-48, -916), cm.getMap());
+                    }
+                } else if (eim.getIntProperty("statusStg6") == 1 && eim.getIntProperty("statusStg7") == -1) {
+                    cm.sendOk("女神像修复流程已简化！现在将带大家进入花园阶段。");
+                    cm.removeAll(4001044);
+                    cm.removeAll(4001045);
+                    cm.removeAll(4001046);
+                    cm.removeAll(4001047);
+                    cm.removeAll(4001048);
+                    cm.removeAll(4001049);
+                    eim.warpEventTeam(920010800);
+                } else if (isStatueComplete()) {
                     if (eim.getIntProperty("statusStg7") == -1) {
                         eim.warpEventTeam(920010800);
                     } else if (eim.getIntProperty("statusStg8") == -1) {
                         cm.sendOk("哦！你带来了#t4001055#！请把它放在雕像的底座上，让雅典娜重生！");
                     } else {
-                        cm.sendOk("谢谢你救了雅典娜！请和她交谈…");
+                        cm.sendOk("谢谢你救了雅典娜！请和她交谈。");
                     }
                 } else {
-                    cm.sendOk("请拯救雅典娜！收集她雕像的六块碎片，然后与我交谈以取回最后一块碎片！");
+                    cm.sendOk("请继续完成前面的阶段，然后再和我对话进入花园阶段。");
                 }
                 break;
             case 920010200: //walkway
-                if (!cm.haveItem(4001050, 30)) {
-                    cm.sendOk("收集这个阶段怪物身上的30个雕像碎片，然后请把它们带给我，这样我就可以把它们拼在一起！");
+                if (eim.getIntProperty("statusStg1") != 1) {
+                    cm.sendOk("第二阶段已简化。请回到中央塔，让队长直接和易克对话完成这一阶段。");
                 } else {
-                    cm.sendOk("你已经找到了它们！这里是第一块雕像碎片。");
-                    cm.removeAll(4001050);
-                    cm.gainItem(4001044, 1); //first piece
-                    eim.giveEventPlayersExp(3500);
-                    clearStage(1, eim);
+                    cm.sendOk("这个阶段已经完成了。去寻找其他雕像碎片吧。");
                 }
                 break;
             case 920010300: //storage
                 if (eim.getIntProperty("statusStg2") != 1) {
-                    if (cm.getMap().countMonsters() == 0 && cm.getMap().countItems() == 0) {
-                        if (cm.canHold(4001045)) {
-                            cm.sendOk("哦，我找到了第二块雕像碎片。拿去吧。");
-                            cm.gainItem(4001045, 1);
-                            eim.giveEventPlayersExp(3500);
-                            clearStage(2, eim);
-                            eim.setProperty("statusStg2", "1");
-                        } else {
-                            cm.sendOk("我已经找到了第二块雕像碎片。在你的背包中腾出一个空位来拿它。");
-                        }
+                    if (cm.canHold(4001045)) {
+                        cm.sendOk("第三阶段已完成！现在将带大家进入下一个阶段。");
+                        cm.gainItem(4001045, 1);
+                        eim.giveEventPlayersExp(3500);
+                        clearStage(2, eim);
+                        eim.setProperty("statusStg2", "1");
+                        eim.warpEventTeam(920010400);
                     } else {
-                        cm.sendOk("在这个房间里找到隐藏的第二块雕像碎片。");
+                        cm.sendOk("我已经找到了第二块雕像碎片。在你的背包中腾出一个空位来拿它。");
                     }
                 } else {
                     cm.sendOk("干得好。去找其他雕像碎片。");
@@ -119,171 +139,72 @@ function action(mode, type, selection) {
 
                 break;
             case 920010400: //lobby
-                if (eim.getIntProperty("statusStg3") == -1) {
-                    cm.sendOk("请找到本周的唱片，并将其放在音乐播放器上。\r\n#v4001056# 星期日\r\n#v4001057# 星期一\r\n#v4001058# 星期二\r\n#v4001059# 星期三\r\n#v4001060# 星期四\r\n#v4001061# 星期五\r\n#v4001062# 星期六");
-                } else if (eim.getIntProperty("statusStg3") == 0) {
-                    cm.getMap().getReactorByName("stone3").forceHitReactor(1);
-                    cm.sendOk("哦，这音乐... 它和环境非常搭配。做得好，一个箱子出现在场地上。从中取出雕像的一部分！");
+                if (eim.getIntProperty("statusStg3") != 2) {
+                    cm.sendOk("第四阶段已完成！现在将带大家进入下一个阶段。");
+                    cm.gainItem(4001046, 1); //third piece
                     eim.giveEventPlayersExp(3500);
                     clearStage(3, eim);
                     eim.setProperty("statusStg3", "2");
+                    eim.warpEventTeam(920010500);
 
                 } else {
-                    cm.sendOk("非常感谢你！");
+                    cm.sendOk("这个阶段已经完成了。去寻找其他雕像碎片吧。");
                 }
                 break;
             case 920010500: //sealed
-                if (eim.getIntProperty("statusStg4") == -1) {
-                    var total = 3;
-                    for (var i = 0; i < 2; i++) {
-                        var rnd = Math.round(Math.random() * total);
-                        total -= rnd;
-
-                        eim.setProperty("stage4_" + i, rnd);
-                    }
-                    eim.setProperty("stage4_2", "" + total);
-
-                    eim.setProperty("statusStg4", "0");
-                }
-                if (eim.getIntProperty("statusStg4") == 0) {
-                    var players = Array();
-                    var total = 0;
-                    for (var i = 0; i < 3; i++) {
-                        var z = cm.getMap().getNumPlayersInArea(i);
-                        players.push(z);
-                        total += z;
-                    }
-                    if (total != 3) {
-                        const GameConfig = Java.type('org.gms.config.GameConfig');
-                        if(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1){
-                            cm.getMap().getReactorByName("stone4").forceHitReactor(1);
-                            eim.giveEventPlayersExp(3500);
-                            clearStage(4, eim);
-                        }else{
-                            cm.sendOk("这些平台上需要有在场的3名玩家。");
-                        }
-                    } else {
-                        var num_correct = 0;
-                        for (var i = 0; i < 3; i++) {
-                            if (eim.getProperty("stage4_" + i) === ("" + players[i])) {
-                                num_correct++;
-                            }
-                        }
-                        if (num_correct == 3) {
-                            cm.sendOk("你找到了正确的组合！地图顶部出现了一个宝箱，去拿取里面的雕像碎片吧！");
-                            cm.getMap().getReactorByName("stone4").forceHitReactor(1);
-                            eim.giveEventPlayersExp(3500);
-                            clearStage(4, eim);
-                        } else {
-                            eim.showWrongEffect();
-                            if (num_correct > 0) {
-                                cm.sendOk("一个平台上有正确数量的玩家。");
-                            } else {
-                                cm.sendOk("所有的平台上都有错误的玩家数量。");
-                            }
-                        }
-                    }
+                if (eim.getIntProperty("statusStg4") != 1) {
+                    cm.sendOk("第五阶段已完成！现在将带大家进入下一个阶段。");
+                    cm.gainItem(4001047, 1); //fourth piece
+                    eim.giveEventPlayersExp(3500);
+                    clearStage(4, eim);
+                    eim.setProperty("statusStg4", "1");
+                    eim.warpEventTeam(920010600);
                 } else {
-                    cm.sendOk("干得好！请去找其他碎片，拯救雅典娜！");
+                    cm.sendOk("这个阶段已经完成了。去寻找其他雕像碎片吧。");
                 }
                 cm.dispose();
                 break;
             case 920010600: //lounge
-                if (eim.getIntProperty("statusStg5") == -1) {
-                    if (!cm.haveItem(4001052, 40)) {
-                        cm.sendOk("在这个阶段从怪物身上收集40个雕像碎片，然后请把它们带给我，这样我就可以把它们拼在一起！");
-                    } else {
-                        cm.sendOk("你已经找到了它们！这里是第五块雕像碎片。");
-                        cm.removeAll(4001052);
-                        cm.gainItem(4001048, 1); //fifth piece
-                        eim.giveEventPlayersExp(3500);
-                        clearStage(5, eim);
-                        eim.setIntProperty("statusStg5", 1);
-                    }
+                if (eim.getIntProperty("statusStg5") != 1) {
+                    cm.sendOk("第六阶段已完成！现在将带大家进入下一个阶段。");
+                    cm.removeAll(4001052);
+                    cm.gainItem(4001048, 1); //fifth piece
+                    eim.giveEventPlayersExp(3500);
+                    clearStage(5, eim);
+                    eim.setIntProperty("statusStg5", 1);
+                    eim.warpEventTeam(920010700);
                 } else {
-                    cm.sendOk("你已经找到了所有的东西。去搜索塔的其他房间吧。");
+                    cm.sendOk("这个阶段已经完成了。去寻找其他雕像碎片吧。");
                 }
                 break;
             case 920010700: //on the way up
-                if (eim.getIntProperty("statusStg6") == -1) {
-                    var rnd1 = Math.floor(Math.random() * 5);
-
-                    var rnd2 = Math.floor(Math.random() * 5);
-                    while (rnd2 == rnd1) {
-                        rnd2 = Math.floor(Math.random() * 5);
-                    }
-
-                    if (rnd1 > rnd2) {
-                        rnd1 = rnd1 ^ rnd2;
-                        rnd2 = rnd1 ^ rnd2;
-                        rnd1 = rnd1 ^ rnd2;
-                    }
-
-                    var comb = "";
-                    for (var i = 0; i < rnd1; i++) {
-                        comb += "0";
-                    }
-                    comb += "1";
-                    for (var i = rnd1 + 1; i < rnd2; i++) {
-                        comb += "0";
-                    }
-                    comb += "1";
-                    for (var i = rnd2 + 1; i < 5; i++) {
-                        comb += "0";
-                    }
-
-                    eim.setProperty("stage6_c", "" + comb);
-
-                    eim.setProperty("statusStg6", "0");
-                }
-
-                var comb = eim.getProperty("stage6_c");
-
-                if (eim.getIntProperty("statusStg6") == 0) {
-                    var react = "";
-                    var total = 0;
-                    for (var i = 1; i <= 5; i++) {
-                        if (cm.getMap().getReactorByName("" + i).getState() > 0) {
-                            react += "1";
-                            total += 1;
-                        } else {
-                            react += "0";
-                        }
-                    }
-
-                    if (total != 2) {
-                        cm.sendOk("地图顶部需要精确地推动两个杠杆。");
-                    } else {
-                        var num_correct = 0;
-                        var psh_correct = 0;
-                        for (var i = 0; i < 5; i++) {
-                            if (react.charCodeAt(i) == comb.charCodeAt(i)) {
-                                num_correct++;
-                                if (react.charAt(i) == '1') {
-                                    psh_correct++;
-                                }
-                            }
-                        }
-                        if (num_correct == 5) {
-                            cm.sendOk("你找到了正确的组合！从里面取出雕像碎片！");
-                            cm.getMap().getReactorByName("stone6").forceHitReactor(1);
-                            eim.giveEventPlayersExp(3500);
-                            clearStage(6, eim);
-                        } else {
-                            eim.showWrongEffect();
-                            if (psh_correct >= 1) {
-                                cm.sendOk("其中一个推动的杠杆是正确的。");
-                            } else {
-                                cm.sendOk("两个推杆都是错误的。");
-                            }
-                        }
-                    }
+                if (eim.getIntProperty("statusStg6") != 1) {
+                    cm.sendOk("第七阶段已完成！现在将带大家回到中央塔。");
+                    cm.gainItem(4001049, 1); //sixth piece
+                    eim.giveEventPlayersExp(3500);
+                    clearStage(6, eim);
+                    eim.setProperty("statusStg6", "1");
+                    eim.warpEventTeam(920010100);
                 } else {
-                    cm.sendOk("干得漂亮！去看看其他的部分吧。");
+                    cm.sendOk("这个阶段已经完成了。请回到中央塔继续前进。");
                 }
                 break;
             case 920010800:
-                cm.sendNext("请找到一种方法来打败远古精灵！一旦你通过种植种子找到了黑暗食人花并打死它，远古精灵就会出现！打败它，拿到生命草来拯救雅典娜！！");
+                if (eim.getIntProperty("statusStg7") == -1) {
+                    cm.getMap().killAllMonsters();
+                    cm.getMap().allowSummonState(false);
+                    cm.spawnMonster(9300039, 260, 490);
+                    eim.setProperty("statusStg7", "0");
+                    cm.sendNext("远古精灵已经出现！请击败它，取得特别奇怪的种子后再和我对话。");
+                } else if (cm.haveItem(4001054, 1)) {
+                    cm.sendOk("你带来了特别奇怪的种子！我会帮你取得生命草，并带大家回到中央塔。");
+                    cm.removeAll(4001054);
+                    cm.gainItem(4001055, 1);
+                    eim.setProperty("statusStg7", "1");
+                    eim.warpEventTeam(920010100);
+                } else {
+                    cm.sendNext("请先击败远古精灵，并带着它掉落的#b#t4001054##k再来找我。我会帮你进入下一个阶段。");
+                }
                 break;
             case 920010900:
                 if (eim.getProperty("statusStg8") == "1") {

--- a/gms-server/scripts-zh-CN/npc/2013002.js
+++ b/gms-server/scripts-zh-CN/npc/2013002.js
@@ -37,12 +37,16 @@ function action(mode, type, selection) {
         status++;
         if (cm.getPlayer().getMapId() == 920010100) { //Center tower
             if (status == 0) {
-                cm.sendYesNo("我已经解除了阻止通往塔楼监狱储藏室的咒语。你可能会在那里找到一些好东西……或者，你可能想现在离开。你准备好离开了吗？");
+                cm.sendNext("谢谢你救出了我，雅典娜。请接受这份奖励，愿女神的祝福与你同在。");
             } else if (status == 1) {
-                cm.warp(920011300, 0);
-                cm.dispose();
+                if (cm.getEventInstance().giveEventReward(cm.getPlayer())) {
+                    cm.warp(200080101, 0);
+                    cm.dispose();
+                } else {
+                    cm.sendOk("请先在背包中腾出空间。");
+                    cm.dispose();
+                }
             }
-
         } else if (cm.getPlayer().getMapId() == 920011100) {
             if (status == 0) {
                 cm.sendYesNo("所以，你准备好退出了吗？");


### PR DESCRIPTION
## 改动点汇总

- 简化女神之塔组队任务的中文脚本流程，减少前置收集、机关、摆放道具等重复操作。
- 第一阶段进入地图后直接生成易克，队长点击易克即可完成魔法云收集阶段。
- 后续多个房间阶段改为队长点击易克后直接完成当前阶段，并传送到下一阶段。
- 花园阶段保留 Boss 战斗：点击易克直接召唤远古精灵，击杀 Boss 后用掉落的特别奇怪的种子继续推进。
- 生命草步骤改为队长带生命草点击中央塔易克后直接召唤雅典娜女神，不再需要把生命草丢到女神像底座。
- 雅典娜女神在中央塔可直接发放最终奖励并退出组队任务。
- 本次改动仅影响服务端中文脚本，不涉及客户端资源或客户端代码改动。

## 修改后的组队任务操作流程

1. 进入女神之塔组队任务后，队长在第一阶段地图点击易克，直接完成魔法云收集阶段并进入中央塔。
2. 在中央塔点击易克，直接获得第一块女神像碎片，并进入仓库阶段。
3. 在仓库阶段点击易克，直接获得第二块女神像碎片，并进入音乐阶段。
4. 在音乐阶段点击易克，直接获得第三块女神像碎片，并进入封印阶段。
5. 在封印阶段点击易克，直接获得第四块女神像碎片，并进入休息室阶段。
6. 在休息室阶段点击易克，直接获得第五块女神像碎片，并进入上行路阶段。
7. 在上行路阶段点击易克，直接获得第六块女神像碎片，并返回中央塔。
8. 回到中央塔后点击易克，直接跳过女神像摆放流程，并进入花园阶段。
9. 在花园阶段点击易克，直接召唤远古精灵 Boss。
10. 击杀远古精灵后拾取特别奇怪的种子，再点击易克，易克会换取生命草并带队伍返回中央塔。
11. 队长带生命草在中央塔点击易克，直接召唤雅典娜女神。
12. 点击雅典娜女神领取奖励，完成组队任务并退出地图。

## 校验

- 已通过 JavaScript 语法检查。
- 已执行 Git diff 空白检查。
- 已对新增中文内容进行乱码特征校验，未发现乱码。
- 已进行完整本地流程测试，通过。