### PR TITLE
fix: 修正新叶城任务分类与赏金猎人汉化

### DIFF
--- a/gms-server/scripts-zh-CN/quest/8231.js
+++ b/gms-server/scripts-zh-CN/quest/8231.js
@@ -1,7 +1,7 @@
 /* ===========================================================
 			Ronan Lana
 	NPC Name: 		Lita Lawless
-	Description: 	Quest - Bounty Hunter - Fool's Gold
+	Description: 	Quest - 赏金猎人 - 愚者的黄金
 =============================================================
 Version 1.0 - Script Done.(11/7/2017)
 =============================================================
@@ -15,17 +15,17 @@ function start(mode, type, selection) {
         if (type == 1 && mode == 0) {
             status -= 2;
         } else {
-            qm.sendOk("好的，再见。");
+            qm.sendOk("好吧，那就这样。回头见。");
             qm.dispose();
             return;
         }
     }
     if (status == 0) {
-        var target = "小矮人";
-        qm.sendAcceptDecline("嘿，游客！我需要你的帮助。新叶城的居民面临新的威胁。我正在招募任何人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
+        var target = "小妖精";
+        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的居民正面临新的威胁。我正在招募愿意出手的人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
     } else if (status == 1) {
-        var reqs = "#r30 个 #t4032031##k";
-        qm.sendOk("非常好。尽快给我 #r" + reqs + "#k，新叶城正在指望你。");
+        var reqs = "#r30 #t4032031##k";
+        qm.sendOk("很好。请尽快把 " + reqs + " 带回来给我。新叶城就指望你了。");
         qm.forceStartQuest();
     } else if (status == 2) {
         qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/8232.js
+++ b/gms-server/scripts-zh-CN/quest/8232.js
@@ -1,7 +1,7 @@
 /* ===========================================================
 			Ronan Lana
 	NPC Name: 		Lita Lawless
-	Description: 	Quest - Bounty Hunter - Fool's Gold
+	Description: 	Quest - 赏金猎人 - 愚者的黄金 - 后续
 =============================================================
 Version 1.0 - Script Done.(11/7/2017)
 =============================================================
@@ -15,17 +15,17 @@ function start(mode, type, selection) {
         if (type == 1 && mode == 0) {
             status -= 2;
         } else {
-            qm.sendOk("好的，再见。");
+            qm.sendOk("好吧，那就这样。回头见。");
             qm.dispose();
             return;
         }
     }
     if (status == 0) {
-        var target = "小矮人";
-        qm.sendAcceptDecline("嘿，游客！我需要你的帮助。新叶城的居民面临新的威胁。我正在招募任何人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
+        var target = "小妖精";
+        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的居民正面临新的威胁。我正在招募愿意出手的人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
     } else if (status == 1) {
-        var reqs = "#r30 个 #t4032031##k";
-        qm.sendOk("非常好。尽快给我 #r" + reqs + "#k，新叶城正在指望你。");
+        var reqs = "#r30 #t4032031##k";
+        qm.sendOk("很好。请尽快把 " + reqs + " 带回来给我。新叶城就指望你了。");
         qm.forceStartQuest();
     } else if (status == 2) {
         qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/8233.js
+++ b/gms-server/scripts-zh-CN/quest/8233.js
@@ -1,7 +1,7 @@
 /* ===========================================================
 			Ronan Lana
 	NPC Name: 		Lita Lawless
-	Description: 	Quest - Bounty Hunter - Rags to Riches
+	Description: 	Quest - 赏金猎人 - 破布生财
 =============================================================
 Version 1.0 - Script Done.(11/7/2017)
 =============================================================
@@ -15,17 +15,17 @@ function start(mode, type, selection) {
         if (type == 1 && mode == 0) {
             status -= 2;
         } else {
-            qm.sendOk("好的，再见。");
+            qm.sendOk("好吧，那就这样。回头见。");
             qm.dispose();
             return;
         }
     }
     if (status == 0) {
         var target = "长者幽灵";
-        qm.sendAcceptDecline("嘿，游客！我需要你的帮助。新叶城的居民出现了新的威胁。我正在招募任何人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
+        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的居民正面临新的威胁。我正在招募愿意出手的人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
     } else if (status == 1) {
         var reqs = "#r30 #t4032011##k";
-        qm.sendOk("非常好。尽快给我带来 #r" + reqs + "#k，新叶城正在指望你。");
+        qm.sendOk("很好。请尽快把 " + reqs + " 带回来给我。新叶城就指望你了。");
         qm.forceStartQuest();
     } else if (status == 2) {
         qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/8234.js
+++ b/gms-server/scripts-zh-CN/quest/8234.js
@@ -1,7 +1,7 @@
 /* ===========================================================
 			Ronan Lana
 	NPC Name: 		Lita Lawless
-	Description: 	Quest - Bounty Hunter - Rags to Riches
+	Description: 	Quest - 赏金猎人 - 破布生财 - 后续
 =============================================================
 Version 1.0 - Script Done.(11/7/2017)
 =============================================================
@@ -15,17 +15,17 @@ function start(mode, type, selection) {
         if (type == 1 && mode == 0) {
             status -= 2;
         } else {
-            qm.sendOk("好的，那就这样吧。再见。");
+            qm.sendOk("好吧，那就这样。回头见。");
             qm.dispose();
             return;
         }
     }
     if (status == 0) {
         var target = "长者幽灵";
-        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的居民面临着新的威胁。我正在招募任何人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
+        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的居民正面临新的威胁。我正在招募愿意出手的人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
     } else if (status == 1) {
         var reqs = "#r30 #t4032011##k";
-        qm.sendOk("非常好。尽快给我 #r" + reqs + "#k，新叶城正在指望你。");
+        qm.sendOk("很好。请尽快把 " + reqs + " 带回来给我。新叶城就指望你了。");
         qm.forceStartQuest();
     } else if (status == 2) {
         qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/8235.js
+++ b/gms-server/scripts-zh-CN/quest/8235.js
@@ -1,7 +1,7 @@
 /* ===========================================================
 			Ronan Lana
 	NPC Name: 		Lita Lawless
-	Description: 	Quest - Bounty Hunter - One Step A-Head
+	Description: 	Quest - 赏金猎人 - 一步之遥
 =============================================================
 Version 1.0 - Script Done.(11/7/2017)
 =============================================================
@@ -15,17 +15,17 @@ function start(mode, type, selection) {
         if (type == 1 && mode == 0) {
             status -= 2;
         } else {
-            qm.sendOk("好的，再见。");
+            qm.sendOk("好吧，那就这样。回头见。");
             qm.dispose();
             return;
         }
     }
     if (status == 0) {
         var target = "无头骑士";
-        qm.sendAcceptDecline("嘿，游侠！我需要你的帮助。新叶城的居民面临着新的威胁。我正在招募任何人，这次的目标是#r" + target + "#k。你愿意加入吗？");
+        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的居民正面临新的威胁。我正在招募愿意出手的人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
     } else if (status == 1) {
         var reqs = "#r1 #t4031903##k";
-        qm.sendOk("很好。尽快给我#r" + reqs + "#k，新叶城正在依赖你。");
+        qm.sendOk("很好。请尽快把 " + reqs + " 带回来给我。新叶城就指望你了。");
         qm.forceStartQuest();
     } else if (status == 2) {
         qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/8236.js
+++ b/gms-server/scripts-zh-CN/quest/8236.js
@@ -1,7 +1,7 @@
 /* ===========================================================
 			Ronan Lana
 	NPC Name: 		Lita Lawless
-	Description: 	Quest - Bounty Hunter - One Step A-Head
+	Description: 	Quest - 赏金猎人 - 一步之遥 - 后续
 =============================================================
 Version 1.0 - Script Done.(11/7/2017)
 =============================================================
@@ -15,17 +15,17 @@ function start(mode, type, selection) {
         if (type == 1 && mode == 0) {
             status -= 2;
         } else {
-            qm.sendOk("好的，再见。");
+            qm.sendOk("好吧，那就这样。回头见。");
             qm.dispose();
             return;
         }
     }
     if (status == 0) {
-        var target = "是无头骑士";
-        qm.sendAcceptDecline("嘿，游侠！我需要你的帮助。新叶城的居民面临新的威胁。我正在招募任何人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
+        var target = "无头骑士";
+        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的居民正面临新的威胁。我正在招募愿意出手的人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
     } else if (status == 1) {
         var reqs = "#r1 #t4031903##k";
-        qm.sendOk("很好。尽快给我 #r" + reqs + "#k。新叶城指望着你。");
+        qm.sendOk("很好。请尽快把 " + reqs + " 带回来给我。新叶城就指望你了。");
         qm.forceStartQuest();
     } else if (status == 2) {
         qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/8237.js
+++ b/gms-server/scripts-zh-CN/quest/8237.js
@@ -1,7 +1,7 @@
 /* ===========================================================
 			Ronan Lana
 	NPC Name: 		Lita Lawless
-	Description: 	Quest - Bounty Hunter - Catch a Bigfoot by the Toe
+	Description: 	Quest - 赏金猎人 - 抓住大脚怪的脚趾
 =============================================================
 Version 1.0 - Script Done.(11/7/2017)
 =============================================================
@@ -15,17 +15,17 @@ function start(mode, type, selection) {
         if (type == 1 && mode == 0) {
             status -= 2;
         } else {
-            qm.sendOk("好吧，那么。回头见.");
+            qm.sendOk("好吧，那就这样。回头见。");
             qm.dispose();
             return;
         }
     }
-    if (status == 0) { //斯库亚斯防御战怪物召唤
+    if (status == 0) {
         var target = "大脚怪";
-        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的市民们受到了新的威胁。我现在正在招募任何人，这次的目标是 #r" + target + "#k. 你要加入吗？");
+        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的居民正面临新的威胁。我正在招募愿意出手的人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
     } else if (status == 1) {
         var reqs = "#r1 #t4032013##k";
-        qm.sendOk("很好。尽快拿到#r" + reqs + "#k，新叶城市民委员会需要你.");
+        qm.sendOk("很好。请尽快把 " + reqs + " 带回来给我。新叶城就指望你了。");
         qm.forceStartQuest();
     } else if (status == 2) {
         qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/8238.js
+++ b/gms-server/scripts-zh-CN/quest/8238.js
@@ -1,7 +1,7 @@
 /* ===========================================================
 			Ronan Lana
 	NPC Name: 		Lita Lawless
-	Description: 	Quest - Bounty Hunter - Catch a Bigfoot by the Toe
+	Description: 	Quest - 赏金猎人 - 抓住大脚怪的脚趾 - 后续
 =============================================================
 Version 1.0 - Script Done.(11/7/2017)
 =============================================================
@@ -15,17 +15,17 @@ function start(mode, type, selection) {
         if (type == 1 && mode == 0) {
             status -= 2;
         } else {
-            qm.sendOk("好的，那就这样吧。再见。");
+            qm.sendOk("好吧，那就这样。回头见。");
             qm.dispose();
             return;
         }
     }
     if (status == 0) {
-        var target = "是巨大的大脚怪";
-        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的居民面临新的威胁。我正在招募任何人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
+        var target = "大脚怪";
+        qm.sendAcceptDecline("嘿，旅行者！我需要你的帮助。新叶城的居民正面临新的威胁。我正在招募愿意出手的人，这次的目标是 #r" + target + "#k。你愿意加入吗？");
     } else if (status == 1) {
         var reqs = "#r1 #t4032013##k";
-        qm.sendOk("非常好。尽快给我 #r" + reqs + "#k，新叶城正在依赖你。");
+        qm.sendOk("很好。请尽快把 " + reqs + " 带回来给我。新叶城就指望你了。");
         qm.forceStartQuest();
     } else if (status == 2) {
         qm.dispose();

--- a/gms-server/wz-zh-CN/Etc.wz/QuestCategory.img.xml
+++ b/gms-server/wz-zh-CN/Etc.wz/QuestCategory.img.xml
@@ -42,14 +42,14 @@
     <string name="39" value="empty"/>
     <string name="40" value="神秘岛"/>
     <string name="41" value="神木村"/>
-    <string name="42" value="empty"/>
+    <string name="42" value="东方神州"/>
     <string name="43" value="empty"/>
     <string name="44" value="武陵桃园+尼哈沙漠"/>
-    <string name="45" value="东方神州"/>
+    <string name="45" value="新叶城"/>
     <string name="46" value="时间神殿"/>
     <string name="47" value="组队任务"/>
     <string name="48" value="海外旅游"/>
-    <string name="49" value="empty"/>
+    <string name="49" value="马来西亚"/>
     <string name="50" value="活动"/>
     <string name="51" value="Title"/>
 </imgdir>

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -18385,79 +18385,83 @@
     </imgdir>
     <imgdir name="8231">
         <string name="name" value="愚者的黄金"/>
-        <string name="0" value="在马斯特利亚和新叶城发生了这么多奇怪的事情，莉塔·罗莉丝肯定忙得不可开交！我敢打赌她一定乐意接受我的帮助……或许我还能借此赚些赏金！只需快速前往废弃都市地铁站，我就能出发去新叶城！"/>
+        <string name="parent" value="赏金猎人"/>
+        <int name="order" value="1"/>
+        <string name="0" value="新叶城一带发生了这么多奇怪的事情，莉塔·罗莉丝肯定忙得不可开交！我敢打赌她一定乐意接受我的帮助……或许我还能借此赚些赏金！只需快速前往废弃都市地铁站，我就能出发去新叶城！"/>
         <string name="1" value="我与莉塔交谈过，她提到幻影森林里有个捣蛋鬼在游荡。这给她带来了不少麻烦——对于像她这样的战士来说，这实在让人感到惊讶。我已同意帮助她清除这些恶劣生物，作为证明，我需要带回#b30#k颗她所称的#b幸运符#k，这些奇怪的银苜蓿。我会提高警惕——据说那片森林闹鬼……"/>
-        <string name="2" value="我深入疯狂的幻影森林，遇到了一些小妖精，并经过一番战斗后收集到了30颗幸运符。我将它们带回给Lita以领取赏金！她对我的帮助表示感谢，并提到我可以回来找她进行更多的赏金工作！"/>
+        <string name="2" value="我深入疯狂的幻影森林，遇到了一些小妖精，并经过一番战斗后收集到了30颗幸运符。我将它们带回给莉塔以领取赏金！她对我的帮助表示感谢，并提到我可以回来找她进行更多的赏金工作！"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8232">
         <string name="name" value="愚者的黄金"/>
-        <string name="0" value="马斯特里亚和新叶城发生了这么多奇怪的事情，莉塔·罗莉丝肯定忙得不可开交！我打赌她很愿意接受我的帮助……也许我还能顺便赚点赏金！坐上废弃都市的地铁，我就能去新叶城了！"/>
+        <string name="parent" value="赏金猎人"/>
+        <int name="order" value="2"/>
+        <string name="0" value="新叶城一带发生了这么多奇怪的事情，莉塔·罗莉丝肯定忙得不可开交！我打赌她很愿意接受我的帮助……也许我还能顺便赚点赏金！坐上废弃都市的地铁，我就能去新叶城了！"/>
         <string name="1" value="我和莉塔聊过，发现#b#m682000001##k里似乎有个捣蛋鬼在游荡。这给她带来了不少麻烦——对于像她这样的战士来说，这实在让人感到惊讶。我已答应帮她清除森林里的这些邪恶生物，作为证明，我需要带回来#b30#k个她称之为#b#t4032031##k的东西。我会保持警惕——据说那片森林闹鬼……"/>
         <string name="2" value="我冒险进入了疯狂的幻影森林，遇到了一些小妖精，经过一系列战斗后，获得了30个#b#t4032031##k。我将它们交还给莉塔以领取赏金！她对我的帮助表示感谢，并提到我可以再来找她领取更多赏金任务！"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8233">
-        <string name="name" value="Rags to Riches"/>
-        <string name="parent" value="Bounty Hunter."/>
-        <int name="order" value="1"/>
-        <string name="0" value="With all the strange occurrences in Masteria and New Leaf City, Lita Lawless must be busy! I&apos;ll bet that she&apos;s willing to accept my help...maybe I can earn some mesos in the process! A quick jaunt to the Kerning City subway and I&apos;ll be on my way to New Leaf City!"/>
-        <string name="1" value="I spoke with LIta, and it seems that there strange, powerful spirits drifting about the Phantom Forest. These strange spirits seemingly have no desire, save for tormenting others. I&apos;ve agreed to eliminate 30 of them, and bring their soiled rags to Lita as proof of valor. I&apos;d better keep sharp-that forest has driven quite a few travelers mad with its confusion..."/>
-        <string name="2" value="I navigated the Phantom Forest and collected 30 of the Soiled Rags the Elder Wraiths had upon them. It was strange to finally fight one, they were eerily quiet for being so vicious. I wonder if there&apos;s more to their story...perhaps someone in the Phantom Forest would know..."/>
+        <string name="name" value="破布生财"/>
+        <string name="parent" value="赏金猎人"/>
+        <int name="order" value="3"/>
+        <string name="0" value="新叶城一带发生了这么多怪事，莉塔·罗莉丝肯定忙得不可开交！我打赌她会愿意接受我的帮助……说不定我还能顺便赚点赏金。只要从废弃都市地铁出发，很快就能到新叶城！"/>
+        <string name="1" value="我和莉塔谈过了。幻影森林里似乎有一些强大的怨灵四处游荡，它们除了折磨别人之外好像没有别的目的。我答应消灭它们，并带回#b30#k个#b#t4032011##k作为英勇的证明。那片森林已经让不少旅行者迷失发疯，我最好保持警惕……"/>
+        <string name="2" value="我穿过幻影森林，收集到了长者幽灵身上的30个#b#t4032011##k。真正和它们交手后感觉很奇怪，它们明明那么凶残，却安静得令人发毛。我怀疑这背后还有别的故事……也许幻影森林里有人知道些什么。"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8234">
-        <string name="name" value="Rags to Riches."/>
-        <string name="parent" value="Bounty Hunter."/>
-        <int name="order" value="2"/>
-        <string name="0" value="With all the strange occurrences in Masteria and New Leaf City, Lita Lawless must be busy! I&apos;ll bet that she&apos;s willing to accept my help...maybe I can earn some mesos in the process! A quick jaunt to the Kerning City subway and I&apos;ll be on my way to New Leaf City!"/>
-        <string name="1" value="I spoke with LIta, and it seems that there strange, powerful spirits drifting about the Phantom Forest. These strange spirits seemingly have no desire, save for tormenting others. I&apos;ve agreed to eliminate 30 of them, and bring their soiled rags to Lita as proof of valor. I&apos;d better keep sharp-that forest has driven quite a few travelers mad with its confusion..."/>
-        <string name="2" value="I navigated the Phantom Forest and collected 30 of the Soiled Rags the Elder Wraiths had upon them. It was strange to finally fight one, they were eerily quiet for being so vicious. I wonder if there&apos;s more to their story...perhaps someone in the Phantom Forest would know..."/>
+        <string name="name" value="破布生财 - 后续"/>
+        <string name="parent" value="赏金猎人"/>
+        <int name="order" value="4"/>
+        <string name="0" value="新叶城一带发生了这么多怪事，莉塔·罗莉丝肯定忙得不可开交！我打赌她会愿意接受我的帮助……说不定我还能顺便赚点赏金。只要从废弃都市地铁出发，很快就能到新叶城！"/>
+        <string name="1" value="我和莉塔谈过了。幻影森林里似乎有一些强大的怨灵四处游荡，它们除了折磨别人之外好像没有别的目的。我答应消灭它们，并带回#b30#k个#b#t4032011##k作为英勇的证明。那片森林已经让不少旅行者迷失发疯，我最好保持警惕……"/>
+        <string name="2" value="我穿过幻影森林，收集到了长者幽灵身上的30个#b#t4032011##k。真正和它们交手后感觉很奇怪，它们明明那么凶残，却安静得令人发毛。我怀疑这背后还有别的故事……也许幻影森林里有人知道些什么。"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8235">
-        <string name="name" value="One Step A-Head"/>
-        <string name="parent" value="Bounty Hunter.."/>
-        <int name="order" value="1"/>
-        <string name="0" value="With all the strange occurrences in Masteria and New Leaf City, Lita Lawless must be busy! I&apos;ll bet that she&apos;s willing to accept my help...maybe I can earn some mesos in the process! A quick jaunt to the Kerning City subway and I&apos;ll be on my way to New Leaf City!"/>
-        <string name="1" value="I spoke with Lita, and she told me the tragic origin of the Headless Horseman. He was a former warrior of Crimsonwood Keep that was experimented on the mysterious Alchemist, the same one who corrupted the Krakians. He now roams the Phantom Forest, and I must bring his Jack O&apos;Lantern head to Lita as proof of my triumph! "/>
-        <string name="2" value="It was a tough fight, but I brought down the mighty horseman and returned his Jack O&apos;Lantern to Lita. I wonder how many other lives the mysterious Alchemist has ruined..."/>
+        <string name="name" value="一步之遥"/>
+        <string name="parent" value="赏金猎人"/>
+        <int name="order" value="5"/>
+        <string name="0" value="新叶城一带发生了这么多怪事，莉塔·罗莉丝肯定忙得不可开交！我打赌她会愿意接受我的帮助……说不定我还能顺便赚点赏金。只要从废弃都市地铁出发，很快就能到新叶城！"/>
+        <string name="1" value="我和莉塔谈过了，她告诉我无头骑士的悲惨来历。他曾经是绯红要塞的战士，却被那位神秘炼金术士拿来做实验；腐化克拉奇亚人的也是同一个人。现在无头骑士徘徊在幻影森林中，我必须把他的#b#t4031903##k带回给莉塔，作为完成赏金的证明！"/>
+        <string name="2" value="这是一场艰难的战斗，但我击败了强大的无头骑士，并把#b#t4031903##k带回给莉塔。不知道还有多少生命被那个神秘炼金术士毁掉了……"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8236">
-        <string name="name" value="One Step A-Head."/>
-        <string name="parent" value="Bounty Hunter.."/>
-        <int name="order" value="2"/>
-        <string name="0" value="With all the strange occurrences in Masteria and New Leaf City, Lita Lawless must be busy! I&apos;ll bet that she&apos;s willing to accept my help...maybe I can earn some mesos in the process! A quick jaunt to the Kerning City subway and I&apos;ll be on my way to New Leaf City!"/>
-        <string name="1" value="I spoke with Lita, and she told me the tragic origin of the Headless Horseman. He was a former warrior of Crimsonwood Keep that was experimented on the mysterious Alchemist, the same one who corrupted the Krakians. He now roams the Phantom Forest, and I must bring his Jack O&apos;Lantern head to Lita as proof of my triumph! "/>
-        <string name="2" value="It was a tough fight, but I brought down the mighty horseman and returned his Jack O&apos;Lantern to Lita. I wonder how many other lives the mysterious Alchemist has ruined..."/>
+        <string name="name" value="一步之遥 - 后续"/>
+        <string name="parent" value="赏金猎人"/>
+        <int name="order" value="6"/>
+        <string name="0" value="新叶城一带发生了这么多怪事，莉塔·罗莉丝肯定忙得不可开交！我打赌她会愿意接受我的帮助……说不定我还能顺便赚点赏金。只要从废弃都市地铁出发，很快就能到新叶城！"/>
+        <string name="1" value="我和莉塔谈过了，她告诉我无头骑士的悲惨来历。他曾经是绯红要塞的战士，却被那位神秘炼金术士拿来做实验；腐化克拉奇亚人的也是同一个人。现在无头骑士徘徊在幻影森林中，我必须把他的#b#t4031903##k带回给莉塔，作为完成赏金的证明！"/>
+        <string name="2" value="这是一场艰难的战斗，但我击败了强大的无头骑士，并把#b#t4031903##k带回给莉塔。不知道还有多少生命被那个神秘炼金术士毁掉了……"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8237">
-        <string name="name" value="Catch a Bigfoot by the Toe"/>
-        <string name="parent" value="Bounty Hunter..."/>
-        <int name="order" value="1"/>
-        <string name="0" value="With all the strange occurrences in Masteria and New Leaf City, Lita Lawless must be busy! I&apos;ll bet that she&apos;s willing to accept my help...maybe I can earn some mesos in the process! A quick jaunt to the Kerning City subway and I&apos;ll be on my way to New Leaf City!"/>
-        <string name="1" value="I spoke with Lita, and I&apos;m pretty sure I&apos;m getting the short end of the stick on this one. I have to venture into the Phantom Forest and find this creature they&apos;ve named Bigfoot and claim its toe as the proof of bounty. Everyone else who&apos;s gone after this thing has never come back-I&apos;d better stock up on potions and keep my guard up-who knows when it could appear?"/>
-        <string name="2" value="I found this mysterious creature, and Lita wasn&apos;t kidding when she said it wrecked everyone that came after it! Although, when I was fighting it, I got the feeling that the Leprechaun on its back was just luring him into things...maybe it just doesn&apos;t know better? At any rate, I returned the Toe to Lita and claimed the Bounty.  The more mesos, the better!"/>
+        <string name="name" value="抓住大脚怪的脚趾"/>
+        <string name="parent" value="赏金猎人"/>
+        <int name="order" value="7"/>
+        <string name="0" value="新叶城一带发生了这么多怪事，莉塔·罗莉丝肯定忙得不可开交！我打赌她会愿意接受我的帮助……说不定我还能顺便赚点赏金。只要从废弃都市地铁出发，很快就能到新叶城！"/>
+        <string name="1" value="我和莉塔谈过了，这次我大概是接了个苦差事。我要深入幻影森林，找到被称作大脚怪的生物，并取回它的#b#t4032013##k作为赏金凭证。之前追捕它的人都没有回来——我最好多准备些药水，随时保持戒备，谁知道它什么时候会出现？"/>
+        <string name="2" value="我找到了那个神秘生物。莉塔说它把所有追捕者都打得落花流水，看来一点也不夸张！不过战斗时我总觉得，它背上的小妖精像是在诱导它惹事……也许它只是分不清好坏？总之，我把#b#t4032013##k交给莉塔，领到了赏金。金币当然越多越好！"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8238">
-        <string name="name" value="Catch a Bigfoot by the Toe."/>
-        <string name="parent" value="Bounty Hunter..."/>
-        <int name="order" value="2"/>
-        <string name="0" value="With all the strange occurrences in Masteria and New Leaf City, Lita Lawless must be busy! I&apos;ll bet that she&apos;s willing to accept my help...maybe I can earn some mesos in the process! A quick jaunt to the Kerning City subway and I&apos;ll be on my way to New Leaf City!"/>
-        <string name="1" value="I spoke with Lita, and I&apos;m pretty sure I&apos;m getting the short end of the stick on this one. I have to venture into the Phantom Forest and find this creature they&apos;ve named Bigfoot and claim its toe as the proof of bounty. Everyone else who&apos;s gone after this thing has never come back-I&apos;d better stock up on potions and keep my guard up-who knows when it could appear?"/>
-        <string name="2" value="I found this mysterious creature, and Lita wasn&apos;t kidding when she said it wrecked everyone that came after it! Although, when I was fighting it, I got the feeling that the Leprechaun on its back was just luring him into things...maybe it just doesn&apos;t know better? At any rate, I returned the Toe to Lita and claimed the Bounty.  The more mesos, the better!"/>
+        <string name="name" value="抓住大脚怪的脚趾 - 后续"/>
+        <string name="parent" value="赏金猎人"/>
+        <int name="order" value="8"/>
+        <string name="0" value="新叶城一带发生了这么多怪事，莉塔·罗莉丝肯定忙得不可开交！我打赌她会愿意接受我的帮助……说不定我还能顺便赚点赏金。只要从废弃都市地铁出发，很快就能到新叶城！"/>
+        <string name="1" value="我和莉塔谈过了，这次我大概是接了个苦差事。我要深入幻影森林，找到被称作大脚怪的生物，并取回它的#b#t4032013##k作为赏金凭证。之前追捕它的人都没有回来——我最好多准备些药水，随时保持戒备，谁知道它什么时候会出现？"/>
+        <string name="2" value="我找到了那个神秘生物。莉塔说它把所有追捕者都打得落花流水，看来一点也不夸张！不过战斗时我总觉得，它背上的小妖精像是在诱导它惹事……也许它只是分不清好坏？总之，我把#b#t4032013##k交给莉塔，领到了赏金。金币当然越多越好！"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8239">
-        <string name="name" value="Bounty Master"/>
-        <string name="parent" value="Bounty Hunter...."/>
-        <int name="order" value="1"/>
-        <string name="0" value="I&apos;ve completed all Bounty Hunter bounties for Lita Lawless! I think its about time I&apos;m deputized!  I should head to New Leaf City and find out more!"/>
-        <string name="1" value="I spoke with Lita, and she&apos;s all set to deputize me whenever I&apos;m ready!  Completing all those quests was hard, but well worth the effort!"/>
-        <string name="2" value="I&apos;ve been deputized by Lita Lawless as an official protector of New Leaf City!  I&apos;ve sworn to defend the area, and Masteria in general from all future threats...and from what it looks like, there&apos;s going to be a lot of them!"/>
+        <string name="name" value="赏金大师"/>
+        <string name="parent" value="赏金猎人"/>
+        <int name="order" value="9"/>
+        <string name="0" value="我已经完成了莉塔·罗莉丝发布的所有赏金任务！我想是时候接受任命了。去新叶城找她了解详情吧！"/>
+        <string name="1" value="我和莉塔谈过了，只要我准备好，她随时都能正式任命我！完成这些任务并不容易，但绝对值得。"/>
+        <string name="2" value="我已经被莉塔·罗莉丝任命为新叶城的正式守护者！我发誓要保护这一带，守护新叶城免受未来的威胁……而且看起来，麻烦恐怕还会有很多！"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8245">
@@ -22821,77 +22825,77 @@
         <string name="0" value="最近#b#p9310010##k家家畜变得很暴躁，农活也变得很困难。去找找他吧。"/>
         <string name="1" value="击退暴躁的家畜之后，去找#b#p9310010##k。\n\n#t4000189# #b#c4000189# / 100 #k \n#t4000190# #b#c4000190# / 100 #k"/>
         <string name="2" value="击败了暴躁的家畜。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="变得暴躁的家畜"/>
     </imgdir>
     <imgdir name="4101">
         <string name="0" value="去找需要帮助的#b#p9310010##k吧。"/>
         <string name="1" value="把#b#p9310010##k给的介绍书拿给#b#p9310008##k。\n\n#t4031288 # #b#c4031288 # / 1 #k "/>
         <string name="2" value="见到了#b#p9310008##k。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="杨叔叔的介绍"/>
     </imgdir>
     <imgdir name="4102">
         <string name="0" value="重新和#b#p9310008##k搭话吧。"/>
         <string name="1" value="击退#r#o9600005##k和#r#o9600006##k，向#b#p9310008##k证明我的能力吧。\n\n#t4000191# #b#c4000191# / 100 #k\n#t4000192# #b#c4000192# / 100 #k"/>
         <string name="2" value="向#b#p9310008##k证明了我的能力。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="资格证明"/>
     </imgdir>
     <imgdir name="4103">
         <string name="0" value="重新和#b#p9310008##k搭话吧。"/>
         <string name="1" value="带着#b#t4031289##k去找#b#p9310004##k，并打败#r#o9600009##k吧。得到#t4031227#的话，回去找#p9310008#。\n\n#t4031227# #b#c4031227# / 1 #k"/>
         <string name="2" value="拯救了处于危险之中的上海。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="秘密任务"/>
     </imgdir>
     <imgdir name="4104">
         <string name="0" value="去找#b#p9310012##k吧。"/>
         <string name="1" value="据说去帮#b#p9310010##k农活的话，可以找到#b#p9310012##k丢失的物品...\n\n#t4031290# #b#c4031290# / 1 #k"/>
         <string name="2" value="#b#p9310012##k找到了丢失的物品。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="摄影师赵先生的请求"/>
     </imgdir>
     <imgdir name="4105">
         <string name="0" value="去找#b#p9310010##k吧。"/>
         <string name="1" value="去帮#b#p9310010##k吧。\n\n#t4000193# #b#c4000193# / 100 #k"/>
         <string name="2" value="帮#b#p9310010##k做农活，得到了#b#p9310012##k丢失的物品。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="帮杨先生做农活"/>
     </imgdir>
     <imgdir name="4106">
         <string name="0" value="丢了用在照相机上的三脚架，去找#b#p9310010##k吧。"/>
         <string name="1" value="去帮#b#p9310010##k。\n\n#t4000192# #b#c4000192# / 50 #k"/>
         <string name="2" value="帮助了#b#p9310010##k，并得到了#b#p9310012##k丢失的物品。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="丢失的照相机用三脚架"/>
     </imgdir>
     <imgdir name="4107">
         <string name="0" value="去看看上海外滩的#b#p9310011##k。"/>
         <string name="1" value="送给#b#p9310011##k #b#t04000187##k吧。\n\n#t04000187# #b#c04000187# / 100 #k"/>
         <string name="2" value="送给#b#p9310011##k #b#t04000187##k，并得倒了好吃的#b#t2022064##k。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="和街头小贩吕氏进行物物交换I"/>
     </imgdir>
     <imgdir name="4108">
         <string name="0" value="去看看上海外滩的#b#p9310011##k。"/>
         <string name="1" value="送给#b#p9310011##k #b#t4000188##k吧。\n\n#t4000188# #b#c04000188# / 100 #k"/>
         <string name="2" value="送给#b#p9310011##k #b#t4000188##k，并得到了好吃的#b#t2022063##k。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="和街头小贩吕氏进行物物交换II"/>
     </imgdir>
     <imgdir name="4109">
         <string name="0" value="去和#b#p9310005##k搭话吧。"/>
         <string name="1" value="答应#b#p9310005##k的请求，击退#r#o9600008##k，并把证据拿给他吧。\n\n#t4000194# #b#c4000194# / 50 #k"/>
         <string name="2" value="帮了#b#p9310005##k。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="郑警官的请求"/>
     </imgdir>
     <imgdir name="8510">
         <string name="0" value="要去徐州岔道见杨叔叔吧。"/>
         <string name="1" value="最近村落的牲口变成了怪物开始攻击居民和旅行者，听说这些事情都是怪物抢走村落的宝物赤珠后才发生的。我会帮助他，但他还不能相信我的能力，所以我要打退山羊后收集#b100个山羊角和60个黑山羊角#k给他。那么他也可以相信我吧？\n\n #t4000190# #b#c4000190##k / 100 \n#t4000191# #b#c4000191##k / 60"/>
         <string name="2" value="打退山羊和黑山羊后收集齐了角。杨叔叔说他可以相信我。他给了我一张介绍信。这是跟上海警察推荐我的文件。那么我要去上海外滩找上海警察处长。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="农民的拜托"/>
         <int name="order" value="1"/>
         <string name="parent" value="牲口的造反"/>
@@ -22900,7 +22904,7 @@
         <string name="0" value="杨叔叔给了我介绍信。我要拿这张介绍信去上海外滩找警察处长。"/>
         <string name="1" value="按照警察的调查在这个事件的背后有很危险的怪物。为了打退这个怪物已经派了很多警察。但太多警察出动后，现在上海附近的治安情况不太好。警察处长拜托了我替他们去打退牛类的怪物。听说这些牛类的怪物是这附近最危险的怪物。我要打退牛和犁杖牛后收集#b100个鼻环和100个犁杖#k给他。\n\n#t4000192# #b#c4000192##k / 100 \n#t4000193# #b#c4000193##k / 100"/>
         <string name="2" value="我打退了牛类的怪物后给了他从牛和犁杖牛身上得到的物品。警察处长现在完全相信我了，他说他要写一张资格证明书给我了。我要等一会儿再去找他。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="资格证明"/>
         <int name="order" value="2"/>
         <string name="parent" value="牲口的造反"/>
@@ -22909,7 +22913,7 @@
         <string name="0" value="警察处长说等一会儿后再找他。。。"/>
         <string name="1" value="警察处长写了一张资格证明书给我。那么我要去抓住这件事情的元凶，然后要找回赤珠。\n\n #t4031735# #b#c4031735##k / 1"/>
         <string name="2" value="我找回赤珠后给处长了。但他说虽然回收了珠子，但变成怪物的牲口还变不回来。所以警察他们打算研究赤珠的秘密。我也希望研究快点得到好结果。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="寻找赤珠"/>
         <int name="order" value="3"/>
         <string name="parent" value="牲口的造反"/>
@@ -22918,35 +22922,35 @@
         <string name="0" value="要去上海外滩找摄影师赵。"/>
         <string name="1" value="摄影师赵是几个月前从农村过来上海做拍照的工作。 但他离家的时候把三脚架忘记在家里了。所以他拍照的时候总觉得不方便。他拜托我去他的老家拿三脚架来。\n\n #t4031290# #b#c4031290##k / 1"/>
         <string name="2" value="从他的老家拿三脚架给他了。我希望以后小赵跟他的姐姐多多联系。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="摄影师的拜托"/>
     </imgdir>
     <imgdir name="8514">
         <string name="0" value="为了拿到三脚架要去徐州平原找摄影师的姐姐。"/>
         <string name="1" value="摄影师的姐姐，赵小姐现在很生气。因为摄影师赵，一句话也没跟他姐姐说，就带着家里最贵重的物品离家出去上海了。为了安慰姐姐。我要收集#b100个羊毛#k给她。\n\n #t4000189# #b#c4000189##k / 100"/>
         <string name="2" value="我都收集齐100个羊毛后给赵小姐后终于收到了三脚架。希望兄妹尽快和解。。。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="姐姐的愤怒"/>
     </imgdir>
     <imgdir name="8515">
         <string name="0" value="要去上海外滩的小摊。"/>
         <string name="1" value="小摊老板吕，他最近生意不太好。所以他想更换一下销售的食品。他说如果我收集#b50个鸡爪和50个鸭蛋#k给他，他就交换给我#r30个玉米和30个糖葫芦#k。这对我来说也不算吃亏。\n\n#t4000187# #b#c4000187##k / 50 \n#t4000188# #b#c4000188##k / 50"/>
         <string name="2" value="我收集鸡爪和鸭蛋给他后收到了玉米和糖葫芦。这些东西看起来非常好吃。我以后也要常常利用这个交易吧。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="食品交换"/>
     </imgdir>
     <imgdir name="8530">
         <string name="0" value="听说想要进#b#m702100000##k要找少林#b#p9310041#。"/>
         <string name="1" value="#b#p9310041##k说最近山路上的怪物和强盗变多了，伤害了很多香客和旅游者。希望我能帮忙清理一下，带给他：\n#r#t4000393# 50#k个,#r#t4000394# 40#k个,#r#t4000395# 30#k个,#r#t4000396# 20#k个,#r#t4000397# 10#k个，就可以让我进#b#m702100000##k参观。 \n\n#t4000393#  #b#c4000393##k / 50\n#t4000394#  #b#c4000394##k / 40\n#t4000395#  #b#c4000395##k / 30\n#t4000396#  #b#c4000396##k / 20\n#t4000397#  #b#c4000397##k / 10"/>
         <string name="2" value="清理了大量盘踞在山路上的怪物，收集好了道具，终于可以进少林参观了。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="拜山门"/>
     </imgdir>
     <imgdir name="8531">
         <string name="0" value="藏经阁的#b#p9310048##k好象是个大高手的样子。"/>
         <string name="1" value="#b#p9310048##k觉得少林出现大量怪物最大的秘密就在藏经阁。希望我消灭#b100只 #o9600020##k，并收集#r50个#t4000407##k 回来给他分析。 \n\n #o9600020# #r#a85311##k \n #t4000407# #b#c4000407##k / 50"/>
         <string name="2" value="消灭了那么多#b#o9600020##k，还带回了#b#t4000407##k，#p9310048#很高兴，让我过段时间再来找他"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="藏经阁的秘密1"/>
         <int name="order" value="1"/>
         <string name="parent" value="藏经阁的秘密"/>
@@ -22954,7 +22958,7 @@
     <imgdir name="8532">
         <string name="1" value="#b#p9310048##k分析了#t4000407##k的构造以及其中蕴涵的气息，认为需要更强大的怪物身上的东西。希望我再去消灭 #r80个#o9600024##k，并收集 #r50个#t4000402##k带给藏经阁的#b#p9310046#。 \n\n#t4000402# #b#c4000402##k / 50\n#o9600024# #r#a85321#"/>
         <string name="2" value="消灭了#o9600024#，并收集了#t4000402#带给了#b#p9310046#大师#k，希望这次能找到怪物出现的原因。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="藏经阁的秘密2"/>
         <int name="order" value="2"/>
         <string name="parent" value="藏经阁的秘密"/>
@@ -22962,7 +22966,7 @@
     <imgdir name="8533">
         <string name="1" value="#b#p9310046#大师#k研究了我带来的东西以后觉得有些眉目了，但是还需要藏经阁里另一位#b#p9310047#大师#k确认一下。还要带#r50个#t4000406##k给#b#p9310047#大师#k进行研究，顺便再消灭#r50个#o9600019##k吧。\n\n#t4000406# #b#c4000406##k / 50\n#o9600019# #r#a85331#"/>
         <string name="2" value="收集足够的#t4000406#带给了#p9310047#大师，大师要闭关一段时间，让我一会再去找他。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="藏经阁的秘密3"/>
         <int name="order" value="3"/>
         <string name="parent" value="藏经阁的秘密"/>
@@ -22970,7 +22974,7 @@
     <imgdir name="8534">
         <string name="1" value="#b#p9310047#大师#k出关后告诉我关键在于控制机关人的机关。于是要我收集 #r30个#t4000406#、30个#t4000402#、30个#t4000407##k，并交给#b#p9310048##k。\n\n#t4000406# #b#c4000406##k / 30\n#t4000402# #b#c4000402##k / 30\n#t4000407# #b#c4000407##k / 30"/>
         <string name="2" value="#b#p9310048##k对3种机关人的核心研究后表示找到了怪物的秘密，希望我找几个人一起去阁顶调查一下#b达摩画像。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="藏经阁的秘密4"/>
         <int name="order" value="4"/>
         <string name="parent" value="藏经阁的秘密"/>
@@ -22979,21 +22983,21 @@
         <string name="0" value="嵩阳镇的#b#p9310049##k好象在找人帮忙。"/>
         <string name="1" value="原来#b#p9310049##k与少林#b#p9310053##k是老朋友,很久没见面了，想要去少林看望一下。但是最近镇外出现大量怪物，老人出门比较危险。希望我帮忙消灭#r100只 #o9600012##k 和#r50只 #o9600013##k \n\n#o9600012# #r#a85361##k\n#o9600013# #r#a85362##k"/>
         <string name="2" value="消灭了不少#b#o9600012##k 和#b#o9600013##k，现在镇子周围要安全一些了吧，希望两位老人见面愉快。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="镇长的委托"/>
     </imgdir>
     <imgdir name="8537">
         <string name="0" value="#b#m702010000##k下经常会有需要帮助的人。"/>
         <string name="1" value="在#b#m702010000##k下遇到了#b#p9310042##k，她是替丈夫来还愿的。因为怪物袭击，受伤了。需要我帮她买点药品和食品来。\n\n#t2010002# #b#c2010002##k / 50\n#t2000011# #b#c2000011##k / 20\n#t2050003# #b#c2050003##k / 10"/>
         <string name="2" value="到#b嵩阳镇的杂货店#k顺利买到了药物和食品，帮助#b#p9310042##k完成了对丈夫的承诺。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="还愿"/>
     </imgdir>
     <imgdir name="8538">
         <string name="0" value="少林寺的小沙弥#b#p9310052##k好象遇到了什么麻烦。"/>
         <string name="1" value="原来#b#p9310052##k的师兄外出苦修。但是过了约定时间却还没有回来，有点担心，希望我去找找。他师兄法号：#b#p9310040##k。好象在哪里见到过啊"/>
         <string name="2" value="在#b#m702030000##k发现了#b#p9310040#和尚#k，但是他似乎还在修行中，听说小师弟担心，让我给#b#p9310052##k带个信。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="寻找师兄1"/>
         <int name="order" value="1"/>
         <string name="parent" value="寻找师兄"/>
@@ -23002,7 +23006,7 @@
         <string name="0" value="#b#p9310040##k和尚#k有事情拜托。"/>
         <string name="1" value="为了不让小师弟担心，希望我带个信给#b#p9310052#。"/>
         <string name="2" value="带了#p9310040#的信给#b#p9310052##k，这下他该放心了吧。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="寻找师兄2"/>
         <int name="order" value="2"/>
         <string name="parent" value="寻找师兄"/>
@@ -23011,7 +23015,7 @@
         <string name="0" value="少林方丈大师似乎有烦恼的事情啊"/>
         <string name="1" value="方丈大师告诉我保存在少林的108颗灭魔佛珠是镇压妖怪的法宝。但是最近发现被窃了。经过努力寻回了一些，但还有几个怎么也找不到了。详细情况要问问负责此事的#b#p9310051#。"/>
         <string name="2" value="#b#p9310051##k说明了情况，果然很严重啊。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="佛珠1"/>
         <int name="order" value="1"/>
         <string name="parent" value="佛珠"/>
@@ -23020,7 +23024,7 @@
         <string name="0" value="#b#p9310051##k需要帮助。"/>
         <string name="1" value="#b#p9310051##k告诉我，最近妖怪突然增加，已经找回的那8颗佛珠就是在那些妖怪身上发现的。所以剩下的100个应该也是某些妖怪藏起来了。希望我找到100颗玉佛珠并交给山门的#b#p9310041#。\n\n#t4000403# #b#c4000403##k / 100"/>
         <string name="2" value="终于在那些怪物身上找到的失落的佛珠，#b#p9310041##k还真是亲切啊。"/>
-        <int name="area" value="45"/>
+        <int name="area" value="42"/>
         <string name="name" value="佛珠2"/>
         <int name="order" value="2"/>
         <string name="parent" value="佛珠"/>


### PR DESCRIPTION
## 改动点汇总

- 修正中文任务分类：将 `45` 显示为“新叶城”，新增 `42` 为“东方神州”，补齐 `49` 为“马来西亚”。
- 将上海、少林等东方神州任务从 `area=45` 调整到 `area=42`，避免与新叶城任务混在同一分类。
- 保持新叶城、幻影森林、赏金猎人相关任务在 `area=45`，使其在任务列表中归到“新叶城”。
- 统一 `8231-8239` 赏金猎人任务分组为“赏金猎人”，并整理显示顺序。
- 汉化赏金猎人任务 `8233-8239` 的任务名、任务描述和完成文本。
- 修复 `scripts-zh-CN/quest/8231.js` 到 `8238.js` 中的乱码接取对话。
- 修正 `8233/8234` 完成与未完成提示中数量不一致的问题。

## 客户端影响

- 本次修改影响客户端任务列表和任务文本显示，需要同步客户端资源。
- 受影响的客户端资源包括：`Data/Etc/QuestCategory.img`、`Data/Quest/QuestInfo.img`、`Data/Quest/Say.img`。
- 后续会在评论中补充客户端 full 包 Release 页面、zip 下载链接和 SHA256。

## 验证

- 已确认本分支相对 `upstream/master` 仅包含 1 个提交。
- 已确认差异文件仅包含本次任务分类、任务文本和中文脚本修复相关文件。
- 已执行 XML 解析校验。
- 已执行乱码特征校验，未发现常见乱码字符。
- 已执行 `git diff --check`。
- 本次不涉及 Java 或构建产物，正式发布阶段再构建 JAR。
