### PR TITLE
fix: 改善阿里安特民居任务交互反馈

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2103003.js
+++ b/gms-server/scripts-zh-CN/npc/2103003.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 0;
 
 function start() {
     status = -1;
@@ -31,32 +32,42 @@ function start() {
 function action(mode, type, selection) {
     if (mode == -1) {
         cm.dispose();
+        return;
+    }
+    if (mode == 0 && type > 0) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 1) {
+        status++;
     } else {
-        if (mode == 0 && type > 0) {
+        status--;
+    }
+
+    if (status == 0) {
+        if (!cm.isQuestStarted(3929)) {
+            cm.sendOk("这里似乎没什么特别的。");
             cm.dispose();
             return;
         }
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
 
-        if (status == 0) {
-            if (cm.isQuestStarted(3929)) {
-                var progress = cm.getQuestProgress(3929);
-                var slot = 0;
-
-                var ch = progress[slot];
-                if (ch == '2') {
-                    var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
-
-                    cm.gainItem(4031580, -1);
-                    cm.setQuestProgress(3929, nextProgress);
-                }
+        var progress = cm.getQuestProgress(3929);
+        var ch = progress[slot];
+        if (ch == '3') {
+            cm.sendOk("这里已经放过食物了。");
+        } else if (ch == '2') {
+            if (!cm.haveItem(4031580, 1)) {
+                cm.sendOk("你身上没有#b#t4031580##k。");
+            } else {
+                var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
+                cm.gainItem(4031580, -1);
+                cm.setQuestProgress(3929, nextProgress);
+                cm.sendOk("你悄悄把#b#t4031580##k放在了居民家里。");
             }
-
-            cm.dispose();
+        } else {
+            cm.sendOk("这里似乎没什么特别的。");
         }
+
+        cm.dispose();
     }
 }

--- a/gms-server/scripts-zh-CN/npc/2103004.js
+++ b/gms-server/scripts-zh-CN/npc/2103004.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 2;
 
 function start() {
     status = -1;
@@ -31,32 +32,42 @@ function start() {
 function action(mode, type, selection) {
     if (mode == -1) {
         cm.dispose();
+        return;
+    }
+    if (mode == 0 && type > 0) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 1) {
+        status++;
     } else {
-        if (mode == 0 && type > 0) {
+        status--;
+    }
+
+    if (status == 0) {
+        if (!cm.isQuestStarted(3929)) {
+            cm.sendOk("这里似乎没什么特别的。");
             cm.dispose();
             return;
         }
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
 
-        if (status == 0) {
-            if (cm.isQuestStarted(3929)) {
-                var progress = cm.getQuestProgress(3929);
-                var slot = 2;
-
-                var ch = progress[slot];
-                if (ch == '2') {
-                    var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
-
-                    cm.gainItem(4031580, -1);
-                    cm.setQuestProgress(3929, nextProgress);
-                }
+        var progress = cm.getQuestProgress(3929);
+        var ch = progress[slot];
+        if (ch == '3') {
+            cm.sendOk("这里已经放过食物了。");
+        } else if (ch == '2') {
+            if (!cm.haveItem(4031580, 1)) {
+                cm.sendOk("你身上没有#b#t4031580##k。");
+            } else {
+                var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
+                cm.gainItem(4031580, -1);
+                cm.setQuestProgress(3929, nextProgress);
+                cm.sendOk("你悄悄把#b#t4031580##k放在了居民家里。");
             }
-
-            cm.dispose();
+        } else {
+            cm.sendOk("这里似乎没什么特别的。");
         }
+
+        cm.dispose();
     }
 }

--- a/gms-server/scripts-zh-CN/npc/2103005.js
+++ b/gms-server/scripts-zh-CN/npc/2103005.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 1;
 
 function start() {
     status = -1;
@@ -31,32 +32,42 @@ function start() {
 function action(mode, type, selection) {
     if (mode == -1) {
         cm.dispose();
+        return;
+    }
+    if (mode == 0 && type > 0) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 1) {
+        status++;
     } else {
-        if (mode == 0 && type > 0) {
+        status--;
+    }
+
+    if (status == 0) {
+        if (!cm.isQuestStarted(3929)) {
+            cm.sendOk("这里似乎没什么特别的。");
             cm.dispose();
             return;
         }
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
 
-        if (status == 0) {
-            if (cm.isQuestStarted(3929)) {
-                var progress = cm.getQuestProgress(3929);
-                var slot = 1;
-
-                var ch = progress[slot];
-                if (ch == '2') {
-                    var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
-
-                    cm.gainItem(4031580, -1);
-                    cm.setQuestProgress(3929, nextProgress);
-                }
+        var progress = cm.getQuestProgress(3929);
+        var ch = progress[slot];
+        if (ch == '3') {
+            cm.sendOk("这里已经放过食物了。");
+        } else if (ch == '2') {
+            if (!cm.haveItem(4031580, 1)) {
+                cm.sendOk("你身上没有#b#t4031580##k。");
+            } else {
+                var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
+                cm.gainItem(4031580, -1);
+                cm.setQuestProgress(3929, nextProgress);
+                cm.sendOk("你悄悄把#b#t4031580##k放在了居民家里。");
             }
-
-            cm.dispose();
+        } else {
+            cm.sendOk("这里似乎没什么特别的。");
         }
+
+        cm.dispose();
     }
 }

--- a/gms-server/scripts-zh-CN/npc/2103006.js
+++ b/gms-server/scripts-zh-CN/npc/2103006.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 3;
 
 function start() {
     status = -1;
@@ -31,32 +32,42 @@ function start() {
 function action(mode, type, selection) {
     if (mode == -1) {
         cm.dispose();
+        return;
+    }
+    if (mode == 0 && type > 0) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 1) {
+        status++;
     } else {
-        if (mode == 0 && type > 0) {
+        status--;
+    }
+
+    if (status == 0) {
+        if (!cm.isQuestStarted(3929)) {
+            cm.sendOk("这里似乎没什么特别的。");
             cm.dispose();
             return;
         }
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
 
-        if (status == 0) {
-            if (cm.isQuestStarted(3929)) {
-                var progress = cm.getQuestProgress(3929);
-                var slot = 3;
-
-                var ch = progress[slot];
-                if (ch == '2') {
-                    var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
-
-                    cm.gainItem(4031580, -1);
-                    cm.setQuestProgress(3929, nextProgress);
-                }
+        var progress = cm.getQuestProgress(3929);
+        var ch = progress[slot];
+        if (ch == '3') {
+            cm.sendOk("这里已经放过食物了。");
+        } else if (ch == '2') {
+            if (!cm.haveItem(4031580, 1)) {
+                cm.sendOk("你身上没有#b#t4031580##k。");
+            } else {
+                var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
+                cm.gainItem(4031580, -1);
+                cm.setQuestProgress(3929, nextProgress);
+                cm.sendOk("你悄悄把#b#t4031580##k放在了居民家里。");
             }
-
-            cm.dispose();
+        } else {
+            cm.sendOk("这里似乎没什么特别的。");
         }
+
+        cm.dispose();
     }
 }

--- a/gms-server/scripts-zh-CN/npc/2103009.js
+++ b/gms-server/scripts-zh-CN/npc/2103009.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 0;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 0;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("这里似乎没有什么特别的。");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("这里已经放过#b#t4031579##k了。");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("你身上没有#b#t4031579##k。先去红蝎子团据点的大箱子里拿一些宝物吧。");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("你悄悄把#b#t4031579##k放在了居民家里。");
                 }
+            } else {
+                cm.sendOk("这里不是需要放宝物的地方。");
             }
 
             cm.dispose();

--- a/gms-server/scripts-zh-CN/npc/2103010.js
+++ b/gms-server/scripts-zh-CN/npc/2103010.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 2;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 2;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("这里似乎没有什么特别的。");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("这里已经放过#b#t4031579##k了。");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("你身上没有#b#t4031579##k。先去红蝎子团据点的大箱子里拿一些宝物吧。");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("你悄悄把#b#t4031579##k放在了居民家里。");
                 }
+            } else {
+                cm.sendOk("这里不是需要放宝物的地方。");
             }
 
             cm.dispose();

--- a/gms-server/scripts-zh-CN/npc/2103011.js
+++ b/gms-server/scripts-zh-CN/npc/2103011.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 1;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 1;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("这里似乎没有什么特别的。");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("这里已经放过#b#t4031579##k了。");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("你身上没有#b#t4031579##k。先去红蝎子团据点的大箱子里拿一些宝物吧。");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("你悄悄把#b#t4031579##k放在了居民家里。");
                 }
+            } else {
+                cm.sendOk("这里不是需要放宝物的地方。");
             }
 
             cm.dispose();

--- a/gms-server/scripts-zh-CN/npc/2103012.js
+++ b/gms-server/scripts-zh-CN/npc/2103012.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 3;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 3;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("这里似乎没有什么特别的。");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("这里已经放过#b#t4031579##k了。");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("你身上没有#b#t4031579##k。先去红蝎子团据点的大箱子里拿一些宝物吧。");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("你悄悄把#b#t4031579##k放在了居民家里。");
                 }
+            } else {
+                cm.sendOk("这里不是需要放宝物的地方。");
             }
 
             cm.dispose();

--- a/gms-server/scripts/npc/2103003.js
+++ b/gms-server/scripts/npc/2103003.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 0;
 
 function start() {
     status = -1;
@@ -31,32 +32,42 @@ function start() {
 function action(mode, type, selection) {
     if (mode == -1) {
         cm.dispose();
+        return;
+    }
+    if (mode == 0 && type > 0) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 1) {
+        status++;
     } else {
-        if (mode == 0 && type > 0) {
+        status--;
+    }
+
+    if (status == 0) {
+        if (!cm.isQuestStarted(3929)) {
+            cm.sendOk("There does not seem to be anything special here.");
             cm.dispose();
             return;
         }
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
 
-        if (status == 0) {
-            if (cm.isQuestStarted(3929)) {
-                var progress = cm.getQuestProgress(3929);
-                var slot = 0;
-
-                var ch = progress[slot];
-                if (ch == '2') {
-                    var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
-
-                    cm.gainItem(4031580, -1);
-                    cm.setQuestProgress(3929, nextProgress);
-                }
+        var progress = cm.getQuestProgress(3929);
+        var ch = progress[slot];
+        if (ch == '3') {
+            cm.sendOk("You have already left food here.");
+        } else if (ch == '2') {
+            if (!cm.haveItem(4031580, 1)) {
+                cm.sendOk("You do not have any #b#t4031580##k.");
+            } else {
+                var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
+                cm.gainItem(4031580, -1);
+                cm.setQuestProgress(3929, nextProgress);
+                cm.sendOk("You quietly left #b#t4031580##k for the residents.");
             }
-
-            cm.dispose();
+        } else {
+            cm.sendOk("There does not seem to be anything special here.");
         }
+
+        cm.dispose();
     }
 }

--- a/gms-server/scripts/npc/2103004.js
+++ b/gms-server/scripts/npc/2103004.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 2;
 
 function start() {
     status = -1;
@@ -31,32 +32,42 @@ function start() {
 function action(mode, type, selection) {
     if (mode == -1) {
         cm.dispose();
+        return;
+    }
+    if (mode == 0 && type > 0) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 1) {
+        status++;
     } else {
-        if (mode == 0 && type > 0) {
+        status--;
+    }
+
+    if (status == 0) {
+        if (!cm.isQuestStarted(3929)) {
+            cm.sendOk("There does not seem to be anything special here.");
             cm.dispose();
             return;
         }
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
 
-        if (status == 0) {
-            if (cm.isQuestStarted(3929)) {
-                var progress = cm.getQuestProgress(3929);
-                var slot = 2;
-
-                var ch = progress[slot];
-                if (ch == '2') {
-                    var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
-
-                    cm.gainItem(4031580, -1);
-                    cm.setQuestProgress(3929, nextProgress);
-                }
+        var progress = cm.getQuestProgress(3929);
+        var ch = progress[slot];
+        if (ch == '3') {
+            cm.sendOk("You have already left food here.");
+        } else if (ch == '2') {
+            if (!cm.haveItem(4031580, 1)) {
+                cm.sendOk("You do not have any #b#t4031580##k.");
+            } else {
+                var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
+                cm.gainItem(4031580, -1);
+                cm.setQuestProgress(3929, nextProgress);
+                cm.sendOk("You quietly left #b#t4031580##k for the residents.");
             }
-
-            cm.dispose();
+        } else {
+            cm.sendOk("There does not seem to be anything special here.");
         }
+
+        cm.dispose();
     }
 }

--- a/gms-server/scripts/npc/2103005.js
+++ b/gms-server/scripts/npc/2103005.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 1;
 
 function start() {
     status = -1;
@@ -31,32 +32,42 @@ function start() {
 function action(mode, type, selection) {
     if (mode == -1) {
         cm.dispose();
+        return;
+    }
+    if (mode == 0 && type > 0) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 1) {
+        status++;
     } else {
-        if (mode == 0 && type > 0) {
+        status--;
+    }
+
+    if (status == 0) {
+        if (!cm.isQuestStarted(3929)) {
+            cm.sendOk("There does not seem to be anything special here.");
             cm.dispose();
             return;
         }
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
 
-        if (status == 0) {
-            if (cm.isQuestStarted(3929)) {
-                var progress = cm.getQuestProgress(3929);
-                var slot = 1;
-
-                var ch = progress[slot];
-                if (ch == '2') {
-                    var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
-
-                    cm.gainItem(4031580, -1);
-                    cm.setQuestProgress(3929, nextProgress);
-                }
+        var progress = cm.getQuestProgress(3929);
+        var ch = progress[slot];
+        if (ch == '3') {
+            cm.sendOk("You have already left food here.");
+        } else if (ch == '2') {
+            if (!cm.haveItem(4031580, 1)) {
+                cm.sendOk("You do not have any #b#t4031580##k.");
+            } else {
+                var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
+                cm.gainItem(4031580, -1);
+                cm.setQuestProgress(3929, nextProgress);
+                cm.sendOk("You quietly left #b#t4031580##k for the residents.");
             }
-
-            cm.dispose();
+        } else {
+            cm.sendOk("There does not seem to be anything special here.");
         }
+
+        cm.dispose();
     }
 }

--- a/gms-server/scripts/npc/2103006.js
+++ b/gms-server/scripts/npc/2103006.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 3;
 
 function start() {
     status = -1;
@@ -31,32 +32,42 @@ function start() {
 function action(mode, type, selection) {
     if (mode == -1) {
         cm.dispose();
+        return;
+    }
+    if (mode == 0 && type > 0) {
+        cm.dispose();
+        return;
+    }
+    if (mode == 1) {
+        status++;
     } else {
-        if (mode == 0 && type > 0) {
+        status--;
+    }
+
+    if (status == 0) {
+        if (!cm.isQuestStarted(3929)) {
+            cm.sendOk("There does not seem to be anything special here.");
             cm.dispose();
             return;
         }
-        if (mode == 1) {
-            status++;
-        } else {
-            status--;
-        }
 
-        if (status == 0) {
-            if (cm.isQuestStarted(3929)) {
-                var progress = cm.getQuestProgress(3929);
-                var slot = 3;
-
-                var ch = progress[slot];
-                if (ch == '2') {
-                    var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
-
-                    cm.gainItem(4031580, -1);
-                    cm.setQuestProgress(3929, nextProgress);
-                }
+        var progress = cm.getQuestProgress(3929);
+        var ch = progress[slot];
+        if (ch == '3') {
+            cm.sendOk("You have already left food here.");
+        } else if (ch == '2') {
+            if (!cm.haveItem(4031580, 1)) {
+                cm.sendOk("You do not have any #b#t4031580##k.");
+            } else {
+                var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
+                cm.gainItem(4031580, -1);
+                cm.setQuestProgress(3929, nextProgress);
+                cm.sendOk("You quietly left #b#t4031580##k for the residents.");
             }
-
-            cm.dispose();
+        } else {
+            cm.sendOk("There does not seem to be anything special here.");
         }
+
+        cm.dispose();
     }
 }

--- a/gms-server/scripts/npc/2103009.js
+++ b/gms-server/scripts/npc/2103009.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 0;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 0;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("There does not seem to be anything special here.");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("You have already placed a #b#t4031579##k here.");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("You do not have a #b#t4031579##k. Take some jewels from the large chest at the Red Scorpion hideout first.");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("You quietly placed a #b#t4031579##k in the residence.");
                 }
+            } else {
+                cm.sendOk("This is not where you need to place the jewels.");
             }
 
             cm.dispose();

--- a/gms-server/scripts/npc/2103010.js
+++ b/gms-server/scripts/npc/2103010.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 2;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 2;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("There does not seem to be anything special here.");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("You have already placed a #b#t4031579##k here.");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("You do not have a #b#t4031579##k. Take some jewels from the large chest at the Red Scorpion hideout first.");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("You quietly placed a #b#t4031579##k in the residence.");
                 }
+            } else {
+                cm.sendOk("This is not where you need to place the jewels.");
             }
 
             cm.dispose();

--- a/gms-server/scripts/npc/2103011.js
+++ b/gms-server/scripts/npc/2103011.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 1;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 1;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("There does not seem to be anything special here.");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("You have already placed a #b#t4031579##k here.");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("You do not have a #b#t4031579##k. Take some jewels from the large chest at the Red Scorpion hideout first.");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("You quietly placed a #b#t4031579##k in the residence.");
                 }
+            } else {
+                cm.sendOk("This is not where you need to place the jewels.");
             }
 
             cm.dispose();

--- a/gms-server/scripts/npc/2103012.js
+++ b/gms-server/scripts/npc/2103012.js
@@ -22,6 +22,7 @@
  */
 
 var status;
+var slot = 3;
 
 function start() {
     status = -1;
@@ -43,17 +44,28 @@ function action(mode, type, selection) {
         }
 
         if (status == 0) {
-            if (cm.isQuestStarted(3926)) {
-                var progress = cm.getQuestProgress(3926);
-                var slot = 3;
+            if (!cm.isQuestStarted(3926)) {
+                cm.sendOk("There does not seem to be anything special here.");
+                cm.dispose();
+                return;
+            }
 
-                var ch = progress[slot];
-                if (ch == '2') {
+            var progress = cm.getQuestProgress(3926);
+            var ch = progress[slot];
+            if (ch == '3') {
+                cm.sendOk("You have already placed a #b#t4031579##k here.");
+            } else if (ch == '2') {
+                if (!cm.haveItem(4031579, 1)) {
+                    cm.sendOk("You do not have a #b#t4031579##k. Take some jewels from the large chest at the Red Scorpion hideout first.");
+                } else {
                     var nextProgress = progress.substr(0, slot) + '3' + progress.substr(slot + 1);
 
                     cm.gainItem(4031579, -1);
                     cm.setQuestProgress(3926, nextProgress);
+                    cm.sendOk("You quietly placed a #b#t4031579##k in the residence.");
                 }
+            } else {
+                cm.sendOk("This is not where you need to place the jewels.");
             }
 
             cm.dispose();

--- a/gms-server/wz-zh-CN/String.wz/Npc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Npc.img.xml
@@ -4708,16 +4708,16 @@
         <string name="name" value="王妃的装饰柜"/>
     </imgdir>
     <imgdir name="2103003">
-        <string name="name" value="阿里安特民宅１"/>
+        <string name="name" value="放置食物"/>
     </imgdir>
     <imgdir name="2103004">
-        <string name="name" value="阿里安特民宅２"/>
+        <string name="name" value="放置食物"/>
     </imgdir>
     <imgdir name="2103005">
-        <string name="name" value="阿里安特民宅４"/>
+        <string name="name" value="放置食物"/>
     </imgdir>
     <imgdir name="2103006">
-        <string name="name" value="阿里安特民宅６"/>
+        <string name="name" value="放置食物"/>
     </imgdir>
     <imgdir name="2103007">
         <string name="name" value="宝物箱"/>

--- a/gms-server/wz/Npc.wz/2103003.img.xml
+++ b/gms-server/wz/Npc.wz/2103003.img.xml
@@ -5,7 +5,7 @@
     <int name="dcTop" value="-16"/>
     <int name="dcRight" value="8"/>
     <int name="dcBottom" value="0"/>
-    <int name="hideName" value="1"/>
+    <int name="hideName" value="0"/>
     <imgdir name="script">
       <imgdir name="0">
         <string name="script" value="ariant_house1"/>

--- a/gms-server/wz/Npc.wz/2103004.img.xml
+++ b/gms-server/wz/Npc.wz/2103004.img.xml
@@ -5,7 +5,7 @@
     <int name="dcTop" value="-16"/>
     <int name="dcRight" value="8"/>
     <int name="dcBottom" value="0"/>
-    <int name="hideName" value="1"/>
+    <int name="hideName" value="0"/>
     <imgdir name="script">
       <imgdir name="0">
         <string name="script" value="ariant_house2"/>

--- a/gms-server/wz/Npc.wz/2103005.img.xml
+++ b/gms-server/wz/Npc.wz/2103005.img.xml
@@ -5,7 +5,7 @@
     <int name="dcTop" value="-16"/>
     <int name="dcRight" value="8"/>
     <int name="dcBottom" value="0"/>
-    <int name="hideName" value="1"/>
+    <int name="hideName" value="0"/>
     <imgdir name="script">
       <imgdir name="0">
         <string name="script" value="ariant_house3"/>

--- a/gms-server/wz/Npc.wz/2103006.img.xml
+++ b/gms-server/wz/Npc.wz/2103006.img.xml
@@ -5,7 +5,7 @@
     <int name="dcTop" value="-16"/>
     <int name="dcRight" value="8"/>
     <int name="dcBottom" value="0"/>
-    <int name="hideName" value="1"/>
+    <int name="hideName" value="0"/>
     <imgdir name="script">
       <imgdir name="0">
         <string name="script" value="ariant_house4"/>

--- a/gms-server/wz/Npc.wz/2103009.img.xml
+++ b/gms-server/wz/Npc.wz/2103009.img.xml
@@ -5,7 +5,7 @@
     <int name="dcTop" value="-16"/>
     <int name="dcRight" value="8"/>
     <int name="dcBottom" value="0"/>
-    <int name="hideName" value="1"/>
+    <int name="hideName" value="0"/>
     <imgdir name="script">
       <imgdir name="0">
         <string name="script" value="ariant_gold1"/>

--- a/gms-server/wz/Npc.wz/2103010.img.xml
+++ b/gms-server/wz/Npc.wz/2103010.img.xml
@@ -5,7 +5,7 @@
     <int name="dcTop" value="-16"/>
     <int name="dcRight" value="8"/>
     <int name="dcBottom" value="0"/>
-    <int name="hideName" value="1"/>
+    <int name="hideName" value="0"/>
     <imgdir name="script">
       <imgdir name="0">
         <string name="script" value="ariant_gold2"/>

--- a/gms-server/wz/Npc.wz/2103011.img.xml
+++ b/gms-server/wz/Npc.wz/2103011.img.xml
@@ -5,7 +5,7 @@
     <int name="dcTop" value="-16"/>
     <int name="dcRight" value="8"/>
     <int name="dcBottom" value="0"/>
-    <int name="hideName" value="1"/>
+    <int name="hideName" value="0"/>
     <imgdir name="script">
       <imgdir name="0">
         <string name="script" value="ariant_gold3"/>

--- a/gms-server/wz/Npc.wz/2103012.img.xml
+++ b/gms-server/wz/Npc.wz/2103012.img.xml
@@ -5,7 +5,7 @@
     <int name="dcTop" value="-16"/>
     <int name="dcRight" value="8"/>
     <int name="dcBottom" value="0"/>
-    <int name="hideName" value="1"/>
+    <int name="hideName" value="0"/>
     <imgdir name="script">
       <imgdir name="0">
         <string name="script" value="ariant_gold4"/>

--- a/gms-server/wz/String.wz/Npc.img.xml
+++ b/gms-server/wz/String.wz/Npc.img.xml
@@ -3965,16 +3965,16 @@
     <string name="name" value="Queen&apos;s cabinet"/>
   </imgdir>
   <imgdir name="2103003">
-    <string name="name" value="Ariant private house1"/>
+    <string name="name" value="Food Drop-off"/>
   </imgdir>
   <imgdir name="2103004">
-    <string name="name" value="Ariant private house2"/>
+    <string name="name" value="Food Drop-off"/>
   </imgdir>
   <imgdir name="2103005">
-    <string name="name" value="Ariant private house4"/>
+    <string name="name" value="Food Drop-off"/>
   </imgdir>
   <imgdir name="2103006">
-    <string name="name" value="Ariant private house6"/>
+    <string name="name" value="Food Drop-off"/>
   </imgdir>
   <imgdir name="2103007">
     <string name="name" value="Treasure Box"/>


### PR DESCRIPTION
## 改动汇总

- 为阿里安特送食物任务的民居交互点（NPC 2103003~2103006）补充明确反馈：未接任务、已放置、缺少包装好的食物、成功放置、位置不匹配时都会给出提示。
- 为阿里安特宝物袋任务的民居橱柜交互点（NPC 2103009~2103012）补充明确反馈：未接任务、已放置、缺少小宝物袋、成功放置、位置不匹配时都会给出提示。
- 增加放置前的物品检查，避免缺少任务物品时仍静默更新任务进度。
- 将放置食物 NPC（2103003~2103006）的 hideName 从 1 改为 0，使 NPC 名称可见，方便玩家识别交互位置。
- 将宝物袋 NPC（2103009~2103012）的 hideName 从 1 改为 0，使 NPC 名称可见，方便玩家识别交互位置。
- 中英文脚本目录保持对称：英文目录保留英文提示，中文目录使用中文提示。

## 涉及文件

- gms-server/scripts/npc/2103003~2103006.js：放置食物 NPC 英文脚本
- gms-server/scripts/npc/2103009~2103012.js：宝物袋 NPC 英文脚本
- gms-server/scripts-zh-CN/npc/2103003~2103006.js：放置食物 NPC 中文脚本
- gms-server/scripts-zh-CN/npc/2103009~2103012.js：宝物袋 NPC 中文脚本
- gms-server/wz/Npc.wz/2103003~2103006.img.xml：放置食物 NPC hideName 改为 0
- gms-server/wz/Npc.wz/2103009~2103012.img.xml：宝物袋 NPC hideName 改为 0
- gms-server/wz/String.wz/Npc.img.xml：放置食物 NPC 英文名称更新
- gms-server/wz-zh-CN/String.wz/Npc.img.xml：放置食物 NPC 中文名称更新

## 客户端影响

- 本次改动包含 Npc.wz 的 hideName 变更和 String.wz 的名称变更，会影响客户端 NPC 显示资源，需同步更新客户端 IMG。
- 受影响客户端文件：Data/Npc/2103003~2103006.img、Data/Npc/2103009~2103012.img、Data/String/Npc.img

## 校验

- 已确认修改文件可按 UTF-8 正常读取，未发现乱码。
- 已对修改的脚本执行 JavaScript 语法检查。
- 已通过工具校验客户端 IMG patch 内容与 XML 一致。