### PR TITLE
fix: 汉化携詹与樵夫相关任务信息

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -14437,34 +14437,34 @@
         <int name="area" value="44"/>
     </imgdir>
     <imgdir name="3948">
-        <string name="name" value="Sejan&apos;s Good Habit"/>
-        <string name="0" value="#b#p2101011##k in #b#m260000200##k seems to be in some kind of trouble... I should go pay him visit."/>
-        <string name="1" value="I met with #b#p2101011##k.  He said because he hadn&apos;t been feeling good, he didn&apos;t collect his arrows for a week and now he has lost some.  I promised #b#p2101011##k that I would collect and bring him back all his missing arrows.  But I didn&apos;t know it was that many.  How many arrows does #b#p2101011##k shoot everyday? \n I thought I heard somewhere that they sell #b#t02060001##k in either #r#m220000000##k or #r#m222000000##k..."/>
-        <string name="2" value="#b#p2101011##k started practicing shooting arrows again.   I wanted to ask #b#p2101011##k how many arrows he shoots on average in one day... but he looked so focused as he was training to fight against the queen, I felt like I shouldn&apos;t bother him."/>
+        <string name="name" value="携詹的好习惯"/>
+        <string name="0" value="#b#m260000200##k的#b#p2101011##k好像遇到了什么麻烦……去看看他吧。"/>
+        <string name="1" value="见到了#b#p2101011##k。他说因为身体不舒服，有一个星期没有回收射出去的箭矢，结果弄丢了一些。我答应#b#p2101011##k帮他把丢失的箭矢全部找回来。可是没想到数量竟然那么多。#b#p2101011##k每天到底要射多少支箭啊？\n听说#b#t02060001##k在#r#m220000000##k或#r#m222000000##k有卖……"/>
+        <string name="2" value="#b#p2101011##k又开始练习射箭了。本来想问问#b#p2101011##k平均一天会射多少支箭……但他看起来正专心训练，准备与王妃作战，我觉得还是不要打扰他比较好。"/>
         <int name="area" value="44"/>
     </imgdir>
     <imgdir name="3949">
-        <string name="name" value="Jiyur&apos;s Palace Entry Pass"/>
-        <string name="parent" value="In Search for His Sister"/>
+        <string name="name" value="吉尤尔的宫殿出入资格证"/>
+        <string name="parent" value="寻找姐姐"/>
         <int name="order" value="1"/>
-        <string name="0" value="#b#p2101001##k says he is going to see his sister.  I&apos;m worried since he&apos;s just a kid.  Maybe I should go see him."/>
-        <string name="1" value="I didn&apos;t really believe it when #p2101001# said he was going inside the palace to see his sister... The plan #p2101001# thought of was to buy #b#t04031582##k from #b#p2101004##k.  Since I already said I would pay for it knowing that #p2101001# has no money... I guess I need to keep the promise now.\n\n#i04031582# #t04031582#  #b#c04031582##k / 1"/>
-        <string name="2" value="#p2101001# looked so happy when he received the #b#t04031582##k ... Then just like that, he ran off to the palace.  I&apos;ll have to ask him later if he was able to meet his sister.  But... was he supposed to write his name on the #t04031582#?  I&apos;ve never heard of that before."/>
+        <string name="0" value="#b#p2101001##k说他要去见姐姐。他还只是个孩子，真让人担心。去看看他吧。"/>
+        <string name="1" value="#p2101001#说要进宫殿见姐姐时，我其实不太相信……#p2101001#想到的办法，是从#b#p2101004##k那里买#b#t04031582##k。既然知道#p2101001#没钱时我已经答应替他付钱……现在就得遵守约定了。\n\n#i04031582# #t04031582#  #b#c04031582##k / 1"/>
+        <string name="2" value="#p2101001#收到#b#t04031582##k后看起来非常高兴……然后就那样跑去宫殿了。之后得问问他有没有见到姐姐。不过……#t04031582#上是需要写名字的吗？我从来没听说过。"/>
         <int name="area" value="44"/>
     </imgdir>
     <imgdir name="3950">
-        <string name="name" value="Dealing with Tigun"/>
-        <string name="parent" value="In Search for His Sister"/>
+        <string name="name" value="对付提干"/>
+        <string name="parent" value="寻找姐姐"/>
         <int name="order" value="2"/>
