### PR TITLE
fix: 修复沙子图团与红蝎子团任务文本

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2103009.js
+++ b/gms-server/scripts-zh-CN/npc/2103009.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 0;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 0;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("这里似乎没有什么特别的。");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("这里已经放过#b#t4031579##k了。");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("你身上没有#b#t4031579##k。先去红蝎子团据点的大箱子里拿一些宝物吧。");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("你悄悄把#b#t4031579##k放在了居民家里。");
                 }
+            } else {
+                cm.sendOk("这里不是需要放宝物的地方。");
             }
 
             cm.dispose();

--- a/gms-server/scripts-zh-CN/npc/2103010.js
+++ b/gms-server/scripts-zh-CN/npc/2103010.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 2;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 2;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("这里似乎没有什么特别的。");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("这里已经放过#b#t4031579##k了。");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("你身上没有#b#t4031579##k。先去红蝎子团据点的大箱子里拿一些宝物吧。");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("你悄悄把#b#t4031579##k放在了居民家里。");
                 }
+            } else {
+                cm.sendOk("这里不是需要放宝物的地方。");
             }
 
             cm.dispose();

--- a/gms-server/scripts-zh-CN/npc/2103011.js
+++ b/gms-server/scripts-zh-CN/npc/2103011.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 1;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 1;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("这里似乎没有什么特别的。");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("这里已经放过#b#t4031579##k了。");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("你身上没有#b#t4031579##k。先去红蝎子团据点的大箱子里拿一些宝物吧。");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("你悄悄把#b#t4031579##k放在了居民家里。");
                 }
+            } else {
+                cm.sendOk("这里不是需要放宝物的地方。");
             }
 
             cm.dispose();

--- a/gms-server/scripts-zh-CN/npc/2103012.js
+++ b/gms-server/scripts-zh-CN/npc/2103012.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 3;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 3;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("这里似乎没有什么特别的。");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("这里已经放过#b#t4031579##k了。");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("你身上没有#b#t4031579##k。先去红蝎子团据点的大箱子里拿一些宝物吧。");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("你悄悄把#b#t4031579##k放在了居民家里。");
                 }
+            } else {
+                cm.sendOk("这里不是需要放宝物的地方。");
             }
 
             cm.dispose();

--- a/gms-server/scripts/npc/2103009.js
+++ b/gms-server/scripts/npc/2103009.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 0;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 0;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("There does not seem to be anything special here.");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("You have already placed a #b#t4031579##k here.");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("You do not have a #b#t4031579##k. Take some jewels from the large chest at the Red Scorpion hideout first.");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("You quietly placed a #b#t4031579##k in the residence.");
                 }
+            } else {
+                cm.sendOk("This is not where you need to place the jewels.");
             }
 
             cm.dispose();

--- a/gms-server/scripts/npc/2103010.js
+++ b/gms-server/scripts/npc/2103010.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 2;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 2;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("There does not seem to be anything special here.");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("You have already placed a #b#t4031579##k here.");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("You do not have a #b#t4031579##k. Take some jewels from the large chest at the Red Scorpion hideout first.");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("You quietly placed a #b#t4031579##k in the residence.");
                 }
+            } else {
+                cm.sendOk("This is not where you need to place the jewels.");
             }
 
             cm.dispose();

--- a/gms-server/scripts/npc/2103011.js
+++ b/gms-server/scripts/npc/2103011.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 1;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 1;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("There does not seem to be anything special here.");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("You have already placed a #b#t4031579##k here.");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("You do not have a #b#t4031579##k. Take some jewels from the large chest at the Red Scorpion hideout first.");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("You quietly placed a #b#t4031579##k in the residence.");
                 }
+            } else {
+                cm.sendOk("This is not where you need to place the jewels.");
             }
 
             cm.dispose();

--- a/gms-server/scripts/npc/2103012.js
+++ b/gms-server/scripts/npc/2103012.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 3;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 3;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("There does not seem to be anything special here.");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("You have already placed a #b#t4031579##k here.");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("You do not have a #b#t4031579##k. Take some jewels from the large chest at the Red Scorpion hideout first.");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("You quietly placed a #b#t4031579##k in the residence.");
                 }
+            } else {
+                cm.sendOk("This is not where you need to place the jewels.");
             }
 
             cm.dispose();


### PR DESCRIPTION
## 改动说明

本次修复围绕阿里安特沙子图团相关任务文本，统一组织名并梳理红蝎子团骗局、入团考验与首个正式任务的文本衔接。

## 主要改动

- 统一沙子图团相关称呼，修正“沙子团”“沙盗”等不一致表述。
- 修复红蝎子团假冒沙子图团任务线中的叙事跳跃，强化真假组织的区分。
- 补充并优化红蝎子团据点、暗号、O/X 民宅与宝物分发相关提示。
- 优化红蝎子团后续补偿任务文本，明确补偿来自据点宝物箱。
- 整理沙子图团入团线中墙壁提示、团员考验、团长认可等任务日志和 NPC 对话。
- 修复提干变身药与丝绸任务中的称谓、对象和语义不一致问题。
- 修正“戒子”“想忙”“很高心”“到目前为之”等错字或直译问题。
- 修复 `#p2103001#` 等文本控制符异常，避免客户端显示原始错误标记。

## 客户端影响

本次改动包含 `wz-zh-CN/Quest.wz/QuestInfo.img.xml` 和 `wz-zh-CN/Quest.wz/Say.img.xml` 的文本更新。正式发布或测试客户端时，需要将对应 Quest 文本资源同步到客户端数据文件，否则客户端任务日志和 NPC 对话仍会显示旧文本。

## 校验

- 已确认变更文件均可按 UTF-8 读取。
- 已确认变更的 XML 文件可正常解析。
- 已对新增 diff 行进行常见乱码模式扫描。
- 已确认本分支相对 `upstream/master` 仅包含本次沙子图团相关文本修复。