### PR TITLE
fix: 修复部分任务与NPC中文文本

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -12415,22 +12415,22 @@
     <imgdir name="3435">
         <string name="name" value="打退外星章鱼枪"/>
         <string name="0" value="去罗斯韦尔草原找冒险勇者"/>
-        <string name="1" value="在地球本部附近遇到了冒险勇者 绿虎. 他已经听到了我的消息.他劝我跟他们一起做冒险勇者的任务.我要首先完成冒险勇者 绿虎的任务.那是打退100个外星章鱼枪的任务\n\n打退外星章鱼枪 : #b#a34351##k"/>
-        <string name="2" value="我打退了100个打退外星章鱼枪.但冒险勇者的任务还没结束. 那我以后有空还要去绿虎."/>
+        <string name="1" value="在地球防卫总部附近遇到了冒险勇者绿虎。他已经听说过我的事，并邀请我一起执行冒险勇者的任务。首先要完成绿虎交给我的任务：消灭100只外星章鱼枪。\n\n外星章鱼枪：#b#a34351##k"/>
+        <string name="2" value="我消灭了100只外星章鱼枪。不过冒险勇者的任务似乎还没结束，以后有空再去找绿虎吧。"/>
         <int name="area" value="37"/>
     </imgdir>
     <imgdir name="3436">
         <string name="name" value="打退外星章鱼坦克"/>
         <string name="0" value="去罗斯韦尔草原找冒险勇者"/>
-        <string name="1" value="在地球本部附近在见到了冒险勇者 绿虎.他拜托我这次打退比以前更强的外星章鱼坦克. 我要打退它们后收集80个外星章鱼的头盔. \n\n#t4000121# #b#c4000121##k/80"/>
-        <string name="2" value="我打退打退外星章鱼坦克后收集它们的头盔给绿虎了.但冒险勇者的任务好像还没结束，有了机会再去找他."/>
+        <string name="1" value="在地球防卫总部附近再次见到了冒险勇者绿虎。他拜托我消灭比外星章鱼枪更强的外星章鱼坦克，并收集80个外星章鱼头盔。\n\n#t4000121# #b#c4000121##k/80"/>
+        <string name="2" value="我消灭了外星章鱼坦克，并把收集到的头盔交给了绿虎。不过冒险勇者的任务好像还没结束，有机会再去找他吧。"/>
         <int name="area" value="37"/>
     </imgdir>
     <imgdir name="3437">
         <string name="name" value="打退外星章鱼坦克和外星章鱼激光棒"/>
         <string name="0" value="去罗斯韦尔草原找冒险勇者"/>
-        <string name="1" value="在地球本部附近再见到了冒险勇者 绿虎. 他最后拜托我这次再打退外星章鱼坦克, 同时收集外星章鱼激光棒的武器的任务.我要打退200个外星章鱼坦克.同时要收集150个光线枪.\n\n外星章鱼坦克 : #b#a34371##k"/>
-        <string name="2" value="我打退外星章鱼坦克了, 而且外星章鱼激光棒的光线枪也都收集好了. 冒险勇者很高兴地说他想希望有机会再跟我一起进行任务."/>
+        <string name="1" value="在地球防卫总部附近又见到了冒险勇者绿虎。他最后一次拜托我消灭外星章鱼坦克，并收集外星章鱼激光棒携带的光线枪。我要消灭150只外星章鱼坦克，并收集120把光线枪。\n\n外星章鱼坦克：#b#a34371##k\n#t4000122# #b#c4000122##k/120"/>
+        <string name="2" value="我消灭了外星章鱼坦克，也收集齐了外星章鱼激光棒的光线枪。冒险勇者很高兴，说以后有机会还想和我一起执行任务。"/>
         <int name="area" value="37"/>
     </imgdir>
     <imgdir name="3438">
@@ -12458,9 +12458,9 @@
         <string name="name" value="士兵克斌的休假请托"/>
         <string name="parent" value="黄金海滩自由旅行券"/>
         <int name="order" value="1"/>
