### PR TITLE
fix: 修复丘比特的信使任务面板显示与中文文本

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -7426,17 +7426,17 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="28103">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 海盗"/>
-        <string name="parent" value="丘比特的信使 - 海盗"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 海盗：捎东西给理查德"/>
+        <string name="parent" value="丘比特的信使 - 海盗：捎东西给理查德"/>
         <int name="order" value="1"/>
         <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
-        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b25个软羽毛#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b25个柔软羽毛#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
         <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="28104">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 海盗"/>
-        <string name="parent" value="丘比特的信使 - 海盗"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 海盗：回信给安琪莉"/>
+        <string name="parent" value="丘比特的信使 - 海盗：回信给安琪莉"/>
         <int name="order" value="2"/>
         <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
         <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
@@ -18994,35 +18994,35 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8850">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 新手"/>
-        <string name="parent" value="丘比特的信使 - 新手"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 新手：捎东西给理查德"/>
+        <string name="parent" value="丘比特的信使 - 新手：捎东西给理查德"/>
         <int name="order" value="1"/>
         <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
-        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b25个硬羽毛#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b25个粗羽毛#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
         <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8851">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 战士"/>
-        <string name="parent" value="丘比特的信使 - 战士"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 战士：捎东西给理查德"/>
+        <string name="parent" value="丘比特的信使 - 战士：捎东西给理查德"/>
         <int name="order" value="1"/>
         <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
-        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b15个粘蜘蛛网#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b15个粘糊糊的蜘蛛网#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
         <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8852">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 法师"/>
-        <string name="parent" value="丘比特的信使 - 法师"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 法师：捎东西给理查德"/>
+        <string name="parent" value="丘比特的信使 - 法师：捎东西给理查德"/>
         <int name="order" value="1"/>
         <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
-        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b月光精灵的月块#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b1个月光精灵的月块#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
         <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8853">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 弓箭手"/>
-        <string name="parent" value="丘比特的信使 - 弓箭手"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 弓箭手：捎东西给理查德"/>
+        <string name="parent" value="丘比特的信使 - 弓箭手：捎东西给理查德"/>
         <int name="order" value="1"/>
         <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
         <string name="1" value="我已经和安琪莉谈过了。她想让我把#b20个玩具小鸭#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
@@ -19030,17 +19030,17 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8854">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 飞侠"/>
-        <string name="parent" value="丘比特的信使 - 飞侠"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 飞侠：捎东西给理查德"/>
+        <string name="parent" value="丘比特的信使 - 飞侠：捎东西给理查德"/>
         <int name="order" value="1"/>
         <string name="0" value="水手的妻子吗？看来她确实需要帮忙。"/>
-        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b20个捕鼠器#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
+        <string name="1" value="我已经和安琪莉谈过了。她想让我把#b20个老鼠陷阱#k送给她的丈夫水手理查德。他在水下世界的太公船上工作。等我把东西收齐后，就去船上交给他，然后回来告诉安琪莉一切顺利。"/>
         <string name="2" value="我把材料交给了理查德，他向我道了谢。安琪莉知道后一定会很高兴。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8855">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 新手"/>
-        <string name="parent" value="丘比特的信使 - 新手"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 新手：回信给安琪莉"/>
+        <string name="parent" value="丘比特的信使 - 新手：回信给安琪莉"/>
         <int name="order" value="2"/>
         <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
         <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
@@ -19048,8 +19048,8 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8856">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 战士"/>
-        <string name="parent" value="丘比特的信使 - 战士"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 战士：回信给安琪莉"/>
+        <string name="parent" value="丘比特的信使 - 战士：回信给安琪莉"/>
         <int name="order" value="2"/>
         <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
         <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
@@ -19057,8 +19057,8 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8857">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 法师"/>
-        <string name="parent" value="丘比特的信使 - 法师"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 法师：回信给安琪莉"/>
+        <string name="parent" value="丘比特的信使 - 法师：回信给安琪莉"/>
         <int name="order" value="2"/>
         <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
         <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
@@ -19066,8 +19066,8 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8858">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 弓箭手"/>
-        <string name="parent" value="丘比特的信使 - 弓箭手"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 弓箭手：回信给安琪莉"/>
+        <string name="parent" value="丘比特的信使 - 弓箭手：回信给安琪莉"/>
         <int name="order" value="2"/>
         <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
         <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>
@@ -19075,8 +19075,8 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8859">
-        <string name="name" value="阿莫里亚：丘比特的信使 - 飞侠"/>
-        <string name="parent" value="丘比特的信使 - 飞侠"/>
+        <string name="name" value="阿莫里亚：丘比特的信使 - 飞侠：回信给安琪莉"/>
+        <string name="parent" value="丘比特的信使 - 飞侠：回信给安琪莉"/>
         <int name="order" value="2"/>
         <string name="0" value="好吧，现在得去见那位水手本人了。他会在哪里呢？"/>
         <string name="1" value="我把东西交给了理查德，他拜托我把他的信带回给妻子。"/>

--- a/gms-server/wz-zh-CN/String.wz/Etc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Etc.img.xml
@@ -7240,8 +7240,8 @@
             <string name="desc" value="要拯救梦幻主题公园所需要的非\n常重要关键物品。"/>
         </imgdir>
         <imgdir name="4032247">
-            <string name="name" value="Richard's Letter"/>
-            <string name="desc" value="A love letter written by Richard. Needs to be delivered to Angelique of Amoria..."/>
+            <string name="name" value="理查的情书"/>
+            <string name="desc" value="把它交给婚礼村的安琪莉……"/>
         </imgdir>
         <imgdir name="4032248">
             <string name="name" value="Map to MV's Lair"/>


### PR DESCRIPTION
## 改动汇总

- 区分阿莫里亚「丘比特的信使」各职业分支的两个阶段任务名称，避免任务面板中第一阶段和第二阶段显示为同名任务。
- 将新手、战士、法师、弓箭手、飞侠、海盗分支的 `parent` 拆分为阶段级父级标题，避免已完成的第二阶段完成时间显示到可再次接取的第一阶段上。
- 校对任务说明和安琪莉相关对白中的需求物品名称，使其与道具数据一致：粗羽毛、柔软羽毛、粘糊糊的蜘蛛网、老鼠陷阱、1个月光精灵的月块。
- 补全海盗分支回信用道具 `4032247` 的中文名称和描述，避免中文资源中仍显示英文。

## 影响范围

- 仅修改中文资源目录 `wz-zh-CN` 下的任务信息、任务对白和道具文本。
- 不修改英文原版资源目录，不修改脚本，不修改 Java 代码。
- 不涉及服务端 JAR 构建。
- 该改动会影响客户端 WZ/IMG 资源显示：客户端需要同步更新 `QuestInfo`、`Say` 和 `String/Etc` 对应资源后才能看到任务面板和对白文本变化。

## 验证

- 已确认本分支相对 `upstream/master` 只有 1 个提交。
- 已确认差异文件仅包含本次中文资源修复相关文件。
- 已对修改后的 XML 进行解析校验，确认格式有效。