### PR TITLE
fix: 汉化幽灵猎人巴柏任务文本

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -11405,28 +11405,28 @@
         <int name="area" value="37"/>
     </imgdir>
     <imgdir name="3248">
-        <string name="name" value="Operation Strategy 1 : Collect All the Eggs"/>
-        <string name="parent" value="The Clocktower Monster Wipe-Out Operation"/>
+        <string name="name" value="作战第1阶段：回收所有的蛋"/>
+        <string name="parent" value="时间塔怪物扫荡作战"/>
         <int name="order" value="1"/>
-        <string name="0" value="#b#p2041026##k in the #b#m220000000# Clocktower basement#k has proposed to begin a Clocktower Monster Wipe-Out Operation. What does he mean by that? Let&apos;s go find #p2041026#."/>
-        <string name="1" value="The Clocktower Monster Wipe-Out Operation has begun. #p2041026# asks you to bring back #b#o4230113##k, #b#o3230306##k, and #b#t4031991##k... It seems he wants to exterminate all the eggs first. Alright, whatever he wants!\nHe says you can find other eggs by hunting #rTick, Tick-Tock, or Chronos type monsters#k, but #b#o5220003s# have a tendency to hatch their eggs in another bird&apos;s nest#k, so their eggs would be amongst eggs of other birds. It seems you have to crack other eggs to find it and take it over to #t4031991#. \n\n#i2022354##t2022354# #b#c2022354#/10#k \n#i2022355##t2022355# #b#c2022355#/10#k \n#i4031991##t4031991# #b#c4031991#/10#k"/>
-        <string name="2" value="You have found all the eggs and gave them to #p2041026#. Ghosthunter Bob seems satisfied and suggest you engage in the operation. "/>
+        <string name="0" value="位于#b#m220000000#时间塔地下#k的#b#p2041026##k提出要展开时间塔怪物扫荡作战。这到底是什么意思呢？去找#p2041026#问问吧。"/>
+        <string name="1" value="时间塔怪物扫荡作战已经开始。#p2041026#让我带回#b#o4230113##k、#b#o3230306##k和#b#t4031991##k……看来他想先把所有的蛋清除掉。好吧，就照他说的做！\n他说，捕捉#r时之啾啾、时之鬼爵或恶魔之母系列怪物#k，就能找到其他蛋。不过#b#o5220003#喜欢把自己的蛋下在其他鸟的巢里#k，所以它的蛋会混在其他蛋中。看来必须把其他蛋打开确认，才能找到#t4031991#。\n\n#i2022354##t2022354# #b#c2022354#/10#k \n#i2022355##t2022355# #b#c2022355#/10#k \n#i4031991##t4031991# #b#c4031991#/10#k"/>
+        <string name="2" value="找齐所有的蛋并交给了#p2041026#。幽灵猎人 巴柏似乎很满意，并建议我继续参加作战。"/>
         <int name="area" value="37"/>
     </imgdir>
     <imgdir name="3249">
-        <string name="name" value="Operation Strategy 2 : Defeat the Monsters"/>
-        <string name="parent" value="The Clocktower Monster Wipe-Out Operation"/>
+        <string name="name" value="作战第2阶段：消灭怪物"/>
+        <string name="parent" value="时间塔怪物扫荡作战"/>
         <int name="order" value="2"/>
-        <string name="1" value="Operation strategy 2 is much simpler than strategy 1. It was to defeat the monsters! You must defeat #r#o4230113##k, #r#o3230306##k, #r#o4230114##k, #r#o4230115##k, and even #r#o5220003##k, so it&apos;s not child&apos;s play... but let&apos;s defeat the monsters.\n\n#o4230113# #r#a32491##k \n#o3230306# #r#a32492##k \n#o4230114# #r#a32493##k \n#o4230115# #r#a32494##k \n#o5220003# #r#a32495##k "/>
-        <string name="2" value="You have reported to #p2041026# after defeating all the monsters. It&apos;s not as easy as it may seem since there are so many types of monsters to hunt!"/>
+        <string name="1" value="作战第2阶段比第1阶段简单多了，就是消灭怪物！必须消灭#r#o4230113##k、#r#o3230306##k、#r#o4230114##k、#r#o4230115##k，甚至还要消灭#r#o5220003##k，所以可不是闹着玩的……不过还是去消灭它们吧。\n\n#o4230113# #r#a32491##k \n#o3230306# #r#a32492##k \n#o4230114# #r#a32493##k \n#o4230115# #r#a32494##k \n#o5220003# #r#a32495##k "/>
+        <string name="2" value="消灭所有怪物后，向#p2041026#进行了报告。要猎杀这么多种怪物，可不像看起来那么简单！"/>
         <int name="area" value="37"/>
     </imgdir>
     <imgdir name="3250">