-        <string name="0" value="听说有人在地球本部遗失了自由旅行券... 要不要去帮助他呢，有空的话去一趟地球本部吧。"/>
+        <string name="0" value="听说地球防卫总部有人捡到了一张破损的自由旅行券……有空的话，要不要去帮帮他呢？"/>
         <string name="1" value="士兵克斌虽然入伍了，却一直负责地球本部的守卫任务，没能真正参加战斗。厌倦守卫工作的他想争取休假去旅行，所以拜托我去消灭外星章鱼枪，并收集它们的触角作为业绩证明。听说外星章鱼枪还带着某个破损的旅行券，也一并找找看吧。\n\n #t4000120# #b#c4000120##k/25 \n #t4031206# #b#c4031206##k/1"/>
-        <string name="2" value="用已被撕裂的旅行券能够做什么呢？不管怎样，先按照票上写的去找导游爱丽吧。"/>
+        <string name="2" value="这张被撕裂的旅行券能用来做什么呢？不管怎样，先按照票背面的提示去找导游爱丽吧。"/>
         <int name="area" value="37"/>
     </imgdir>
     <imgdir name="3442">
@@ -12468,7 +12468,7 @@
         <string name="parent" value="黄金海滩自由旅行券"/>
         <int name="order" value="2"/>
         <string name="1" value="爱丽说破损的自由旅行券已经无法使用，也不能重新补发。不过她提到，天空之城的导游贵英也许知道修复方法。带着破损的自由旅行券去找贵英吧。"/>
-        <string name="2" value="呃.. 直接给一个新的多好，但不能啊。既然来到这里了，那就做到底吧。"/>
+        <string name="2" value="看来不能直接补发一张新的旅行券。既然已经查到这里了，就继续想办法把它修好吧。"/>
         <int name="area" value="37"/>
     </imgdir>
     <imgdir name="3443">
@@ -18062,21 +18062,21 @@
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8061">
-        <string name="name" value="Doll in the Dark 1"/>
-        <string name="parent" value="Doll in the Dark"/>
+        <string name="name" value="黑暗中的娃娃 1"/>
+        <string name="parent" value="黑暗中的娃娃"/>
         <int name="order" value="1"/>
-        <string name="0" value="#b#p1012109##k of #b#m100000000##k in Victoria Island has apparently started writing a book."/>
-        <string name="1" value="#p1012109# of #m100000000# has requested my help in writing his book. For more information, he recommended me to talk to #b#p2041022##k in #b#m220000400##k of Ludibrium. Should I go there...?"/>
-        <string name="2" value="#b#p2041022##k asked me to look for some subjects worthy of writing a book on. I should talk to him when the research is over."/>
+        <string name="0" value="维多利亚岛#m100000000#的#b#p1012109##k似乎开始撰写一本新书。"/>
+        <string name="1" value="#m100000000#的#p1012109#拜托我协助他撰写新书。为了获得更多资料，他建议我去玩具城#m220000400#找#b#p2041022##k谈谈。要去看看吗？"/>
+        <string name="2" value="#b#p2041022##k让我寻找适合写进书里的研究对象。调查结束后，再去找他谈谈吧。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8062">
-        <string name="name" value="Doll in the Dark 2"/>
-        <string name="parent" value="Doll in the Dark"/>
+        <string name="name" value="黑暗中的娃娃 2"/>
+        <string name="parent" value="黑暗中的娃娃"/>
         <int name="order" value="2"/>
-        <string name="0" value="#b#p2041022##k said he looked for some subjects that may go along with the book that&apos;s being written. What do I need to do now? I better ask him."/>
-        <string name="1" value="#p2041022# requested me to defeat #b#o6230400##k and collect #b50 #t04000143#s#k so I can hand them to #b#p1012109##k. I don&apos;t know if #p1012109# wants to be in on this, but I&apos;ll ask first."/>
-        <string name="2" value="Just the way #p2041022# ordered, I gathered up #b50 #t04000143#s#k from #b#o6230400##k, and gave them to #p1012109# of #m100000000#. #p1012109# seemed very ecstatic, and rewarded me for my effort, but will that really help him write the next chapter?"/>
+        <string name="0" value="#b#p2041022##k说他找到了一些适合那本新书的研究对象。接下来该做什么呢？去问问他吧。"/>
+        <string name="1" value="#p2041022#让我打倒#b#o6230400##k并收集#b50个#t4000143##k，交给#m100000000#的#b#p1012109##k。不知道#p1012109#是否需要这些材料，先去问问他吧。"/>
+        <string name="2" value="按照#p2041022#的建议，我从#b#o6230400##k身上收集了#b50个#t4000143##k，并交给了#m100000000#的#p1012109#。#p1012109#非常高兴，还给了我谢礼。不知道这些资料能不能帮他写出下一章呢？"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8064">

