### PR TITLE
fix: 修正修理配件的下落任务分组

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -11338,7 +11338,7 @@
     </imgdir>
     <imgdir name="3239">
         <string name="name" value="修理配件的下落"/>
-        <string name="parent" value="丢失的空间"/>
+        <string name="parent" value=""/>
         <string name="0" value="要找玩具工厂某处的助教 尚。"/>
         <string name="1" value="在玩具厂见到了助教 尚。尚说最近发生了玩具厂机械的配件丢失的事件。他拜托我替他找那个配件。通过尚到隐藏配件的玩具工厂&lt;骨干工程1&gt;第4地区后，收集10个配件。\n\n#t4031092#  #b#c4031092#/10#k"/>
         <string name="2" value="都找到在玩具工厂丢失的10个配件给助教 尚了。今后玩具工厂也能正常运转吧？"/>


### PR DESCRIPTION
## 问题原因

中文 QuestInfo 中，任务 `3239 修理配件的下落` 被错误设置为 `丢失的空间` 的子任务；英文原版该任务的 `parent` 为空。客户端任务栏会根据 `parent` 汇总任务组，因此会把该任务计入 `丢失的空间`，造成父任务进度显示为 `3/4`，并与已完成子任务的完成时间混在一起。

## 改动点

- 将中文 QuestInfo 中任务 `3239 修理配件的下落` 的 `parent` 从 `丢失的空间` 改为空字符串。
- 保持任务名称、任务描述、区域字段不变。
- 不修改英文原版 WZ 内容。
- 不涉及 Java 代码或服务端 JAR 构建。

## 客户端影响

- 该修复属于 WZ 任务信息数据变更，客户端发布或测试时需要同步更新 `QuestInfo.img`。
- 如果客户端仍使用旧版任务信息资源，任务栏仍可能显示旧的错误分组。

## 校验

- 已确认本分支相对 `upstream/master` 只有 1 个提交。
- 已确认 diff 只包含本次 QuestInfo 修复文件。
- 已完成 UTF-8 解码和 XML 解析校验。
- 已确认未引入常见乱码或替换字符。