-        <string name="name" value="Operation Strategy 3: A Cute Baby Bird"/>
-        <string name="parent" value="The Clocktower Monster Wipe-Out Operation"/>
+        <string name="name" value="作战第3阶段：可爱的小鸟"/>
+        <string name="parent" value="时间塔怪物扫荡作战"/>
         <int name="order" value="3"/>
-        <string name="1" value="#p2041026# seems to be preoccupied with raising birds. According to the new research conducted, #o5220003#s have undergone changes under the management of Papulatus, but can make great pets when tamed. He has given you a cute baby bird, saying you can feed the bird #b#t4031992#s#k that can be obtained from the Clocktower Monsters. He has asked you to return the bird when it&apos;s fully grown."/>
-        <string name="2" value="The baby bird has become full-fledged since you&apos;ve been diligently feeding the bird #t4031992#s. Although it&apos;s sad to let go of the bird to which you have grown attached, but you have no choice but to return the bird to Ghosthunter Bob. Be well, bird."/>
+        <string name="1" value="#p2041026#似乎正忙着养鸟。根据最新研究，#o5220003#是在帕普拉图斯的支配下才发生变化的，但只要好好驯养，也能成为很棒的宠物。他给了我一只可爱的小鸟，并说可以喂它吃从时间塔怪物身上获得的#b#t4031992##k。等小鸟完全长大后，再把它交还给他。"/>
+        <string name="2" value="一直坚持喂食#t4031992#后，小鸟终于完全长大了。虽然舍不得离开这只已经产生感情的小鸟，但还是只能把它交还给幽灵猎人 巴柏。再见了，小鸟。"/>
         <int name="area" value="37"/>
     </imgdir>
     <imgdir name="3300">
@@ -12489,7 +12489,7 @@
     <imgdir name="3445">
         <string name="name" value="自由的灵魂"/>
         <string name="0" value="幽灵的数量越来越多，快坚持不下去了。还是去见一下特派到玩具城的#p2041026#吧。"/>
-        <string name="1" value="经过玩具城下方的时间通道，可在附近见到#p2041026#。他请求我让#o6230500#得到自由，并将其灵魂带来。\n\n#t4000144# #b#c4000144#/100#k"/>
+        <string name="1" value="经过玩具城下方的时间通道，可在附近见到#p2041026#。他请求我让#o6230500#得到自由，并将其灵魂带来。\n\n#t4000144# #b#c4000144#/80#k"/>
         <string name="2" value="帮助幽灵猎人 巴柏让大恶灵附身的娃娃获得了自由。"/>
         <int name="area" value="37"/>
     </imgdir>


### PR DESCRIPTION
## 改动内容
- 汉化玩具城「时间消失之路<1>」NPC「幽灵猎人 巴柏」相关任务文本。
- 补全任务「作战第1阶段：回收所有的蛋」「作战第2阶段：消灭怪物」「作战第3阶段：可爱的小鸟」的任务名、父标题和任务描述。
- 修正任务「自由的灵魂」中灵魂数量显示，将任务描述和对话统一为 80 个，与任务检查条件一致。
- 润色任务「灵魂收集器」的未完成提示，统一使用「灵魂收集器」和「大海贼」等中文称呼。
- 本次为中文 WZ 文本修复，仅修改中文目录；英文原版目录未改动。

## 影响范围
- 影响服务端中文 WZ 任务文本。
- 影响客户端任务窗口和任务对话显示，需要同步客户端资源包。

## 验证情况
- 已执行 XML 解析检查。
- 已执行中文乱码检查，未发现常见乱码或替换字符。
- 已确认 PR 差异仅包含本次中文任务文本修复相关文件。
- 已在测试服务端完成 WZ 加载和登录、频道端口启动检查。

## 客户端资源
客户端资源包将通过 Release 提供，并在 PR 评论中补充下载链接与 SHA256。