--- a/gms-server/wz-zh-CN/String.wz/Etc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Etc.img.xml
@@ -4000,8 +4000,8 @@
             <string name="desc" value="儿童节时用于装饰的绿色鲤鱼。"/>
         </imgdir>
         <imgdir name="4031134">
-            <string name="name" value="自由旅行券"/>
-            <string name="desc" value="可以免费去黄金海滩的票"/>
+            <string name="name" value="黄金海滩自由旅行券"/>
+            <string name="desc" value="可以免费前往黄金海滩的旅行券。"/>
         </imgdir>
         <imgdir name="4031135">
             <string name="name" value="无光水晶"/>
@@ -4288,12 +4288,12 @@
             <string name="desc" value="由丽萨亲手制作的特殊治疗剂。\n可以闻到一股香甜的味道。"/>
         </imgdir>
         <imgdir name="4031206">
-            <string name="name" value="破损的旅游券之一"/>
-            <string name="desc" value="被撕破的旅游券其中的一部份。"/>
+            <string name="name" value="破损的自由旅行券之一"/>
+            <string name="desc" value="被撕破的自由旅行券其中一部分。"/>
         </imgdir>
         <imgdir name="4031207">
-            <string name="name" value="破损的旅游券之二"/>
-            <string name="desc" value="被撕破的旅游券其中的一部份。"/>
+            <string name="name" value="破损的自由旅行券之二"/>
+            <string name="desc" value="被撕破的自由旅行券其中一部分。"/>
         </imgdir>
         <imgdir name="4031208">
             <string name="name" value="空瓶"/>
@@ -4432,8 +4432,8 @@
             <string name="desc" value="可使用水世界海豚TAXI的使用券\n，搭乘海豚TAXI可前往矩形地带"/>
         </imgdir>
         <imgdir name="4031243">
-            <string name="name" value="破损的旅游券之一"/>
-            <string name="desc" value="被撕破的旅游券其中的一部分。"/>
+            <string name="name" value="破损的自由旅行券之一"/>
+            <string name="desc" value="被撕破的自由旅行券其中一部分。"/>
         </imgdir>
         <imgdir name="4031244">
             <string name="name" value="兴夫的葫芦种子"/>

--- a/gms-server/wz-zh-CN/String.wz/Npc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Npc.img.xml
@@ -45,8 +45,8 @@
     <imgdir name="1002002">
         <string name="name" value="佩森"/>
         <string name="func" value="导游"/>
-        <string name="n0" value="你不想去美丽的佛罗利纳海边吗?"/>
-        <string name="n1" value="金银岛附近有叫做佛罗利纳海边的梦幻般的海滩。"/>
+        <string name="n0" value="想去美丽的黄金海滩看看吗？"/>
+        <string name="n1" value="金银岛附近有一片风景优美的黄金海滩。"/>
     </imgdir>
     <imgdir name="1002003">
         <string name="name" value="智慧爷爷"/>
@@ -3017,10 +3017,10 @@
     </imgdir>
     <imgdir name="2040017">
         <string name="name" value="冒险勇者 绿虎"/>
