### PR TITLE
fix: 汉化雾海传闻任务文本

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -14038,11 +14038,11 @@
         <int name="area" value="49"/>
     </imgdir>
     <imgdir name="3845">
-        <string name="name" value="The Rumor in the Sea of Fog"/>
+        <string name="name" value="雾海中的传闻"/>
         <int name="area" value="44"/>
-        <string name="0" value="Captain Hwang from Herb Town wants to tell you a creepy rumor about the Sea of Fog, located east of Herb Town. His story could be interesting. How about it, huh?"/>
-        <string name="1" value="Captain Hwang from Herb Town tells you about the eastern route that connects Herb Town and Aqua Road. As the longest waterway in Maple World, this route passes through what is known as the #b&quot;Sea of Fog&quot;#k, located east of Mu Lung Garden. He says there is a rumor that a ghost ship sails around this Sea of Fog.\r\nCaptain Hwang then suggests that you look for the ghost ship. He hints that you might be able to get some information from the Dolphin Taxi."/>
-        <string name="2" value="Captain Hwang from Herb Town told you about the eastern route that connects Herb Town and Aqua Road. As the longest waterway in Maple World, this route passes through what is known as the #b&quot;Sea of Fog&quot;#k, located east of Mu Lung Garden. He says there is a rumor that a ghost ship sails around this Sea of Fog. You were instantly drawn to Captain Hwang&apos;s story and arrived in an unknown island in the Sea of Fog. You discovered the ghost ship with the help of the Dolphin Taxi, which brought you to that mysterious place."/>
+        <string name="0" value="百草村的黄船长想告诉你一个关于百草村东边雾海的诡异传闻。他的故事似乎很有趣，要不要听听看？"/>
+        <string name="1" value="百草村的黄船长讲述了连接百草村和水下世界的东部航线。这条航线是冒险岛世界最长的水路，途经武陵桃园东边被称为#b&quot;雾海&quot;#k的海域。据说有一艘幽灵船在雾海中出没。\r\n黄船长建议你去寻找那艘幽灵船，并提示说也许能从海豚出租车那里得到一些线索。"/>
+        <string name="2" value="百草村的黄船长讲述了连接百草村和水下世界的东部航线。这条航线是冒险岛世界最长的水路，途经武陵桃园东边被称为#b&quot;雾海&quot;#k的海域。据说有一艘幽灵船在雾海中出没。你被黄船长的故事吸引，在海豚出租车的帮助下来到了雾海中的无名小岛，并发现了那艘幽灵船。"/>
         <int name="autoStart" value="1"/>
     </imgdir>
     <imgdir name="3900">

--- a/gms-server/wz-zh-CN/String.wz/Npc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Npc.img.xml
@@ -3681,9 +3681,9 @@
         <string name="name" value="次元空间入口"/>
     </imgdir>
     <imgdir name="2060103">
-        <string name="name" value="Norrington"/>
-        <string name="n0" value="I feel a mysterious current of air blowing."/>
-        <string name="n1" value="Their spirits must still be lingering here."/>
+        <string name="name" value="诺林顿"/>
+        <string name="n0" value="我感到一股神秘的气流正在吹过。"/>
+        <string name="n1" value="他们的灵魂一定还徘徊在这里。"/>
     </imgdir>
     <imgdir name="2070000">
         <string name="name" value="鲁先生"/>


### PR DESCRIPTION
## 改动内容
- 汉化任务 `3845`「雾海中的传闻」的任务名称、接取说明、进行中说明和完成说明。
- 汉化关联 NPC `2060103`「诺林顿」的名称与头顶气泡文本。
- 本次仅涉及中文 WZ 目录，英文原版目录未改动。

## 影响范围
- 影响服务端中文 WZ 文本与客户端任务/NPC 显示文本。
- 需要同步客户端资源包。
- 不涉及任务流程、奖励、掉落、脚本逻辑或 Java/JAR。

## 验证情况
- 已执行 XML 解析检查。
- 已执行目标节点英文残留与乱码检查。
- 已同步到本地测试环境并确认 WZ 加载完成、登录端口和频道端口启动完成。
- 已读取客户端 IMG，确认任务 `3845` 与 NPC `2060103` 的目标文本已更新为中文。

## 客户端资源
客户端资源包将通过 Release 提供，并在 PR 评论中补充下载链接与 SHA256。