-        <string name="1" value="I feel bad for #p2101001#.  He really wanted to get in the palace...  I should step in and try to convince #b#p2101004##k.  A fine of #b50000 mesos#k... I&apos;ll pay it off instead and ask for him to let #p2101001# to meet his sister.\n\n#b50000 mesos#k"/>
-        <string name="2" value="It is unfortunate that #p2101001# wasn&apos;t able to meet his sister but it&apos;s good to know that they can at least send and receive letters from each other.  But, #p2101004#!  Don&apos;t you think the delivery fee is a bit ridiculous?"/>
+        <string name="1" value="#p2101001#真可怜。他真的很想进宫殿……我得出面试着说服#b#p2101004##k。罚款#b50000金币#k……就由我来替他付掉，再拜托对方让#p2101001#见到姐姐吧。\n\n#b50000金币#k"/>
+        <string name="2" value="#p2101001#没能见到姐姐虽然很遗憾，但至少知道他们可以互相寄信了。不过，#p2101004#！你不觉得这个送信手续费有点太离谱了吗？"/>
         <int name="area" value="44"/>
     </imgdir>
     <imgdir name="3951">
-        <string name="name" value="The Tree Cutter&apos;s Test"/>
-        <string name="0" value="#b#p2071011##k in #b#m222010102##k is looking for me? That&apos;s strange.  What does he want with me...? "/>
-        <string name="1" value="I spoke with #p2071011#.  He saw that I come here often, so he wanted to tell me to stay away from this dangerous place.  But, seriously?  He&apos;s afraid to walk around the forest because of #o5100003#?  If I don&apos;t convince #p2071011# that I&apos;m strong enough to handle myself here, he might physically drag me out of  #m222000000#.  I better hurry up and prove it to him!\n\n#r30 minute time limit\n#k#o5100003#  #r#a39511##k"/>
-        <string name="2" value="#p2071011# was amazed that I was able to hunt all the #o5100003# in such a short time.  But after all that work, all I got was permission to freely roam around the forest...  Wonderful..."/>
+        <string name="name" value="樵夫的考验"/>
+        <string name="0" value="#b#m222010102##k的#b#p2071011##k在找我？真奇怪，他找我有什么事呢……"/>
+        <string name="1" value="和#p2071011#谈过了。他看到我最近常来这里，就想劝我远离这个危险的地方。可是，真的吗？他是因为害怕#o5100003#才不敢在森林里走动？如果不能让#p2071011#相信我有足够的实力照顾自己，他可能会把我硬拖出#m222000000#。得快点证明给他看！\n\n#r30分钟限制时间\n#k#o5100003#  #r#a39511##k"/>
+        <string name="2" value="#p2071011#很惊讶我能在这么短的时间内猎杀所有#o5100003#。可辛苦了半天，得到的只是可以在森林里自由走动的许可……真不错……"/>
         <int name="timeLimit" value="1800"/>
         <int name="area" value="37"/>
     </imgdir>


### PR DESCRIPTION
## 改动点汇总

- 汉化任务 `3948` 的任务标题与任务记录文本：`Sejan&apos;s Good Habit` -> `携詹的好习惯`。
- 汉化携詹后续任务 `3949`、`3950` 的任务标题、父任务名与任务记录文本。
- 汉化任务 `3951` 的任务标题与任务记录文本：`The Tree Cutter&apos;s Test` -> `樵夫的考验`。
- 仅修改中文 WZ 目录中的 `QuestInfo.img.xml`，英文原版目录不变，任务结构与字段结构保持不变。
- 该改动会影响客户端任务窗口/任务记录显示；正式发布时需要由现有发布流程同步或生成对应客户端 `QuestInfo.img`。

## 校验

- 已确认本次触及的任务块可按 UTF-8 正常读取。
- 已检查本次触及的任务块中没有常见乱码标记，包括替换符号、`锟斤拷`、`Ã`、`Â` 等。
- 已确认相关英文任务标题不再残留在本次触及的中文任务块中。
- 本次不涉及 Java 代码或 JAR 变更，因此未重新构建 JAR。