-        <string name="d0" value="我是地球防御本部派来执行重要任务的。这里很危险，一般人不要出入。"/>
-        <string name="d1" value="在这鲁斯韦尔草原出没很多外星人，是特别管理地区。现在攻击开始了，一般人不能在这里停留。我要去执行任务了。。"/>
-        <string name="n0" value="有我们，这里一定安全。你放心吧！"/>
-        <string name="n1" value="出发时间。。。过去了？"/>
+        <string name="d0" value="我是地球防卫总部派来执行重要任务的。这里非常危险，普通人请不要靠近。"/>
+        <string name="d1" value="鲁斯韦尔草原经常有外星人出没，因此这里被列为特别管制区域。战斗还在持续，普通人不宜久留。我还要回总部处理任务，后会有期！"/>
+        <string name="n0" value="只要有我们在，这里一定会安全。放心吧！"/>
+        <string name="n1" value="我们……错过出发时间了吗？"/>
     </imgdir>
     <imgdir name="2040018">
         <string name="name" value="冒险勇者 熊猫"/>
@@ -7029,11 +7029,11 @@
     </imgdir>
     <imgdir name="9201085">
         <string name="name" value="尼古拉斯"/>
-        <string name="d0" value="我们已经找到了所有的方法你！"/>
-        <string name="d1" value="我们已经找到了所有的方法你！ 我只是卖给我上次冒险岛游戏卡！您可能需要检查其他城市更冒险岛游戏卡！务必做家务杂事的爸爸妈妈第一次！"/>
-        <string name="func" value="CVS里盖伊"/>
-        <string name="n0" value="我们已经找到了所有的方法你！"/>
-        <string name="n1" value="冒险岛游戏卡作出巨大礼物送给您和您的朋友。节日快乐！"/>
+        <string name="d0" value="我们为你的每一份心意都准备了好东西！"/>
+        <string name="d1" value="糟糕！我刚刚卖掉了最后一张冒险岛游戏卡！你可以去其他城镇看看还有没有。记得先帮爸爸妈妈做完家务哦！"/>
+        <string name="func" value="游戏卡销售员"/>
+        <string name="n0" value="我们为你的每一份心意都准备了好东西！"/>
+        <string name="n1" value="冒险岛游戏卡很适合作为送给你和朋友的礼物。节日快乐！"/>
     </imgdir>
     <imgdir name="9201086">
         <string name="name" value="安迪"/>
@@ -7824,10 +7824,10 @@
         <string name="n1" value="要变更您的眼睛的颜色，以寻找更具吸引力？"/>
     </imgdir>
     <imgdir name="9270027">
-        <string name="name" value="Alwyn"/>
-        <string name="func" value="特产"/>
-        <string name="n0" value="供应当地粮食这里！"/>
-        <string name="n1" value="所有你可以看到，吃在新加坡！"/>
+        <string name="name" value="阿尔文"/>
+        <string name="func" value="当地特产"/>
+        <string name="n0" value="这里出售本地美食！"/>
+        <string name="n1" value="在新加坡，边逛边吃，尽情享受吧！"/>
     </imgdir>
     <imgdir name="9270028">
         <string name="name" value="阿德里安"/>


### PR DESCRIPTION
## 改动说明

本次修复若干中文文本资源中的未汉化、机翻语序和数量不一致问题：

- 汉化并润色 `Doll in the Dark` 任务链的任务名、任务摘要和任务对话。
- 修复新加坡中心商务区 NPC `Alwyn` 的中文名、功能名和闲聊文本。
- 修复阿莫利亚 NPC `Nicholas` 的功能名和机翻对话，保留「尼古拉斯」译名。
- 润色冒险勇者绿虎相关 NPC 文本和任务对话，并修正任务数量显示：
  - 外星章鱼头盔统一为 80 个。
  - 外星章鱼坦克统一为 150 只，光线枪统一为 120 个。
- 润色「黄金海滩自由旅行券」任务链文本，并统一相关旅行券物品名称与描述。

## 客户端影响

本次改动涉及 `wz-zh-CN` 文本资源，客户端需要同步对应的中文资源文件后才能看到最新文本。

## 校验

- 已确认 XML 可正常解析。
- 已检查新增文本中没有乱码、旧英文标题和旧机翻短语残留。
- 已确认本次分支相对上游仅包含 1 个提交，且 diff 仅包含本次中文资源修复文件。