### PR TITLE
fix: 修复 Boss 对话乱码并补齐中文资源回退

### DIFF
--- a/gms-server/src/main/java/org/gms/net/server/channel/Channel.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/Channel.java
@@ -454,27 +454,47 @@ public final class Channel {
     }
 
     private static String[] getEvents() {
-        // 优先取语言文件夹，没有则取scripts
+        // 事件脚本固定放在 scripts/event 以及对应的语言目录 scripts-语言/event。
         String scriptName = "scripts";
         String eventPath = "event";
+        // 读取当前服务端语言配置，用来定位语言事件脚本目录。
         ServiceProperty serviceProperty = ServerManager.getApplicationContext().getBean(ServiceProperty.class);
         String scriptLangName = scriptName + "-" + serviceProperty.getLanguage();
 
+        // 默认目录保留英文原版事件，语言目录只保留已本地化的事件。
         Path scriptPath = Path.of(scriptName, eventPath);
         Path scriptLangPath = Path.of(scriptLangName, eventPath);
-        Path actualPath = Files.exists(scriptLangPath) ? scriptLangPath : scriptPath;
 
+        // 先枚举默认事件，保证未翻译事件不会因为语言目录存在而丢失。
         List<String> events = new ArrayList<>();
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(actualPath)) {
+        addEvents(scriptPath, events);
+        // 再枚举语言事件，补充中文专属事件；同名事件会在 addEvents 中去重。
+        addEvents(scriptLangPath, events);
+        // 这里只返回事件名，真正加载脚本时仍由 AbstractScriptManager 做文件级回退。
+        return events.toArray(new String[0]);
+    }
+
+    private static void addEvents(Path eventPath, List<String> events) {
+        // 某些语言可能没有 event 目录，没有目录时直接跳过，继续使用默认事件。
+        if (!Files.isDirectory(eventPath)) {
+            return;
+        }
+
+        // 只枚举 JS 事件脚本，避免把其他辅助文件当成事件名注册。
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(eventPath, "*.js")) {
             for (Path path : stream) {
+                // 事件管理器使用不带 .js 后缀的脚本名。
                 String fileName = path.getFileName().toString();
-                events.add(fileName.substring(0, fileName.length() - 3));
+                String eventName = fileName.substring(0, fileName.length() - 3);
+                // 默认目录和语言目录可能存在同名事件，同名只注册一次。
+                if (!events.contains(eventName)) {
+                    events.add(eventName);
+                }
             }
         } catch (IOException e) {
             log.warn("Unable to load events !");
             e.printStackTrace();
         }
-        return events.toArray(new String[0]);
     }
 
     public int getStoredVar(int key) {

--- a/gms-server/src/main/java/org/gms/provider/DataProviderFactory.java
+++ b/gms-server/src/main/java/org/gms/provider/DataProviderFactory.java
@@ -24,6 +24,7 @@ package org.gms.provider;
 import org.gms.provider.wz.WZFiles;
 import org.gms.provider.wz.XMLWZFile;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class DataProviderFactory {
@@ -32,6 +33,13 @@ public class DataProviderFactory {
     }
 
     public static DataProvider getDataProvider(WZFiles in) {
-        return getWZ(in.getFile());
+        Path basePath = in.getBaseFile();
+        Path languagePath = in.getLanguageFile();
+        DataProvider baseProvider = getWZ(basePath);
+        if (!Files.exists(languagePath) || languagePath.equals(basePath)) {
+            return baseProvider;
+        }
+        // 中文 WZ 只维护被本地化过的文件，缺失的文件继续回退到原始 WZ。
+        return new LocalizedDataProvider(getWZ(languagePath), baseProvider);
     }
 }

--- a/gms-server/src/main/java/org/gms/provider/LocalizedDataProvider.java
+++ b/gms-server/src/main/java/org/gms/provider/LocalizedDataProvider.java
@@ -1,0 +1,24 @@
+package org.gms.provider;
+
+public class LocalizedDataProvider implements DataProvider {
+    private final DataProvider localized;
+    private final DataProvider fallback;
+
+    public LocalizedDataProvider(DataProvider localized, DataProvider fallback) {
+        this.localized = localized;
+        this.fallback = fallback;
+    }
+
+    @Override
+    public Data getData(String path) {
+        Data data = localized.getData(path);
+        // 语言目录里没有该 XML 时，使用原始 WZ，避免为了少量翻译复制整包资源。
+        return data != null ? data : fallback.getData(path);
+    }
+
+    @Override
+    public DataDirectoryEntry getRoot() {
+        // 导航目录保持原始 WZ 的完整文件树，确保未翻译资源仍然可枚举。
+        return fallback.getRoot();
+    }
+}

--- a/gms-server/src/main/java/org/gms/provider/wz/WZFiles.java
+++ b/gms-server/src/main/java/org/gms/provider/wz/WZFiles.java
@@ -29,12 +29,19 @@ public enum WZFiles {
     }
 
     public Path getFile() {
-        // 优先取语言文件夹，没有则取wz
-        Path wzPath = Path.of(DIRECTORY, fileName);
-        ServiceProperty serviceProperty = ServerManager.getApplicationContext().getBean(ServiceProperty.class);
-        Path langPath = Path.of(DIRECTORY + "-" + serviceProperty.getLanguage(), fileName);
+        Path langPath = getLanguageFile();
 
-        return Files.exists(langPath) ? langPath : wzPath;
+        // 兼容旧调用：语言目录存在时优先使用，否则使用原始 WZ。
+        return Files.exists(langPath) ? langPath : getBaseFile();
+    }
+
+    public Path getBaseFile() {
+        return Path.of(DIRECTORY, fileName);
+    }
+
+    public Path getLanguageFile() {
+        ServiceProperty serviceProperty = ServerManager.getApplicationContext().getBean(ServiceProperty.class);
+        return Path.of(DIRECTORY + "-" + serviceProperty.getLanguage(), fileName);
     }
 
     public String getFilePath() {

--- a/gms-server/src/main/java/org/gms/scripting/AbstractScriptManager.java
+++ b/gms-server/src/main/java/org/gms/scripting/AbstractScriptManager.java
@@ -41,6 +41,7 @@ import java.nio.file.Path;
  */
 public abstract class AbstractScriptManager {
     private static final Logger log = LoggerFactory.getLogger(AbstractScriptManager.class);
+    private static final String SCRIPT_DIRECTORY = "scripts";
     private final ScriptEngineFactory sef;
 
     protected AbstractScriptManager() {
@@ -48,30 +49,34 @@ public abstract class AbstractScriptManager {
     }
 
     protected ScriptEngine getInvocableScriptEngine(String path) {
-        // 优先取语言文件夹，没有则取scripts
-        String scriptName = "scripts";
+        // 读取当前服务端语言配置，用于拼出 scripts-语言 目录名，例如 scripts-zh-CN。
         ServiceProperty serviceProperty = ServerManager.getApplicationContext().getBean(ServiceProperty.class);
-        String scriptLangName = scriptName + "-" + serviceProperty.getLanguage();
 
-        Path scriptPath = Path.of(scriptName, path);
-        Path scriptLangPath = Path.of(scriptLangName, path);
+        // 默认脚本目录始终是 scripts，里面保留英文原版脚本。
+        Path scriptPath = Path.of(SCRIPT_DIRECTORY, path);
+        // 语言脚本目录只放已本地化的脚本文件，不要求复制完整 scripts 目录。
+        Path scriptLangPath = Path.of(SCRIPT_DIRECTORY + "-" + serviceProperty.getLanguage(), path);
 
+        // 按文件级别选择脚本：先找语言文件，找不到再回退到英文原版文件。
         Path actualPath;
         if (Files.exists(scriptLangPath)) {
             actualPath = scriptLangPath;
-        } else if (Files.exists(scriptPath)){
+        } else if (Files.exists(scriptPath)) {
             actualPath = scriptPath;
         } else {
             return null;
         }
 
+        // 为本次实际命中的脚本文件创建独立 JS 引擎。
         ScriptEngine engine = sef.getScriptEngine();
         if (!(engine instanceof GraalJSScriptEngine graalScriptEngine)) {
             throw new IllegalStateException(I18nUtil.getExceptionMessage("AbstractScriptManager.getInvocableScriptEngine.exception1"));
         }
 
+        // 开启脚本访问 Java 类的能力，保持现有脚本里的 Java.type 调用可用。
         enableScriptHostAccess(graalScriptEngine);
 
+        // 用 UTF-8 读取并执行脚本；执行失败时返回 null，让调用方按原逻辑处理缺失脚本。
         try (BufferedReader br = Files.newBufferedReader(actualPath, StandardCharsets.UTF_8)) {
             engine.eval(br);
         } catch (final ScriptException | IOException t) {
@@ -83,25 +88,30 @@ public abstract class AbstractScriptManager {
     }
 
     protected ScriptEngine getInvocableScriptEngine(String path, Client c) {
-        ScriptEngine engine = c.getScriptEngine("scripts/" + path);
+        // 缓存键统一使用默认脚本前缀加相对路径，避免读取和写入缓存时使用不同 key。
+        String scriptKey = SCRIPT_DIRECTORY + "/" + path;
+        ScriptEngine engine = c.getScriptEngine(scriptKey);
         if (engine == null) {
+            // 客户端当前没有缓存时，再按文件级 i18n 规则加载脚本。
             engine = getInvocableScriptEngine(path);
-            c.setScriptEngine(path, engine);
+            c.setScriptEngine(scriptKey, engine);
         }
 
         return engine;
     }
 
     /**
-     * Allow usage of "Java.type()" in script to look up host class
+     * 允许脚本通过 Java.type() 查找并调用服务端 Java 类。
      */
     private void enableScriptHostAccess(GraalJSScriptEngine engine) {
+        // GraalJS 的 host 访问开关需要写入引擎作用域绑定。
         Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
         bindings.put("polyglot.js.allowHostAccess", true);
         bindings.put("polyglot.js.allowHostClassLookup", true);
     }
 
     protected void resetContext(String path, Client c) {
-        c.removeScriptEngine("scripts/" + path);
+        // 重置时使用同一个缓存 key，确保能清掉上面 setScriptEngine 写入的脚本引擎。
+        c.removeScriptEngine(SCRIPT_DIRECTORY + "/" + path);
     }
 }

--- a/gms-server/wz-zh-CN/Mob.wz/2220000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/2220000.img.xml
@@ -1,0 +1,325 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="2220000.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="20"/>
+    <int name="maxHP" value="2000"/>
+    <int name="maxMP" value="30"/>
+    <int name="speed" value="-40"/>
+    <int name="PADamage" value="90"/>
+    <int name="PDDamage" value="20"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="30"/>
+    <int name="acc" value="60"/>
+    <int name="eva" value="8"/>
+    <int name="exp" value="120"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1"/>
+    <int name="hpRecovery" value="10"/>
+    <int name="mpRecovery" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="mobType" value="0"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="126"/>
+        <int name="action" value="1"/>
+        <int name="level" value="7"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="78"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="113"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="2153"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+        <imgdir name="1">
+          <int name="pet" value="5000054"/>
+        </imgdir>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="越是紧急，越不能慌张……"/>
+        <int name="hp" value="1200"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="104" height="97">
+      <vector name="origin" x="51" y="97"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-51" y="-83"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="-24" y="-82"/>
+    </canvas>
+    <canvas name="1" width="104" height="96">
+      <vector name="origin" x="51" y="96"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-51" y="-84"/>
+      <vector name="rb" x="51" y="0"/>
+      <vector name="head" x="-24" y="-83"/>
+    </canvas>
+    <canvas name="2" width="105" height="96">
+      <vector name="origin" x="51" y="96"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-51" y="-84"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="-24" y="-83"/>
+    </canvas>
+    <canvas name="3" width="105" height="98">
+      <vector name="origin" x="51" y="98"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-51" y="-81"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="-24" y="-81"/>
+    </canvas>
+    <canvas name="4" width="106" height="99">
+      <vector name="origin" x="52" y="99"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-52" y="-79"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="-24" y="-80"/>
+    </canvas>
+    <canvas name="5" width="104" height="99">
+      <vector name="origin" x="51" y="99"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-52" y="-81"/>
+      <vector name="rb" x="51" y="0"/>
+      <vector name="head" x="-25" y="-81"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="104" height="96">
+      <vector name="origin" x="51" y="96"/>
+      <vector name="lt" x="-51" y="-80"/>
+      <vector name="rb" x="51" y="0"/>
+      <vector name="head" x="-24" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="104" height="96">
+      <vector name="origin" x="51" y="96"/>
+      <vector name="lt" x="-51" y="-78"/>
+      <vector name="rb" x="51" y="0"/>
+      <vector name="head" x="-24" y="-78"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="104" height="96">
+      <vector name="origin" x="51" y="96"/>
+      <vector name="lt" x="-51" y="-78"/>
+      <vector name="rb" x="51" y="0"/>
+      <vector name="head" x="-25" y="-78"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="104" height="96">
+      <vector name="origin" x="51" y="96"/>
+      <vector name="lt" x="-51" y="-78"/>
+      <vector name="rb" x="51" y="0"/>
+      <vector name="head" x="-25" y="-78"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="104" height="96">
+      <vector name="origin" x="51" y="96"/>
+      <vector name="lt" x="-51" y="-80"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="-24" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="105" height="95">
+      <vector name="origin" x="52" y="95"/>
+      <vector name="lt" x="-52" y="-79"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="-24" y="-79"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="104" height="96">
+      <vector name="origin" x="51" y="96"/>
+      <vector name="lt" x="-51" y="-79"/>
+      <vector name="rb" x="51" y="0"/>
+      <vector name="head" x="-24" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="105" height="95">
+      <vector name="origin" x="52" y="95"/>
+      <vector name="lt" x="-52" y="-79"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="-24" y="-81"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="104" height="96">
+      <vector name="origin" x="51" y="96"/>
+      <vector name="lt" x="-51" y="-81"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="-24" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="104" height="102">
+      <vector name="origin" x="53" y="99"/>
+      <vector name="lt" x="-54" y="-81"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-24" y="-82"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="107" height="105">
+      <vector name="origin" x="55" y="101"/>
+      <vector name="lt" x="-52" y="-82"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="-22" y="-82"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="106" height="107">
+      <vector name="origin" x="55" y="102"/>
+      <vector name="lt" x="-51" y="-83"/>
+      <vector name="rb" x="49" y="-1"/>
+      <vector name="head" x="-21" y="-83"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="105" height="106">
+      <vector name="origin" x="54" y="101"/>
+      <vector name="lt" x="-50" y="-82"/>
+      <vector name="rb" x="47" y="0"/>
+      <vector name="head" x="-21" y="-82"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="105" height="108">
+      <vector name="origin" x="53" y="102"/>
+      <vector name="lt" x="-48" y="-83"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-21" y="-84"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="108" height="142">
+      <vector name="origin" x="55" y="136"/>
+      <vector name="lt" x="-48" y="-82"/>
+      <vector name="rb" x="48" y="0"/>
+      <vector name="head" x="-22" y="-82"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="108" height="141">
+      <vector name="origin" x="54" y="136"/>
+      <vector name="lt" x="-50" y="-81"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="-22" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="112" height="150">
+      <vector name="origin" x="54" y="146"/>
+      <vector name="lt" x="-51" y="-83"/>
+      <vector name="rb" x="53" y="0"/>
+      <vector name="head" x="-21" y="-83"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="142" height="153">
+      <vector name="origin" x="64" y="150"/>
+      <vector name="lt" x="-50" y="-83"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="-24" y="-83"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="147" height="155">
+      <vector name="origin" x="66" y="152"/>
+      <vector name="lt" x="-50" y="-82"/>
+      <vector name="rb" x="50" y="-1"/>
+      <vector name="head" x="-24" y="-82"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="住手！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="111" height="105">
+      <vector name="origin" x="51" y="105"/>
+      <vector name="lt" x="-52" y="-86"/>
+      <vector name="rb" x="56" y="0"/>
+      <int name="delay" value="600"/>
+      <vector name="head" x="-20" y="-86"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="啊呀！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="107" height="97">
+      <vector name="origin" x="52" y="97"/>
+      <vector name="head" x="-23" y="-81"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="107" height="102">
+      <vector name="origin" x="52" y="102"/>
+      <vector name="head" x="-23" y="-79"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="125" height="116">
+      <vector name="origin" x="56" y="116"/>
+      <vector name="head" x="-23" y="-78"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="113" height="117">
+      <vector name="origin" x="57" y="117"/>
+      <vector name="head" x="-23" y="-67"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="111" height="117">
+      <vector name="origin" x="56" y="116"/>
+      <vector name="head" x="-22" y="-66"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="111" height="117">
+      <vector name="origin" x="56" y="115"/>
+      <vector name="head" x="-22" y="-64"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="110" height="102">
+      <vector name="origin" x="56" y="100"/>
+      <vector name="head" x="-22" y="-64"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="111" height="98">
+      <vector name="origin" x="56" y="95"/>
+      <vector name="head" x="-22" y="-63"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="111" height="97">
+      <vector name="origin" x="56" y="94"/>
+      <vector name="head" x="-22" y="-62"/>
+      <int name="delay" value="450"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我只是想喝一口清澈的露水……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/3220000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/3220000.img.xml
@@ -1,0 +1,640 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="3220000.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="35"/>
+    <int name="maxHP" value="7000"/>
+    <int name="maxMP" value="120"/>
+    <int name="speed" value="-60"/>
+    <int name="PADamage" value="125"/>
+    <int name="PDDamage" value="50"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="70"/>
+    <int name="acc" value="80"/>
+    <int name="eva" value="12"/>
+    <int name="exp" value="405"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1"/>
+    <int name="hpRecovery" value="35"/>
+    <int name="mpRecovery" value="1"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="mobType" value="4"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="1500"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="15"/>
+        <int name="effectAfter" value="1500"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="113"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="2144"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="竟敢踏入我的领地！"/>
+        <int name="hp" value="6000"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="181" height="177">
+      <vector name="origin" x="91" y="176"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-59" y="-123"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-6" y="-123"/>
+    </canvas>
+    <canvas name="1" width="180" height="177">
+      <vector name="origin" x="91" y="177"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-59" y="-122"/>
+      <vector name="rb" x="57" y="5"/>
+      <vector name="head" x="-6" y="-124"/>
+    </canvas>
+    <canvas name="2" width="176" height="178">
+      <vector name="origin" x="91" y="178"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-59" y="-118"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-6" y="-122"/>
+    </canvas>
+    <canvas name="3" width="175" height="177">
+      <vector name="origin" x="91" y="177"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-56" y="-120"/>
+      <vector name="rb" x="59" y="-1"/>
+      <vector name="head" x="-1" y="-122"/>
+    </canvas>
+    <canvas name="4" width="176" height="176">
+      <vector name="origin" x="91" y="176"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-58" y="-130"/>
+      <vector name="rb" x="59" y="-1"/>
+      <vector name="head" x="-1" y="-124"/>
+    </canvas>
+    <canvas name="5" width="178" height="175">
+      <vector name="origin" x="91" y="175"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-128"/>
+      <vector name="rb" x="61" y="-1"/>
+      <vector name="head" x="-1" y="-125"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="181" height="172">
+      <vector name="origin" x="91" y="172"/>
+      <vector name="lt" x="-55" y="-126"/>
+      <vector name="rb" x="57" y="-1"/>
+      <vector name="head" x="-1" y="-119"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="180" height="173">
+      <vector name="origin" x="91" y="173"/>
+      <vector name="lt" x="-53" y="-117"/>
+      <vector name="rb" x="63" y="-1"/>
+      <vector name="head" x="0" y="-118"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="176" height="174">
+      <vector name="origin" x="91" y="174"/>
+      <vector name="lt" x="-50" y="-127"/>
+      <vector name="rb" x="66" y="0"/>
+      <vector name="head" x="0" y="-120"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="175" height="175">
+      <vector name="origin" x="91" y="175"/>
+      <vector name="lt" x="-55" y="-122"/>
+      <vector name="rb" x="60" y="2"/>
+      <vector name="head" x="0" y="-121"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="176" height="174">
+      <vector name="origin" x="91" y="174"/>
+      <vector name="lt" x="-58" y="-117"/>
+      <vector name="rb" x="51" y="-1"/>
+      <vector name="head" x="0" y="-120"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="178" height="173">
+      <vector name="origin" x="91" y="173"/>
+      <vector name="lt" x="-52" y="-120"/>
+      <vector name="rb" x="56" y="0"/>
+      <vector name="head" x="0" y="-119"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-288" y="-172"/>
+        <vector name="rb" x="255" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="99" height="107">
+          <vector name="origin" x="50" y="70"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="78" height="75">
+          <vector name="origin" x="36" y="51"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="66" height="63">
+          <vector name="origin" x="36" y="51"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="effectAfter" value="0"/>
+      <int name="attackAfter" value="1500"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="135"/>
+    </imgdir>
+    <canvas name="0" width="181" height="172">
+      <vector name="origin" x="91" y="172"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="1" y="-116"/>
+    </canvas>
+    <canvas name="1" width="184" height="180">
+      <vector name="origin" x="95" y="175"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-54" y="-114"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="3" y="-116"/>
+    </canvas>
+    <canvas name="2" width="182" height="181">
+      <vector name="origin" x="97" y="175"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-59" y="-112"/>
+      <vector name="rb" x="59" y="8"/>
+      <vector name="head" x="0" y="-114"/>
+    </canvas>
+    <canvas name="3" width="181" height="182">
+      <vector name="origin" x="97" y="175"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-59" y="-112"/>
+      <vector name="rb" x="71" y="2"/>
+      <vector name="head" x="3" y="-113"/>
+    </canvas>
+    <canvas name="4" width="183" height="183">
+      <vector name="origin" x="98" y="176"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-59" y="-113"/>
+      <vector name="rb" x="60" y="1"/>
+      <vector name="head" x="1" y="-113"/>
+    </canvas>
+    <canvas name="5" width="187" height="206">
+      <vector name="origin" x="100" y="222"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-64" y="-160"/>
+      <vector name="rb" x="67" y="-17"/>
+      <vector name="head" x="0" y="-159"/>
+    </canvas>
+    <canvas name="6" width="189" height="204">
+      <vector name="origin" x="99" y="224"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-59" y="-157"/>
+      <vector name="rb" x="68" y="-17"/>
+      <vector name="head" x="1" y="-162"/>
+    </canvas>
+    <canvas name="7" width="182" height="203">
+      <vector name="origin" x="98" y="224"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-65" y="-155"/>
+      <vector name="rb" x="65" y="-16"/>
+      <vector name="head" x="-1" y="-163"/>
+    </canvas>
+    <canvas name="8" width="187" height="200">
+      <vector name="origin" x="97" y="220"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-59" y="-147"/>
+      <vector name="rb" x="63" y="-13"/>
+      <vector name="head" x="-1" y="-159"/>
+    </canvas>
+    <canvas name="9" width="183" height="178">
+      <vector name="origin" x="94" y="174"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-59" y="-111"/>
+      <vector name="rb" x="71" y="1"/>
+      <vector name="head" x="-3" y="-116"/>
+    </canvas>
+    <canvas name="10" width="176" height="173">
+      <vector name="origin" x="91" y="169"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-62" y="-112"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="0" y="-115"/>
+    </canvas>
+    <canvas name="11" width="175" height="174">
+      <vector name="origin" x="91" y="169"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-63" y="-111"/>
+      <vector name="rb" x="61" y="1"/>
+      <vector name="head" x="0" y="-114"/>
+    </canvas>
+    <canvas name="12" width="176" height="176">
+      <vector name="origin" x="91" y="171"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-61" y="-114"/>
+      <vector name="rb" x="61" y="1"/>
+      <vector name="head" x="0" y="-119"/>
+    </canvas>
+    <canvas name="13" width="178" height="175">
+      <vector name="origin" x="91" y="172"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-64" y="-117"/>
+      <vector name="rb" x="61" y="0"/>
+      <vector name="head" x="-1" y="-118"/>
+      <imgdir name="hit">
+        <canvas name="0" width="134" height="97">
+          <vector name="origin" x="70" y="84"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="136" height="94">
+          <vector name="origin" x="73" y="81"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="121" height="91">
+          <vector name="origin" x="60" y="79"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="103" height="79">
+          <vector name="origin" x="46" y="69"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="80" height="61">
+          <vector name="origin" x="36" y="58"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+    </canvas>
+    <canvas name="14" width="181" height="172">
+      <vector name="origin" x="91" y="172"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-64" y="-113"/>
+      <vector name="rb" x="61" y="0"/>
+      <vector name="head" x="0" y="-118"/>
+    </canvas>
+    <canvas name="15" width="180" height="172">
+      <vector name="origin" x="91" y="172"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-63" y="-114"/>
+      <vector name="rb" x="64" y="-1"/>
+      <vector name="head" x="0" y="-118"/>
+    </canvas>
+    <canvas name="16" width="176" height="172">
+      <vector name="origin" x="91" y="172"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-62" y="-114"/>
+      <vector name="rb" x="67" y="0"/>
+      <vector name="head" x="-1" y="-118"/>
+    </canvas>
+    <canvas name="17" width="175" height="172">
+      <vector name="origin" x="91" y="172"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-64" y="-115"/>
+      <vector name="rb" x="53" y="-1"/>
+      <vector name="head" x="-1" y="-117"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="滚出我的领地！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <int name="r" value="200"/>
+        <vector name="sp" x="6" y="-60"/>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="107" height="57">
+          <vector name="origin" x="9" y="31"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="106" height="57">
+          <vector name="origin" x="8" y="31"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="106" height="56">
+          <vector name="origin" x="7" y="30"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="103" height="56">
+          <vector name="origin" x="6" y="30"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="134" height="97">
+          <vector name="origin" x="83" y="101"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="1" width="136" height="94">
+          <vector name="origin" x="86" y="98"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="2" width="121" height="91">
+          <vector name="origin" x="73" y="96"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="3" width="103" height="79">
+          <vector name="origin" x="59" y="86"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="4" width="80" height="61">
+          <vector name="origin" x="49" y="75"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="2"/>
+      <int name="attackAfter" value="1320"/>
+      <int name="bulletSpeed" value="140"/>
+      <int name="PADamage" value="135"/>
+    </imgdir>
+    <canvas name="0" width="189" height="187">
+      <vector name="origin" x="99" y="172"/>
+      <vector name="lt" x="-64" y="-112"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-1" y="-117"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="184" height="190">
+      <vector name="origin" x="94" y="174"/>
+      <vector name="lt" x="-59" y="-110"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-1" y="-117"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="183" height="189">
+      <vector name="origin" x="95" y="174"/>
+      <vector name="lt" x="-58" y="-111"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-1" y="-116"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="184" height="185">
+      <vector name="origin" x="96" y="174"/>
+      <vector name="lt" x="-57" y="-112"/>
+      <vector name="rb" x="54" y="0"/>
+      <vector name="head" x="-1" y="-115"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="186" height="180">
+      <vector name="origin" x="97" y="174"/>
+      <vector name="lt" x="-56" y="-108"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="0" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="188" height="182">
+      <vector name="origin" x="97" y="175"/>
+      <vector name="lt" x="-57" y="-112"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="0" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="191" height="182">
+      <vector name="origin" x="97" y="175"/>
+      <vector name="lt" x="-57" y="-111"/>
+      <vector name="rb" x="59" y="1"/>
+      <vector name="head" x="0" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="191" height="183">
+      <vector name="origin" x="98" y="176"/>
+      <vector name="lt" x="-59" y="-114"/>
+      <vector name="rb" x="63" y="0"/>
+      <vector name="head" x="0" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="188" height="183">
+      <vector name="origin" x="98" y="176"/>
+      <vector name="lt" x="-58" y="-112"/>
+      <vector name="rb" x="69" y="0"/>
+      <vector name="head" x="0" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="191" height="207">
+      <vector name="origin" x="101" y="199"/>
+      <vector name="lt" x="-63" y="-137"/>
+      <vector name="rb" x="62" y="-1"/>
+      <vector name="head" x="0" y="-136"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="191" height="207">
+      <vector name="origin" x="101" y="200"/>
+      <vector name="lt" x="-59" y="-136"/>
+      <vector name="rb" x="62" y="-1"/>
+      <vector name="head" x="0" y="-138"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="191" height="205">
+      <vector name="origin" x="100" y="198"/>
+      <vector name="lt" x="-60" y="-132"/>
+      <vector name="rb" x="64" y="-1"/>
+      <vector name="head" x="-2" y="-138"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="192" height="200">
+      <vector name="origin" x="99" y="194"/>
+      <vector name="lt" x="-61" y="-131"/>
+      <vector name="rb" x="62" y="-1"/>
+      <vector name="head" x="1" y="-133"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="184" height="178">
+      <vector name="origin" x="94" y="174"/>
+      <vector name="lt" x="-56" y="-113"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="0" y="-115"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="14" width="176" height="169">
+      <vector name="origin" x="91" y="169"/>
+      <vector name="lt" x="-59" y="-113"/>
+      <vector name="rb" x="61" y="-1"/>
+      <vector name="head" x="2" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="15" width="175" height="169">
+      <vector name="origin" x="91" y="169"/>
+      <vector name="lt" x="-57" y="-113"/>
+      <vector name="rb" x="63" y="0"/>
+      <vector name="head" x="0" y="-113"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="16" width="176" height="171">
+      <vector name="origin" x="91" y="171"/>
+      <vector name="lt" x="-56" y="-109"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="0" y="-116"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="17" width="178" height="172">
+      <vector name="origin" x="91" y="172"/>
+      <vector name="lt" x="-57" y="-111"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="0" y="-116"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="我要让你噩梦缠身！去吧！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <uol name="0" value="../attack2/0"/>
+    <uol name="1" value="../attack2/1"/>
+    <uol name="2" value="../attack2/2"/>
+    <uol name="3" value="../attack2/3"/>
+    <uol name="4" value="../attack2/4"/>
+    <uol name="5" value="../attack2/5"/>
+    <uol name="6" value="../attack2/6"/>
+    <uol name="7" value="../attack2/7"/>
+    <uol name="8" value="../attack2/8"/>
+    <uol name="9" value="../attack2/9"/>
+    <uol name="10" value="../attack2/10"/>
+    <uol name="11" value="../attack2/11"/>
+    <uol name="12" value="../attack2/12"/>
+    <uol name="13" value="../attack2/13"/>
+    <uol name="14" value="../attack2/14"/>
+    <uol name="15" value="../attack2/15"/>
+    <uol name="16" value="../attack2/16"/>
+    <uol name="17" value="../attack2/17"/>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="你这只小老鼠！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="178" height="184">
+      <vector name="origin" x="89" y="183"/>
+      <vector name="lt" x="-63" y="-130"/>
+      <vector name="rb" x="65" y="0"/>
+      <vector name="head" x="2" y="-130"/>
+      <int name="delay" value="600"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="呃啊！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="178" height="184">
+      <vector name="origin" x="91" y="184"/>
+      <vector name="head" x="0" y="-131"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="174" height="184">
+      <vector name="origin" x="91" y="183"/>
+      <vector name="head" x="0" y="-131"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="173" height="184">
+      <vector name="origin" x="91" y="182"/>
+      <vector name="head" x="-1" y="-129"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="174" height="184">
+      <vector name="origin" x="91" y="181"/>
+      <vector name="head" x="-1" y="-128"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="176" height="164">
+      <vector name="origin" x="91" y="161"/>
+      <vector name="head" x="0" y="-106"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="179" height="163">
+      <vector name="origin" x="91" y="160"/>
+      <vector name="head" x="0" y="-106"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="178" height="164">
+      <vector name="origin" x="91" y="160"/>
+      <vector name="head" x="0" y="-104"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="174" height="164">
+      <vector name="origin" x="91" y="160"/>
+      <vector name="head" x="2" y="-103"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="174" height="160">
+      <vector name="origin" x="91" y="159"/>
+      <vector name="head" x="4" y="-100"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="174" height="150">
+      <vector name="origin" x="91" y="156"/>
+      <vector name="head" x="0" y="-124"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="144" height="54">
+      <vector name="origin" x="59" y="154"/>
+      <vector name="head" x="9" y="-154"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="145" height="55">
+      <vector name="origin" x="57" y="155"/>
+      <vector name="head" x="15" y="-155"/>
+      <int name="delay" value="150"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="这里是我的领地……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/3220001.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/3220001.img.xml
@@ -1,0 +1,399 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="3220001.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="38"/>
+    <int name="maxHP" value="7700"/>
+    <int name="maxMP" value="200"/>
+    <int name="speed" value="-60"/>
+    <int name="PADamage" value="130"/>
+    <int name="PDDamage" value="100"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="120"/>
+    <int name="acc" value="130"/>
+    <int name="eva" value="18"/>
+    <int name="exp" value="445"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1"/>
+    <int name="hpRecovery" value="50"/>
+    <int name="mpRecovery" value="20"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="mobType" value="4"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="1500"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3952"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="今天的阳光依旧灿烂。"/>
+        <int name="hp" value="6500"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="105" height="128">
+      <vector name="origin" x="56" y="128"/>
+      <vector name="lt" x="-56" y="-111"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="102" height="128">
+      <vector name="origin" x="53" y="128"/>
+      <vector name="lt" x="-56" y="-111"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="99" height="125">
+      <vector name="origin" x="50" y="125"/>
+      <vector name="lt" x="-56" y="-111"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="105" height="129">
+      <vector name="origin" x="56" y="129"/>
+      <vector name="lt" x="-56" y="-111"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="105" height="127">
+      <vector name="origin" x="56" y="127"/>
+      <vector name="lt" x="-56" y="-111"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="105" height="127">
+      <vector name="origin" x="56" y="127"/>
+      <vector name="lt" x="-56" y="-111"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="105" height="124">
+      <vector name="origin" x="56" y="124"/>
+      <vector name="lt" x="-56" y="-111"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="105" height="127">
+      <vector name="origin" x="56" y="127"/>
+      <vector name="lt" x="-56" y="-111"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="105" height="129">
+      <vector name="origin" x="56" y="129"/>
+      <vector name="lt" x="-56" y="-111"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="105" height="130">
+      <vector name="origin" x="56" y="130"/>
+      <vector name="lt" x="-56" y="-111"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-290" y="-120"/>
+        <vector name="rb" x="0" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="33" height="14">
+          <vector name="origin" x="17" y="12"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="104" height="96">
+          <vector name="origin" x="53" y="94"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="81" height="91">
+          <vector name="origin" x="41" y="89"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="78" height="90">
+          <vector name="origin" x="41" y="87"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="84" height="85">
+          <vector name="origin" x="50" y="83"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="90" height="89">
+          <vector name="origin" x="52" y="87"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="96" height="42">
+          <vector name="origin" x="52" y="40"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="38" height="42">
+          <vector name="origin" x="22" y="40"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="8" width="38" height="40">
+          <vector name="origin" x="22" y="39"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="9" width="38" height="39">
+          <vector name="origin" x="22" y="38"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="10" width="38" height="38">
+          <vector name="origin" x="22" y="37"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="effectAfter" value="0"/>
+      <int name="attackAfter" value="1080"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="145"/>
+    </imgdir>
+    <canvas name="0" width="103" height="129">
+      <vector name="origin" x="54" y="129"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="100" height="129">
+      <vector name="origin" x="52" y="129"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="107" height="135">
+      <vector name="origin" x="56" y="132"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="111" height="141">
+      <vector name="origin" x="58" y="135"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="114" height="144">
+      <vector name="origin" x="59" y="137"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="113" height="144">
+      <vector name="origin" x="58" y="136"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="115" height="147">
+      <vector name="origin" x="59" y="138"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="115" height="147">
+      <vector name="origin" x="59" y="138"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="115" height="147">
+      <vector name="origin" x="59" y="138"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="148" height="140">
+      <vector name="origin" x="90" y="131"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="152" height="140">
+      <vector name="origin" x="95" y="132"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="160" height="138">
+      <vector name="origin" x="103" y="130"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="159" height="137">
+      <vector name="origin" x="105" y="131"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="167" height="132">
+      <vector name="origin" x="115" y="129"/>
+      <vector name="lt" x="-60" y="-117"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="14" value="../stand/0"/>
+    <uol name="15" value="../stand/1"/>
+    <uol name="16" value="../stand/2"/>
+    <uol name="17" value="../stand/3"/>
+    <uol name="18" value="../stand/4"/>
+    <uol name="19" value="../stand/5"/>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="走开！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="155" height="140">
+      <vector name="origin" x="80" y="130"/>
+      <vector name="lt" x="-44" y="-108"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="134" height="138">
+      <vector name="origin" x="65" y="130"/>
+      <vector name="lt" x="-44" y="-108"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="131" height="140">
+      <vector name="origin" x="57" y="132"/>
+      <vector name="lt" x="-44" y="-108"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="132" height="143">
+      <vector name="origin" x="58" y="134"/>
+      <vector name="lt" x="-44" y="-108"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="143" height="149">
+      <vector name="origin" x="64" y="139"/>
+      <vector name="lt" x="-44" y="-108"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="132" height="145">
+      <vector name="origin" x="58" y="139"/>
+      <vector name="lt" x="-44" y="-108"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-10" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="6" value="../stand/0"/>
+    <uol name="7" value="../stand/1"/>
+    <uol name="8" value="../stand/2"/>
+    <uol name="9" value="../stand/3"/>
+    <uol name="10" value="../stand/4"/>
+    <uol name="11" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="144" height="126">
+      <vector name="origin" x="73" y="131"/>
+      <vector name="lt" x="-36" y="-112"/>
+      <vector name="rb" x="53" y="-5"/>
+      <vector name="head" x="2" y="-109"/>
+      <int name="delay" value="600"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="哎呀……"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="144" height="126">
+      <vector name="origin" x="72" y="131"/>
+      <vector name="head" x="2" y="-108"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="149" height="127">
+      <vector name="origin" x="74" y="129"/>
+      <vector name="head" x="7" y="-106"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="153" height="127">
+      <vector name="origin" x="76" y="128"/>
+      <vector name="head" x="12" y="-101"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="152" height="126">
+      <vector name="origin" x="76" y="125"/>
+      <vector name="head" x="10" y="-99"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="152" height="127">
+      <vector name="origin" x="76" y="124"/>
+      <vector name="head" x="14" y="-100"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="153" height="126">
+      <vector name="origin" x="76" y="119"/>
+      <vector name="head" x="15" y="-97"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="155" height="126">
+      <vector name="origin" x="76" y="117"/>
+      <vector name="head" x="19" y="-91"/>
+      <int name="delay" value="300"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="你们这些小辈，真是不懂尊重长者……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/4220000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/4220000.img.xml
@@ -1,0 +1,486 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="4220000.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="45"/>
+    <int name="maxHP" value="7800"/>
+    <int name="maxMP" value="150"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="135"/>
+    <int name="PDDamage" value="150"/>
+    <int name="MADamage" value="155"/>
+    <int name="MDDamage" value="200"/>
+    <int name="acc" value="200"/>
+    <int name="eva" value="20"/>
+    <int name="exp" value="330"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="300"/>
+    <int name="hpRecovery" value="650"/>
+    <int name="mpRecovery" value="40"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="140"/>
+        <int name="action" value="1"/>
+        <int name="level" value="14"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="121"/>
+        <int name="action" value="1"/>
+        <int name="level" value="8"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="6500"/>
+        <string name="0" value="我会让你后悔的！"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="140" height="132">
+      <vector name="origin" x="66" y="131"/>
+      <vector name="lt" x="-66" y="-131"/>
+      <vector name="rb" x="73" y="0"/>
+      <vector name="head" x="-6" y="-108"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="140" height="133">
+      <vector name="origin" x="66" y="132"/>
+      <vector name="lt" x="-66" y="-132"/>
+      <vector name="rb" x="74" y="0"/>
+      <vector name="head" x="-6" y="-109"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="140" height="133">
+      <vector name="origin" x="66" y="132"/>
+      <vector name="lt" x="-66" y="-132"/>
+      <vector name="rb" x="73" y="0"/>
+      <vector name="head" x="-6" y="-108"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="140" height="132">
+      <vector name="origin" x="66" y="131"/>
+      <vector name="lt" x="-66" y="-131"/>
+      <vector name="rb" x="73" y="0"/>
+      <vector name="head" x="-6" y="-107"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="140" height="130">
+      <vector name="origin" x="66" y="129"/>
+      <vector name="lt" x="-66" y="-129"/>
+      <vector name="rb" x="74" y="1"/>
+      <vector name="head" x="-6" y="-106"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="140" height="131">
+      <vector name="origin" x="66" y="130"/>
+      <vector name="lt" x="-66" y="-130"/>
+      <vector name="rb" x="74" y="1"/>
+      <vector name="head" x="-6" y="-107"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <int name="r" value="160"/>
+        <vector name="sp" x="-93" y="-44"/>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="32" height="32">
+          <vector name="origin" x="16" y="16"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="1" width="32" height="32">
+          <vector name="origin" x="16" y="16"/>
+          <int name="delay" value="60"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="72" height="83">
+          <vector name="origin" x="28" y="82"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="64" height="72">
+          <vector name="origin" x="31" y="74"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="56" height="58">
+          <vector name="origin" x="27" y="69"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="2"/>
+      <int name="attackAfter" value="1320"/>
+      <int name="bulletSpeed" value="140"/>
+      <int name="PADamage" value="110"/>
+    </imgdir>
+    <canvas name="0" width="140" height="132">
+      <vector name="origin" x="66" y="131"/>
+      <vector name="lt" x="-66" y="-131"/>
+      <vector name="rb" x="74" y="1"/>
+      <vector name="head" x="-6" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="140" height="131">
+      <vector name="origin" x="65" y="130"/>
+      <vector name="lt" x="-65" y="-130"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-5" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="140" height="131">
+      <vector name="origin" x="65" y="130"/>
+      <vector name="lt" x="-65" y="-130"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-5" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="140" height="131">
+      <vector name="origin" x="65" y="130"/>
+      <vector name="lt" x="-65" y="-130"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-5" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="140" height="131">
+      <vector name="origin" x="65" y="130"/>
+      <vector name="lt" x="-65" y="-130"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-5" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="140" height="131">
+      <vector name="origin" x="65" y="130"/>
+      <vector name="lt" x="-65" y="-130"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-5" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="140" height="131">
+      <vector name="origin" x="65" y="130"/>
+      <vector name="lt" x="-65" y="-130"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-5" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="140" height="131">
+      <vector name="origin" x="64" y="130"/>
+      <vector name="lt" x="-64" y="-130"/>
+      <vector name="rb" x="76" y="1"/>
+      <vector name="head" x="-4" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="140" height="132">
+      <vector name="origin" x="63" y="131"/>
+      <vector name="lt" x="-63" y="-131"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="-3" y="-109"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="140" height="132">
+      <vector name="origin" x="62" y="131"/>
+      <vector name="lt" x="-62" y="-131"/>
+      <vector name="rb" x="78" y="1"/>
+      <vector name="head" x="-2" y="-109"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="177" height="137">
+      <vector name="origin" x="102" y="136"/>
+      <vector name="lt" x="-102" y="-136"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-5" y="-110"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="140" height="130">
+      <vector name="origin" x="68" y="129"/>
+      <vector name="lt" x="-68" y="-129"/>
+      <vector name="rb" x="72" y="1"/>
+      <vector name="head" x="-6" y="-109"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="140" height="131">
+      <vector name="origin" x="67" y="130"/>
+      <vector name="lt" x="-67" y="-130"/>
+      <vector name="rb" x="73" y="1"/>
+      <vector name="head" x="-5" y="-110"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="140" height="132">
+      <vector name="origin" x="66" y="131"/>
+      <vector name="lt" x="-66" y="-131"/>
+      <vector name="rb" x="74" y="1"/>
+      <vector name="head" x="-6" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="140" height="132">
+      <vector name="origin" x="66" y="131"/>
+      <vector name="lt" x="-66" y="-131"/>
+      <vector name="rb" x="74" y="1"/>
+      <vector name="head" x="-6" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="15" value="../stand/1"/>
+    <uol name="16" value="../stand/2"/>
+    <uol name="17" value="../stand/3"/>
+    <uol name="18" value="../stand/4"/>
+    <uol name="19" value="../stand/5"/>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="哈呀！接招！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-190" y="-97"/>
+        <vector name="rb" x="50" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="76" height="68">
+          <vector name="origin" x="34" y="74"/>
+        </canvas>
+        <canvas name="1" width="60" height="60">
+          <vector name="origin" x="25" y="69"/>
+        </canvas>
+        <canvas name="2" width="58" height="57">
+          <vector name="origin" x="25" y="67"/>
+        </canvas>
+        <canvas name="3" width="62" height="52">
+          <vector name="origin" x="32" y="64"/>
+        </canvas>
+        <canvas name="4" width="66" height="52">
+          <vector name="origin" x="33" y="66"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="attackAfter" value="1200"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="110"/>
+    </imgdir>
+    <canvas name="0" width="140" height="132">
+      <vector name="origin" x="66" y="131"/>
+      <vector name="lt" x="-66" y="-131"/>
+      <vector name="rb" x="74" y="1"/>
+      <vector name="head" x="-6" y="-107"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="221" height="182">
+      <vector name="origin" x="112" y="146"/>
+      <vector name="lt" x="-113" y="-146"/>
+      <vector name="rb" x="109" y="36"/>
+      <vector name="head" x="6" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="214" height="181">
+      <vector name="origin" x="110" y="149"/>
+      <vector name="lt" x="-110" y="-149"/>
+      <vector name="rb" x="104" y="32"/>
+      <vector name="head" x="13" y="-120"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="193" height="188">
+      <vector name="origin" x="96" y="152"/>
+      <vector name="lt" x="-97" y="-152"/>
+      <vector name="rb" x="97" y="36"/>
+      <vector name="head" x="14" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="168" height="183">
+      <vector name="origin" x="69" y="154"/>
+      <vector name="lt" x="-69" y="-154"/>
+      <vector name="rb" x="99" y="29"/>
+      <vector name="head" x="16" y="-123"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="168" height="166">
+      <vector name="origin" x="68" y="156"/>
+      <vector name="lt" x="-68" y="-156"/>
+      <vector name="rb" x="100" y="10"/>
+      <vector name="head" x="17" y="-123"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="170" height="166">
+      <vector name="origin" x="69" y="156"/>
+      <vector name="lt" x="-69" y="-156"/>
+      <vector name="rb" x="101" y="10"/>
+      <vector name="head" x="18" y="-124"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="170" height="166">
+      <vector name="origin" x="69" y="156"/>
+      <vector name="lt" x="-69" y="-156"/>
+      <vector name="rb" x="101" y="10"/>
+      <vector name="head" x="17" y="-123"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="170" height="166">
+      <vector name="origin" x="69" y="156"/>
+      <vector name="lt" x="-69" y="-156"/>
+      <vector name="rb" x="101" y="10"/>
+      <vector name="head" x="17" y="-123"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="263" height="159">
+      <vector name="origin" x="188" y="134"/>
+      <vector name="lt" x="-188" y="-134"/>
+      <vector name="rb" x="75" y="25"/>
+      <vector name="head" x="1" y="-99"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="263" height="167">
+      <vector name="origin" x="189" y="129"/>
+      <vector name="lt" x="-189" y="-129"/>
+      <vector name="rb" x="74" y="38"/>
+      <vector name="head" x="3" y="-102"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="271" height="172">
+      <vector name="origin" x="199" y="123"/>
+      <vector name="lt" x="-199" y="-123"/>
+      <vector name="rb" x="72" y="48"/>
+      <vector name="head" x="0" y="-97"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="260" height="123">
+      <vector name="origin" x="193" y="118"/>
+      <vector name="lt" x="-193" y="-119"/>
+      <vector name="rb" x="67" y="4"/>
+      <vector name="head" x="-2" y="-97"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="258" height="121">
+      <vector name="origin" x="192" y="118"/>
+      <vector name="lt" x="-193" y="-119"/>
+      <vector name="rb" x="66" y="2"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="14" width="260" height="155">
+      <vector name="origin" x="194" y="154"/>
+      <vector name="lt" x="-195" y="-154"/>
+      <vector name="rb" x="66" y="0"/>
+      <vector name="head" x="-2" y="-98"/>
+    </canvas>
+    <canvas name="15" width="127" height="176">
+      <vector name="origin" x="61" y="175"/>
+      <vector name="lt" x="-61" y="-175"/>
+      <vector name="rb" x="66" y="0"/>
+      <vector name="head" x="2" y="-99"/>
+    </canvas>
+    <uol name="16" value="0"/>
+    <uol name="17" value="../stand/1"/>
+    <uol name="18" value="../stand/2"/>
+    <uol name="19" value="../stand/3"/>
+    <uol name="20" value="../stand/4"/>
+    <uol name="21" value="../stand/5"/>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="你是在耍我吗？我生气了！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="140" height="132">
+      <vector name="origin" x="66" y="131"/>
+      <vector name="lt" x="-66" y="-131"/>
+      <vector name="rb" x="74" y="1"/>
+      <vector name="head" x="-6" y="-107"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <uol name="1" value="../stand/1"/>
+    <uol name="2" value="../stand/2"/>
+    <uol name="3" value="../stand/3"/>
+    <uol name="4" value="../stand/4"/>
+    <uol name="5" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="153" height="166">
+      <vector name="origin" x="60" y="165"/>
+      <vector name="lt" x="-61" y="-165"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="8" y="-118"/>
+      <int name="delay" value="600"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="呀啊！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="153" height="166">
+      <vector name="origin" x="60" y="165"/>
+      <vector name="head" x="6" y="-117"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="142" height="166">
+      <vector name="origin" x="50" y="165"/>
+      <vector name="head" x="17" y="-117"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="142" height="164">
+      <vector name="origin" x="49" y="163"/>
+      <vector name="head" x="17" y="-117"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="142" height="166">
+      <vector name="origin" x="48" y="165"/>
+      <vector name="head" x="17" y="-117"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="142" height="167">
+      <vector name="origin" x="47" y="166"/>
+      <vector name="head" x="18" y="-98"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="142" height="168">
+      <vector name="origin" x="47" y="167"/>
+      <vector name="head" x="18" y="-98"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="99" height="102">
+      <vector name="origin" x="31" y="118"/>
+      <vector name="head" x="18" y="-98"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="98" height="101">
+      <vector name="origin" x="30" y="117"/>
+      <vector name="head" x="18" y="-98"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="99" height="102">
+      <vector name="origin" x="31" y="92"/>
+      <vector name="head" x="18" y="-71"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="96" height="102">
+      <vector name="origin" x="29" y="91"/>
+      <vector name="head" x="18" y="-71"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="99" height="102">
+      <vector name="origin" x="31" y="90"/>
+      <vector name="head" x="18" y="-71"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="96" height="102">
+      <vector name="origin" x="29" y="89"/>
+      <vector name="head" x="18" y="-71"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="不！你不能这样！请放过我！"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/4220001.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/4220001.img.xml
@@ -1,0 +1,95 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="4220001.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="45"/>
+    <int name="maxHP" value="2550"/>
+    <int name="maxMP" value="150"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="135"/>
+    <int name="PDDamage" value="150"/>
+    <int name="MADamage" value="155"/>
+    <int name="MDDamage" value="200"/>
+    <int name="acc" value="200"/>
+    <int name="eva" value="20"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="3000"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="noFlip" value="1"/>
+    <imgdir name="revive">
+      <int name="0" value="4220000"/>
+    </imgdir>
+    <int name="mobType" value="3"/>
+    <int name="mbookID" value="4220000"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="1000"/>
+        <string name="0" value="我生气了！"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="140" height="77">
+      <vector name="origin" x="66" y="76"/>
+      <vector name="lt" x="-79" y="-129"/>
+      <vector name="rb" x="63" y="0"/>
+      <vector name="head" x="-30" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="140" height="77">
+      <vector name="origin" x="66" y="76"/>
+      <vector name="head" x="-29" y="-96"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="1" width="140" height="78">
+      <vector name="origin" x="66" y="77"/>
+      <vector name="head" x="-29" y="-94"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="2" width="140" height="80">
+      <vector name="origin" x="66" y="79"/>
+      <vector name="head" x="-29" y="-95"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="3" width="140" height="151">
+      <vector name="origin" x="66" y="150"/>
+      <vector name="head" x="-29" y="-94"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="140" height="153">
+      <vector name="origin" x="66" y="152"/>
+      <vector name="head" x="-29" y="-96"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="140" height="152">
+      <vector name="origin" x="66" y="151"/>
+      <vector name="head" x="-28" y="-99"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="140" height="130">
+      <vector name="origin" x="66" y="129"/>
+      <vector name="head" x="-27" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="140" height="133">
+      <vector name="origin" x="66" y="132"/>
+      <vector name="head" x="-26" y="-113"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="140" height="132">
+      <vector name="origin" x="66" y="131"/>
+      <vector name="head" x="-26" y="-125"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="是谁吵醒了沉睡的贝壳？！"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/4300013.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/4300013.img.xml
@@ -1,0 +1,1452 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="4300013.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="49"/>
+    <int name="maxHP" value="250000"/>
+    <int name="maxMP" value="50000"/>
+    <int name="mpRecovery" value="1000"/>
+    <int name="speed" value="20"/>
+    <int name="PADamage" value="200"/>
+    <int name="PDDamage" value="250"/>
+    <int name="MADamage" value="230"/>
+    <int name="MDDamage" value="280"/>
+    <int name="acc" value="160"/>
+    <int name="eva" value="22"/>
+    <int name="pushed" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="mobType" value="7"/>
+    <int name="boss" value="1"/>
+    <int name="exp" value="1700"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <string name="level" value="173"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="145"/>
+        <int name="action" value="2"/>
+        <string name="level" value="5"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="114"/>
+        <int name="action" value="3"/>
+        <string name="level" value="33"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="2288"/>
+            <int name="state" value="1"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chataBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="500000"/>
+        <int name="prob" value="100"/>
+        <string name="0" value="摇滚万岁！兄弟，痛快！耶！♪"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="hp" value="250000"/>
+        <int name="prob" value="100"/>
+        <string name="0" value="竟敢玷污我的音乐，愚蠢的灵魂！"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="hp" value="150000"/>
+        <int name="prob" value="100"/>
+        <string name="0" value="我是摇滚之魂！"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="revive">
+      <int name="0" value="4300017"/>
+    </imgdir>
+    <int name="hpTagColor" value="3"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="119" height="98">
+      <vector name="origin" x="47" y="102"/>
+      <vector name="lt" x="-49" y="-103"/>
+      <vector name="rb" x="71" y="0"/>
+      <vector name="head" x="-16" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="126" height="98">
+      <vector name="origin" x="47" y="97"/>
+      <vector name="lt" x="-49" y="-103"/>
+      <vector name="rb" x="71" y="0"/>
+      <vector name="head" x="-16" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="127" height="98">
+      <vector name="origin" x="47" y="102"/>
+      <vector name="lt" x="-49" y="-103"/>
+      <vector name="rb" x="80" y="0"/>
+      <vector name="head" x="-16" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="124" height="99">
+      <vector name="origin" x="47" y="98"/>
+      <vector name="lt" x="-49" y="-103"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-16" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="105" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="105" height="100">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="103" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="103" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="103" height="100">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="103" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="102" height="114">
+      <vector name="origin" x="45" y="113"/>
+      <vector name="lt" x="-45" y="-113"/>
+      <vector name="rb" x="56" y="-1"/>
+      <vector name="head" x="-5" y="-62"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="102" height="114">
+      <vector name="origin" x="45" y="113"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="102" height="102">
+      <vector name="origin" x="45" y="101"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="102" height="104">
+      <vector name="origin" x="45" y="99"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="102" height="100">
+      <vector name="origin" x="45" y="95"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="102" height="97">
+      <vector name="origin" x="45" y="92"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="102" height="113">
+      <vector name="origin" x="45" y="108"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="104" height="129">
+      <vector name="origin" x="45" y="124"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="100" height="147">
+      <vector name="origin" x="43" y="146"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="106" height="180">
+      <vector name="origin" x="47" y="179"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="104" height="192">
+      <vector name="origin" x="44" y="191"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="100" height="202">
+      <vector name="origin" x="43" y="201"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="97" height="213">
+      <vector name="origin" x="40" y="212"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="100" height="219">
+      <vector name="origin" x="41" y="218"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="96" height="230">
+      <vector name="origin" x="39" y="229"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="93" height="147">
+      <vector name="origin" x="39" y="223"/>
+      <vector name="head" x="-4" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我的……我的音乐永远不会终结……"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-434" y="-105"/>
+        <vector name="rb" x="50" y="3"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="65" height="40">
+          <vector name="origin" x="30" y="88"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="65" height="62">
+          <vector name="origin" x="33" y="85"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="74" height="64">
+          <vector name="origin" x="37" y="71"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="59" height="33">
+          <vector name="origin" x="28" y="35"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="56" height="17">
+          <vector name="origin" x="26" y="18"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1080"/>
+      <int name="PADamage" value="200"/>
+      <int name="knockback" value="1"/>
+    </imgdir>
+    <canvas name="0" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="1" width="105" height="102">
+      <vector name="origin" x="48" y="101"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="2" width="110" height="102">
+      <vector name="origin" x="53" y="100"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="3" width="183" height="105">
+      <vector name="origin" x="87" y="99"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="4" width="238" height="147">
+      <vector name="origin" x="109" y="143"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="5" width="282" height="168">
+      <vector name="origin" x="124" y="165"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="6" width="313" height="182">
+      <vector name="origin" x="131" y="179"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="7" width="448" height="200">
+      <vector name="origin" x="254" y="191"/>
+      <int name="delay" value="60"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="8" width="376" height="103">
+      <vector name="origin" x="319" y="98"/>
+      <int name="delay" value="60"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="9" width="491" height="102">
+      <vector name="origin" x="434" y="98"/>
+      <int name="delay" value="60"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="10" width="651" height="101">
+      <vector name="origin" x="594" y="98"/>
+      <int name="delay" value="60"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="11" width="736" height="101">
+      <vector name="origin" x="679" y="99"/>
+      <int name="delay" value="60"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="12" width="769" height="105">
+      <vector name="origin" x="712" y="103"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="13" width="746" height="106">
+      <vector name="origin" x="689" y="104"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="14" width="690" height="106">
+      <vector name="origin" x="633" y="105"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="15" width="647" height="106">
+      <vector name="origin" x="590" y="105"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="105" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="105" height="100">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-436" y="-128"/>
+        <vector name="rb" x="206" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="49" height="357">
+          <vector name="origin" x="19" y="563"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="97" height="569">
+          <vector name="origin" x="40" y="563"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="190" height="569">
+          <vector name="origin" x="87" y="563"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="253" height="570">
+          <vector name="origin" x="119" y="563"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="288" height="569">
+          <vector name="origin" x="136" y="563"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="284" height="568">
+          <vector name="origin" x="142" y="563"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="219" height="568">
+          <vector name="origin" x="104" y="563"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="15"/>
+      <int name="attackAfter" value="1080"/>
+      <int name="effectAfter" value="0"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="101" height="102">
+      <vector name="origin" x="43" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="101" height="102">
+      <vector name="origin" x="41" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="121" height="151">
+      <vector name="origin" x="54" y="100"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="147" height="109">
+      <vector name="origin" x="84" y="99"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="99" height="115">
+      <vector name="origin" x="42" y="100"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="105" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="108" height="102">
+      <vector name="origin" x="51" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="109" height="102">
+      <vector name="origin" x="52" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="107" height="103">
+      <vector name="origin" x="50" y="102"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="106" height="104">
+      <vector name="origin" x="49" y="103"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="110" height="108">
+      <vector name="origin" x="53" y="106"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="12" width="121" height="123">
+      <vector name="origin" x="54" y="119"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="13" width="326" height="163">
+      <vector name="origin" x="131" y="158"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="14" width="344" height="168">
+      <vector name="origin" x="141" y="163"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="15" width="338" height="166">
+      <vector name="origin" x="137" y="161"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="16" width="338" height="165">
+      <vector name="origin" x="134" y="160"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="17" width="341" height="142">
+      <vector name="origin" x="134" y="137"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="18" width="175" height="136">
+      <vector name="origin" x="54" y="132"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="19" width="154" height="108">
+      <vector name="origin" x="53" y="106"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="20" width="125" height="102">
+      <vector name="origin" x="41" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="21" width="110" height="102">
+      <vector name="origin" x="43" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-401" y="-200"/>
+        <vector name="rb" x="23" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="66" height="41">
+          <vector name="origin" x="30" y="88"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="65" height="62">
+          <vector name="origin" x="33" y="84"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="74" height="65">
+          <vector name="origin" x="37" y="70"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="61" height="33">
+          <vector name="origin" x="29" y="34"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="57" height="18">
+          <vector name="origin" x="26" y="18"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="attackAfter" value="2220"/>
+      <int name="conMP" value="10"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="1" width="101" height="102">
+      <vector name="origin" x="43" y="101"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="2" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="3" width="121" height="151">
+      <vector name="origin" x="54" y="100"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="4" width="355" height="109">
+      <vector name="origin" x="99" y="99"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="5" width="375" height="119">
+      <vector name="origin" x="109" y="104"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="6" width="367" height="118">
+      <vector name="origin" x="105" y="116"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-116"/>
+      <vector name="rb" x="208" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="7" width="362" height="121">
+      <vector name="origin" x="102" y="119"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="8" width="361" height="126">
+      <vector name="origin" x="102" y="124"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="9" width="259" height="168">
+      <vector name="origin" x="50" y="166"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="10" width="258" height="170">
+      <vector name="origin" x="49" y="168"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="11" width="262" height="171">
+      <vector name="origin" x="53" y="169"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="12" width="267" height="173">
+      <vector name="origin" x="56" y="169"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="13" width="288" height="171">
+      <vector name="origin" x="76" y="169"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="14" width="302" height="172">
+      <vector name="origin" x="93" y="169"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="15" width="348" height="170">
+      <vector name="origin" x="137" y="166"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="16" width="383" height="202">
+      <vector name="origin" x="171" y="195"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="17" width="460" height="202">
+      <vector name="origin" x="251" y="196"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="18" width="532" height="201">
+      <vector name="origin" x="321" y="196"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="19" width="603" height="200">
+      <vector name="origin" x="391" y="196"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="20" width="647" height="204">
+      <vector name="origin" x="438" y="197"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="21" width="722" height="205">
+      <vector name="origin" x="511" y="200"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="22" width="616" height="205">
+      <vector name="origin" x="404" y="201"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="23" width="348" height="182">
+      <vector name="origin" x="139" y="178"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="24" width="350" height="194">
+      <vector name="origin" x="139" y="190"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="25" width="307" height="171">
+      <vector name="origin" x="98" y="169"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="26" width="258" height="171">
+      <vector name="origin" x="49" y="169"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="27" width="263" height="173">
+      <vector name="origin" x="54" y="169"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="28" width="262" height="171">
+      <vector name="origin" x="53" y="169"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-50" y="-166"/>
+      <vector name="rb" x="209" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+    </canvas>
+    <canvas name="29" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="30" width="105" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="31" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="32" width="105" height="100">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="33" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="34" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="35" width="103" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="109" height="102">
+      <vector name="origin" x="52" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="107" height="103">
+      <vector name="origin" x="50" y="102"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-3" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="106" height="104">
+      <vector name="origin" x="49" y="103"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="0" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="106" height="104">
+      <vector name="origin" x="49" y="103"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="110" height="108">
+      <vector name="origin" x="53" y="106"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="111" height="119">
+      <vector name="origin" x="54" y="115"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="112" height="118">
+      <vector name="origin" x="55" y="113"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="112" height="118">
+      <vector name="origin" x="55" y="113"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="112" height="118">
+      <vector name="origin" x="55" y="113"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="203" height="149">
+      <vector name="origin" x="94" y="148"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="226" height="158">
+      <vector name="origin" x="101" y="153"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="233" height="152">
+      <vector name="origin" x="102" y="151"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="231" height="151">
+      <vector name="origin" x="102" y="150"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="218" height="149">
+      <vector name="origin" x="94" y="148"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="216" height="154">
+      <vector name="origin" x="101" y="153"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="251" height="152">
+      <vector name="origin" x="134" y="151"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="220" height="151">
+      <vector name="origin" x="102" y="150"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="216" height="120">
+      <vector name="origin" x="97" y="119"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="214" height="102">
+      <vector name="origin" x="96" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="210" height="102">
+      <vector name="origin" x="94" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="109" height="102">
+      <vector name="origin" x="52" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="107" height="103">
+      <vector name="origin" x="50" y="102"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="106" height="104">
+      <vector name="origin" x="49" y="103"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="110" height="108">
+      <vector name="origin" x="53" y="106"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="189" height="124">
+      <vector name="origin" x="92" y="115"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="215" height="122">
+      <vector name="origin" x="91" y="113"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="221" height="128">
+      <vector name="origin" x="94" y="119"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="225" height="149">
+      <vector name="origin" x="96" y="140"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="225" height="156">
+      <vector name="origin" x="96" y="149"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="203" height="139">
+      <vector name="origin" x="94" y="135"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="216" height="144">
+      <vector name="origin" x="101" y="140"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="219" height="142">
+      <vector name="origin" x="102" y="138"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="220" height="141">
+      <vector name="origin" x="102" y="137"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="149" height="123">
+      <vector name="origin" x="67" y="119"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="149" height="123">
+      <vector name="origin" x="67" y="119"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="149" height="118">
+      <vector name="origin" x="67" y="114"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="145" height="114">
+      <vector name="origin" x="65" y="112"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="105" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="105" height="100">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill3">
+    <canvas name="0" width="109" height="102">
+      <vector name="origin" x="52" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="107" height="103">
+      <vector name="origin" x="50" y="102"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="106" height="208">
+      <vector name="origin" x="49" y="207"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="106" height="205">
+      <vector name="origin" x="49" y="204"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="110" height="203">
+      <vector name="origin" x="53" y="201"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="111" height="203">
+      <vector name="origin" x="54" y="199"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="114" height="203">
+      <vector name="origin" x="55" y="198"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="114" height="202">
+      <vector name="origin" x="55" y="197"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="127" height="221">
+      <vector name="origin" x="55" y="216"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="203" height="220">
+      <vector name="origin" x="94" y="219"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="216" height="222">
+      <vector name="origin" x="101" y="221"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="219" height="223">
+      <vector name="origin" x="102" y="222"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="220" height="225">
+      <vector name="origin" x="102" y="224"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="132" height="226">
+      <vector name="origin" x="59" y="225"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="134" height="233">
+      <vector name="origin" x="61" y="224"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="179" height="232">
+      <vector name="origin" x="84" y="222"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="240" height="219">
+      <vector name="origin" x="112" y="209"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="256" height="220">
+      <vector name="origin" x="120" y="210"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="265" height="221">
+      <vector name="origin" x="125" y="211"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="225" height="220">
+      <vector name="origin" x="104" y="212"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="153" height="102">
+      <vector name="origin" x="72" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="104" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="105" height="102">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="26" width="105" height="100">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="27" width="105" height="101">
+      <vector name="origin" x="47" y="101"/>
+      <vector name="lt" x="-48" y="-102"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/5220000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/5220000.img.xml
@@ -1,0 +1,457 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="5220000.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="55"/>
+    <int name="maxHP" value="25000"/>
+    <int name="maxMP" value="200"/>
+    <int name="speed" value="-20"/>
+    <int name="PADamage" value="165"/>
+    <int name="PDDamage" value="120"/>
+    <int name="MADamage" value="175"/>
+    <int name="MDDamage" value="120"/>
+    <int name="acc" value="100"/>
+    <int name="eva" value="20"/>
+    <int name="exp" value="1210"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1000"/>
+    <int name="hpRecovery" value="1250"/>
+    <int name="mpRecovery" value="10"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="123"/>
+        <int name="action" value="1"/>
+        <int name="level" value="8"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="82"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="110"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="113"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="15"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="20000"/>
+        <string name="0" value="为什么要打扰我晒太阳？"/>
+      </imgdir>
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="2157"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="231" height="194">
+      <vector name="origin" x="110" y="192"/>
+      <vector name="lt" x="-110" y="-179"/>
+      <vector name="rb" x="121" y="1"/>
+      <vector name="head" x="-13" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="233" height="192">
+      <vector name="origin" x="111" y="191"/>
+      <vector name="lt" x="-110" y="-179"/>
+      <vector name="rb" x="121" y="1"/>
+      <vector name="head" x="-13" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="237" height="190">
+      <vector name="origin" x="112" y="188"/>
+      <vector name="lt" x="-110" y="-179"/>
+      <vector name="rb" x="121" y="1"/>
+      <vector name="head" x="-13" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="233" height="184">
+      <vector name="origin" x="111" y="183"/>
+      <vector name="lt" x="-110" y="-179"/>
+      <vector name="rb" x="121" y="1"/>
+      <vector name="head" x="-13" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="231" height="188">
+      <vector name="origin" x="110" y="187"/>
+      <vector name="lt" x="-110" y="-179"/>
+      <vector name="rb" x="121" y="1"/>
+      <vector name="head" x="-13" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="231" height="194">
+      <vector name="origin" x="110" y="192"/>
+      <vector name="lt" x="-110" y="-180"/>
+      <vector name="rb" x="120" y="1"/>
+      <vector name="head" x="-13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="231" height="193">
+      <vector name="origin" x="110" y="191"/>
+      <vector name="lt" x="-110" y="-180"/>
+      <vector name="rb" x="120" y="1"/>
+      <vector name="head" x="-13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="231" height="190">
+      <vector name="origin" x="110" y="188"/>
+      <vector name="lt" x="-110" y="-180"/>
+      <vector name="rb" x="120" y="1"/>
+      <vector name="head" x="-13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="231" height="185">
+      <vector name="origin" x="110" y="183"/>
+      <vector name="lt" x="-110" y="-180"/>
+      <vector name="rb" x="120" y="1"/>
+      <vector name="head" x="-13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="231" height="189">
+      <vector name="origin" x="110" y="187"/>
+      <vector name="lt" x="-110" y="-180"/>
+      <vector name="rb" x="120" y="1"/>
+      <vector name="head" x="-13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="231" height="194">
+      <vector name="origin" x="110" y="192"/>
+      <vector name="lt" x="-110" y="-180"/>
+      <vector name="rb" x="120" y="1"/>
+      <vector name="head" x="-13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="231" height="193">
+      <vector name="origin" x="110" y="191"/>
+      <vector name="lt" x="-110" y="-180"/>
+      <vector name="rb" x="120" y="1"/>
+      <vector name="head" x="-13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="231" height="190">
+      <vector name="origin" x="110" y="188"/>
+      <vector name="lt" x="-110" y="-180"/>
+      <vector name="rb" x="120" y="1"/>
+      <vector name="head" x="-13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="231" height="185">
+      <vector name="origin" x="110" y="183"/>
+      <vector name="lt" x="-110" y="-180"/>
+      <vector name="rb" x="120" y="1"/>
+      <vector name="head" x="-13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="231" height="184">
+      <vector name="origin" x="110" y="182"/>
+      <vector name="lt" x="-110" y="-180"/>
+      <vector name="rb" x="120" y="1"/>
+      <vector name="head" x="-13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-250" y="-150"/>
+        <vector name="rb" x="250" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="99" height="107">
+          <vector name="origin" x="50" y="84"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="80" height="77">
+          <vector name="origin" x="37" y="66"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="76" height="74">
+          <vector name="origin" x="35" y="65"/>
+          <int name="delay" value="120"/>
+          <int name="a0" value="255"/>
+          <int name="a1" value="0"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="attackAfter" value="1200"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="180"/>
+    </imgdir>
+    <canvas name="0" width="225" height="194">
+      <vector name="origin" x="109" y="192"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="225" height="192">
+      <vector name="origin" x="109" y="190"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="225" height="186">
+      <vector name="origin" x="109" y="184"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="225" height="181">
+      <vector name="origin" x="109" y="179"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="225" height="181">
+      <vector name="origin" x="109" y="179"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="224" height="179">
+      <vector name="origin" x="108" y="177"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="235" height="194">
+      <vector name="origin" x="114" y="186"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="232" height="204">
+      <vector name="origin" x="112" y="196"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="223" height="211">
+      <vector name="origin" x="108" y="203"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="250" height="172">
+      <vector name="origin" x="122" y="168"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="256" height="171">
+      <vector name="origin" x="125" y="168"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="256" height="167">
+      <vector name="origin" x="124" y="163"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="304" height="162">
+      <vector name="origin" x="144" y="158"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="339" height="157">
+      <vector name="origin" x="164" y="153"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="356" height="163">
+      <vector name="origin" x="172" y="158"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="429" height="183">
+      <vector name="origin" x="209" y="176"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="230" height="186">
+      <vector name="origin" x="114" y="183"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="225" height="192">
+      <vector name="origin" x="109" y="190"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="222" height="193">
+      <vector name="origin" x="106" y="191"/>
+      <vector name="lt" x="-113" y="-162"/>
+      <vector name="rb" x="123" y="3"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="19" value="../stand/0"/>
+    <uol name="20" value="../stand/1"/>
+    <uol name="21" value="../stand/2"/>
+    <uol name="22" value="../stand/3"/>
+    <uol name="23" value="../stand/4"/>
+    <uol name="24" value="../stand/5"/>
+    <uol name="25" value="../stand/6"/>
+    <uol name="26" value="../stand/7"/>
+    <uol name="27" value="../stand/8"/>
+    <uol name="28" value="../stand/9"/>
+  </imgdir>
+  <imgdir name="skill1">
+    <uol name="0" value="../attack1/0"/>
+    <uol name="1" value="../attack1/1"/>
+    <uol name="2" value="../attack1/2"/>
+    <uol name="3" value="../attack1/3"/>
+    <uol name="4" value="../attack1/4"/>
+    <uol name="5" value="../attack1/5"/>
+    <uol name="6" value="../attack1/6"/>
+    <uol name="7" value="../attack1/7"/>
+    <uol name="8" value="../attack1/8"/>
+    <uol name="9" value="../attack1/7"/>
+    <uol name="10" value="../attack1/6"/>
+    <uol name="11" value="../attack1/5"/>
+    <uol name="12" value="../attack1/4"/>
+    <uol name="13" value="../attack1/3"/>
+    <uol name="14" value="../attack1/2"/>
+    <uol name="15" value="../attack1/0"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="239" height="201">
+      <vector name="origin" x="101" y="201"/>
+      <vector name="lt" x="-102" y="-187"/>
+      <vector name="rb" x="137" y="0"/>
+      <vector name="head" x="9" y="-153"/>
+      <int name="delay" value="600"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="呃！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="253" height="194">
+      <vector name="origin" x="121" y="192"/>
+      <vector name="head" x="-6" y="-148"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="250" height="195">
+      <vector name="origin" x="119" y="194"/>
+      <vector name="head" x="-4" y="-150"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="223" height="195">
+      <vector name="origin" x="104" y="205"/>
+      <vector name="head" x="6" y="-160"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="175" height="199">
+      <vector name="origin" x="49" y="228"/>
+      <vector name="head" x="25" y="-179"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="166" height="199">
+      <vector name="origin" x="39" y="229"/>
+      <vector name="head" x="27" y="-178"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="158" height="188">
+      <vector name="origin" x="30" y="228"/>
+      <vector name="head" x="27" y="-179"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="154" height="182">
+      <vector name="origin" x="22" y="214"/>
+      <vector name="head" x="33" y="-168"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="148" height="175">
+      <vector name="origin" x="17" y="189"/>
+      <vector name="head" x="38" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="141" height="155">
+      <vector name="origin" x="15" y="151"/>
+      <vector name="head" x="32" y="-125"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="141" height="154">
+      <vector name="origin" x="15" y="152"/>
+      <vector name="head" x="33" y="-124"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="141" height="153">
+      <vector name="origin" x="15" y="152"/>
+      <vector name="head" x="34" y="-124"/>
+      <int name="delay" value="150"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我只是想好好享受日光浴……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/5220002.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/5220002.img.xml
@@ -1,0 +1,522 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="5220002.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="50"/>
+    <int name="maxHP" value="9800"/>
+    <int name="maxMP" value="100"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="165"/>
+    <int name="PDDamage" value="110"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="150"/>
+    <int name="acc" value="100"/>
+    <int name="eva" value="20"/>
+    <int name="exp" value="410"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="600"/>
+    <int name="hpRecovery" value="800"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="18"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="110"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="113"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="84"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="skill" value="140"/>
+        <int name="action" value="1"/>
+        <int name="level" value="12"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="default">
+      <canvas name="0" width="135" height="210">
+        <vector name="origin" x="67" y="105"/>
+        <int name="z" value="0"/>
+      </canvas>
+    </imgdir>
+    <imgdir name="speak">
+      <imgdir name="0">
+        <int name="hp" value="80000"/>
+        <string name="0" value="别再烦我了……求、求你让我一个人待着……"/>
+      </imgdir>
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="2222"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+        <imgdir name="1">
+          <int name="pet" value="5000011"/>
+        </imgdir>
+        <imgdir name="2">
+          <int name="pet" value="5000026"/>
+        </imgdir>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="155" height="240">
+      <vector name="origin" x="91" y="240"/>
+      <vector name="lt" x="-91" y="-163"/>
+      <vector name="rb" x="82" y="-1"/>
+      <vector name="head" x="-17" y="-162"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="160" height="241">
+      <vector name="origin" x="91" y="241"/>
+      <vector name="lt" x="-91" y="-163"/>
+      <vector name="rb" x="68" y="0"/>
+      <vector name="head" x="-17" y="-164"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="169" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-91" y="-163"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="-17" y="-162"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="173" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-91" y="-163"/>
+      <vector name="rb" x="82" y="-1"/>
+      <vector name="head" x="-17" y="-167"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="184" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-91" y="-163"/>
+      <vector name="rb" x="92" y="-1"/>
+      <vector name="head" x="-17" y="-164"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="173" height="241">
+      <vector name="origin" x="91" y="241"/>
+      <vector name="lt" x="-91" y="-163"/>
+      <vector name="rb" x="82" y="-1"/>
+      <vector name="head" x="-17" y="-161"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="156" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="65" y="-1"/>
+      <vector name="head" x="-16" y="-164"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="162" height="241">
+      <vector name="origin" x="91" y="241"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="71" y="-1"/>
+      <vector name="head" x="-16" y="-162"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="167" height="240">
+      <vector name="origin" x="91" y="240"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-16" y="-162"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="173" height="241">
+      <vector name="origin" x="91" y="241"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-16" y="-161"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="184" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="93" y="1"/>
+      <vector name="head" x="-16" y="-163"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="173" height="243">
+      <vector name="origin" x="91" y="243"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="82" y="-1"/>
+      <vector name="head" x="-16" y="-163"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="156" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="64" y="-1"/>
+      <vector name="head" x="-16" y="-164"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="162" height="241">
+      <vector name="origin" x="91" y="241"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="71" y="-1"/>
+      <vector name="head" x="-16" y="-165"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="167" height="240">
+      <vector name="origin" x="91" y="240"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-16" y="-162"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="173" height="241">
+      <vector name="origin" x="91" y="241"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="82" y="-1"/>
+      <vector name="head" x="-16" y="-162"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="184" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="93" y="0"/>
+      <vector name="head" x="-16" y="-162"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="173" height="243">
+      <vector name="origin" x="91" y="243"/>
+      <vector name="lt" x="-91" y="-164"/>
+      <vector name="rb" x="82" y="-1"/>
+      <vector name="head" x="-16" y="-163"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <int name="r" value="160"/>
+        <vector name="sp" x="-111" y="-46"/>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="27" height="42">
+          <vector name="origin" x="-4" y="21"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="1" width="36" height="38">
+          <vector name="origin" x="2" y="23"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="2" width="36" height="39">
+          <vector name="origin" x="1" y="17"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="3" width="39" height="35">
+          <vector name="origin" x="0" y="15"/>
+          <int name="delay" value="60"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="84" height="83">
+          <vector name="origin" x="42" y="77"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="64" height="72">
+          <vector name="origin" x="33" y="69"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="56" height="58">
+          <vector name="origin" x="29" y="64"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="2"/>
+      <int name="attackAfter" value="1500"/>
+      <int name="bulletSpeed" value="140"/>
+      <int name="PADamage" value="190"/>
+    </imgdir>
+    <canvas name="0" width="156" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="65" y="1"/>
+      <vector name="head" x="-17" y="-163"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="187" height="244">
+      <vector name="origin" x="90" y="244"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="72" y="1"/>
+      <vector name="head" x="-17" y="-164"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="187" height="255">
+      <vector name="origin" x="94" y="250"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="78" y="1"/>
+      <vector name="head" x="-17" y="-166"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="186" height="257">
+      <vector name="origin" x="95" y="250"/>
+      <vector name="lt" x="-90" y="-155"/>
+      <vector name="rb" x="85" y="1"/>
+      <vector name="head" x="-13" y="-166"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="198" height="257">
+      <vector name="origin" x="94" y="249"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="96" y="-1"/>
+      <vector name="head" x="-11" y="-169"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="188" height="258">
+      <vector name="origin" x="93" y="249"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="88" y="1"/>
+      <vector name="head" x="-11" y="-169"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="171" height="260">
+      <vector name="origin" x="93" y="251"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="74" y="1"/>
+      <vector name="head" x="-9" y="-171"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="178" height="262">
+      <vector name="origin" x="93" y="253"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="76" y="1"/>
+      <vector name="head" x="-11" y="-171"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="185" height="263">
+      <vector name="origin" x="93" y="254"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="83" y="1"/>
+      <vector name="head" x="-9" y="-171"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="232" height="264">
+      <vector name="origin" x="110" y="252"/>
+      <vector name="lt" x="-102" y="-155"/>
+      <vector name="rb" x="112" y="1"/>
+      <vector name="head" x="-26" y="-153"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="228" height="261">
+      <vector name="origin" x="109" y="249"/>
+      <vector name="lt" x="-106" y="-150"/>
+      <vector name="rb" x="110" y="1"/>
+      <vector name="head" x="-28" y="-151"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="191" height="252">
+      <vector name="origin" x="103" y="247"/>
+      <vector name="lt" x="-101" y="-147"/>
+      <vector name="rb" x="85" y="-1"/>
+      <vector name="head" x="-24" y="-155"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="走开！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="158" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="65" y="1"/>
+      <vector name="head" x="-17" y="-164"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="160" height="244">
+      <vector name="origin" x="91" y="244"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="69" y="1"/>
+      <vector name="head" x="-17" y="-164"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="178" height="250">
+      <vector name="origin" x="96" y="245"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="74" y="1"/>
+      <vector name="head" x="-17" y="-166"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="187" height="253">
+      <vector name="origin" x="98" y="246"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="78" y="1"/>
+      <vector name="head" x="-17" y="-166"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="226" height="255">
+      <vector name="origin" x="99" y="247"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="117" y="1"/>
+      <vector name="head" x="-17" y="-167"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="226" height="256">
+      <vector name="origin" x="99" y="247"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="116" y="0"/>
+      <vector name="head" x="-17" y="-168"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="228" height="256">
+      <vector name="origin" x="100" y="247"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="120" y="0"/>
+      <vector name="head" x="-17" y="-169"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="228" height="256">
+      <vector name="origin" x="100" y="247"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="121" y="0"/>
+      <vector name="head" x="-16" y="-170"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="226" height="255">
+      <vector name="origin" x="100" y="247"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="120" y="-1"/>
+      <vector name="head" x="-17" y="-170"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="224" height="252">
+      <vector name="origin" x="101" y="247"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="119" y="0"/>
+      <vector name="head" x="-17" y="-169"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="204" height="252">
+      <vector name="origin" x="96" y="247"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="104" y="0"/>
+      <vector name="head" x="-17" y="-166"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="178" height="245">
+      <vector name="origin" x="91" y="245"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="86" y="1"/>
+      <vector name="head" x="-17" y="-165"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="158" height="244">
+      <vector name="origin" x="91" y="244"/>
+      <vector name="lt" x="-91" y="-155"/>
+      <vector name="rb" x="68" y="0"/>
+      <vector name="head" x="-17" y="-165"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="222" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-79" y="-157"/>
+      <vector name="rb" x="129" y="2"/>
+      <vector name="head" x="-5" y="-167"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="222" height="242">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="head" x="-4" y="-165"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="230" height="242">
+      <vector name="origin" x="94" y="242"/>
+      <vector name="head" x="0" y="-164"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="233" height="242">
+      <vector name="origin" x="95" y="242"/>
+      <vector name="head" x="3" y="-165"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="210" height="267">
+      <vector name="origin" x="71" y="267"/>
+      <vector name="head" x="4" y="-164"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="210" height="252">
+      <vector name="origin" x="70" y="252"/>
+      <vector name="head" x="4" y="-163"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="195" height="247">
+      <vector name="origin" x="70" y="241"/>
+      <vector name="head" x="5" y="-143"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="176" height="244">
+      <vector name="origin" x="70" y="238"/>
+      <vector name="head" x="5" y="-142"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="161" height="239">
+      <vector name="origin" x="70" y="232"/>
+      <vector name="head" x="3" y="-141"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="163" height="229">
+      <vector name="origin" x="70" y="222"/>
+      <vector name="head" x="4" y="-140"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="165" height="210">
+      <vector name="origin" x="70" y="207"/>
+      <vector name="head" x="5" y="-139"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="124" height="202">
+      <vector name="origin" x="31" y="205"/>
+      <vector name="head" x="26" y="-111"/>
+      <int name="delay" value="450"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我要诅咒你！"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/5220003.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/5220003.img.xml
@@ -1,0 +1,678 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="5220003.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="59"/>
+    <int name="maxHP" value="21000"/>
+    <int name="maxMP" value="200"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="200"/>
+    <int name="PDDamage" value="180"/>
+    <int name="MADamage" value="205"/>
+    <int name="MDDamage" value="230"/>
+    <int name="acc" value="150"/>
+    <int name="eva" value="20"/>
+    <int name="exp" value="650"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1100"/>
+    <int name="hpRecovery" value="1200"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="17"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="110"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="113"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="123"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="skill" value="140"/>
+        <int name="action" value="1"/>
+        <int name="level" value="12"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="6">
+        <int name="skill" value="141"/>
+        <int name="action" value="1"/>
+        <int name="level" value="3"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="8"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+        </imgdir>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="19500"/>
+        <string name="0" value="呵呵……时间是无法停止的！"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="146" height="146">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="144" height="147">
+      <vector name="origin" x="69" y="149"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-6"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="144" height="145">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="-5" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="144" height="145">
+      <vector name="origin" x="69" y="151"/>
+      <vector name="lt" x="-71" y="-152"/>
+      <vector name="rb" x="75" y="-7"/>
+      <vector name="head" x="-4" y="-151"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="144" height="146">
+      <vector name="origin" x="68" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="76" y="-4"/>
+      <vector name="head" x="-3" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="146" height="147">
+      <vector name="origin" x="69" y="149"/>
+      <vector name="lt" x="-70" y="-150"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="-2" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="146" height="145">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="145" height="144">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-6"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="144" height="143">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="-4" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="145" height="145">
+      <vector name="origin" x="70" y="151"/>
+      <vector name="lt" x="-71" y="-152"/>
+      <vector name="rb" x="75" y="-7"/>
+      <vector name="head" x="-4" y="-151"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="146" height="146">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="76" y="-4"/>
+      <vector name="head" x="-4" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="147" height="147">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-70" y="-150"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="-2" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="146" height="145">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="145" height="144">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="75" y="-5"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="144" height="143">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-70" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="-4" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="145" height="145">
+      <vector name="origin" x="70" y="151"/>
+      <vector name="lt" x="-70" y="-152"/>
+      <vector name="rb" x="75" y="-6"/>
+      <vector name="head" x="-5" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="146" height="146">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="-3" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="147" height="147">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-70" y="-151"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="-3" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-41" y="-14"/>
+        <int name="r" value="320"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="99" height="107">
+          <vector name="origin" x="52" y="87"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="80" height="94">
+          <vector name="origin" x="39" y="86"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="39" height="43">
+          <vector name="origin" x="16" y="95"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="36" height="44">
+          <vector name="origin" x="14" y="106"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="14" height="16">
+          <vector name="origin" x="-5" y="90"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="1"/>
+      <int name="magic" value="1"/>
+      <int name="attackAfter" value="2160"/>
+      <int name="bulletSpeed" value="140"/>
+      <int name="knockback" value="1"/>
+    </imgdir>
+    <canvas name="0" width="146" height="146">
+      <vector name="origin" x="70" y="152"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="146" height="148">
+      <vector name="origin" x="70" y="153"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-6"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="152" height="156">
+      <vector name="origin" x="74" y="157"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="154" height="161">
+      <vector name="origin" x="75" y="159"/>
+      <vector name="lt" x="-71" y="-152"/>
+      <vector name="rb" x="75" y="-7"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="160" height="156">
+      <vector name="origin" x="78" y="158"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="76" y="-4"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="160" height="156">
+      <vector name="origin" x="78" y="158"/>
+      <vector name="lt" x="-70" y="-150"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="164" height="155">
+      <vector name="origin" x="80" y="157"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="140" height="155">
+      <vector name="origin" x="70" y="157"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="75" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="145" height="155">
+      <vector name="origin" x="69" y="157"/>
+      <vector name="lt" x="-70" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="141" height="155">
+      <vector name="origin" x="67" y="157"/>
+      <vector name="lt" x="-70" y="-152"/>
+      <vector name="rb" x="75" y="-6"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="149" height="164">
+      <vector name="origin" x="71" y="162"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="166" height="169">
+      <vector name="origin" x="73" y="164"/>
+      <vector name="lt" x="-70" y="-151"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="175" height="168">
+      <vector name="origin" x="82" y="164"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="189" height="167">
+      <vector name="origin" x="96" y="163"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-6"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="193" height="165">
+      <vector name="origin" x="106" y="162"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="200" height="162">
+      <vector name="origin" x="119" y="161"/>
+      <vector name="lt" x="-71" y="-152"/>
+      <vector name="rb" x="75" y="-7"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="210" height="155">
+      <vector name="origin" x="137" y="157"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="76" y="-4"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="218" height="155">
+      <vector name="origin" x="142" y="157"/>
+      <vector name="lt" x="-70" y="-150"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="189" height="155">
+      <vector name="origin" x="119" y="157"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="187" height="155">
+      <vector name="origin" x="117" y="157"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="75" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="143" height="156">
+      <vector name="origin" x="70" y="158"/>
+      <vector name="lt" x="-70" y="-157"/>
+      <vector name="rb" x="75" y="-6"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="144" height="156">
+      <vector name="origin" x="70" y="158"/>
+      <vector name="lt" x="-71" y="-158"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="146" height="156">
+      <vector name="origin" x="70" y="158"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="146" height="157">
+      <vector name="origin" x="70" y="159"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="146" height="148">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="146" height="146">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="即使在时间之中，也存在光与黑暗。记住这一点！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="146" height="146">
+      <vector name="origin" x="70" y="152"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="146" height="148">
+      <vector name="origin" x="70" y="153"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-6"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="152" height="156">
+      <vector name="origin" x="74" y="157"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="154" height="161">
+      <vector name="origin" x="75" y="159"/>
+      <vector name="lt" x="-71" y="-152"/>
+      <vector name="rb" x="75" y="-7"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="160" height="156">
+      <vector name="origin" x="78" y="158"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="76" y="-4"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="160" height="156">
+      <vector name="origin" x="78" y="158"/>
+      <vector name="lt" x="-70" y="-150"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="164" height="155">
+      <vector name="origin" x="80" y="157"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="140" height="155">
+      <vector name="origin" x="70" y="157"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="75" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="145" height="155">
+      <vector name="origin" x="69" y="157"/>
+      <vector name="lt" x="-70" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="141" height="155">
+      <vector name="origin" x="67" y="157"/>
+      <vector name="lt" x="-70" y="-152"/>
+      <vector name="rb" x="75" y="-6"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="149" height="164">
+      <vector name="origin" x="71" y="162"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="166" height="169">
+      <vector name="origin" x="73" y="164"/>
+      <vector name="lt" x="-70" y="-151"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="175" height="168">
+      <vector name="origin" x="82" y="164"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="189" height="167">
+      <vector name="origin" x="96" y="163"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-6"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="193" height="165">
+      <vector name="origin" x="106" y="162"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="200" height="162">
+      <vector name="origin" x="119" y="161"/>
+      <vector name="lt" x="-71" y="-152"/>
+      <vector name="rb" x="75" y="-7"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="210" height="155">
+      <vector name="origin" x="137" y="157"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="76" y="-4"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="218" height="155">
+      <vector name="origin" x="142" y="157"/>
+      <vector name="lt" x="-70" y="-150"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="189" height="155">
+      <vector name="origin" x="119" y="157"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="187" height="155">
+      <vector name="origin" x="117" y="157"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="75" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="143" height="156">
+      <vector name="origin" x="70" y="158"/>
+      <vector name="lt" x="-70" y="-152"/>
+      <vector name="rb" x="75" y="-6"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="144" height="156">
+      <vector name="origin" x="70" y="158"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="146" height="156">
+      <vector name="origin" x="70" y="158"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="146" height="157">
+      <vector name="origin" x="70" y="159"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="146" height="148">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="146" height="146">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="2" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="166" height="169">
+      <vector name="origin" x="72" y="173"/>
+      <vector name="lt" x="-67" y="-165"/>
+      <vector name="rb" x="86" y="-8"/>
+      <vector name="head" x="4" y="-157"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="147" height="158">
+      <vector name="origin" x="63" y="162"/>
+      <vector name="head" x="4" y="-156"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="144" height="155">
+      <vector name="origin" x="58" y="157"/>
+      <vector name="head" x="7" y="-156"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="144" height="156">
+      <vector name="origin" x="57" y="152"/>
+      <vector name="head" x="7" y="-152"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="144" height="149">
+      <vector name="origin" x="55" y="145"/>
+      <vector name="head" x="9" y="-139"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="144" height="147">
+      <vector name="origin" x="54" y="141"/>
+      <vector name="head" x="10" y="-137"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="146" height="147">
+      <vector name="origin" x="55" y="139"/>
+      <vector name="head" x="1" y="-137"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="146" height="147">
+      <vector name="origin" x="54" y="138"/>
+      <vector name="head" x="12" y="-133"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="143" height="26">
+      <vector name="origin" x="56" y="32"/>
+      <vector name="head" x="14" y="-37"/>
+      <int name="delay" value="450"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我又要回到过去了吗……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/5220004.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/5220004.img.xml
@@ -1,0 +1,707 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="5220004.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="50"/>
+    <int name="maxHP" value="15000"/>
+    <int name="maxMP" value="200"/>
+    <int name="speed" value="-20"/>
+    <int name="PADamage" value="180"/>
+    <int name="PDDamage" value="150"/>
+    <int name="MADamage" value="200"/>
+    <int name="MDDamage" value="150"/>
+    <int name="acc" value="150"/>
+    <int name="eva" value="27"/>
+    <int name="exp" value="425"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <imgdir name="speak">
+      <imgdir name="0">
+        <int name="hp" value="13000"/>
+        <string name="0" value="咕噜……低贱的人类竟敢挑战我！"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="195" height="137">
+      <vector name="origin" x="97" y="137"/>
+      <vector name="lt" x="-97" y="-137"/>
+      <vector name="rb" x="98" y="0"/>
+      <vector name="head" x="-64" y="-84"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="1" width="188" height="138">
+      <vector name="origin" x="94" y="137"/>
+      <vector name="lt" x="-94" y="-137"/>
+      <vector name="rb" x="94" y="1"/>
+      <vector name="head" x="-62" y="-83"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="2" width="184" height="135">
+      <vector name="origin" x="91" y="136"/>
+      <vector name="lt" x="-91" y="-136"/>
+      <vector name="rb" x="93" y="-1"/>
+      <vector name="head" x="-59" y="-83"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="3" width="188" height="138">
+      <vector name="origin" x="93" y="137"/>
+      <vector name="lt" x="-93" y="-137"/>
+      <vector name="rb" x="95" y="1"/>
+      <vector name="head" x="-61" y="-84"/>
+      <int name="delay" value="240"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="189" height="137">
+      <vector name="origin" x="97" y="137"/>
+      <vector name="lt" x="-97" y="-137"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="-64" y="-84"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="1" width="188" height="138">
+      <vector name="origin" x="94" y="138"/>
+      <vector name="lt" x="-94" y="-138"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="-61" y="-85"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="2" width="191" height="136">
+      <vector name="origin" x="92" y="136"/>
+      <vector name="lt" x="-92" y="-136"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-61" y="-83"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="3" width="191" height="132">
+      <vector name="origin" x="90" y="132"/>
+      <vector name="lt" x="-90" y="-132"/>
+      <vector name="rb" x="101" y="0"/>
+      <vector name="head" x="-59" y="-81"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="4" width="191" height="136">
+      <vector name="origin" x="92" y="136"/>
+      <vector name="lt" x="-92" y="-136"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-60" y="-83"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="5" width="189" height="138">
+      <vector name="origin" x="95" y="138"/>
+      <vector name="lt" x="-95" y="-138"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="-61" y="-84"/>
+      <int name="delay" value="240"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-136" y="-139"/>
+        <vector name="rb" x="146" y="6"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="49" height="46">
+          <vector name="origin" x="24" y="73"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="62" height="59">
+          <vector name="origin" x="31" y="79"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="67" height="64">
+          <vector name="origin" x="33" y="82"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="73" height="66">
+          <vector name="origin" x="36" y="86"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="77" height="71">
+          <vector name="origin" x="38" y="85"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="81" height="75">
+          <vector name="origin" x="40" y="87"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="84" height="79">
+          <vector name="origin" x="42" y="89"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="840"/>
+      <string name="elemAttr" value="S"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="189" height="137">
+      <vector name="origin" x="97" y="137"/>
+      <vector name="lt" x="-97" y="-137"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="-64" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="188" height="138">
+      <vector name="origin" x="94" y="138"/>
+      <vector name="lt" x="-94" y="-138"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="-61" y="-85"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="191" height="136">
+      <vector name="origin" x="92" y="136"/>
+      <vector name="lt" x="-92" y="-136"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-60" y="-83"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="191" height="132">
+      <vector name="origin" x="90" y="132"/>
+      <vector name="lt" x="-90" y="-132"/>
+      <vector name="rb" x="101" y="0"/>
+      <vector name="head" x="-59" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="189" height="131">
+      <vector name="origin" x="89" y="131"/>
+      <vector name="lt" x="-89" y="-131"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-58" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="184" height="137">
+      <vector name="origin" x="88" y="130"/>
+      <vector name="lt" x="-89" y="-131"/>
+      <vector name="rb" x="95" y="6"/>
+      <vector name="head" x="-55" y="-79"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="193" height="137">
+      <vector name="origin" x="92" y="130"/>
+      <vector name="lt" x="-98" y="-133"/>
+      <vector name="rb" x="95" y="4"/>
+      <vector name="head" x="-60" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="269" height="147">
+      <vector name="origin" x="130" y="139"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="112" y="8"/>
+      <vector name="head" x="-69" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="277" height="147">
+      <vector name="origin" x="134" y="139"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="112" y="8"/>
+      <vector name="head" x="-72" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="281" height="147">
+      <vector name="origin" x="136" y="139"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="112" y="8"/>
+      <vector name="head" x="-70" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="282" height="146">
+      <vector name="origin" x="136" y="139"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="112" y="8"/>
+      <vector name="head" x="-72" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="207" height="146">
+      <vector name="origin" x="105" y="139"/>
+      <vector name="lt" x="-105" y="-139"/>
+      <vector name="rb" x="102" y="6"/>
+      <vector name="head" x="-71" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="269" height="147">
+      <vector name="origin" x="130" y="139"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="112" y="8"/>
+      <vector name="head" x="-70" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="277" height="147">
+      <vector name="origin" x="134" y="139"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="112" y="8"/>
+      <vector name="head" x="-72" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="281" height="147">
+      <vector name="origin" x="136" y="139"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="112" y="8"/>
+      <vector name="head" x="-70" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="282" height="145">
+      <vector name="origin" x="136" y="139"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="109" y="6"/>
+      <vector name="head" x="-71" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我要诅咒你！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-248" y="-102"/>
+        <vector name="rb" x="282" y="8"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="78" height="73">
+          <vector name="origin" x="39" y="71"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="85" height="80">
+          <vector name="origin" x="42" y="75"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="85" height="84">
+          <vector name="origin" x="42" y="77"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="83" height="84">
+          <vector name="origin" x="41" y="77"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="16" height="2">
+          <vector name="origin" x="77" y="2"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="241" height="11">
+          <vector name="origin" x="129" y="7"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="396" height="42">
+          <vector name="origin" x="181" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="495" height="106">
+          <vector name="origin" x="228" y="99"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="501" height="107">
+          <vector name="origin" x="231" y="100"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="515" height="108">
+          <vector name="origin" x="240" y="100"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="521" height="109">
+          <vector name="origin" x="243" y="101"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="529" height="107">
+          <vector name="origin" x="247" y="100"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="507" height="106">
+          <vector name="origin" x="235" y="98"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="525" height="44">
+          <vector name="origin" x="245" y="37"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1520"/>
+      <int name="effectAfter" value="1040"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="188" height="137">
+      <vector name="origin" x="106" y="137"/>
+      <vector name="lt" x="-92" y="-137"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-60" y="-83"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="186" height="137">
+      <vector name="origin" x="106" y="137"/>
+      <vector name="lt" x="-92" y="-137"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-60" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="213" height="137">
+      <vector name="origin" x="132" y="137"/>
+      <vector name="lt" x="-92" y="-137"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-60" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="211" height="145">
+      <vector name="origin" x="132" y="139"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="78" y="6"/>
+      <vector name="head" x="-69" y="-77"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="210" height="172">
+      <vector name="origin" x="132" y="166"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-70" y="-77"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="244" height="172">
+      <vector name="origin" x="131" y="166"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-71" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="257" height="172">
+      <vector name="origin" x="142" y="166"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-71" y="-77"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="259" height="172">
+      <vector name="origin" x="142" y="166"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-71" y="-75"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="236" height="172">
+      <vector name="origin" x="141" y="166"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-72" y="-76"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="236" height="170">
+      <vector name="origin" x="141" y="165"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-72" y="-75"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="235" height="170">
+      <vector name="origin" x="140" y="165"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-72" y="-77"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="216" height="168">
+      <vector name="origin" x="125" y="164"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-72" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="182" height="138">
+      <vector name="origin" x="105" y="138"/>
+      <vector name="lt" x="-105" y="-139"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="-72" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="182" height="139">
+      <vector name="origin" x="105" y="138"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="-71" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="182" height="138">
+      <vector name="origin" x="105" y="137"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="77" y="0"/>
+      <vector name="head" x="-72" y="-79"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="198" height="137">
+      <vector name="origin" x="97" y="136"/>
+      <vector name="lt" x="-96" y="-136"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-63" y="-83"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="60"/>
+      <string name="0" value="真是愚蠢！！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-300" y="-139"/>
+        <vector name="rb" x="0" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="16" height="2">
+          <vector name="origin" x="8" y="2"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="22" height="11">
+          <vector name="origin" x="11" y="11"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="78" height="73">
+          <vector name="origin" x="35" y="69"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="85" height="111">
+          <vector name="origin" x="40" y="103"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="85" height="115">
+          <vector name="origin" x="37" y="103"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="86" height="115">
+          <vector name="origin" x="37" y="102"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="83" height="84">
+          <vector name="origin" x="36" y="72"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1520"/>
+      <int name="effectAfter" value="1040"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="198" height="137">
+      <vector name="origin" x="97" y="137"/>
+      <vector name="lt" x="-97" y="-137"/>
+      <vector name="rb" x="101" y="0"/>
+      <vector name="head" x="-64" y="-82"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="183" height="136">
+      <vector name="origin" x="92" y="136"/>
+      <vector name="lt" x="-92" y="-136"/>
+      <vector name="rb" x="91" y="0"/>
+      <vector name="head" x="-60" y="-82"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="174" height="132">
+      <vector name="origin" x="90" y="132"/>
+      <vector name="lt" x="-90" y="-132"/>
+      <vector name="rb" x="84" y="0"/>
+      <vector name="head" x="-59" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="183" height="131">
+      <vector name="origin" x="89" y="131"/>
+      <vector name="lt" x="-89" y="-131"/>
+      <vector name="rb" x="80" y="0"/>
+      <vector name="head" x="-59" y="-79"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="186" height="130">
+      <vector name="origin" x="88" y="130"/>
+      <vector name="lt" x="-88" y="-130"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-58" y="-78"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="198" height="139">
+      <vector name="origin" x="104" y="139"/>
+      <vector name="lt" x="-104" y="-139"/>
+      <vector name="rb" x="80" y="0"/>
+      <vector name="head" x="-70" y="-79"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="221" height="139">
+      <vector name="origin" x="105" y="139"/>
+      <vector name="lt" x="-105" y="-139"/>
+      <vector name="rb" x="96" y="0"/>
+      <vector name="head" x="-72" y="-79"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="223" height="138">
+      <vector name="origin" x="105" y="138"/>
+      <vector name="lt" x="-105" y="-138"/>
+      <vector name="rb" x="96" y="0"/>
+      <vector name="head" x="-72" y="-78"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="225" height="139">
+      <vector name="origin" x="105" y="139"/>
+      <vector name="lt" x="-105" y="-139"/>
+      <vector name="rb" x="96" y="0"/>
+      <vector name="head" x="-72" y="-79"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="203" height="138">
+      <vector name="origin" x="105" y="138"/>
+      <vector name="lt" x="-105" y="-138"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-72" y="-78"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="203" height="139">
+      <vector name="origin" x="105" y="139"/>
+      <vector name="lt" x="-105" y="-139"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-72" y="-79"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="203" height="138">
+      <vector name="origin" x="105" y="138"/>
+      <vector name="lt" x="-105" y="-138"/>
+      <vector name="rb" x="77" y="0"/>
+      <vector name="head" x="-72" y="-78"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="199" height="139">
+      <vector name="origin" x="105" y="139"/>
+      <vector name="lt" x="-105" y="-139"/>
+      <vector name="rb" x="77" y="0"/>
+      <vector name="head" x="-72" y="-79"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="182" height="138">
+      <vector name="origin" x="105" y="138"/>
+      <vector name="lt" x="-105" y="-138"/>
+      <vector name="rb" x="77" y="0"/>
+      <vector name="head" x="-72" y="-78"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="1" width="197" height="136">
+      <vector name="origin" x="105" y="136"/>
+      <vector name="lt" x="-105" y="-136"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="-57" y="-82"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="197" height="136">
+      <vector name="origin" x="105" y="136"/>
+      <vector name="head" x="-57" y="-82"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="197" height="136">
+      <vector name="origin" x="105" y="136"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="199" height="136">
+      <vector name="origin" x="107" y="136"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="202" height="154">
+      <vector name="origin" x="110" y="154"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="205" height="161">
+      <vector name="origin" x="113" y="161"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="205" height="162">
+      <vector name="origin" x="113" y="162"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="206" height="164">
+      <vector name="origin" x="114" y="164"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="192" height="164">
+      <vector name="origin" x="100" y="164"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="193" height="166">
+      <vector name="origin" x="101" y="166"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="158" height="166">
+      <vector name="origin" x="66" y="166"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="154" height="136">
+      <vector name="origin" x="62" y="136"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="157" height="115">
+      <vector name="origin" x="65" y="113"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="160" height="123">
+      <vector name="origin" x="68" y="115"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="160" height="127">
+      <vector name="origin" x="68" y="115"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="168" height="129">
+      <vector name="origin" x="69" y="117"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="154" height="105">
+      <vector name="origin" x="52" y="88"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="151" height="89">
+      <vector name="origin" x="46" y="70"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="153" height="93">
+      <vector name="origin" x="47" y="70"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="119" height="83">
+      <vector name="origin" x="9" y="72"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="120"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我活了百年，竟会这样迎来终结？"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/6220000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/6220000.img.xml
@@ -1,0 +1,356 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="6220000.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="65"/>
+    <int name="maxHP" value="31000"/>
+    <int name="maxMP" value="200"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="190"/>
+    <int name="PDDamage" value="190"/>
+    <int name="MADamage" value="200"/>
+    <int name="MDDamage" value="220"/>
+    <int name="acc" value="150"/>
+    <int name="eva" value="30"/>
+    <int name="exp" value="810"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1500"/>
+    <int name="hpRecovery" value="1400"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="17"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="110"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="4"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="113"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="140"/>
+        <int name="action" value="1"/>
+        <int name="level" value="8"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="1"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="2213"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+        <imgdir name="1">
+          <int name="pet" value="5000009"/>
+        </imgdir>
+        <imgdir name="2">
+          <int name="pet" value="5000010"/>
+        </imgdir>
+      </imgdir>
+      <imgdir name="0">
+        <int name="hp" value="28000"/>
+        <string name="0" value="冲锋！"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="176" height="150">
+      <vector name="origin" x="99" y="150"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="1" width="175" height="150">
+      <vector name="origin" x="99" y="151"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="2" width="175" height="150">
+      <vector name="origin" x="99" y="149"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="3" width="178" height="150">
+      <vector name="origin" x="99" y="150"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="4" width="179" height="150">
+      <vector name="origin" x="99" y="151"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="5" width="178" height="150">
+      <vector name="origin" x="99" y="149"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="210"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="176" height="151">
+      <vector name="origin" x="99" y="151"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="176" height="154">
+      <vector name="origin" x="99" y="154"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="176" height="145">
+      <vector name="origin" x="99" y="145"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="176" height="154">
+      <vector name="origin" x="99" y="154"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="176" height="145">
+      <vector name="origin" x="99" y="145"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="217" height="151">
+      <vector name="origin" x="128" y="151"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="89" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="219" height="151">
+      <vector name="origin" x="130" y="151"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="88" y="-1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="220" height="151">
+      <vector name="origin" x="132" y="151"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="87" y="-1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="211" height="151">
+      <vector name="origin" x="135" y="151"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="176" height="151">
+      <vector name="origin" x="99" y="151"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="176" height="192">
+      <vector name="origin" x="99" y="192"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="176" height="190">
+      <vector name="origin" x="99" y="190"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="176" height="190">
+      <vector name="origin" x="99" y="190"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="176" height="190">
+      <vector name="origin" x="99" y="190"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="191" height="191">
+      <vector name="origin" x="99" y="191"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="192" height="194">
+      <vector name="origin" x="99" y="194"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="244" height="173">
+      <vector name="origin" x="124" y="158"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="237" height="169">
+      <vector name="origin" x="123" y="154"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="214" height="168">
+      <vector name="origin" x="117" y="152"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="218" height="165">
+      <vector name="origin" x="117" y="152"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="229" height="165">
+      <vector name="origin" x="125" y="155"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="233" height="161">
+      <vector name="origin" x="121" y="155"/>
+      <vector name="lt" x="-99" y="-149"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="7" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="70"/>
+      <string name="0" value="振作起来！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="219" height="170">
+      <vector name="origin" x="117" y="169"/>
+      <vector name="lt" x="-106" y="-146"/>
+      <vector name="rb" x="99" y="3"/>
+      <vector name="head" x="29" y="-174"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="176" height="151">
+      <vector name="origin" x="118" y="151"/>
+      <vector name="head" x="-13" y="-151"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="219" height="170">
+      <vector name="origin" x="117" y="169"/>
+      <vector name="head" x="34" y="-176"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="216" height="174">
+      <vector name="origin" x="110" y="173"/>
+      <vector name="head" x="45" y="-180"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="217" height="171">
+      <vector name="origin" x="112" y="170"/>
+      <vector name="head" x="54" y="-177"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="215" height="163">
+      <vector name="origin" x="111" y="162"/>
+      <vector name="head" x="63" y="-167"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="185" height="144">
+      <vector name="origin" x="81" y="142"/>
+      <vector name="head" x="42" y="-143"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="194" height="121">
+      <vector name="origin" x="81" y="116"/>
+      <vector name="head" x="17" y="-116"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="186" height="104">
+      <vector name="origin" x="81" y="97"/>
+      <vector name="head" x="18" y="-108"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="186" height="105">
+      <vector name="origin" x="81" y="96"/>
+      <vector name="head" x="22" y="-105"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="186" height="105">
+      <vector name="origin" x="81" y="95"/>
+      <vector name="head" x="16" y="-102"/>
+      <int name="delay" value="150"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="对不起，伯迪……我没能保护你……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/6220001.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/6220001.img.xml
@@ -1,0 +1,361 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="6220001.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="65"/>
+    <int name="maxHP" value="36000"/>
+    <int name="maxMP" value="300"/>
+    <int name="speed" value="-40"/>
+    <int name="PADamage" value="205"/>
+    <int name="PDDamage" value="210"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="200"/>
+    <int name="acc" value="150"/>
+    <int name="eva" value="29"/>
+    <int name="exp" value="940"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="5400"/>
+    <int name="hpRecovery" value="1500"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="mobType" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3453"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="30000"/>
+        <string name="0" value="＜警报声＞——攻击地球防御本部。攻击。"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="129" height="133">
+      <vector name="origin" x="69" y="133"/>
+      <vector name="lt" x="-69" y="-110"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-31" y="-102"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="130" height="140">
+      <vector name="origin" x="70" y="140"/>
+      <vector name="lt" x="-70" y="-122"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-31" y="-103"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="131" height="141">
+      <vector name="origin" x="71" y="141"/>
+      <vector name="lt" x="-71" y="-107"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-31" y="-100"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="137" height="143">
+      <vector name="origin" x="77" y="143"/>
+      <vector name="lt" x="-67" y="-110"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-31" y="-102"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="128" height="131">
+      <vector name="origin" x="68" y="131"/>
+      <vector name="lt" x="-68" y="-109"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-31" y="-103"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="128" height="126">
+      <vector name="origin" x="68" y="126"/>
+      <vector name="lt" x="-68" y="-108"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-31" y="-100"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="132" height="128">
+      <vector name="origin" x="65" y="128"/>
+      <vector name="lt" x="-65" y="-112"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-26" y="-103"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="130" height="132">
+      <vector name="origin" x="64" y="132"/>
+      <vector name="lt" x="-64" y="-107"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-27" y="-102"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="128" height="137">
+      <vector name="origin" x="63" y="137"/>
+      <vector name="lt" x="-63" y="-112"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-27" y="-101"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="128" height="140">
+      <vector name="origin" x="63" y="140"/>
+      <vector name="lt" x="-63" y="-111"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-27" y="-100"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="130" height="141">
+      <vector name="origin" x="64" y="141"/>
+      <vector name="lt" x="-64" y="-105"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-27" y="-100"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="132" height="129">
+      <vector name="origin" x="65" y="129"/>
+      <vector name="lt" x="-65" y="-102"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-27" y="-101"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-320" y="-60"/>
+        <vector name="rb" x="-10" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="80" height="43">
+          <vector name="origin" x="42" y="33"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="88" height="50">
+          <vector name="origin" x="48" y="41"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="99" height="53">
+          <vector name="origin" x="54" y="53"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="103" height="54">
+          <vector name="origin" x="56" y="54"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="104" height="55">
+          <vector name="origin" x="56" y="55"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="attackAfter" value="1080"/>
+      <int name="PADamage" value="230"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="knockback" value="1"/>
+    </imgdir>
+    <canvas name="0" width="128" height="126">
+      <vector name="origin" x="63" y="126"/>
+      <vector name="lt" x="-63" y="-110"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-26" y="-100"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="132" height="132">
+      <vector name="origin" x="65" y="131"/>
+      <vector name="lt" x="-63" y="-110"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-26" y="-100"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="138" height="145">
+      <vector name="origin" x="67" y="141"/>
+      <vector name="lt" x="-63" y="-110"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-23" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="142" height="154">
+      <vector name="origin" x="68" y="147"/>
+      <vector name="lt" x="-63" y="-110"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-21" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="144" height="154">
+      <vector name="origin" x="68" y="147"/>
+      <vector name="lt" x="-63" y="-110"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-19" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="144" height="143">
+      <vector name="origin" x="67" y="135"/>
+      <vector name="lt" x="-63" y="-110"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-17" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="144" height="141">
+      <vector name="origin" x="67" y="133"/>
+      <vector name="lt" x="-63" y="-110"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-17" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="146" height="146">
+      <vector name="origin" x="68" y="138"/>
+      <vector name="lt" x="-63" y="-110"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-17" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="146" height="154">
+      <vector name="origin" x="68" y="145"/>
+      <vector name="lt" x="-63" y="-110"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-17" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="173" height="150">
+      <vector name="origin" x="101" y="138"/>
+      <vector name="lt" x="-62" y="-93"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-31" y="-87"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="182" height="149">
+      <vector name="origin" x="111" y="139"/>
+      <vector name="lt" x="-64" y="-96"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-31" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="184" height="134">
+      <vector name="origin" x="114" y="125"/>
+      <vector name="lt" x="-62" y="-95"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-31" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="168" height="130">
+      <vector name="origin" x="99" y="122"/>
+      <vector name="lt" x="-61" y="-96"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-31" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="167" height="130">
+      <vector name="origin" x="100" y="126"/>
+      <vector name="lt" x="-61" y="-96"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-31" y="-90"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="160" height="128">
+      <vector name="origin" x="98" y="128"/>
+      <vector name="lt" x="-61" y="-96"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-31" y="-91"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="126" height="134">
+      <vector name="origin" x="64" y="134"/>
+      <vector name="lt" x="-63" y="-96"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-31" y="-93"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="126" height="135">
+      <vector name="origin" x="64" y="135"/>
+      <vector name="lt" x="-64" y="-99"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-31" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="126" height="124">
+      <vector name="origin" x="64" y="124"/>
+      <vector name="lt" x="-64" y="-103"/>
+      <vector name="rb" x="66" y="-1"/>
+      <vector name="head" x="-30" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="清除障碍。清除。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="128" height="153">
+      <vector name="origin" x="53" y="153"/>
+      <vector name="lt" x="-53" y="-106"/>
+      <vector name="rb" x="75" y="0"/>
+      <vector name="head" x="-16" y="-96"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="128" height="153">
+      <vector name="origin" x="53" y="153"/>
+      <vector name="head" x="-16" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="128" height="153">
+      <vector name="origin" x="53" y="153"/>
+      <vector name="head" x="-16" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="128" height="153">
+      <vector name="origin" x="53" y="153"/>
+      <vector name="head" x="-16" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="128" height="153">
+      <vector name="origin" x="53" y="153"/>
+      <vector name="head" x="-16" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="128" height="153">
+      <vector name="origin" x="53" y="153"/>
+      <vector name="head" x="-16" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="128" height="153">
+      <vector name="origin" x="53" y="153"/>
+      <vector name="head" x="-16" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="128" height="153">
+      <vector name="origin" x="53" y="153"/>
+      <vector name="head" x="-16" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="128" height="153">
+      <vector name="origin" x="53" y="153"/>
+      <vector name="head" x="-16" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="128" height="153">
+      <vector name="origin" x="53" y="153"/>
+      <vector name="head" x="-16" y="-96"/>
+      <int name="delay" value="300"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="任务完成！完……成……＜警报声＞"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/6300005.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/6300005.img.xml
@@ -1,0 +1,242 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="6300005.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="65"/>
+    <int name="maxHP" value="35000"/>
+    <int name="maxMP" value="220"/>
+    <int name="speed" value="5"/>
+    <int name="PADamage" value="250"/>
+    <int name="PDDamage" value="350"/>
+    <int name="MADamage" value="380"/>
+    <int name="MDDamage" value="400"/>
+    <int name="acc" value="155"/>
+    <int name="eva" value="30"/>
+    <int name="exp" value="1500"/>
+    <int name="undead" value="1"/>
+    <int name="pushed" value="1500"/>
+    <int name="hpRecovery" value="100"/>
+    <int name="mpRecovery" value="5"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="mobType" value="7"/>
+    <int name="rareItemDropLevel" value="2"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="118" height="102">
+      <vector name="origin" x="59" y="102"/>
+      <int name="delay" value="500"/>
+      <vector name="lt" x="-59" y="-102"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+    <canvas name="1" width="118" height="106">
+      <vector name="origin" x="60" y="105"/>
+      <int name="delay" value="100"/>
+      <vector name="lt" x="-60" y="-105"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+    <canvas name="2" width="118" height="102">
+      <vector name="origin" x="59" y="102"/>
+      <int name="delay" value="100"/>
+      <vector name="lt" x="-59" y="-103"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+    <canvas name="3" width="118" height="125">
+      <vector name="origin" x="59" y="180"/>
+      <int name="delay" value="300"/>
+      <vector name="lt" x="-59" y="-180"/>
+      <vector name="rb" x="59" y="-55"/>
+      <vector name="head" x="-1" y="-170"/>
+    </canvas>
+    <canvas name="4" width="118" height="125">
+      <vector name="origin" x="59" y="160"/>
+      <int name="delay" value="100"/>
+      <vector name="lt" x="-59" y="-160"/>
+      <vector name="rb" x="59" y="-35"/>
+      <vector name="head" x="-8" y="-149"/>
+    </canvas>
+    <uol name="5" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="118" height="99">
+      <vector name="origin" x="59" y="99"/>
+      <vector name="lt" x="-59" y="-99"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="jump">
+    <canvas name="0" width="118" height="151">
+      <vector name="origin" x="59" y="151"/>
+      <vector name="lt" x="-59" y="-125"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-5" y="-112"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-250" y="-150"/>
+        <vector name="rb" x="250" y="0"/>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="32" height="42">
+          <vector name="origin" x="46" y="63"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="41" height="53">
+          <vector name="origin" x="51" y="69"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="82" height="71">
+          <vector name="origin" x="58" y="78"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="88" height="75">
+          <vector name="origin" x="59" y="80"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="90" height="71">
+          <vector name="origin" x="53" y="75"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="5" width="59" height="76">
+          <vector name="origin" x="19" y="77"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="6" width="61" height="79">
+          <vector name="origin" x="19" y="78"/>
+          <int name="delay" value="200"/>
+        </canvas>
+        <canvas name="7" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="300"/>
+        </canvas>
+        <canvas name="8" width="217" height="51">
+          <vector name="origin" x="108" y="50"/>
+          <int name="delay" value="100"/>
+          <int name="z" value="1"/>
+        </canvas>
+        <canvas name="9" width="242" height="54">
+          <vector name="origin" x="122" y="54"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="10" width="254" height="56">
+          <vector name="origin" x="129" y="58"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="11" width="209" height="53">
+          <vector name="origin" x="101" y="60"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="12" width="209" height="43">
+          <vector name="origin" x="102" y="61"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="13" width="209" height="41">
+          <vector name="origin" x="103" y="64"/>
+          <int name="delay" value="200"/>
+        </canvas>
+        <canvas name="14" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="50"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="50"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="effectAfter" value="0"/>
+      <int name="attackAfter" value="1050"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="300"/>
+    </imgdir>
+    <canvas name="0" width="118" height="102">
+      <vector name="origin" x="59" y="102"/>
+      <vector name="lt" x="-59" y="-102"/>
+      <vector name="rb" x="59" y="0"/>
+      <int name="delay" value="800"/>
+      <vector name="head" x="-11" y="-82"/>
+    </canvas>
+    <canvas name="1" width="118" height="125">
+      <vector name="origin" x="59" y="213"/>
+      <vector name="lt" x="-59" y="-213"/>
+      <vector name="rb" x="58" y="-90"/>
+      <vector name="head" x="-3" y="-201"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="2" width="118" height="151">
+      <vector name="origin" x="59" y="220"/>
+      <vector name="lt" x="-59" y="-220"/>
+      <vector name="rb" x="59" y="-70"/>
+      <int name="delay" value="50"/>
+      <vector name="head" x="-4" y="-186"/>
+    </canvas>
+    <canvas name="3" width="118" height="151">
+      <vector name="origin" x="59" y="157"/>
+      <vector name="lt" x="-59" y="-157"/>
+      <vector name="rb" x="58" y="-7"/>
+      <int name="delay" value="50"/>
+      <vector name="head" x="-8" y="-122"/>
+    </canvas>
+    <canvas name="4" width="120" height="105">
+      <vector name="origin" x="58" y="105"/>
+      <vector name="lt" x="-58" y="-105"/>
+      <vector name="rb" x="62" y="0"/>
+      <int name="delay" value="750"/>
+      <vector name="head" x="-6" y="-85"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="118" height="161">
+      <vector name="origin" x="57" y="160"/>
+      <vector name="lt" x="-59" y="-140"/>
+      <vector name="rb" x="59" y="0"/>
+      <int name="delay" value="600"/>
+      <vector name="head" x="-6" y="-127"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="120" height="140">
+      <vector name="origin" x="60" y="140"/>
+      <vector name="head" x="-6" y="-82"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="1" width="138" height="68">
+      <vector name="origin" x="72" y="61"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="147" height="65">
+      <vector name="origin" x="76" y="57"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="154" height="65">
+      <vector name="origin" x="81" y="56"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="156" height="34">
+      <vector name="origin" x="80" y="30"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="450"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="死了……又死了一次……终于！"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/7120108.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/7120108.img.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="7120108.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="77"/>
+    <int name="maxHP" value="19000"/>
+    <int name="maxMP" value="160"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="325"/>
+    <int name="PDDamage" value="318"/>
+    <int name="MADamage" value="375"/>
+    <int name="MDDamage" value="400"/>
+    <int name="acc" value="168"/>
+    <int name="eva" value="22"/>
+    <int name="exp" value="462"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1520"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3730"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="95" height="92">
+      <vector name="origin" x="55" y="92"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="99" height="99">
+      <vector name="origin" x="55" y="99"/>
+      <vector name="lt" x="-55" y="-99"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="111" height="112">
+      <vector name="origin" x="55" y="112"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="124" height="119">
+      <vector name="origin" x="55" y="119"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="124" height="124">
+      <vector name="origin" x="55" y="124"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="95" height="92">
+      <vector name="origin" x="55" y="92"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="95" height="92">
+      <vector name="origin" x="55" y="92"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="99" height="98">
+      <vector name="origin" x="53" y="98"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="109" height="113">
+      <vector name="origin" x="50" y="113"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="47" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="122" height="119">
+      <vector name="origin" x="53" y="119"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="125" height="125">
+      <vector name="origin" x="58" y="125"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="95" height="91">
+      <vector name="origin" x="57" y="91"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-177" y="-64"/>
+        <vector name="rb" x="-15" y="8"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="84" height="96">
+          <vector name="origin" x="41" y="88"/>
+        </canvas>
+        <canvas name="1" width="97" height="93">
+          <vector name="origin" x="48" y="84"/>
+        </canvas>
+        <canvas name="2" width="91" height="95">
+          <vector name="origin" x="45" y="88"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="PADamage" value="325"/>
+      <int name="attackAfter" value="640"/>
+    </imgdir>
+    <canvas name="0" width="95" height="92">
+      <vector name="origin" x="55" y="92"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="101" height="99">
+      <vector name="origin" x="55" y="99"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="114" height="113">
+      <vector name="origin" x="55" y="113"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="127" height="120">
+      <vector name="origin" x="55" y="120"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="47" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="134" height="94">
+      <vector name="origin" x="96" y="94"/>
+      <vector name="lt" x="-96" y="-94"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="134" height="94">
+      <vector name="origin" x="96" y="94"/>
+      <vector name="lt" x="-96" y="-93"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="136" height="94">
+      <vector name="origin" x="98" y="94"/>
+      <vector name="lt" x="-98" y="-93"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="135" height="94">
+      <vector name="origin" x="97" y="94"/>
+      <vector name="lt" x="-97" y="-94"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="138" height="94">
+      <vector name="origin" x="100" y="94"/>
+      <vector name="lt" x="-100" y="-94"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="131" height="92">
+      <vector name="origin" x="93" y="92"/>
+      <vector name="lt" x="-50" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="95" height="92">
+      <vector name="origin" x="55" y="92"/>
+      <vector name="lt" x="-55" y="-92"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="95" height="92">
+      <vector name="origin" x="55" y="92"/>
+      <vector name="head" x="2" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="101" height="102">
+      <vector name="origin" x="29" y="106"/>
+      <vector name="head" x="31" y="-95"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="97" height="92">
+      <vector name="origin" x="23" y="91"/>
+      <vector name="head" x="35" y="-89"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="104" height="77">
+      <vector name="origin" x="32" y="74"/>
+      <vector name="head" x="35" y="-74"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="137" height="95">
+      <vector name="origin" x="56" y="90"/>
+      <vector name="head" x="23" y="-74"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="168" height="107">
+      <vector name="origin" x="74" y="104"/>
+      <vector name="head" x="23" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="109" height="102">
+      <vector name="origin" x="34" y="91"/>
+      <vector name="head" x="23" y="-91"/>
+      <int name="delay" value="150"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/7120109.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/7120109.img.xml
@@ -1,0 +1,1260 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="7120109.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="79"/>
+    <int name="maxHP" value="23500"/>
+    <int name="maxMP" value="200"/>
+    <int name="speed" value="50"/>
+    <int name="PADamage" value="340"/>
+    <int name="PDDamage" value="625"/>
+    <int name="MADamage" value="385"/>
+    <int name="MDDamage" value="450"/>
+    <int name="acc" value="170"/>
+    <int name="eva" value="30"/>
+    <int name="exp" value="750"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="2500"/>
+    <float name="fs" value="10.0"/>
+    <string name="elemAttr" value="S1"/>
+    <int name="summonType" value="1"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3730"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="regen">
+    <canvas name="0" width="34" height="121">
+      <vector name="origin" x="12" y="147"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="1" width="72" height="153">
+      <vector name="origin" x="31" y="148"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="2" width="98" height="157">
+      <vector name="origin" x="44" y="150"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="3" width="114" height="156">
+      <vector name="origin" x="52" y="150"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="4" width="114" height="156">
+      <vector name="origin" x="52" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="5" width="114" height="156">
+      <vector name="origin" x="52" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="114" height="156">
+      <vector name="origin" x="52" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="114" height="156">
+      <vector name="origin" x="52" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="114" height="156">
+      <vector name="origin" x="52" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="9" width="114" height="156">
+      <vector name="origin" x="52" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="10" width="114" height="156">
+      <vector name="origin" x="52" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="11" width="98" height="157">
+      <vector name="origin" x="44" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="87" height="153">
+      <vector name="origin" x="38" y="148"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="13" width="87" height="147">
+      <vector name="origin" x="38" y="147"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="14" width="87" height="116">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="15" width="87" height="116">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="16" width="87" height="116">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="17" width="87" height="116">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="18" width="87" height="116">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="19" width="87" height="116">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="20" width="87" height="116">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="21" width="87" height="116">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="22" width="87" height="121">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="23" width="87" height="128">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="24" width="87" height="128">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="87" height="128">
+      <vector name="origin" x="38" y="116"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-9" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="87" height="127">
+      <vector name="origin" x="37" y="115"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-8" y="-90"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="86" height="124">
+      <vector name="origin" x="35" y="113"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-7" y="-91"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="87" height="126">
+      <vector name="origin" x="37" y="115"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-8" y="-90"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="89" height="128">
+      <vector name="origin" x="40" y="115"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-9" y="-88"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="93" height="125">
+      <vector name="origin" x="43" y="116"/>
+      <vector name="lt" x="-43" y="-82"/>
+      <vector name="rb" x="40" y="5"/>
+      <vector name="head" x="-18" y="-82"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="103" height="130">
+      <vector name="origin" x="54" y="120"/>
+      <vector name="lt" x="-43" y="-82"/>
+      <vector name="rb" x="40" y="5"/>
+      <vector name="head" x="-17" y="-77"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="96" height="110">
+      <vector name="origin" x="48" y="104"/>
+      <vector name="lt" x="-43" y="-82"/>
+      <vector name="rb" x="40" y="5"/>
+      <vector name="head" x="-20" y="-82"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="97" height="125">
+      <vector name="origin" x="43" y="116"/>
+      <vector name="lt" x="-43" y="-82"/>
+      <vector name="rb" x="40" y="5"/>
+      <vector name="head" x="-18" y="-78"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="114" height="130">
+      <vector name="origin" x="54" y="120"/>
+      <vector name="lt" x="-43" y="-82"/>
+      <vector name="rb" x="40" y="5"/>
+      <vector name="head" x="-17" y="-77"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="86" height="110">
+      <vector name="origin" x="48" y="104"/>
+      <vector name="lt" x="-43" y="-82"/>
+      <vector name="rb" x="40" y="5"/>
+      <vector name="head" x="-20" y="-82"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-136" y="-64"/>
+        <vector name="rb" x="5" y="3"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="66" height="115">
+          <vector name="origin" x="36" y="114"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="90" height="85">
+          <vector name="origin" x="41" y="77"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="42" height="81">
+          <vector name="origin" x="-6" y="77"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="32" height="53">
+          <vector name="origin" x="-15" y="75"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="PADamage" value="370"/>
+      <int name="attackAfter" value="450"/>
+    </imgdir>
+    <canvas name="0" width="87" height="128">
+      <vector name="origin" x="38" y="116"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="45" y="3"/>
+      <vector name="head" x="-9" y="-89"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="94" height="111">
+      <vector name="origin" x="46" y="111"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="45" y="3"/>
+      <vector name="head" x="-10" y="-89"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="96" height="116">
+      <vector name="origin" x="50" y="116"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="45" y="3"/>
+      <vector name="head" x="-12" y="-89"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="188" height="138">
+      <vector name="origin" x="136" y="125"/>
+      <vector name="lt" x="-48" y="-93"/>
+      <vector name="rb" x="45" y="3"/>
+      <vector name="head" x="-16" y="-81"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="189" height="123">
+      <vector name="origin" x="146" y="111"/>
+      <vector name="lt" x="-48" y="-93"/>
+      <vector name="rb" x="45" y="3"/>
+      <vector name="head" x="-16" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="184" height="113">
+      <vector name="origin" x="142" y="104"/>
+      <vector name="lt" x="-48" y="-93"/>
+      <vector name="rb" x="45" y="3"/>
+      <vector name="head" x="-16" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="181" height="116">
+      <vector name="origin" x="139" y="107"/>
+      <vector name="lt" x="-48" y="-93"/>
+      <vector name="rb" x="45" y="3"/>
+      <vector name="head" x="-16" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="181" height="116">
+      <vector name="origin" x="139" y="107"/>
+      <vector name="lt" x="-48" y="-93"/>
+      <vector name="rb" x="45" y="3"/>
+      <vector name="head" x="-16" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="86" height="112">
+      <vector name="origin" x="44" y="103"/>
+      <vector name="lt" x="-48" y="-93"/>
+      <vector name="rb" x="45" y="3"/>
+      <vector name="head" x="-16" y="-81"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-354" y="-64"/>
+        <vector name="rb" x="0" y="15"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="121" height="125">
+          <vector name="origin" x="62" y="110"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="1" width="144" height="141">
+          <vector name="origin" x="77" y="113"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="2" width="158" height="142">
+          <vector name="origin" x="88" y="114"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <uol name="3" value="1"/>
+        <uol name="4" value="0"/>
+        <uol name="5" value="1"/>
+        <uol name="6" value="2"/>
+        <canvas name="7" width="143" height="138">
+          <vector name="origin" x="85" y="116"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="8" width="82" height="75">
+          <vector name="origin" x="34" y="101"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="PADamage" value="400"/>
+      <int name="attackAfter" value="2130"/>
+      <int name="knockback" value="1"/>
+    </imgdir>
+    <canvas name="0" width="87" height="128">
+      <vector name="origin" x="38" y="116"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-9" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="86" height="206">
+      <vector name="origin" x="38" y="194"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-10" y="-89"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="109" height="167">
+      <vector name="origin" x="62" y="155"/>
+      <vector name="lt" x="-39" y="-93"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-11" y="-89"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="114" height="164">
+      <vector name="origin" x="67" y="152"/>
+      <vector name="lt" x="-39" y="-93"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-11" y="-89"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="117" height="163">
+      <vector name="origin" x="70" y="151"/>
+      <vector name="lt" x="-39" y="-93"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-11" y="-89"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="87" height="163">
+      <vector name="origin" x="40" y="151"/>
+      <vector name="lt" x="-39" y="-93"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-11" y="-89"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="87" height="163">
+      <vector name="origin" x="40" y="151"/>
+      <vector name="lt" x="-39" y="-93"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-11" y="-89"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="87" height="163">
+      <vector name="origin" x="40" y="151"/>
+      <vector name="lt" x="-39" y="-93"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-11" y="-89"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="132" height="160">
+      <vector name="origin" x="92" y="140"/>
+      <vector name="lt" x="-47" y="-85"/>
+      <vector name="rb" x="35" y="0"/>
+      <vector name="head" x="-19" y="-81"/>
+      <int name="delay" value="9"/>
+    </canvas>
+    <canvas name="9" width="167" height="140">
+      <vector name="origin" x="127" y="112"/>
+      <vector name="lt" x="-50" y="-77"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-22" y="-73"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-127" y="-32"/>
+          <vector name="rb" x="-33" y="-1"/>
+        </imgdir>
+      </imgdir>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="10" width="170" height="125">
+      <vector name="origin" x="134" y="98"/>
+      <vector name="lt" x="-50" y="-78"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-22" y="-74"/>
+      <int name="delay" value="90"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-127" y="-32"/>
+          <vector name="rb" x="-33" y="-1"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="11" width="172" height="128">
+      <vector name="origin" x="136" y="101"/>
+      <vector name="lt" x="-50" y="-78"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-22" y="-74"/>
+      <int name="delay" value="90"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-127" y="-32"/>
+          <vector name="rb" x="-33" y="-1"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="12" width="174" height="128">
+      <vector name="origin" x="138" y="101"/>
+      <vector name="lt" x="-50" y="-78"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-22" y="-74"/>
+      <int name="delay" value="120"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-127" y="-32"/>
+          <vector name="rb" x="-33" y="-1"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="13" width="155" height="128">
+      <vector name="origin" x="119" y="101"/>
+      <vector name="lt" x="-50" y="-78"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-22" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-127" y="-32"/>
+          <vector name="rb" x="-33" y="-1"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="14" width="206" height="128">
+      <vector name="origin" x="170" y="101"/>
+      <vector name="lt" x="-50" y="-78"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-22" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-144" y="-41"/>
+          <vector name="rb" x="-33" y="-1"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="15" width="193" height="130">
+      <vector name="origin" x="157" y="103"/>
+      <vector name="lt" x="-50" y="-78"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-22" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-157" y="-49"/>
+          <vector name="rb" x="-33" y="-1"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="16" width="273" height="156">
+      <vector name="origin" x="237" y="129"/>
+      <vector name="lt" x="-50" y="-78"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-22" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-177" y="-53"/>
+          <vector name="rb" x="-33" y="-1"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="17" width="233" height="128">
+      <vector name="origin" x="197" y="101"/>
+      <vector name="lt" x="-50" y="-78"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-22" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-187" y="-64"/>
+          <vector name="rb" x="-32" y="16"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="18" width="244" height="128">
+      <vector name="origin" x="208" y="101"/>
+      <vector name="lt" x="-50" y="-78"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-22" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-197" y="-71"/>
+          <vector name="rb" x="-30" y="16"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="19" width="295" height="123">
+      <vector name="origin" x="258" y="96"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-258" y="-64"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="20" width="395" height="139">
+      <vector name="origin" x="354" y="112"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="21" width="389" height="128">
+      <vector name="origin" x="353" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="22" width="390" height="129">
+      <vector name="origin" x="354" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="23" width="389" height="128">
+      <vector name="origin" x="353" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="24" width="390" height="128">
+      <vector name="origin" x="354" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="25" width="389" height="128">
+      <vector name="origin" x="353" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-127" y="-32"/>
+          <vector name="rb" x="-33" y="-1"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="26" width="390" height="128">
+      <vector name="origin" x="354" y="101"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="27" width="390" height="128">
+      <vector name="origin" x="354" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="28" width="390" height="128">
+      <vector name="origin" x="354" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="29" width="390" height="128">
+      <vector name="origin" x="354" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="30" width="389" height="128">
+      <vector name="origin" x="353" y="101"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="31" width="389" height="128">
+      <vector name="origin" x="353" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-354" y="-56"/>
+          <vector name="rb" x="-33" y="15"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="32" width="387" height="128">
+      <vector name="origin" x="351" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="33" width="385" height="128">
+      <vector name="origin" x="349" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="34" width="363" height="129">
+      <vector name="origin" x="327" y="101"/>
+      <vector name="lt" x="-49" y="-78"/>
+      <vector name="rb" x="33" y="0"/>
+      <vector name="head" x="-21" y="-74"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="35" width="131" height="160">
+      <vector name="origin" x="92" y="140"/>
+      <vector name="lt" x="-47" y="-85"/>
+      <vector name="rb" x="35" y="0"/>
+      <vector name="head" x="-19" y="-81"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="36" width="86" height="167">
+      <vector name="origin" x="39" y="155"/>
+      <vector name="lt" x="-39" y="-93"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-11" y="-89"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="37" width="87" height="216">
+      <vector name="origin" x="39" y="204"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-10" y="-89"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-256" y="-48"/>
+        <vector name="rb" x="224" y="38"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="144" height="79">
+          <vector name="origin" x="65" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="128" height="76">
+          <vector name="origin" x="52" y="70"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="122" height="46">
+          <vector name="origin" x="51" y="47"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="116" height="35">
+          <vector name="origin" x="56" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="99" height="30">
+          <vector name="origin" x="39" y="39"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="10"/>
+      <int name="magic" value="1"/>
+      <int name="attackAfter" value="1440"/>
+      <int name="MADamage" value="420"/>
+    </imgdir>
+    <canvas name="0" width="87" height="128">
+      <vector name="origin" x="38" y="116"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-9" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="92" height="130">
+      <vector name="origin" x="42" y="118"/>
+      <vector name="lt" x="-37" y="-95"/>
+      <vector name="rb" x="45" y="0"/>
+      <vector name="head" x="-8" y="-91"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="137" height="136">
+      <vector name="origin" x="68" y="117"/>
+      <vector name="lt" x="-39" y="-95"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-10" y="-91"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="149" height="149">
+      <vector name="origin" x="74" y="124"/>
+      <vector name="lt" x="-39" y="-96"/>
+      <vector name="rb" x="43" y="-1"/>
+      <vector name="head" x="-10" y="-92"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="170" height="169">
+      <vector name="origin" x="84" y="136"/>
+      <vector name="lt" x="-39" y="-97"/>
+      <vector name="rb" x="43" y="-2"/>
+      <vector name="head" x="-10" y="-93"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="191" height="191">
+      <vector name="origin" x="95" y="149"/>
+      <vector name="lt" x="-39" y="-99"/>
+      <vector name="rb" x="43" y="-4"/>
+      <vector name="head" x="-10" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="201" height="201">
+      <vector name="origin" x="100" y="154"/>
+      <vector name="lt" x="-39" y="-100"/>
+      <vector name="rb" x="43" y="-5"/>
+      <vector name="head" x="-10" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="207" height="207">
+      <vector name="origin" x="103" y="159"/>
+      <vector name="lt" x="-39" y="-102"/>
+      <vector name="rb" x="43" y="-7"/>
+      <vector name="head" x="-10" y="-98"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="210" height="209">
+      <vector name="origin" x="104" y="164"/>
+      <vector name="lt" x="-39" y="-103"/>
+      <vector name="rb" x="43" y="-8"/>
+      <vector name="head" x="-10" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="211" height="211">
+      <vector name="origin" x="105" y="169"/>
+      <vector name="lt" x="-39" y="-105"/>
+      <vector name="rb" x="43" y="-10"/>
+      <vector name="head" x="-10" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="223" height="213">
+      <vector name="origin" x="116" y="173"/>
+      <vector name="lt" x="-39" y="-107"/>
+      <vector name="rb" x="43" y="-12"/>
+      <vector name="head" x="-10" y="-103"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="227" height="213">
+      <vector name="origin" x="120" y="178"/>
+      <vector name="lt" x="-39" y="-112"/>
+      <vector name="rb" x="43" y="-17"/>
+      <vector name="head" x="-10" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="303" height="222">
+      <vector name="origin" x="130" y="182"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-116"/>
+      <vector name="rb" x="43" y="-21"/>
+      <vector name="head" x="-10" y="-112"/>
+    </canvas>
+    <canvas name="13" width="395" height="222">
+      <vector name="origin" x="212" y="185"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-119"/>
+      <vector name="rb" x="43" y="-24"/>
+      <vector name="head" x="-10" y="-115"/>
+    </canvas>
+    <canvas name="14" width="437" height="225">
+      <vector name="origin" x="221" y="188"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-120"/>
+      <vector name="rb" x="43" y="-25"/>
+      <vector name="head" x="-10" y="-116"/>
+    </canvas>
+    <canvas name="15" width="477" height="233">
+      <vector name="origin" x="248" y="189"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-121"/>
+      <vector name="rb" x="43" y="-26"/>
+      <vector name="head" x="-10" y="-117"/>
+    </canvas>
+    <canvas name="16" width="492" height="233">
+      <vector name="origin" x="260" y="190"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-122"/>
+      <vector name="rb" x="43" y="-27"/>
+      <vector name="head" x="-10" y="-118"/>
+    </canvas>
+    <canvas name="17" width="511" height="234">
+      <vector name="origin" x="265" y="192"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-124"/>
+      <vector name="rb" x="43" y="-29"/>
+      <vector name="head" x="-10" y="-120"/>
+    </canvas>
+    <canvas name="18" width="524" height="235">
+      <vector name="origin" x="286" y="194"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-126"/>
+      <vector name="rb" x="43" y="-31"/>
+      <vector name="head" x="-10" y="-122"/>
+    </canvas>
+    <canvas name="19" width="498" height="236">
+      <vector name="origin" x="268" y="196"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-128"/>
+      <vector name="rb" x="43" y="-33"/>
+      <vector name="head" x="-10" y="-124"/>
+    </canvas>
+    <canvas name="20" width="445" height="235">
+      <vector name="origin" x="249" y="196"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-128"/>
+      <vector name="rb" x="43" y="-33"/>
+      <vector name="head" x="-10" y="-124"/>
+    </canvas>
+    <canvas name="21" width="403" height="237">
+      <vector name="origin" x="215" y="194"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-128"/>
+      <vector name="rb" x="43" y="-33"/>
+      <vector name="head" x="-10" y="-124"/>
+    </canvas>
+    <canvas name="22" width="342" height="233">
+      <vector name="origin" x="195" y="194"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-128"/>
+      <vector name="rb" x="43" y="-33"/>
+      <vector name="head" x="-10" y="-124"/>
+    </canvas>
+    <canvas name="23" width="312" height="228">
+      <vector name="origin" x="173" y="194"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-128"/>
+      <vector name="rb" x="43" y="-33"/>
+      <vector name="head" x="-10" y="-124"/>
+    </canvas>
+    <canvas name="24" width="256" height="227">
+      <vector name="origin" x="144" y="194"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-128"/>
+      <vector name="rb" x="43" y="-33"/>
+      <vector name="head" x="-10" y="-124"/>
+    </canvas>
+    <canvas name="25" width="227" height="226">
+      <vector name="origin" x="120" y="194"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-128"/>
+      <vector name="rb" x="43" y="-33"/>
+      <vector name="head" x="-10" y="-124"/>
+    </canvas>
+    <canvas name="26" width="208" height="214">
+      <vector name="origin" x="103" y="191"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-39" y="-128"/>
+      <vector name="rb" x="43" y="-33"/>
+      <vector name="head" x="-10" y="-124"/>
+    </canvas>
+    <canvas name="27" width="191" height="191">
+      <vector name="origin" x="95" y="183"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-39" y="-128"/>
+      <vector name="rb" x="43" y="-33"/>
+      <vector name="head" x="-10" y="-124"/>
+    </canvas>
+    <canvas name="28" width="163" height="163">
+      <vector name="origin" x="81" y="169"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-39" y="-128"/>
+      <vector name="rb" x="43" y="-33"/>
+      <vector name="head" x="-10" y="-124"/>
+    </canvas>
+    <canvas name="29" width="156" height="156">
+      <vector name="origin" x="75" y="161"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-39" y="-125"/>
+      <vector name="rb" x="43" y="-30"/>
+      <vector name="head" x="-10" y="-121"/>
+    </canvas>
+    <canvas name="30" width="188" height="186">
+      <vector name="origin" x="93" y="179"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-39" y="-118"/>
+      <vector name="rb" x="43" y="-23"/>
+      <vector name="head" x="-10" y="-114"/>
+    </canvas>
+    <canvas name="31" width="96" height="151">
+      <vector name="origin" x="47" y="156"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-39" y="-103"/>
+      <vector name="rb" x="43" y="-8"/>
+      <vector name="head" x="-10" y="-99"/>
+    </canvas>
+    <canvas name="32" width="86" height="116">
+      <vector name="origin" x="45" y="109"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-46" y="-89"/>
+      <vector name="rb" x="36" y="6"/>
+      <vector name="head" x="-17" y="-85"/>
+    </canvas>
+    <canvas name="33" width="87" height="130">
+      <vector name="origin" x="38" y="117"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-38" y="-94"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-9" y="-90"/>
+    </canvas>
+    <canvas name="34" width="87" height="128">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="2"/>
+      <vector name="head" x="-9" y="-89"/>
+    </canvas>
+    <canvas name="35" width="87" height="128">
+      <vector name="origin" x="38" y="116"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-38" y="-93"/>
+      <vector name="rb" x="44" y="2"/>
+      <vector name="head" x="-9" y="-89"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="100" height="135">
+      <vector name="origin" x="41" y="131"/>
+      <vector name="lt" x="-32" y="-96"/>
+      <vector name="rb" x="48" y="0"/>
+      <vector name="head" x="0" y="-94"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="87" height="128">
+      <vector name="origin" x="38" y="116"/>
+      <vector name="head" x="-10" y="-87"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="99" height="132">
+      <vector name="origin" x="40" y="131"/>
+      <vector name="head" x="2" y="-91"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="102" height="132">
+      <vector name="origin" x="39" y="130"/>
+      <vector name="head" x="2" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="100" height="110">
+      <vector name="origin" x="35" y="107"/>
+      <vector name="head" x="5" y="-72"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="86" height="96">
+      <vector name="origin" x="22" y="91"/>
+      <vector name="head" x="8" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="87" height="99">
+      <vector name="origin" x="23" y="95"/>
+      <vector name="head" x="5" y="-65"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="88" height="107">
+      <vector name="origin" x="24" y="103"/>
+      <vector name="head" x="5" y="-65"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="97" height="123">
+      <vector name="origin" x="29" y="119"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-65"/>
+    </canvas>
+    <canvas name="8" width="100" height="143">
+      <vector name="origin" x="34" y="139"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-65"/>
+    </canvas>
+    <canvas name="9" width="88" height="153">
+      <vector name="origin" x="24" y="149"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-65"/>
+    </canvas>
+    <canvas name="10" width="87" height="159">
+      <vector name="origin" x="23" y="155"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-65"/>
+    </canvas>
+    <canvas name="11" width="87" height="99">
+      <vector name="origin" x="23" y="95"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-65"/>
+    </canvas>
+    <canvas name="12" width="87" height="150">
+      <vector name="origin" x="23" y="147"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="4" y="-73"/>
+    </canvas>
+    <canvas name="13" width="87" height="153">
+      <vector name="origin" x="25" y="148"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="3" y="-90"/>
+    </canvas>
+    <canvas name="14" width="98" height="157">
+      <vector name="origin" x="31" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="4" y="-108"/>
+    </canvas>
+    <canvas name="15" width="114" height="156">
+      <vector name="origin" x="39" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="6" y="-128"/>
+    </canvas>
+    <canvas name="16" width="114" height="156">
+      <vector name="origin" x="39" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="2" y="-141"/>
+    </canvas>
+    <canvas name="17" width="114" height="156">
+      <vector name="origin" x="39" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="2" y="-141"/>
+    </canvas>
+    <canvas name="18" width="114" height="156">
+      <vector name="origin" x="39" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="2" y="-141"/>
+    </canvas>
+    <canvas name="19" width="114" height="156">
+      <vector name="origin" x="39" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="2" y="-141"/>
+    </canvas>
+    <canvas name="20" width="114" height="156">
+      <vector name="origin" x="39" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="2" y="-141"/>
+    </canvas>
+    <canvas name="21" width="114" height="156">
+      <vector name="origin" x="39" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="2" y="-141"/>
+    </canvas>
+    <canvas name="22" width="114" height="156">
+      <vector name="origin" x="39" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="2" y="-141"/>
+    </canvas>
+    <canvas name="23" width="98" height="157">
+      <vector name="origin" x="31" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="2" y="-141"/>
+    </canvas>
+    <canvas name="24" width="72" height="153">
+      <vector name="origin" x="18" y="148"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="2" y="-141"/>
+    </canvas>
+    <canvas name="25" width="34" height="121">
+      <vector name="origin" x="-1" y="147"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="2" y="-141"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/7220000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/7220000.img.xml
@@ -1,0 +1,726 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="7220000.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="71"/>
+    <int name="maxHP" value="93000"/>
+    <int name="maxMP" value="200"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="285"/>
+    <int name="PDDamage" value="335"/>
+    <int name="MADamage" value="310"/>
+    <int name="MDDamage" value="265"/>
+    <int name="acc" value="175"/>
+    <int name="eva" value="30"/>
+    <int name="exp" value="1580"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1500"/>
+    <int name="hpRecovery" value="2200"/>
+    <int name="mpRecovery" value="10"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="140"/>
+        <int name="action" value="1"/>
+        <int name="level" value="4"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="110"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="4"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="113"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="83"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="0"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3835"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chataBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="88000"/>
+        <string name="0" value="你够强吗？够强就来攻击我！"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="172" height="143">
+      <vector name="origin" x="96" y="143"/>
+      <vector name="lt" x="-96" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-50" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="173" height="144">
+      <vector name="origin" x="96" y="144"/>
+      <vector name="lt" x="-96" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-50" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="174" height="143">
+      <vector name="origin" x="97" y="143"/>
+      <vector name="lt" x="-96" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-50" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="172" height="142">
+      <vector name="origin" x="95" y="142"/>
+      <vector name="lt" x="-96" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-50" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="171" height="143">
+      <vector name="origin" x="96" y="142"/>
+      <vector name="lt" x="-96" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-50" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="172" height="143">
+      <vector name="origin" x="96" y="143"/>
+      <vector name="lt" x="-96" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-50" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="176" height="142">
+      <vector name="origin" x="98" y="142"/>
+      <vector name="lt" x="-96" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-50" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="174" height="142">
+      <vector name="origin" x="97" y="141"/>
+      <vector name="lt" x="-96" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-50" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="171" height="143">
+      <vector name="origin" x="95" y="143"/>
+      <vector name="lt" x="-95" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-49" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="176" height="144">
+      <vector name="origin" x="98" y="144"/>
+      <vector name="lt" x="-95" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-49" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="182" height="145">
+      <vector name="origin" x="101" y="145"/>
+      <vector name="lt" x="-95" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-49" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="184" height="145">
+      <vector name="origin" x="102" y="145"/>
+      <vector name="lt" x="-95" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-49" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="180" height="144">
+      <vector name="origin" x="100" y="144"/>
+      <vector name="lt" x="-95" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-49" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="175" height="143">
+      <vector name="origin" x="97" y="143"/>
+      <vector name="lt" x="-95" y="-143"/>
+      <vector name="rb" x="76" y="0"/>
+      <vector name="head" x="-49" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-41" y="-14"/>
+        <int name="r" value="270"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="99" height="107">
+          <vector name="origin" x="50" y="86"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="81" height="110">
+          <vector name="origin" x="38" y="96"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="71" height="110">
+          <vector name="origin" x="41" y="98"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="71" height="104">
+          <vector name="origin" x="41" y="100"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="72" height="104">
+          <vector name="origin" x="42" y="114"/>
+          <int name="delay" value="90"/>
+          <int name="a0" value="255"/>
+          <int name="a1" value="0"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="1"/>
+      <int name="attackAfter" value="1200"/>
+      <int name="magic" value="1"/>
+      <int name="knockback" value="1"/>
+      <int name="jumpAttack" value="1"/>
+    </imgdir>
+    <canvas name="0" width="174" height="147">
+      <vector name="origin" x="97" y="145"/>
+      <vector name="lt" x="-96" y="-144"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="188" height="156">
+      <vector name="origin" x="104" y="150"/>
+      <vector name="lt" x="-96" y="-144"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="195" height="161">
+      <vector name="origin" x="107" y="153"/>
+      <vector name="lt" x="-96" y="-144"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="201" height="162">
+      <vector name="origin" x="110" y="154"/>
+      <vector name="lt" x="-96" y="-144"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="205" height="165">
+      <vector name="origin" x="112" y="156"/>
+      <vector name="lt" x="-96" y="-144"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="209" height="166">
+      <vector name="origin" x="113" y="157"/>
+      <vector name="lt" x="-96" y="-144"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="211" height="167">
+      <vector name="origin" x="114" y="158"/>
+      <vector name="lt" x="-114" y="-150"/>
+      <vector name="rb" x="89" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="213" height="168">
+      <vector name="origin" x="115" y="159"/>
+      <vector name="lt" x="-113" y="-146"/>
+      <vector name="rb" x="94" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="215" height="169">
+      <vector name="origin" x="116" y="160"/>
+      <vector name="lt" x="-115" y="-149"/>
+      <vector name="rb" x="93" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="176" height="152">
+      <vector name="origin" x="125" y="141"/>
+      <vector name="lt" x="-119" y="-140"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="172" height="147">
+      <vector name="origin" x="123" y="141"/>
+      <vector name="lt" x="-113" y="-140"/>
+      <vector name="rb" x="35" y="0"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="166" height="180">
+      <vector name="origin" x="120" y="174"/>
+      <vector name="lt" x="-114" y="-132"/>
+      <vector name="rb" x="40" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="170" height="163">
+      <vector name="origin" x="120" y="157"/>
+      <vector name="lt" x="-118" y="-128"/>
+      <vector name="rb" x="40" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="187" height="150">
+      <vector name="origin" x="125" y="144"/>
+      <vector name="lt" x="-117" y="-140"/>
+      <vector name="rb" x="47" y="0"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="197" height="143">
+      <vector name="origin" x="130" y="137"/>
+      <vector name="lt" x="-118" y="-138"/>
+      <vector name="rb" x="44" y="2"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="166" height="142">
+      <vector name="origin" x="117" y="136"/>
+      <vector name="lt" x="-120" y="-134"/>
+      <vector name="rb" x="41" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="179" height="144">
+      <vector name="origin" x="112" y="137"/>
+      <vector name="lt" x="-111" y="-136"/>
+      <vector name="rb" x="62" y="2"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="174" height="143">
+      <vector name="origin" x="99" y="142"/>
+      <vector name="lt" x="-101" y="-142"/>
+      <vector name="rb" x="74" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="169" height="143">
+      <vector name="origin" x="96" y="143"/>
+      <vector name="lt" x="-98" y="-142"/>
+      <vector name="rb" x="72" y="0"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="169" height="143">
+      <vector name="origin" x="96" y="143"/>
+      <vector name="lt" x="-96" y="-144"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="169" height="143">
+      <vector name="origin" x="96" y="143"/>
+      <vector name="lt" x="-96" y="-144"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="169" height="143">
+      <vector name="origin" x="96" y="143"/>
+      <vector name="lt" x="-96" y="-144"/>
+      <vector name="rb" x="75" y="1"/>
+      <vector name="head" x="-47" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="22" value="../stand/0"/>
+    <uol name="23" value="../stand/1"/>
+    <uol name="24" value="../stand/2"/>
+    <uol name="25" value="../stand/3"/>
+    <uol name="26" value="../stand/4"/>
+    <uol name="27" value="../stand/5"/>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="让开，小菜鸟！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-147" y="-47"/>
+        <int name="r" value="270"/>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="83" height="80">
+          <vector name="origin" x="41" y="39"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="77" height="80">
+          <vector name="origin" x="38" y="41"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="79" height="82">
+          <vector name="origin" x="38" y="42"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="72" height="82">
+          <vector name="origin" x="35" y="43"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="83" height="78">
+          <vector name="origin" x="41" y="38"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="77" height="80">
+          <vector name="origin" x="38" y="41"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="101" height="98">
+          <vector name="origin" x="50" y="85"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="122" height="103">
+          <vector name="origin" x="62" y="91"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="142" height="111">
+          <vector name="origin" x="62" y="94"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="128" height="109">
+          <vector name="origin" x="50" y="94"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="127" height="106">
+          <vector name="origin" x="55" y="89"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="112" height="106">
+          <vector name="origin" x="53" y="92"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="117" height="103">
+          <vector name="origin" x="55" y="87"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="105" height="98">
+          <vector name="origin" x="44" y="88"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="2"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="1680"/>
+      <int name="magic" value="1"/>
+      <int name="bulletSpeed" value="200"/>
+    </imgdir>
+    <canvas name="0" width="171" height="145">
+      <vector name="origin" x="95" y="144"/>
+      <vector name="lt" x="-94" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="183" height="154">
+      <vector name="origin" x="101" y="148"/>
+      <vector name="lt" x="-94" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="194" height="158">
+      <vector name="origin" x="108" y="149"/>
+      <vector name="lt" x="-94" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="285" height="193">
+      <vector name="origin" x="196" y="149"/>
+      <vector name="lt" x="-94" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="281" height="190">
+      <vector name="origin" x="192" y="150"/>
+      <vector name="lt" x="-113" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="278" height="187">
+      <vector name="origin" x="188" y="151"/>
+      <vector name="lt" x="-103" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="269" height="178">
+      <vector name="origin" x="179" y="151"/>
+      <vector name="lt" x="-110" y="-146"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="256" height="173">
+      <vector name="origin" x="165" y="152"/>
+      <vector name="lt" x="-102" y="-145"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="239" height="171">
+      <vector name="origin" x="148" y="152"/>
+      <vector name="lt" x="-102" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="228" height="173">
+      <vector name="origin" x="136" y="152"/>
+      <vector name="lt" x="-102" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="226" height="171">
+      <vector name="origin" x="134" y="152"/>
+      <vector name="lt" x="-101" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="310" height="191">
+      <vector name="origin" x="232" y="153"/>
+      <vector name="lt" x="-164" y="-145"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="311" height="190">
+      <vector name="origin" x="234" y="150"/>
+      <vector name="lt" x="-163" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="323" height="190">
+      <vector name="origin" x="247" y="147"/>
+      <vector name="lt" x="-163" y="-148"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="333" height="183">
+      <vector name="origin" x="256" y="145"/>
+      <vector name="lt" x="-161" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="333" height="174">
+      <vector name="origin" x="259" y="144"/>
+      <vector name="lt" x="-159" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="330" height="181">
+      <vector name="origin" x="259" y="147"/>
+      <vector name="lt" x="-152" y="-147"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="199" height="142">
+      <vector name="origin" x="140" y="140"/>
+      <vector name="lt" x="-140" y="-139"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="175" height="143">
+      <vector name="origin" x="105" y="141"/>
+      <vector name="lt" x="-104" y="-141"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="176" height="143">
+      <vector name="origin" x="102" y="141"/>
+      <vector name="lt" x="-94" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="171" height="143">
+      <vector name="origin" x="95" y="143"/>
+      <vector name="lt" x="-94" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="171" height="143">
+      <vector name="origin" x="95" y="143"/>
+      <vector name="lt" x="-94" y="-144"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-47" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="22" value="../stand/0"/>
+    <uol name="23" value="../stand/1"/>
+    <uol name="24" value="../stand/2"/>
+    <uol name="25" value="../stand/3"/>
+    <uol name="26" value="../stand/4"/>
+    <uol name="27" value="../stand/5"/>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="你就这点本事吗？"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <uol name="0" value="../attack1/0"/>
+    <uol name="1" value="../attack1/1"/>
+    <uol name="2" value="../attack1/2"/>
+    <uol name="3" value="../attack1/3"/>
+    <uol name="4" value="../attack1/4"/>
+    <uol name="5" value="../attack1/5"/>
+    <uol name="6" value="../attack1/6"/>
+    <uol name="7" value="../attack1/7"/>
+    <uol name="8" value="../attack1/8"/>
+    <uol name="9" value="../attack1/8"/>
+    <uol name="10" value="../attack1/7"/>
+    <uol name="11" value="../attack1/6"/>
+    <uol name="12" value="../attack1/5"/>
+    <uol name="13" value="../attack1/4"/>
+    <uol name="14" value="../attack1/3"/>
+    <uol name="15" value="../attack1/2"/>
+    <uol name="16" value="../attack1/1"/>
+    <uol name="17" value="../attack1/0"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="179" height="172">
+      <vector name="origin" x="100" y="176"/>
+      <vector name="lt" x="-100" y="-176"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="-42" y="-161"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="179" height="172">
+      <vector name="origin" x="100" y="176"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="182" height="165">
+      <vector name="origin" x="106" y="170"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="187" height="161">
+      <vector name="origin" x="109" y="167"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="182" height="156">
+      <vector name="origin" x="103" y="164"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="186" height="153">
+      <vector name="origin" x="103" y="160"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="189" height="153">
+      <vector name="origin" x="102" y="159"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="256" height="140">
+      <vector name="origin" x="124" y="134"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="268" height="139">
+      <vector name="origin" x="130" y="134"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="270" height="139">
+      <vector name="origin" x="129" y="134"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="9" width="279" height="139">
+      <vector name="origin" x="130" y="134"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="10" width="279" height="138">
+      <vector name="origin" x="129" y="134"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="11" width="279" height="137">
+      <vector name="origin" x="136" y="134"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="175" height="135">
+      <vector name="origin" x="84" y="134"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="13" width="175" height="132">
+      <vector name="origin" x="84" y="134"/>
+      <vector name="head" x="-43" y="-159"/>
+      <int name="delay" value="90"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="难道我的修行……还不够吗？"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/7220001.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/7220001.img.xml
@@ -1,0 +1,628 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="7220001.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="70"/>
+    <int name="maxHP" value="89000"/>
+    <int name="maxMP" value="200"/>
+    <int name="speed" value="-40"/>
+    <int name="PADamage" value="260"/>
+    <int name="PDDamage" value="280"/>
+    <int name="MADamage" value="310"/>
+    <int name="MDDamage" value="265"/>
+    <int name="acc" value="130"/>
+    <int name="eva" value="25"/>
+    <int name="exp" value="1300"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1500"/>
+    <int name="hpRecovery" value="1900"/>
+    <int name="mpRecovery" value="10"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="15"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="121"/>
+        <int name="action" value="2"/>
+        <int name="level" value="7"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="122"/>
+        <int name="action" value="2"/>
+        <int name="level" value="10"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="123"/>
+        <int name="action" value="2"/>
+        <int name="level" value="7"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="0"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3641"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chataBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="80000"/>
+        <string name="0" value="小心点，你只有一条命！"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="176" height="141">
+      <vector name="origin" x="76" y="141"/>
+      <vector name="lt" x="-76" y="-144"/>
+      <vector name="rb" x="100" y="-1"/>
+      <vector name="head" x="-25" y="-132"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="177" height="140">
+      <vector name="origin" x="76" y="143"/>
+      <vector name="lt" x="-76" y="-144"/>
+      <vector name="rb" x="102" y="-3"/>
+      <vector name="head" x="-23" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="173" height="140">
+      <vector name="origin" x="76" y="145"/>
+      <vector name="lt" x="-77" y="-142"/>
+      <vector name="rb" x="97" y="-6"/>
+      <vector name="head" x="-24" y="-135"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="182" height="139">
+      <vector name="origin" x="76" y="142"/>
+      <vector name="lt" x="-77" y="-137"/>
+      <vector name="rb" x="106" y="-4"/>
+      <vector name="head" x="-24" y="-134"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="176" height="137">
+      <vector name="origin" x="76" y="137"/>
+      <vector name="lt" x="-77" y="-134"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-22" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="177" height="140">
+      <vector name="origin" x="76" y="143"/>
+      <vector name="lt" x="-77" y="-140"/>
+      <vector name="rb" x="101" y="-3"/>
+      <vector name="head" x="-24" y="-134"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="173" height="140">
+      <vector name="origin" x="76" y="145"/>
+      <vector name="lt" x="-76" y="-140"/>
+      <vector name="rb" x="96" y="-6"/>
+      <vector name="head" x="-22" y="-137"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="182" height="139">
+      <vector name="origin" x="76" y="142"/>
+      <vector name="lt" x="-76" y="-138"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-23" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="176" height="141">
+      <vector name="origin" x="76" y="141"/>
+      <vector name="lt" x="-76" y="-136"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-23" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="177" height="140">
+      <vector name="origin" x="76" y="140"/>
+      <vector name="lt" x="-76" y="-137"/>
+      <vector name="rb" x="101" y="-1"/>
+      <vector name="head" x="-22" y="-129"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="179" height="138">
+      <vector name="origin" x="76" y="138"/>
+      <vector name="lt" x="-76" y="-134"/>
+      <vector name="rb" x="103" y="-1"/>
+      <vector name="head" x="-24" y="-128"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="173" height="136">
+      <vector name="origin" x="76" y="136"/>
+      <vector name="lt" x="-76" y="-134"/>
+      <vector name="rb" x="96" y="0"/>
+      <vector name="head" x="-26" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="175" height="140">
+      <vector name="origin" x="76" y="140"/>
+      <vector name="lt" x="-77" y="-136"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-24" y="-132"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="182" height="138">
+      <vector name="origin" x="76" y="138"/>
+      <vector name="lt" x="-76" y="-135"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-23" y="-134"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="176" height="141">
+      <vector name="origin" x="76" y="141"/>
+      <vector name="lt" x="-76" y="-136"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-21" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="177" height="140">
+      <vector name="origin" x="76" y="140"/>
+      <vector name="lt" x="-76" y="-134"/>
+      <vector name="rb" x="101" y="0"/>
+      <vector name="head" x="-23" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="180" height="139">
+      <vector name="origin" x="77" y="139"/>
+      <vector name="lt" x="-77" y="-135"/>
+      <vector name="rb" x="103" y="-1"/>
+      <vector name="head" x="-23" y="-129"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="175" height="140">
+      <vector name="origin" x="78" y="140"/>
+      <vector name="lt" x="-78" y="-136"/>
+      <vector name="rb" x="97" y="0"/>
+      <vector name="head" x="-24" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="176" height="141">
+      <vector name="origin" x="77" y="141"/>
+      <vector name="lt" x="-76" y="-137"/>
+      <vector name="rb" x="98" y="-1"/>
+      <vector name="head" x="-22" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="182" height="142">
+      <vector name="origin" x="76" y="142"/>
+      <vector name="lt" x="-76" y="-136"/>
+      <vector name="rb" x="105" y="-1"/>
+      <vector name="head" x="-24" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-212" y="-138"/>
+        <vector name="rb" x="56" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="99" height="107">
+          <vector name="origin" x="49" y="83"/>
+          <int name="delay" value="120"/>
+          <int name="a0" value="200"/>
+          <int name="a1" value="150"/>
+        </canvas>
+        <canvas name="1" width="80" height="77">
+          <vector name="origin" x="40" y="68"/>
+          <int name="delay" value="120"/>
+          <int name="a0" value="150"/>
+          <int name="a1" value="120"/>
+        </canvas>
+        <canvas name="2" width="76" height="74">
+          <vector name="origin" x="38" y="67"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="70" height="68">
+          <vector name="origin" x="35" y="64"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="attackAfter" value="1440"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="280"/>
+    </imgdir>
+    <canvas name="0" width="176" height="141">
+      <vector name="origin" x="76" y="141"/>
+      <vector name="lt" x="-76" y="-136"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-23" y="-134"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="209" height="151">
+      <vector name="origin" x="98" y="139"/>
+      <vector name="lt" x="-77" y="-131"/>
+      <vector name="rb" x="109" y="0"/>
+      <vector name="head" x="-20" y="-129"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="221" height="168">
+      <vector name="origin" x="103" y="141"/>
+      <vector name="lt" x="-72" y="-130"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-17" y="-127"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="212" height="160">
+      <vector name="origin" x="96" y="141"/>
+      <vector name="lt" x="-73" y="-131"/>
+      <vector name="rb" x="108" y="-1"/>
+      <vector name="head" x="-15" y="-125"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="197" height="152">
+      <vector name="origin" x="79" y="142"/>
+      <vector name="lt" x="-70" y="-129"/>
+      <vector name="rb" x="111" y="1"/>
+      <vector name="head" x="-15" y="-126"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="204" height="153">
+      <vector name="origin" x="79" y="143"/>
+      <vector name="lt" x="-70" y="-128"/>
+      <vector name="rb" x="117" y="-1"/>
+      <vector name="head" x="-15" y="-126"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="196" height="182">
+      <vector name="origin" x="85" y="168"/>
+      <vector name="lt" x="-77" y="-155"/>
+      <vector name="rb" x="104" y="-17"/>
+      <vector name="head" x="-22" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="195" height="184">
+      <vector name="origin" x="87" y="168"/>
+      <vector name="lt" x="-78" y="-157"/>
+      <vector name="rb" x="102" y="-17"/>
+      <vector name="head" x="-22" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="190" height="176">
+      <vector name="origin" x="82" y="168"/>
+      <vector name="lt" x="-79" y="-156"/>
+      <vector name="rb" x="104" y="-17"/>
+      <vector name="head" x="-23" y="-153"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="190" height="186">
+      <vector name="origin" x="82" y="168"/>
+      <vector name="lt" x="-78" y="-158"/>
+      <vector name="rb" x="103" y="-21"/>
+      <vector name="head" x="-23" y="-155"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="186" height="168">
+      <vector name="origin" x="80" y="163"/>
+      <vector name="lt" x="-77" y="-151"/>
+      <vector name="rb" x="102" y="-15"/>
+      <vector name="head" x="-22" y="-148"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="182" height="164">
+      <vector name="origin" x="78" y="152"/>
+      <vector name="lt" x="-77" y="-142"/>
+      <vector name="rb" x="104" y="-4"/>
+      <vector name="head" x="-23" y="-137"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="176" height="155">
+      <vector name="origin" x="76" y="141"/>
+      <vector name="lt" x="-76" y="-137"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-24" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="176" height="141">
+      <vector name="origin" x="76" y="141"/>
+      <vector name="lt" x="-77" y="-136"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-25" y="-132"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="14" value="../stand/0"/>
+    <uol name="15" value="../stand/1"/>
+    <uol name="16" value="../stand/2"/>
+    <uol name="17" value="../stand/3"/>
+    <uol name="18" value="../stand/4"/>
+    <uol name="19" value="../stand/5"/>
+    <uol name="20" value="../stand/6"/>
+    <uol name="21" value="../stand/7"/>
+    <uol name="22" value="../stand/8"/>
+    <uol name="23" value="../stand/9"/>
+    <uol name="24" value="../stand/10"/>
+    <uol name="25" value="../stand/11"/>
+    <imgdir name="speak">
+      <int name="prob" value="60"/>
+      <string name="0" value="你是我的了！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="176" height="141">
+      <vector name="origin" x="76" y="141"/>
+      <vector name="lt" x="-76" y="-136"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-23" y="-134"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="209" height="151">
+      <vector name="origin" x="98" y="139"/>
+      <vector name="lt" x="-77" y="-131"/>
+      <vector name="rb" x="109" y="0"/>
+      <vector name="head" x="-20" y="-129"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="221" height="168">
+      <vector name="origin" x="103" y="141"/>
+      <vector name="lt" x="-72" y="-130"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-17" y="-127"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="212" height="160">
+      <vector name="origin" x="96" y="141"/>
+      <vector name="lt" x="-73" y="-131"/>
+      <vector name="rb" x="108" y="-1"/>
+      <vector name="head" x="-15" y="-125"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="197" height="152">
+      <vector name="origin" x="79" y="142"/>
+      <vector name="lt" x="-70" y="-129"/>
+      <vector name="rb" x="111" y="1"/>
+      <vector name="head" x="-15" y="-126"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="204" height="153">
+      <vector name="origin" x="79" y="143"/>
+      <vector name="lt" x="-70" y="-128"/>
+      <vector name="rb" x="117" y="-1"/>
+      <vector name="head" x="-15" y="-126"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="196" height="182">
+      <vector name="origin" x="85" y="168"/>
+      <vector name="lt" x="-77" y="-155"/>
+      <vector name="rb" x="104" y="-17"/>
+      <vector name="head" x="-22" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="195" height="184">
+      <vector name="origin" x="87" y="168"/>
+      <vector name="lt" x="-78" y="-157"/>
+      <vector name="rb" x="102" y="-17"/>
+      <vector name="head" x="-22" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="190" height="176">
+      <vector name="origin" x="82" y="168"/>
+      <vector name="lt" x="-79" y="-156"/>
+      <vector name="rb" x="104" y="-17"/>
+      <vector name="head" x="-23" y="-153"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="190" height="186">
+      <vector name="origin" x="82" y="168"/>
+      <vector name="lt" x="-78" y="-158"/>
+      <vector name="rb" x="103" y="-21"/>
+      <vector name="head" x="-23" y="-155"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="186" height="168">
+      <vector name="origin" x="80" y="163"/>
+      <vector name="lt" x="-77" y="-151"/>
+      <vector name="rb" x="102" y="-15"/>
+      <vector name="head" x="-22" y="-148"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="182" height="164">
+      <vector name="origin" x="78" y="152"/>
+      <vector name="lt" x="-77" y="-142"/>
+      <vector name="rb" x="104" y="-4"/>
+      <vector name="head" x="-23" y="-137"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="176" height="155">
+      <vector name="origin" x="76" y="141"/>
+      <vector name="lt" x="-76" y="-137"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-24" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="176" height="141">
+      <vector name="origin" x="76" y="141"/>
+      <vector name="lt" x="-77" y="-136"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-25" y="-132"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="176" height="141">
+      <vector name="origin" x="76" y="141"/>
+      <vector name="lt" x="-76" y="-137"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-24" y="-132"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="259" height="214">
+      <vector name="origin" x="119" y="160"/>
+      <vector name="lt" x="-83" y="-136"/>
+      <vector name="rb" x="102" y="0"/>
+      <vector name="head" x="-25" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="253" height="208">
+      <vector name="origin" x="118" y="161"/>
+      <vector name="lt" x="-79" y="-135"/>
+      <vector name="rb" x="101" y="0"/>
+      <vector name="head" x="-24" y="-128"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="243" height="205">
+      <vector name="origin" x="115" y="160"/>
+      <vector name="lt" x="-81" y="-133"/>
+      <vector name="rb" x="102" y="0"/>
+      <vector name="head" x="-24" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="218" height="191">
+      <vector name="origin" x="104" y="153"/>
+      <vector name="lt" x="-83" y="-132"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-25" y="-126"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="195" height="174">
+      <vector name="origin" x="89" y="146"/>
+      <vector name="lt" x="-81" y="-132"/>
+      <vector name="rb" x="98" y="0"/>
+      <vector name="head" x="-22" y="-128"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="187" height="157">
+      <vector name="origin" x="81" y="143"/>
+      <vector name="lt" x="-79" y="-131"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-22" y="-126"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="190" height="151">
+      <vector name="origin" x="83" y="144"/>
+      <vector name="lt" x="-80" y="-132"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-23" y="-127"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="191" height="153">
+      <vector name="origin" x="83" y="145"/>
+      <vector name="lt" x="-79" y="-133"/>
+      <vector name="rb" x="99" y="-1"/>
+      <vector name="head" x="-22" y="-128"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="206" height="203">
+      <vector name="origin" x="102" y="186"/>
+      <vector name="lt" x="-80" y="-157"/>
+      <vector name="rb" x="103" y="-18"/>
+      <vector name="head" x="-25" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="209" height="203">
+      <vector name="origin" x="102" y="186"/>
+      <vector name="lt" x="-80" y="-158"/>
+      <vector name="rb" x="104" y="-19"/>
+      <vector name="head" x="-23" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="214" height="203">
+      <vector name="origin" x="102" y="186"/>
+      <vector name="lt" x="-81" y="-157"/>
+      <vector name="rb" x="103" y="-19"/>
+      <vector name="head" x="-23" y="-151"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="219" height="189">
+      <vector name="origin" x="103" y="163"/>
+      <vector name="lt" x="-76" y="-135"/>
+      <vector name="rb" x="103" y="0"/>
+      <vector name="head" x="-24" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="176" height="139">
+      <vector name="origin" x="76" y="138"/>
+      <vector name="lt" x="-76" y="-133"/>
+      <vector name="rb" x="100" y="1"/>
+      <vector name="head" x="-24" y="-128"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="176" height="139">
+      <vector name="origin" x="76" y="140"/>
+      <vector name="lt" x="-76" y="-136"/>
+      <vector name="rb" x="100" y="-2"/>
+      <vector name="head" x="-24" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="192" height="152">
+      <vector name="origin" x="78" y="167"/>
+      <vector name="lt" x="-78" y="-149"/>
+      <vector name="rb" x="114" y="-16"/>
+      <vector name="head" x="-41" y="-141"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="192" height="152">
+      <vector name="origin" x="78" y="167"/>
+      <vector name="head" x="-40" y="-142"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="193" height="152">
+      <vector name="origin" x="73" y="172"/>
+      <vector name="head" x="-36" y="-148"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="193" height="152">
+      <vector name="origin" x="71" y="174"/>
+      <vector name="head" x="-37" y="-148"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="189" height="151">
+      <vector name="origin" x="70" y="172"/>
+      <vector name="head" x="-37" y="-149"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="180" height="135">
+      <vector name="origin" x="62" y="149"/>
+      <vector name="head" x="-9" y="-138"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="179" height="120">
+      <vector name="origin" x="51" y="116"/>
+      <vector name="head" x="2" y="-105"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="180" height="122">
+      <vector name="origin" x="51" y="117"/>
+      <vector name="head" x="-1" y="-104"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="179" height="120">
+      <vector name="origin" x="51" y="116"/>
+      <vector name="head" x="6" y="-103"/>
+      <int name="delay" value="450"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="就差一点……我就快要变成人了……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/7220002.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/7220002.img.xml
@@ -1,0 +1,548 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="7220002.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="77"/>
+    <int name="maxHP" value="108000"/>
+    <int name="maxMP" value="520"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="320"/>
+    <int name="PDDamage" value="520"/>
+    <int name="MADamage" value="350"/>
+    <int name="MDDamage" value="410"/>
+    <int name="acc" value="160"/>
+    <int name="eva" value="27"/>
+    <int name="exp" value="2280"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="2500"/>
+    <int name="hpRecovery" value="2700"/>
+    <int name="mpRecovery" value="10"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="15"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="110"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="113"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="140"/>
+        <int name="action" value="1"/>
+        <int name="level" value="4"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3840"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chataBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="90000"/>
+        <string name="0" value="你想救道？你的愚蠢会招来灾祸。"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="179" height="203">
+      <vector name="origin" x="74" y="210"/>
+      <vector name="lt" x="-74" y="-211"/>
+      <vector name="rb" x="104" y="-7"/>
+      <vector name="head" x="-2" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="175" height="204">
+      <vector name="origin" x="74" y="211"/>
+      <vector name="lt" x="-75" y="-211"/>
+      <vector name="rb" x="101" y="-7"/>
+      <vector name="head" x="-1" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="176" height="204">
+      <vector name="origin" x="73" y="212"/>
+      <vector name="lt" x="-75" y="-214"/>
+      <vector name="rb" x="103" y="-8"/>
+      <vector name="head" x="-1" y="-212"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="180" height="205">
+      <vector name="origin" x="74" y="211"/>
+      <vector name="lt" x="-75" y="-212"/>
+      <vector name="rb" x="106" y="-6"/>
+      <vector name="head" x="-2" y="-212"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="179" height="204">
+      <vector name="origin" x="76" y="210"/>
+      <vector name="lt" x="-77" y="-211"/>
+      <vector name="rb" x="102" y="-6"/>
+      <vector name="head" x="-1" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="178" height="202">
+      <vector name="origin" x="75" y="209"/>
+      <vector name="lt" x="-75" y="-208"/>
+      <vector name="rb" x="103" y="-7"/>
+      <vector name="head" x="-1" y="-210"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="179" height="203">
+      <vector name="origin" x="74" y="210"/>
+      <vector name="lt" x="-75" y="-211"/>
+      <vector name="rb" x="105" y="-7"/>
+      <vector name="head" x="-1" y="-210"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="175" height="205">
+      <vector name="origin" x="74" y="211"/>
+      <vector name="lt" x="-75" y="-213"/>
+      <vector name="rb" x="101" y="-7"/>
+      <vector name="head" x="-2" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="176" height="207">
+      <vector name="origin" x="73" y="212"/>
+      <vector name="lt" x="-72" y="-212"/>
+      <vector name="rb" x="103" y="-5"/>
+      <vector name="head" x="-3" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="180" height="207">
+      <vector name="origin" x="74" y="211"/>
+      <vector name="lt" x="-74" y="-211"/>
+      <vector name="rb" x="105" y="-4"/>
+      <vector name="head" x="-3" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="179" height="205">
+      <vector name="origin" x="76" y="210"/>
+      <vector name="lt" x="-76" y="-210"/>
+      <vector name="rb" x="103" y="-5"/>
+      <vector name="head" x="-3" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="178" height="202">
+      <vector name="origin" x="75" y="209"/>
+      <vector name="lt" x="-76" y="-210"/>
+      <vector name="rb" x="103" y="-7"/>
+      <vector name="head" x="-1" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-299" y="-112"/>
+        <vector name="rb" x="-22" y="-5"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="110" height="113">
+          <vector name="origin" x="57" y="97"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="118" height="124">
+          <vector name="origin" x="64" y="111"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="96" height="98">
+          <vector name="origin" x="46" y="90"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="95" height="94">
+          <vector name="origin" x="47" y="87"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="96" height="85">
+          <vector name="origin" x="53" y="80"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="101" height="84">
+          <vector name="origin" x="58" y="80"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="105" height="85">
+          <vector name="origin" x="60" y="82"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="109" height="89">
+          <vector name="origin" x="61" y="84"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="1680"/>
+      <int name="magic" value="1"/>
+      <int name="knockback" value="1"/>
+    </imgdir>
+    <canvas name="0" width="178" height="206">
+      <vector name="origin" x="74" y="213"/>
+      <vector name="lt" x="-75" y="-214"/>
+      <vector name="rb" x="104" y="-7"/>
+      <vector name="head" x="-2" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="245" height="249">
+      <vector name="origin" x="142" y="214"/>
+      <vector name="lt" x="-75" y="-214"/>
+      <vector name="rb" x="104" y="-10"/>
+      <vector name="head" x="-1" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="237" height="254">
+      <vector name="origin" x="135" y="219"/>
+      <vector name="lt" x="-78" y="-213"/>
+      <vector name="rb" x="101" y="-10"/>
+      <vector name="head" x="-2" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="234" height="258">
+      <vector name="origin" x="127" y="224"/>
+      <vector name="lt" x="-78" y="-215"/>
+      <vector name="rb" x="101" y="-12"/>
+      <vector name="head" x="-1" y="-216"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="223" height="256">
+      <vector name="origin" x="115" y="227"/>
+      <vector name="lt" x="-73" y="-216"/>
+      <vector name="rb" x="103" y="-9"/>
+      <vector name="head" x="0" y="-216"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="203" height="251">
+      <vector name="origin" x="95" y="229"/>
+      <vector name="lt" x="-74" y="-218"/>
+      <vector name="rb" x="103" y="-6"/>
+      <vector name="head" x="0" y="-217"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="193" height="242">
+      <vector name="origin" x="85" y="231"/>
+      <vector name="lt" x="-76" y="-218"/>
+      <vector name="rb" x="99" y="-8"/>
+      <vector name="head" x="-2" y="-219"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="193" height="237">
+      <vector name="origin" x="86" y="232"/>
+      <vector name="lt" x="-77" y="-218"/>
+      <vector name="rb" x="99" y="-11"/>
+      <vector name="head" x="0" y="-220"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="194" height="238">
+      <vector name="origin" x="87" y="234"/>
+      <vector name="lt" x="-79" y="-218"/>
+      <vector name="rb" x="99" y="-15"/>
+      <vector name="head" x="-1" y="-221"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="196" height="239">
+      <vector name="origin" x="89" y="235"/>
+      <vector name="lt" x="-80" y="-218"/>
+      <vector name="rb" x="96" y="-6"/>
+      <vector name="head" x="0" y="-222"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="195" height="240">
+      <vector name="origin" x="87" y="237"/>
+      <vector name="lt" x="-76" y="-221"/>
+      <vector name="rb" x="100" y="-10"/>
+      <vector name="head" x="-2" y="-222"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="198" height="240">
+      <vector name="origin" x="87" y="238"/>
+      <vector name="lt" x="-76" y="-221"/>
+      <vector name="rb" x="101" y="-10"/>
+      <vector name="head" x="-1" y="-223"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="228" height="238">
+      <vector name="origin" x="113" y="235"/>
+      <vector name="lt" x="-77" y="-221"/>
+      <vector name="rb" x="108" y="-9"/>
+      <vector name="head" x="0" y="-221"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="256" height="233">
+      <vector name="origin" x="144" y="224"/>
+      <vector name="lt" x="-73" y="-210"/>
+      <vector name="rb" x="104" y="-5"/>
+      <vector name="head" x="0" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="248" height="231">
+      <vector name="origin" x="133" y="219"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="109" y="-2"/>
+      <vector name="head" x="1" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="267" height="222">
+      <vector name="origin" x="157" y="215"/>
+      <vector name="lt" x="-79" y="-204"/>
+      <vector name="rb" x="103" y="-4"/>
+      <vector name="head" x="0" y="-206"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="282" height="221">
+      <vector name="origin" x="174" y="217"/>
+      <vector name="lt" x="-71" y="-208"/>
+      <vector name="rb" x="104" y="-6"/>
+      <vector name="head" x="-1" y="-210"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="288" height="207">
+      <vector name="origin" x="184" y="212"/>
+      <vector name="lt" x="-72" y="-211"/>
+      <vector name="rb" x="104" y="-6"/>
+      <vector name="head" x="-1" y="-212"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+    <imgdir name="speak">
+      <int name="prob" value="70"/>
+      <string name="0" value="要怪就怪你太弱。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="176" height="208">
+      <vector name="origin" x="72" y="214"/>
+      <vector name="lt" x="-71" y="-214"/>
+      <vector name="rb" x="103" y="-9"/>
+      <vector name="head" x="-1" y="-213"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="182" height="219">
+      <vector name="origin" x="77" y="220"/>
+      <vector name="lt" x="-70" y="-212"/>
+      <vector name="rb" x="104" y="-10"/>
+      <vector name="head" x="0" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="187" height="224">
+      <vector name="origin" x="80" y="223"/>
+      <vector name="lt" x="-73" y="-212"/>
+      <vector name="rb" x="101" y="-12"/>
+      <vector name="head" x="1" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="189" height="226">
+      <vector name="origin" x="82" y="225"/>
+      <vector name="lt" x="-75" y="-213"/>
+      <vector name="rb" x="100" y="-12"/>
+      <vector name="head" x="2" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="188" height="229">
+      <vector name="origin" x="81" y="227"/>
+      <vector name="lt" x="-76" y="-217"/>
+      <vector name="rb" x="100" y="-8"/>
+      <vector name="head" x="3" y="-216"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="201" height="238">
+      <vector name="origin" x="89" y="230"/>
+      <vector name="lt" x="-74" y="-216"/>
+      <vector name="rb" x="98" y="-4"/>
+      <vector name="head" x="4" y="-217"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="234" height="249">
+      <vector name="origin" x="107" y="243"/>
+      <vector name="lt" x="-73" y="-216"/>
+      <vector name="rb" x="100" y="-8"/>
+      <vector name="head" x="5" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="227" height="258">
+      <vector name="origin" x="104" y="252"/>
+      <vector name="lt" x="-75" y="-217"/>
+      <vector name="rb" x="101" y="-8"/>
+      <vector name="head" x="5" y="-219"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="240" height="266">
+      <vector name="origin" x="103" y="259"/>
+      <vector name="lt" x="-74" y="-223"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="5" y="-221"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="218" height="261">
+      <vector name="origin" x="94" y="254"/>
+      <vector name="lt" x="-75" y="-219"/>
+      <vector name="rb" x="102" y="-4"/>
+      <vector name="head" x="6" y="-221"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="206" height="256">
+      <vector name="origin" x="83" y="249"/>
+      <vector name="lt" x="-74" y="-218"/>
+      <vector name="rb" x="101" y="-9"/>
+      <vector name="head" x="3" y="-219"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="256" height="249">
+      <vector name="origin" x="111" y="242"/>
+      <vector name="lt" x="-75" y="-215"/>
+      <vector name="rb" x="101" y="-3"/>
+      <vector name="head" x="3" y="-217"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="235" height="238">
+      <vector name="origin" x="105" y="232"/>
+      <vector name="lt" x="-76" y="-215"/>
+      <vector name="rb" x="99" y="-8"/>
+      <vector name="head" x="2" y="-216"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="195" height="232">
+      <vector name="origin" x="83" y="228"/>
+      <vector name="lt" x="-73" y="-216"/>
+      <vector name="rb" x="100" y="-8"/>
+      <vector name="head" x="1" y="-216"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="193" height="229">
+      <vector name="origin" x="83" y="225"/>
+      <vector name="lt" x="-73" y="-212"/>
+      <vector name="rb" x="101" y="-7"/>
+      <vector name="head" x="-1" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="193" height="227">
+      <vector name="origin" x="83" y="224"/>
+      <vector name="lt" x="-76" y="-211"/>
+      <vector name="rb" x="104" y="-12"/>
+      <vector name="head" x="-2" y="-213"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="188" height="222">
+      <vector name="origin" x="79" y="221"/>
+      <vector name="lt" x="-73" y="-211"/>
+      <vector name="rb" x="106" y="-9"/>
+      <vector name="head" x="-1" y="-212"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="176" height="208">
+      <vector name="origin" x="72" y="213"/>
+      <vector name="lt" x="-71" y="-209"/>
+      <vector name="rb" x="104" y="-9"/>
+      <vector name="head" x="-2" y="-212"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="189" height="205">
+      <vector name="origin" x="71" y="215"/>
+      <vector name="lt" x="-68" y="-215"/>
+      <vector name="rb" x="117" y="-12"/>
+      <vector name="head" x="3" y="-215"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="189" height="205">
+      <vector name="origin" x="71" y="215"/>
+      <vector name="head" x="5" y="-215"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="190" height="205">
+      <vector name="origin" x="71" y="214"/>
+      <vector name="head" x="7" y="-213"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="191" height="205">
+      <vector name="origin" x="71" y="213"/>
+      <vector name="head" x="6" y="-213"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="194" height="205">
+      <vector name="origin" x="73" y="212"/>
+      <vector name="head" x="9" y="-211"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="198" height="205">
+      <vector name="origin" x="76" y="211"/>
+      <vector name="head" x="7" y="-211"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="200" height="205">
+      <vector name="origin" x="77" y="210"/>
+      <vector name="head" x="10" y="-210"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="171" height="147">
+      <vector name="origin" x="78" y="214"/>
+      <vector name="head" x="11" y="-170"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="175" height="158">
+      <vector name="origin" x="80" y="217"/>
+      <vector name="head" x="21" y="-163"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="161" height="165">
+      <vector name="origin" x="65" y="218"/>
+      <vector name="head" x="24" y="-150"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="79" height="67">
+      <vector name="origin" x="5" y="116"/>
+      <vector name="head" x="31" y="-116"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="195" height="207">
+      <vector name="origin" x="90" y="221"/>
+      <vector name="head" x="32" y="-84"/>
+      <int name="delay" value="450"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="不……不……还不是时候！"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8220000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8220000.img.xml
@@ -1,0 +1,652 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8220000.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="83"/>
+    <int name="maxHP" value="87000"/>
+    <int name="maxMP" value="320"/>
+    <int name="speed" value="-50"/>
+    <int name="PADamage" value="420"/>
+    <int name="PDDamage" value="600"/>
+    <int name="MADamage" value="400"/>
+    <int name="MDDamage" value="450"/>
+    <int name="acc" value="150"/>
+    <int name="eva" value="30"/>
+    <int name="exp" value="2800"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="3000"/>
+    <int name="hpRecovery" value="100"/>
+    <int name="mpRecovery" value="5"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="80"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="101"/>
+        <int name="action" value="2"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="720"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="111"/>
+        <int name="action" value="2"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="720"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="121"/>
+        <int name="action" value="2"/>
+        <int name="level" value="7"/>
+        <int name="effectAfter" value="720"/>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="0"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3111"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+        <imgdir name="1">
+          <int name="pet" value="5000004"/>
+        </imgdir>
+        <imgdir name="2">
+          <int name="pet" value="5000000"/>
+        </imgdir>
+      </imgdir>
+      <imgdir name="0">
+        <string name="hp" value="84000"/>
+        <string name="0" value="吼……以女神之名，我绝不会离开这里！"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="154" height="123">
+      <vector name="origin" x="72" y="123"/>
+      <vector name="lt" x="-73" y="-123"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-32" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="153" height="122">
+      <vector name="origin" x="72" y="122"/>
+      <vector name="lt" x="-73" y="-122"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-32" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="154" height="122">
+      <vector name="origin" x="72" y="122"/>
+      <vector name="lt" x="-73" y="-122"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-32" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="162" height="123">
+      <vector name="origin" x="72" y="123"/>
+      <vector name="lt" x="-73" y="-120"/>
+      <vector name="rb" x="90" y="0"/>
+      <vector name="head" x="-32" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="170" height="122">
+      <vector name="origin" x="72" y="122"/>
+      <vector name="lt" x="-72" y="-121"/>
+      <vector name="rb" x="96" y="0"/>
+      <vector name="head" x="-32" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="159" height="122">
+      <vector name="origin" x="72" y="122"/>
+      <vector name="lt" x="-73" y="-121"/>
+      <vector name="rb" x="86" y="-1"/>
+      <vector name="head" x="-32" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="161" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-33" y="-118"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="153" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-33" y="-118"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="152" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="80" y="0"/>
+      <vector name="head" x="-33" y="-118"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="153" height="123">
+      <vector name="origin" x="72" y="123"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-33" y="-118"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="161" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-33" y="-118"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="169" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="97" y="0"/>
+      <vector name="head" x="-33" y="-118"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="jump">
+    <canvas name="0" width="159" height="122">
+      <vector name="origin" x="72" y="122"/>
+      <vector name="lt" x="-73" y="-121"/>
+      <vector name="rb" x="86" y="-1"/>
+      <vector name="head" x="-32" y="-114"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-20" y="-75"/>
+        <vector name="rb" x="20" y="10"/>
+        <int name="start" value="-9"/>
+        <int name="areaCount" value="15"/>
+        <int name="attackCount" value="4"/>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="4" height="4">
+          <vector name="origin" x="2" y="2"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="4" height="4">
+          <vector name="origin" x="2" y="2"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="4" height="4">
+          <vector name="origin" x="2" y="2"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="4" height="4">
+          <vector name="origin" x="2" y="2"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="4" height="4">
+          <vector name="origin" x="2" y="2"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="4" height="4">
+          <vector name="origin" x="2" y="2"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="51" height="26">
+          <vector name="origin" x="24" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="51" height="33">
+          <vector name="origin" x="24" y="42"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="52" height="43">
+          <vector name="origin" x="24" y="52"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="53" height="55">
+          <vector name="origin" x="25" y="62"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="54" height="55">
+          <vector name="origin" x="25" y="63"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="53" height="55">
+          <vector name="origin" x="26" y="63"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="51" height="55">
+          <vector name="origin" x="24" y="63"/>
+          <int name="delay" value="360"/>
+        </canvas>
+        <canvas name="7" width="58" height="56">
+          <vector name="origin" x="31" y="63"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="86" height="59">
+          <vector name="origin" x="46" y="67"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="93" height="58">
+          <vector name="origin" x="46" y="66"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="85" height="68">
+          <vector name="origin" x="39" y="76"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="11" width="84" height="72">
+          <vector name="origin" x="38" y="80"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="12" width="77" height="72">
+          <vector name="origin" x="37" y="80"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="13" width="81" height="72">
+          <vector name="origin" x="40" y="80"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="14" width="74" height="67">
+          <vector name="origin" x="33" y="79"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="99" height="107">
+          <vector name="origin" x="49" y="83"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="80" height="77">
+          <vector name="origin" x="40" y="68"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="76" height="74">
+          <vector name="origin" x="38" y="67"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="70" height="68">
+          <vector name="origin" x="35" y="64"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="conMP" value="3"/>
+      <int name="attackAfter" value="1200"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="161" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="153" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="158" height="131">
+      <vector name="origin" x="74" y="125"/>
+      <vector name="lt" x="-75" y="-125"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="168" height="139">
+      <vector name="origin" x="79" y="129"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="84" y="-1"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="181" height="144">
+      <vector name="origin" x="81" y="132"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="189" height="146">
+      <vector name="origin" x="82" y="133"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="97" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="172" height="154">
+      <vector name="origin" x="73" y="142"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="159" height="151">
+      <vector name="origin" x="70" y="141"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="147" height="141">
+      <vector name="origin" x="64" y="136"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="154" height="123">
+      <vector name="origin" x="73" y="121"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="162" height="124">
+      <vector name="origin" x="73" y="121"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="170" height="124">
+      <vector name="origin" x="73" y="121"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="98" y="-1"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="171" height="129">
+      <vector name="origin" x="82" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="166" height="130">
+      <vector name="origin" x="85" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="82" y="-1"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="155" height="124">
+      <vector name="origin" x="75" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="80" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="153" height="123">
+      <vector name="origin" x="72" y="123"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="161" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="169" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="96" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+    <uol name="24" value="../stand/0"/>
+    <uol name="25" value="../stand/1"/>
+    <uol name="26" value="../stand/2"/>
+    <uol name="27" value="../stand/3"/>
+    <uol name="28" value="../stand/4"/>
+    <uol name="29" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="161" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="153" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="158" height="131">
+      <vector name="origin" x="74" y="125"/>
+      <vector name="lt" x="-75" y="-125"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="168" height="139">
+      <vector name="origin" x="79" y="129"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="84" y="-1"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="181" height="144">
+      <vector name="origin" x="81" y="132"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="189" height="146">
+      <vector name="origin" x="82" y="133"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="97" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="172" height="154">
+      <vector name="origin" x="73" y="142"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="159" height="151">
+      <vector name="origin" x="70" y="141"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="147" height="141">
+      <vector name="origin" x="64" y="136"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="154" height="123">
+      <vector name="origin" x="73" y="121"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="162" height="124">
+      <vector name="origin" x="73" y="121"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="170" height="124">
+      <vector name="origin" x="73" y="121"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="98" y="-1"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="171" height="129">
+      <vector name="origin" x="82" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="166" height="130">
+      <vector name="origin" x="85" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="82" y="-1"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="155" height="124">
+      <vector name="origin" x="75" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="80" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="153" height="123">
+      <vector name="origin" x="72" y="123"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="161" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="169" height="124">
+      <vector name="origin" x="72" y="124"/>
+      <vector name="lt" x="-72" y="-124"/>
+      <vector name="rb" x="96" y="0"/>
+      <vector name="head" x="-33" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <uol name="0" value="../skill1/0"/>
+    <uol name="1" value="../skill1/1"/>
+    <uol name="2" value="../skill1/2"/>
+    <uol name="3" value="../skill1/3"/>
+    <uol name="4" value="../skill1/4"/>
+    <uol name="5" value="../skill1/5"/>
+    <uol name="6" value="../skill1/5"/>
+    <uol name="7" value="../skill1/4"/>
+    <uol name="8" value="../skill1/3"/>
+    <uol name="9" value="../skill1/2"/>
+    <uol name="10" value="../skill1/1"/>
+    <uol name="11" value="../skill1/0"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="154" height="121">
+      <vector name="origin" x="66" y="121"/>
+      <vector name="lt" x="-66" y="-121"/>
+      <vector name="rb" x="88" y="0"/>
+      <int name="delay" value="600"/>
+      <vector name="head" x="-26" y="-122"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="154" height="121">
+      <vector name="origin" x="66" y="121"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="167" height="128">
+      <vector name="origin" x="79" y="128"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="164" height="125">
+      <vector name="origin" x="76" y="125"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="159" height="124">
+      <vector name="origin" x="71" y="124"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="157" height="124">
+      <vector name="origin" x="67" y="122"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="159" height="126">
+      <vector name="origin" x="68" y="123"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="140" height="111">
+      <vector name="origin" x="58" y="115"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="126" height="108">
+      <vector name="origin" x="54" y="120"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="109" height="123">
+      <vector name="origin" x="48" y="148"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="144" height="145">
+      <vector name="origin" x="67" y="137"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="142" height="141">
+      <vector name="origin" x="66" y="135"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="138" height="138">
+      <vector name="origin" x="64" y="134"/>
+      <vector name="head" x="-26" y="-121"/>
+      <int name="delay" value="150"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="不要激怒女神……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8220001.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8220001.img.xml
@@ -1,0 +1,542 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8220001.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="90"/>
+    <int name="maxHP" value="120000"/>
+    <int name="maxMP" value="300"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="450"/>
+    <int name="PDDamage" value="800"/>
+    <int name="MADamage" value="430"/>
+    <int name="MDDamage" value="500"/>
+    <int name="acc" value="195"/>
+    <int name="eva" value="38"/>
+    <int name="exp" value="5200"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="3000"/>
+    <int name="hpRecovery" value="110"/>
+    <int name="mpRecovery" value="5"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="77"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="123"/>
+        <int name="action" value="2"/>
+        <int name="level" value="8"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="131"/>
+        <int name="action" value="2"/>
+        <int name="level" value="7"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="0"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3105"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+        <imgdir name="1">
+          <int name="pet" value="5000020"/>
+        </imgdir>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="100000"/>
+        <string name="0" value="好痛……别打我……很痛的。"/>
+        <string name="1" value="滑雪真好玩。我喜欢滑雪，最喜欢滑雪了。"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="201" height="179">
+      <vector name="origin" x="90" y="179"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-80" y="-173"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-6" y="-177"/>
+    </canvas>
+    <canvas name="1" width="204" height="180">
+      <vector name="origin" x="93" y="178"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-91" y="-174"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-6" y="-173"/>
+    </canvas>
+    <canvas name="2" width="201" height="180">
+      <vector name="origin" x="90" y="177"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-85" y="-174"/>
+      <vector name="rb" x="80" y="0"/>
+      <vector name="head" x="-5" y="-172"/>
+    </canvas>
+    <canvas name="3" width="180" height="182">
+      <vector name="origin" x="69" y="182"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-68" y="-177"/>
+      <vector name="rb" x="98" y="0"/>
+      <vector name="head" x="-6" y="-175"/>
+    </canvas>
+    <canvas name="4" width="180" height="191">
+      <vector name="origin" x="69" y="191"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-67" y="-186"/>
+      <vector name="rb" x="95" y="-1"/>
+      <vector name="head" x="-5" y="-186"/>
+    </canvas>
+    <canvas name="5" width="180" height="192">
+      <vector name="origin" x="69" y="192"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-68" y="-183"/>
+      <vector name="rb" x="95" y="-1"/>
+      <vector name="head" x="-5" y="-185"/>
+    </canvas>
+    <canvas name="6" width="182" height="191">
+      <vector name="origin" x="71" y="191"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-68" y="-181"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="-6" y="-184"/>
+    </canvas>
+    <canvas name="7" width="193" height="181">
+      <vector name="origin" x="82" y="181"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-75" y="-172"/>
+      <vector name="rb" x="83" y="-2"/>
+      <vector name="head" x="-6" y="-177"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="209" height="175">
+      <vector name="origin" x="98" y="175"/>
+      <vector name="lt" x="-74" y="-164"/>
+      <vector name="rb" x="80" y="0"/>
+      <vector name="head" x="-4" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="209" height="176">
+      <vector name="origin" x="98" y="176"/>
+      <vector name="lt" x="-74" y="-165"/>
+      <vector name="rb" x="88" y="-1"/>
+      <vector name="head" x="-3" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="189" height="176">
+      <vector name="origin" x="78" y="176"/>
+      <vector name="lt" x="-73" y="-165"/>
+      <vector name="rb" x="88" y="-1"/>
+      <vector name="head" x="-8" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="189" height="175">
+      <vector name="origin" x="78" y="175"/>
+      <vector name="lt" x="-72" y="-165"/>
+      <vector name="rb" x="86" y="0"/>
+      <vector name="head" x="-6" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="207" height="174">
+      <vector name="origin" x="96" y="174"/>
+      <vector name="lt" x="-71" y="-162"/>
+      <vector name="rb" x="87" y="-1"/>
+      <vector name="head" x="-5" y="-168"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="209" height="174">
+      <vector name="origin" x="98" y="174"/>
+      <vector name="lt" x="-77" y="-162"/>
+      <vector name="rb" x="85" y="-1"/>
+      <vector name="head" x="-5" y="-167"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-59" y="-59"/>
+        <int name="r" value="250"/>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="52" height="50">
+          <vector name="origin" x="25" y="27"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="49" height="52">
+          <vector name="origin" x="25" y="27"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="50" height="52">
+          <vector name="origin" x="25" y="27"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="81" height="68">
+          <vector name="origin" x="40" y="68"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="86" height="94">
+          <vector name="origin" x="33" y="80"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="91" height="104">
+          <vector name="origin" x="32" y="82"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="92" height="105">
+          <vector name="origin" x="29" y="83"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="96" height="99">
+          <vector name="origin" x="32" y="81"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="2"/>
+      <int name="attackAfter" value="1200"/>
+      <int name="bulletSpeed" value="140"/>
+    </imgdir>
+    <canvas name="0" width="189" height="175">
+      <vector name="origin" x="78" y="175"/>
+      <vector name="lt" x="-77" y="-163"/>
+      <vector name="rb" x="86" y="0"/>
+      <vector name="head" x="-5" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="225" height="189">
+      <vector name="origin" x="111" y="178"/>
+      <vector name="lt" x="-69" y="-161"/>
+      <vector name="rb" x="84" y="-1"/>
+      <vector name="head" x="-6" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="215" height="199">
+      <vector name="origin" x="98" y="180"/>
+      <vector name="lt" x="-70" y="-165"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-6" y="-166"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="213" height="192">
+      <vector name="origin" x="94" y="180"/>
+      <vector name="lt" x="-76" y="-161"/>
+      <vector name="rb" x="88" y="-1"/>
+      <vector name="head" x="-7" y="-167"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="207" height="191">
+      <vector name="origin" x="87" y="180"/>
+      <vector name="lt" x="-75" y="-162"/>
+      <vector name="rb" x="91" y="-1"/>
+      <vector name="head" x="-8" y="-167"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="205" height="191">
+      <vector name="origin" x="85" y="180"/>
+      <vector name="lt" x="-70" y="-160"/>
+      <vector name="rb" x="90" y="-1"/>
+      <vector name="head" x="-9" y="-167"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="206" height="190">
+      <vector name="origin" x="86" y="179"/>
+      <vector name="lt" x="-77" y="-160"/>
+      <vector name="rb" x="93" y="-1"/>
+      <vector name="head" x="-11" y="-164"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="206" height="190">
+      <vector name="origin" x="86" y="179"/>
+      <vector name="lt" x="-75" y="-160"/>
+      <vector name="rb" x="93" y="-1"/>
+      <vector name="head" x="-9" y="-166"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="206" height="190">
+      <vector name="origin" x="86" y="179"/>
+      <vector name="lt" x="-75" y="-156"/>
+      <vector name="rb" x="91" y="-1"/>
+      <vector name="head" x="-10" y="-165"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="246" height="196">
+      <vector name="origin" x="116" y="182"/>
+      <vector name="lt" x="-81" y="-160"/>
+      <vector name="rb" x="96" y="-1"/>
+      <vector name="head" x="7" y="-167"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="248" height="194">
+      <vector name="origin" x="116" y="181"/>
+      <vector name="lt" x="-79" y="-161"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="10" y="-166"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="248" height="193">
+      <vector name="origin" x="116" y="180"/>
+      <vector name="lt" x="-80" y="-154"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="11" y="-167"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="244" height="193">
+      <vector name="origin" x="116" y="180"/>
+      <vector name="lt" x="-76" y="-160"/>
+      <vector name="rb" x="92" y="-1"/>
+      <vector name="head" x="8" y="-168"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="203" height="184">
+      <vector name="origin" x="84" y="178"/>
+      <vector name="lt" x="-56" y="-113"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="0" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="189" height="175">
+      <vector name="origin" x="78" y="175"/>
+      <vector name="lt" x="-70" y="-161"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-5" y="-169"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="189" height="175">
+      <vector name="origin" x="78" y="175"/>
+      <vector name="lt" x="-70" y="-162"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-5" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="189" height="175">
+      <vector name="origin" x="78" y="175"/>
+      <vector name="lt" x="-70" y="-163"/>
+      <vector name="rb" x="84" y="0"/>
+      <vector name="head" x="-5" y="-169"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="17" value="../stand/0"/>
+    <uol name="18" value="../stand/1"/>
+    <uol name="19" value="../stand/2"/>
+    <uol name="20" value="../stand/3"/>
+    <uol name="21" value="../stand/4"/>
+    <uol name="22" value="../stand/5"/>
+    <uol name="23" value="../stand/0"/>
+    <uol name="24" value="../stand/1"/>
+    <uol name="25" value="../stand/2"/>
+    <uol name="26" value="../stand/3"/>
+    <uol name="27" value="../stand/4"/>
+    <uol name="28" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="189" height="175">
+      <vector name="origin" x="78" y="175"/>
+      <vector name="lt" x="-71" y="-165"/>
+      <vector name="rb" x="90" y="-1"/>
+      <vector name="head" x="-5" y="-169"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="189" height="174">
+      <vector name="origin" x="78" y="174"/>
+      <vector name="lt" x="-72" y="-166"/>
+      <vector name="rb" x="86" y="0"/>
+      <vector name="head" x="-5" y="-171"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="189" height="173">
+      <vector name="origin" x="78" y="173"/>
+      <vector name="lt" x="-73" y="-163"/>
+      <vector name="rb" x="86" y="0"/>
+      <vector name="head" x="-4" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="189" height="172">
+      <vector name="origin" x="78" y="172"/>
+      <vector name="lt" x="-73" y="-165"/>
+      <vector name="rb" x="86" y="0"/>
+      <vector name="head" x="-5" y="-168"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="189" height="180">
+      <vector name="origin" x="78" y="180"/>
+      <vector name="lt" x="-75" y="-178"/>
+      <vector name="rb" x="86" y="-1"/>
+      <vector name="head" x="-6" y="-166"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="189" height="190">
+      <vector name="origin" x="78" y="190"/>
+      <vector name="lt" x="-71" y="-182"/>
+      <vector name="rb" x="87" y="0"/>
+      <vector name="head" x="-3" y="-167"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="189" height="192">
+      <vector name="origin" x="78" y="192"/>
+      <vector name="lt" x="-72" y="-181"/>
+      <vector name="rb" x="85" y="0"/>
+      <vector name="head" x="-4" y="-168"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="189" height="193">
+      <vector name="origin" x="78" y="193"/>
+      <vector name="lt" x="-74" y="-189"/>
+      <vector name="rb" x="86" y="0"/>
+      <vector name="head" x="-5" y="-168"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="315" height="184">
+      <vector name="origin" x="204" y="180"/>
+      <vector name="lt" x="-85" y="-168"/>
+      <vector name="rb" x="86" y="0"/>
+      <vector name="head" x="-3" y="-175"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="317" height="184">
+      <vector name="origin" x="206" y="181"/>
+      <vector name="lt" x="-192" y="-272"/>
+      <vector name="rb" x="198" y="0"/>
+      <vector name="head" x="-64" y="-269"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="318" height="181">
+      <vector name="origin" x="207" y="178"/>
+      <vector name="lt" x="-76" y="-168"/>
+      <vector name="rb" x="90" y="4"/>
+      <vector name="head" x="-5" y="-174"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="319" height="179">
+      <vector name="origin" x="208" y="177"/>
+      <vector name="lt" x="-75" y="-164"/>
+      <vector name="rb" x="87" y="2"/>
+      <vector name="head" x="-5" y="-172"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="321" height="175">
+      <vector name="origin" x="210" y="175"/>
+      <vector name="lt" x="-68" y="-161"/>
+      <vector name="rb" x="85" y="0"/>
+      <vector name="head" x="-4" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="323" height="175">
+      <vector name="origin" x="212" y="175"/>
+      <vector name="lt" x="-73" y="-165"/>
+      <vector name="rb" x="90" y="0"/>
+      <vector name="head" x="-5" y="-169"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="324" height="175">
+      <vector name="origin" x="213" y="175"/>
+      <vector name="lt" x="-70" y="-165"/>
+      <vector name="rb" x="85" y="0"/>
+      <vector name="head" x="-4" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <uol name="0" value="../stand/0"/>
+    <uol name="1" value="../stand/1"/>
+    <uol name="2" value="../stand/2"/>
+    <uol name="3" value="../stand/3"/>
+    <uol name="4" value="../stand/4"/>
+    <uol name="5" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="215" height="175">
+      <vector name="origin" x="85" y="175"/>
+      <vector name="lt" x="-75" y="-159"/>
+      <vector name="rb" x="111" y="0"/>
+      <int name="delay" value="700"/>
+      <vector name="head" x="16" y="-169"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="215" height="175">
+      <vector name="origin" x="145" y="175"/>
+      <vector name="head" x="-44" y="-170"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="215" height="175">
+      <vector name="origin" x="141" y="175"/>
+      <vector name="head" x="-42" y="-170"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="215" height="175">
+      <vector name="origin" x="138" y="175"/>
+      <vector name="head" x="-38" y="-171"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="215" height="175">
+      <vector name="origin" x="136" y="175"/>
+      <vector name="head" x="-38" y="-171"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="215" height="175">
+      <vector name="origin" x="135" y="175"/>
+      <vector name="head" x="-35" y="-170"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="226" height="175">
+      <vector name="origin" x="146" y="174"/>
+      <vector name="head" x="-35" y="-168"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="229" height="171">
+      <vector name="origin" x="149" y="168"/>
+      <vector name="head" x="-36" y="-163"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="230" height="170">
+      <vector name="origin" x="150" y="167"/>
+      <vector name="head" x="-36" y="-162"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="233" height="157">
+      <vector name="origin" x="153" y="153"/>
+      <vector name="head" x="-35" y="-148"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="232" height="156">
+      <vector name="origin" x="152" y="152"/>
+      <vector name="head" x="-35" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="233" height="151">
+      <vector name="origin" x="153" y="151"/>
+      <vector name="head" x="-37" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="211" height="32">
+      <vector name="origin" x="153" y="36"/>
+      <vector name="head" x="-50" y="-37"/>
+      <int name="delay" value="450"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我喜欢睡觉……睡很久……呼……呼……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8220002.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8220002.img.xml
@@ -1,0 +1,525 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8220002.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="85"/>
+    <int name="maxHP" value="96000"/>
+    <int name="maxMP" value="350"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="430"/>
+    <int name="PDDamage" value="700"/>
+    <int name="MADamage" value="430"/>
+    <int name="MDDamage" value="465"/>
+    <int name="acc" value="160"/>
+    <int name="eva" value="27"/>
+    <int name="exp" value="3000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="3000"/>
+    <int name="hpRecovery" value="100"/>
+    <int name="mpRecovery" value="5"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="mobType" value="8"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="88"/>
+        <int name="effectAfter" value="1200"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="101"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="1200"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="111"/>
+        <int name="action" value="1"/>
+        <int name="level" value="5"/>
+        <int name="effectAfter" value="1200"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="19"/>
+        <int name="effectAfter" value="1200"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="140"/>
+        <int name="action" value="1"/>
+        <int name="level" value="13"/>
+        <int name="effectAfter" value="1200"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="skill" value="103"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="1200"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <imgdir name="0">
+        <int name="hp" value="93000"/>
+        <string name="0" value="别再靠近了！别再靠近了！"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="104" height="119">
+      <vector name="origin" x="59" y="119"/>
+      <vector name="lt" x="-59" y="-119"/>
+      <vector name="rb" x="45" y="0"/>
+      <vector name="head" x="-27" y="-103"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="99" height="122">
+      <vector name="origin" x="59" y="122"/>
+      <vector name="lt" x="-59" y="-122"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-27" y="-101"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="102" height="126">
+      <vector name="origin" x="59" y="126"/>
+      <vector name="lt" x="-59" y="-126"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-27" y="-100"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="104" height="119">
+      <vector name="origin" x="59" y="119"/>
+      <vector name="lt" x="-59" y="-119"/>
+      <vector name="rb" x="45" y="0"/>
+      <vector name="head" x="-27" y="-103"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="109" height="122">
+      <vector name="origin" x="59" y="122"/>
+      <vector name="lt" x="-59" y="-122"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="-27" y="-101"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="107" height="126">
+      <vector name="origin" x="59" y="126"/>
+      <vector name="lt" x="-59" y="-126"/>
+      <vector name="rb" x="48" y="0"/>
+      <vector name="head" x="-27" y="-100"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="104" height="125">
+      <vector name="origin" x="59" y="125"/>
+      <vector name="lt" x="-59" y="-125"/>
+      <vector name="rb" x="45" y="0"/>
+      <vector name="head" x="-27" y="-104"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="99" height="133">
+      <vector name="origin" x="59" y="133"/>
+      <vector name="lt" x="-59" y="-133"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-27" y="-103"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="102" height="132">
+      <vector name="origin" x="59" y="132"/>
+      <vector name="lt" x="-59" y="-132"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-28" y="-102"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="104" height="124">
+      <vector name="origin" x="59" y="124"/>
+      <vector name="lt" x="-59" y="-124"/>
+      <vector name="rb" x="45" y="0"/>
+      <vector name="head" x="-27" y="-103"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="109" height="134">
+      <vector name="origin" x="59" y="134"/>
+      <vector name="lt" x="-60" y="-134"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="-27" y="-104"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="107" height="135">
+      <vector name="origin" x="59" y="135"/>
+      <vector name="lt" x="-59" y="-135"/>
+      <vector name="rb" x="48" y="0"/>
+      <vector name="head" x="-27" y="-105"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-81" y="-30"/>
+        <int name="r" value="250"/>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="47" height="16">
+          <vector name="origin" x="27" y="2"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="51" height="20">
+          <vector name="origin" x="27" y="4"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="57" height="23">
+          <vector name="origin" x="27" y="5"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="59" height="20">
+          <vector name="origin" x="27" y="4"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="62" height="18">
+          <vector name="origin" x="27" y="3"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="64" height="55">
+          <vector name="origin" x="29" y="59"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="114" height="84">
+          <vector name="origin" x="52" y="75"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="132" height="92">
+          <vector name="origin" x="63" y="81"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="94" height="90">
+          <vector name="origin" x="41" y="81"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="103" height="87">
+          <vector name="origin" x="48" y="76"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="98" height="88">
+          <vector name="origin" x="48" y="83"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="2"/>
+      <int name="attackAfter" value="1200"/>
+      <int name="bulletSpeed" value="140"/>
+    </imgdir>
+    <canvas name="0" width="102" height="132">
+      <vector name="origin" x="60" y="130"/>
+      <vector name="lt" x="-61" y="-130"/>
+      <vector name="rb" x="41" y="2"/>
+      <vector name="head" x="-28" y="-104"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="112" height="138">
+      <vector name="origin" x="64" y="133"/>
+      <vector name="lt" x="-65" y="-133"/>
+      <vector name="rb" x="47" y="5"/>
+      <vector name="head" x="-28" y="-103"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="116" height="139">
+      <vector name="origin" x="65" y="133"/>
+      <vector name="lt" x="-66" y="-133"/>
+      <vector name="rb" x="50" y="6"/>
+      <vector name="head" x="-28" y="-102"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="120" height="136">
+      <vector name="origin" x="66" y="129"/>
+      <vector name="lt" x="-67" y="-129"/>
+      <vector name="rb" x="53" y="7"/>
+      <vector name="head" x="-28" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="126" height="133">
+      <vector name="origin" x="71" y="125"/>
+      <vector name="lt" x="-72" y="-125"/>
+      <vector name="rb" x="54" y="8"/>
+      <vector name="head" x="-28" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="125" height="133">
+      <vector name="origin" x="70" y="125"/>
+      <vector name="lt" x="-71" y="-125"/>
+      <vector name="rb" x="54" y="8"/>
+      <vector name="head" x="-29" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="125" height="133">
+      <vector name="origin" x="70" y="125"/>
+      <vector name="lt" x="-71" y="-125"/>
+      <vector name="rb" x="54" y="8"/>
+      <vector name="head" x="-28" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="127" height="135">
+      <vector name="origin" x="71" y="126"/>
+      <vector name="lt" x="-72" y="-126"/>
+      <vector name="rb" x="55" y="9"/>
+      <vector name="head" x="-29" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="127" height="135">
+      <vector name="origin" x="71" y="126"/>
+      <vector name="lt" x="-72" y="-126"/>
+      <vector name="rb" x="55" y="9"/>
+      <vector name="head" x="-29" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="130" height="135">
+      <vector name="origin" x="71" y="126"/>
+      <vector name="lt" x="-72" y="-126"/>
+      <vector name="rb" x="58" y="9"/>
+      <vector name="head" x="-29" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="160" height="140">
+      <vector name="origin" x="100" y="131"/>
+      <vector name="lt" x="-101" y="-131"/>
+      <vector name="rb" x="59" y="9"/>
+      <vector name="head" x="-25" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="177" height="148">
+      <vector name="origin" x="113" y="139"/>
+      <vector name="lt" x="-114" y="-139"/>
+      <vector name="rb" x="63" y="9"/>
+      <vector name="head" x="-26" y="-100"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="171" height="148">
+      <vector name="origin" x="105" y="139"/>
+      <vector name="lt" x="-106" y="-139"/>
+      <vector name="rb" x="65" y="9"/>
+      <vector name="head" x="-27" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="173" height="138">
+      <vector name="origin" x="105" y="130"/>
+      <vector name="lt" x="-106" y="-130"/>
+      <vector name="rb" x="67" y="8"/>
+      <vector name="head" x="-29" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="133" height="144">
+      <vector name="origin" x="66" y="137"/>
+      <vector name="lt" x="-67" y="-137"/>
+      <vector name="rb" x="66" y="7"/>
+      <vector name="head" x="-28" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="131" height="139">
+      <vector name="origin" x="65" y="133"/>
+      <vector name="lt" x="-66" y="-133"/>
+      <vector name="rb" x="65" y="6"/>
+      <vector name="head" x="-29" y="-102"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="112" height="138">
+      <vector name="origin" x="64" y="133"/>
+      <vector name="lt" x="-65" y="-133"/>
+      <vector name="rb" x="47" y="5"/>
+      <vector name="head" x="-28" y="-103"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="104" height="126">
+      <vector name="origin" x="59" y="126"/>
+      <vector name="lt" x="-60" y="-126"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-29" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="197" height="163">
+      <vector name="origin" x="107" y="139"/>
+      <vector name="lt" x="-108" y="-139"/>
+      <vector name="rb" x="89" y="24"/>
+      <vector name="head" x="-28" y="-104"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="182" height="169">
+      <vector name="origin" x="102" y="137"/>
+      <vector name="lt" x="-103" y="-137"/>
+      <vector name="rb" x="79" y="32"/>
+      <vector name="head" x="-29" y="-104"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="157" height="167">
+      <vector name="origin" x="90" y="137"/>
+      <vector name="lt" x="-91" y="-137"/>
+      <vector name="rb" x="66" y="30"/>
+      <vector name="head" x="-28" y="-102"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="138" height="162">
+      <vector name="origin" x="76" y="135"/>
+      <vector name="lt" x="-78" y="-135"/>
+      <vector name="rb" x="61" y="27"/>
+      <vector name="head" x="-28" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="126" height="152">
+      <vector name="origin" x="71" y="133"/>
+      <vector name="lt" x="-72" y="-133"/>
+      <vector name="rb" x="54" y="19"/>
+      <vector name="head" x="-28" y="-100"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="121" height="142">
+      <vector name="origin" x="68" y="133"/>
+      <vector name="lt" x="-69" y="-133"/>
+      <vector name="rb" x="52" y="9"/>
+      <vector name="head" x="-28" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="117" height="143">
+      <vector name="origin" x="68" y="133"/>
+      <vector name="lt" x="-69" y="-133"/>
+      <vector name="rb" x="48" y="10"/>
+      <vector name="head" x="-28" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="117" height="143">
+      <vector name="origin" x="68" y="133"/>
+      <vector name="lt" x="-69" y="-133"/>
+      <vector name="rb" x="48" y="10"/>
+      <vector name="head" x="-27" y="-100"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="169" height="165">
+      <vector name="origin" x="95" y="138"/>
+      <vector name="lt" x="-96" y="-138"/>
+      <vector name="rb" x="73" y="27"/>
+      <vector name="head" x="-27" y="-103"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="169" height="164">
+      <vector name="origin" x="95" y="140"/>
+      <vector name="lt" x="-96" y="-140"/>
+      <vector name="rb" x="73" y="24"/>
+      <vector name="head" x="-27" y="-103"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="167" height="161">
+      <vector name="origin" x="99" y="139"/>
+      <vector name="lt" x="-101" y="-139"/>
+      <vector name="rb" x="67" y="22"/>
+      <vector name="head" x="-28" y="-102"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="163" height="157">
+      <vector name="origin" x="102" y="141"/>
+      <vector name="lt" x="-103" y="-141"/>
+      <vector name="rb" x="60" y="16"/>
+      <vector name="head" x="-28" y="-103"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="116" height="135">
+      <vector name="origin" x="64" y="130"/>
+      <vector name="lt" x="-66" y="-130"/>
+      <vector name="rb" x="51" y="5"/>
+      <vector name="head" x="-27" y="-105"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="14" value="1"/>
+    <uol name="15" value="0"/>
+    <uol name="16" value="../stand/0"/>
+    <uol name="17" value="../stand/1"/>
+    <uol name="18" value="../stand/2"/>
+    <uol name="19" value="../stand/3"/>
+    <uol name="20" value="../stand/4"/>
+    <uol name="21" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="125" height="155">
+      <vector name="origin" x="62" y="155"/>
+      <vector name="lt" x="-64" y="-155"/>
+      <vector name="rb" x="63" y="0"/>
+      <vector name="head" x="-23" y="-103"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="97" height="127">
+      <vector name="origin" x="60" y="127"/>
+      <vector name="head" x="-28" y="-105"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="125" height="168">
+      <vector name="origin" x="55" y="168"/>
+      <vector name="head" x="-15" y="-104"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="115" height="170">
+      <vector name="origin" x="61" y="169"/>
+      <vector name="head" x="-13" y="-104"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="117" height="163">
+      <vector name="origin" x="62" y="161"/>
+      <vector name="head" x="-13" y="-104"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="103" height="173">
+      <vector name="origin" x="47" y="171"/>
+      <vector name="head" x="-12" y="-104"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="101" height="173">
+      <vector name="origin" x="45" y="172"/>
+      <vector name="head" x="-12" y="-104"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="127" height="166">
+      <vector name="origin" x="61" y="163"/>
+      <vector name="head" x="-11" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="130" height="94">
+      <vector name="origin" x="61" y="91"/>
+      <vector name="head" x="-12" y="-83"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="134" height="94">
+      <vector name="origin" x="61" y="90"/>
+      <vector name="head" x="-12" y="-82"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="136" height="93">
+      <vector name="origin" x="61" y="89"/>
+      <vector name="head" x="-12" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="136" height="89">
+      <vector name="origin" x="61" y="88"/>
+      <vector name="head" x="-12" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="火归于土，土化为风，风入于水，水又归于火……周而复始。"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8220003.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8220003.img.xml
@@ -1,0 +1,755 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8220003.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="120"/>
+    <int name="maxHP" value="13400000"/>
+    <int name="maxMP" value="3500"/>
+    <int name="speed" value="-20"/>
+    <int name="PADamage" value="620"/>
+    <int name="PDDamage" value="950"/>
+    <int name="MADamage" value="710"/>
+    <int name="MDDamage" value="1050"/>
+    <int name="acc" value="230"/>
+    <int name="eva" value="41"/>
+    <int name="exp" value="47355"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="10000"/>
+    <int name="hpRecovery" value="1000"/>
+    <int name="mpRecovery" value="100"/>
+    <string name="elemAttr" value="F2I2"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="132"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="122"/>
+        <int name="action" value="1"/>
+        <int name="level" value="3"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="89"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="90"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="91"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <imgdir name="0">
+        <int name="hp" value="13000000"/>
+        <string name="0" value="若你不懂恐惧，我就亲自教会你！"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="204" height="226">
+      <vector name="origin" x="91" y="240"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-205"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="205" height="231">
+      <vector name="origin" x="90" y="241"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-48" y="-206"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="204" height="233">
+      <vector name="origin" x="89" y="242"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-47" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="204" height="234">
+      <vector name="origin" x="88" y="243"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-46" y="-208"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="200" height="234">
+      <vector name="origin" x="90" y="245"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-48" y="-210"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="208" height="231">
+      <vector name="origin" x="91" y="244"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-209"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="205" height="232">
+      <vector name="origin" x="91" y="243"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-208"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="205" height="234">
+      <vector name="origin" x="91" y="244"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-209"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="201" height="235">
+      <vector name="origin" x="91" y="243"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-208"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="211" height="235">
+      <vector name="origin" x="91" y="241"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-206"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="205" height="235">
+      <vector name="origin" x="91" y="240"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-205"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="205" height="233">
+      <vector name="origin" x="91" y="239"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-204"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="201" height="232">
+      <vector name="origin" x="91" y="240"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-205"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="211" height="232">
+      <vector name="origin" x="91" y="242"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-416" y="-300"/>
+        <vector name="rb" x="-100" y="10"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="54" height="21">
+          <vector name="origin" x="25" y="20"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="104" height="96">
+          <vector name="origin" x="50" y="95"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="81" height="91">
+          <vector name="origin" x="38" y="90"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="78" height="89">
+          <vector name="origin" x="38" y="88"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="84" height="85">
+          <vector name="origin" x="47" y="84"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="90" height="88">
+          <vector name="origin" x="49" y="88"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="96" height="43">
+          <vector name="origin" x="49" y="43"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="17" height="27">
+          <vector name="origin" x="11" y="28"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+        <int name="hitAfter" value="240"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1800"/>
+      <int name="magic" value="1"/>
+      <string name="elemAttr" value="I"/>
+    </imgdir>
+    <canvas name="0" width="205" height="233">
+      <vector name="origin" x="91" y="243"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="241" height="253">
+      <vector name="origin" x="117" y="273"/>
+      <vector name="lt" x="-81" y="-219"/>
+      <vector name="rb" x="88" y="-20"/>
+      <vector name="head" x="-39" y="-217"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="252" height="252">
+      <vector name="origin" x="119" y="273"/>
+      <vector name="lt" x="-69" y="-224"/>
+      <vector name="rb" x="96" y="-21"/>
+      <vector name="head" x="-32" y="-224"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="251" height="246">
+      <vector name="origin" x="115" y="269"/>
+      <vector name="lt" x="-68" y="-228"/>
+      <vector name="rb" x="96" y="-23"/>
+      <vector name="head" x="-27" y="-229"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="246" height="251">
+      <vector name="origin" x="111" y="275"/>
+      <vector name="lt" x="-64" y="-236"/>
+      <vector name="rb" x="99" y="-24"/>
+      <vector name="head" x="-22" y="-234"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="240" height="256">
+      <vector name="origin" x="101" y="281"/>
+      <vector name="lt" x="-63" y="-236"/>
+      <vector name="rb" x="101" y="-33"/>
+      <vector name="head" x="-19" y="-239"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="230" height="258">
+      <vector name="origin" x="88" y="285"/>
+      <vector name="lt" x="-58" y="-241"/>
+      <vector name="rb" x="104" y="-34"/>
+      <vector name="head" x="-16" y="-243"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="218" height="259">
+      <vector name="origin" x="73" y="288"/>
+      <vector name="lt" x="-54" y="-242"/>
+      <vector name="rb" x="107" y="-36"/>
+      <vector name="head" x="-14" y="-245"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="213" height="260">
+      <vector name="origin" x="67" y="289"/>
+      <vector name="lt" x="-54" y="-242"/>
+      <vector name="rb" x="106" y="-40"/>
+      <vector name="head" x="-13" y="-246"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="210" height="260">
+      <vector name="origin" x="63" y="290"/>
+      <vector name="lt" x="-51" y="-241"/>
+      <vector name="rb" x="106" y="-40"/>
+      <vector name="head" x="-12" y="-247"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="210" height="260">
+      <vector name="origin" x="62" y="291"/>
+      <vector name="lt" x="-48" y="-248"/>
+      <vector name="rb" x="112" y="-41"/>
+      <vector name="head" x="-11" y="-248"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="472" height="239">
+      <vector name="origin" x="345" y="230"/>
+      <vector name="lt" x="-160" y="-186"/>
+      <vector name="rb" x="113" y="-3"/>
+      <vector name="head" x="-123" y="-188"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="515" height="237">
+      <vector name="origin" x="394" y="225"/>
+      <vector name="lt" x="-167" y="-189"/>
+      <vector name="rb" x="112" y="-2"/>
+      <vector name="head" x="-127" y="-184"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="540" height="251">
+      <vector name="origin" x="421" y="222"/>
+      <vector name="lt" x="-166" y="-192"/>
+      <vector name="rb" x="112" y="-1"/>
+      <vector name="head" x="-128" y="-183"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="533" height="255">
+      <vector name="origin" x="422" y="220"/>
+      <vector name="lt" x="-168" y="-192"/>
+      <vector name="rb" x="109" y="-1"/>
+      <vector name="head" x="-128" y="-185"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="533" height="263">
+      <vector name="origin" x="423" y="223"/>
+      <vector name="lt" x="-161" y="-192"/>
+      <vector name="rb" x="109" y="-3"/>
+      <vector name="head" x="-120" y="-188"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="526" height="262">
+      <vector name="origin" x="423" y="238"/>
+      <vector name="lt" x="-130" y="-202"/>
+      <vector name="rb" x="95" y="-5"/>
+      <vector name="head" x="-91" y="-203"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="205" height="232">
+      <vector name="origin" x="96" y="238"/>
+      <vector name="lt" x="-96" y="-204"/>
+      <vector name="rb" x="80" y="-6"/>
+      <vector name="head" x="-54" y="-203"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="205" height="232">
+      <vector name="origin" x="95" y="239"/>
+      <vector name="lt" x="-95" y="-208"/>
+      <vector name="rb" x="84" y="-7"/>
+      <vector name="head" x="-53" y="-204"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="205" height="232">
+      <vector name="origin" x="94" y="240"/>
+      <vector name="lt" x="-94" y="-208"/>
+      <vector name="rb" x="83" y="-8"/>
+      <vector name="head" x="-52" y="-205"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="20" value="../stand/0"/>
+    <uol name="21" value="../stand/1"/>
+    <uol name="22" value="../stand/2"/>
+    <uol name="23" value="../stand/3"/>
+    <uol name="24" value="../stand/4"/>
+    <uol name="25" value="../stand/5"/>
+    <uol name="26" value="../stand/6"/>
+    <uol name="27" value="../stand/7"/>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-810" y="-304"/>
+        <vector name="rb" x="-20" y="10"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="81" height="80">
+          <vector name="origin" x="31" y="73"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="61" height="48">
+          <vector name="origin" x="32" y="41"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="91" height="82">
+          <vector name="origin" x="51" y="75"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="90" height="84">
+          <vector name="origin" x="50" y="74"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="92" height="92">
+          <vector name="origin" x="52" y="87"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="92" height="86">
+          <vector name="origin" x="52" y="84"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="53" height="76">
+          <vector name="origin" x="53" y="84"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1440"/>
+      <int name="magic" value="1"/>
+      <string name="elemAttr" value="F"/>
+      <int name="knockback" value="1"/>
+      <int name="jumpAttack" value="1"/>
+    </imgdir>
+    <canvas name="0" width="205" height="233">
+      <vector name="origin" x="91" y="243"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="241" height="253">
+      <vector name="origin" x="117" y="273"/>
+      <vector name="lt" x="-81" y="-219"/>
+      <vector name="rb" x="88" y="-20"/>
+      <vector name="head" x="-39" y="-217"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="252" height="252">
+      <vector name="origin" x="119" y="273"/>
+      <vector name="lt" x="-69" y="-224"/>
+      <vector name="rb" x="96" y="-21"/>
+      <vector name="head" x="-32" y="-224"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="251" height="246">
+      <vector name="origin" x="115" y="269"/>
+      <vector name="lt" x="-68" y="-228"/>
+      <vector name="rb" x="96" y="-23"/>
+      <vector name="head" x="-27" y="-229"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="246" height="251">
+      <vector name="origin" x="111" y="275"/>
+      <vector name="lt" x="-64" y="-236"/>
+      <vector name="rb" x="99" y="-24"/>
+      <vector name="head" x="-22" y="-234"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="240" height="256">
+      <vector name="origin" x="101" y="281"/>
+      <vector name="lt" x="-63" y="-236"/>
+      <vector name="rb" x="101" y="-33"/>
+      <vector name="head" x="-19" y="-239"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="230" height="258">
+      <vector name="origin" x="88" y="285"/>
+      <vector name="lt" x="-58" y="-241"/>
+      <vector name="rb" x="104" y="-34"/>
+      <vector name="head" x="-16" y="-243"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="218" height="259">
+      <vector name="origin" x="73" y="288"/>
+      <vector name="lt" x="-54" y="-242"/>
+      <vector name="rb" x="107" y="-36"/>
+      <vector name="head" x="-14" y="-245"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="213" height="260">
+      <vector name="origin" x="67" y="289"/>
+      <vector name="lt" x="-54" y="-242"/>
+      <vector name="rb" x="106" y="-40"/>
+      <vector name="head" x="-13" y="-246"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="210" height="260">
+      <vector name="origin" x="63" y="290"/>
+      <vector name="lt" x="-51" y="-241"/>
+      <vector name="rb" x="106" y="-40"/>
+      <vector name="head" x="-12" y="-247"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="210" height="260">
+      <vector name="origin" x="63" y="290"/>
+      <vector name="lt" x="-48" y="-248"/>
+      <vector name="rb" x="112" y="-41"/>
+      <vector name="head" x="-11" y="-248"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="316" height="237">
+      <vector name="origin" x="188" y="232"/>
+      <vector name="lt" x="-160" y="-186"/>
+      <vector name="rb" x="113" y="-3"/>
+      <vector name="head" x="-123" y="-188"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="343" height="241">
+      <vector name="origin" x="217" y="229"/>
+      <vector name="lt" x="-167" y="-189"/>
+      <vector name="rb" x="112" y="-2"/>
+      <vector name="head" x="-124" y="-187"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="355" height="245">
+      <vector name="origin" x="232" y="227"/>
+      <vector name="lt" x="-166" y="-192"/>
+      <vector name="rb" x="112" y="-1"/>
+      <vector name="head" x="-125" y="-186"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="356" height="237">
+      <vector name="origin" x="237" y="222"/>
+      <vector name="lt" x="-168" y="-192"/>
+      <vector name="rb" x="109" y="-1"/>
+      <vector name="head" x="-126" y="-185"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="335" height="235">
+      <vector name="origin" x="219" y="219"/>
+      <vector name="lt" x="-161" y="-192"/>
+      <vector name="rb" x="109" y="-3"/>
+      <vector name="head" x="-127" y="-184"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="354" height="235">
+      <vector name="origin" x="239" y="218"/>
+      <vector name="lt" x="-169" y="-192"/>
+      <vector name="rb" x="113" y="-1"/>
+      <vector name="head" x="-128" y="-183"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="305" height="230">
+      <vector name="origin" x="191" y="217"/>
+      <vector name="lt" x="-171" y="-192"/>
+      <vector name="rb" x="107" y="-1"/>
+      <vector name="head" x="-129" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="285" height="217">
+      <vector name="origin" x="172" y="216"/>
+      <vector name="lt" x="-172" y="-192"/>
+      <vector name="rb" x="107" y="1"/>
+      <vector name="head" x="-130" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="285" height="217">
+      <vector name="origin" x="173" y="215"/>
+      <vector name="lt" x="-173" y="-190"/>
+      <vector name="rb" x="107" y="0"/>
+      <vector name="head" x="-131" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="281" height="219">
+      <vector name="origin" x="170" y="218"/>
+      <vector name="lt" x="-170" y="-192"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-128" y="-183"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="272" height="221">
+      <vector name="origin" x="162" y="223"/>
+      <vector name="lt" x="-162" y="-193"/>
+      <vector name="rb" x="107" y="-2"/>
+      <vector name="head" x="-120" y="-188"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="230" height="233">
+      <vector name="origin" x="133" y="238"/>
+      <vector name="lt" x="-133" y="-206"/>
+      <vector name="rb" x="96" y="-5"/>
+      <vector name="head" x="-91" y="-203"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="23" value="../stand/0"/>
+    <uol name="24" value="../stand/1"/>
+    <uol name="25" value="../stand/2"/>
+    <uol name="26" value="../stand/3"/>
+    <uol name="27" value="../stand/4"/>
+    <uol name="28" value="../stand/5"/>
+    <uol name="29" value="../stand/6"/>
+    <uol name="30" value="../stand/7"/>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="205" height="232">
+      <vector name="origin" x="91" y="243"/>
+      <vector name="lt" x="-91" y="-244"/>
+      <vector name="rb" x="80" y="-11"/>
+      <vector name="head" x="-49" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="295" height="244">
+      <vector name="origin" x="179" y="249"/>
+      <vector name="lt" x="-87" y="-211"/>
+      <vector name="rb" x="82" y="-10"/>
+      <vector name="head" x="-46" y="-210"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="290" height="251">
+      <vector name="origin" x="176" y="253"/>
+      <vector name="lt" x="-83" y="-214"/>
+      <vector name="rb" x="86" y="-10"/>
+      <vector name="head" x="-43" y="-212"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="287" height="256">
+      <vector name="origin" x="171" y="256"/>
+      <vector name="lt" x="-83" y="-215"/>
+      <vector name="rb" x="85" y="-10"/>
+      <vector name="head" x="-41" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="281" height="260">
+      <vector name="origin" x="162" y="258"/>
+      <vector name="lt" x="-82" y="-215"/>
+      <vector name="rb" x="85" y="-9"/>
+      <vector name="head" x="-39" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="268" height="260">
+      <vector name="origin" x="148" y="258"/>
+      <vector name="lt" x="-100" y="-216"/>
+      <vector name="rb" x="84" y="-7"/>
+      <vector name="head" x="-38" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="266" height="260">
+      <vector name="origin" x="145" y="258"/>
+      <vector name="lt" x="-74" y="-216"/>
+      <vector name="rb" x="86" y="-7"/>
+      <vector name="head" x="-37" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="267" height="260">
+      <vector name="origin" x="145" y="258"/>
+      <vector name="lt" x="-70" y="-215"/>
+      <vector name="rb" x="85" y="-7"/>
+      <vector name="head" x="-36" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="266" height="260">
+      <vector name="origin" x="143" y="258"/>
+      <vector name="lt" x="-78" y="-217"/>
+      <vector name="rb" x="86" y="-8"/>
+      <vector name="head" x="-35" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="269" height="259">
+      <vector name="origin" x="145" y="258"/>
+      <vector name="lt" x="-74" y="-212"/>
+      <vector name="rb" x="89" y="-10"/>
+      <vector name="head" x="-34" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="265" height="256">
+      <vector name="origin" x="142" y="256"/>
+      <vector name="lt" x="-75" y="-217"/>
+      <vector name="rb" x="89" y="-8"/>
+      <vector name="head" x="-33" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="261" height="252">
+      <vector name="origin" x="139" y="254"/>
+      <vector name="lt" x="-73" y="-216"/>
+      <vector name="rb" x="90" y="-8"/>
+      <vector name="head" x="-32" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="247" height="243">
+      <vector name="origin" x="128" y="250"/>
+      <vector name="lt" x="-71" y="-218"/>
+      <vector name="rb" x="88" y="-7"/>
+      <vector name="head" x="-31" y="-215"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="193" height="238">
+      <vector name="origin" x="76" y="247"/>
+      <vector name="lt" x="-76" y="-213"/>
+      <vector name="rb" x="96" y="-9"/>
+      <vector name="head" x="-34" y="-212"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="200" height="235">
+      <vector name="origin" x="80" y="245"/>
+      <vector name="lt" x="-80" y="-211"/>
+      <vector name="rb" x="93" y="-10"/>
+      <vector name="head" x="-38" y="-210"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="15" value="../stand/0"/>
+    <uol name="16" value="../stand/1"/>
+    <uol name="17" value="../stand/2"/>
+    <uol name="18" value="../stand/3"/>
+    <uol name="19" value="../stand/4"/>
+    <uol name="20" value="../stand/5"/>
+    <uol name="21" value="../stand/6"/>
+    <uol name="22" value="../stand/7"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="213" height="254">
+      <vector name="origin" x="85" y="270"/>
+      <vector name="lt" x="-84" y="-263"/>
+      <vector name="rb" x="66" y="-19"/>
+      <vector name="head" x="-47" y="-231"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="209" height="250">
+      <vector name="origin" x="68" y="274"/>
+      <vector name="head" x="-28" y="-236"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="210" height="240">
+      <vector name="origin" x="63" y="265"/>
+      <vector name="head" x="-21" y="-228"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="201" height="235">
+      <vector name="origin" x="62" y="259"/>
+      <vector name="head" x="-21" y="-225"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="205" height="242">
+      <vector name="origin" x="57" y="227"/>
+      <vector name="head" x="-16" y="-191"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="208" height="240">
+      <vector name="origin" x="61" y="225"/>
+      <vector name="head" x="-17" y="-190"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="212" height="238">
+      <vector name="origin" x="65" y="222"/>
+      <vector name="head" x="-17" y="-187"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="218" height="237">
+      <vector name="origin" x="71" y="221"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="178" height="40">
+      <vector name="origin" x="70" y="28"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="177" height="32">
+      <vector name="origin" x="72" y="30"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="任何踏入龙之峡谷的人，都要付出代价。"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8220004.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8220004.img.xml
@@ -1,0 +1,742 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8220004.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="121"/>
+    <int name="maxHP" value="5900000"/>
+    <int name="maxMP" value="2000"/>
+    <int name="speed" value="-70"/>
+    <int name="PADamage" value="630"/>
+    <int name="PDDamage" value="950"/>
+    <int name="MADamage" value="715"/>
+    <int name="MDDamage" value="1050"/>
+    <int name="acc" value="218"/>
+    <int name="eva" value="42"/>
+    <int name="exp" value="20850"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="10000"/>
+    <int name="hpRecovery" value="5000"/>
+    <int name="mpRecovery" value="200"/>
+    <float name="fs" value="10.0"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="102"/>
+        <int name="action" value="2"/>
+        <int name="level" value="3"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="You have been ousted by the force of Dodo."/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="270010410"/>
+          <string name="portal" value="sp"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <string name="elemAttr" value="F2I2L2S2"/>
+    <int name="firstAttack" value="1"/>
+    <imgdir name="speak">
+      <imgdir name="0">
+        <string name="hp" value="5500000"/>
+        <string name="0" value="被过去记忆束缚的人啊……醒来吧，解放自己。"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3501"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="234" height="208">
+      <vector name="origin" x="100" y="199"/>
+      <vector name="lt" x="-99" y="-162"/>
+      <vector name="rb" x="67" y="7"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="238" height="209">
+      <vector name="origin" x="100" y="201"/>
+      <vector name="lt" x="-100" y="-162"/>
+      <vector name="rb" x="47" y="4"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="233" height="206">
+      <vector name="origin" x="100" y="204"/>
+      <vector name="lt" x="-100" y="-169"/>
+      <vector name="rb" x="45" y="-2"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="228" height="204">
+      <vector name="origin" x="100" y="208"/>
+      <vector name="lt" x="-99" y="-174"/>
+      <vector name="rb" x="39" y="-5"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="223" height="206">
+      <vector name="origin" x="100" y="207"/>
+      <vector name="lt" x="-100" y="-171"/>
+      <vector name="rb" x="49" y="-2"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="239" height="205">
+      <vector name="origin" x="100" y="203"/>
+      <vector name="lt" x="-100" y="-173"/>
+      <vector name="rb" x="48" y="-2"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="238" height="208">
+      <vector name="origin" x="100" y="201"/>
+      <vector name="lt" x="-99" y="-170"/>
+      <vector name="rb" x="69" y="4"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="239" height="202">
+      <vector name="origin" x="100" y="200"/>
+      <vector name="lt" x="-100" y="-168"/>
+      <vector name="rb" x="68" y="-1"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="235" height="208">
+      <vector name="origin" x="100" y="211"/>
+      <vector name="lt" x="-101" y="-179"/>
+      <vector name="rb" x="70" y="-5"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="236" height="208">
+      <vector name="origin" x="100" y="212"/>
+      <vector name="lt" x="-100" y="-179"/>
+      <vector name="rb" x="68" y="-5"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="238" height="208">
+      <vector name="origin" x="100" y="213"/>
+      <vector name="lt" x="-99" y="-181"/>
+      <vector name="rb" x="63" y="-7"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="236" height="208">
+      <vector name="origin" x="100" y="214"/>
+      <vector name="lt" x="-99" y="-182"/>
+      <vector name="rb" x="61" y="-7"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="243" height="208">
+      <vector name="origin" x="100" y="215"/>
+      <vector name="lt" x="-100" y="-183"/>
+      <vector name="rb" x="54" y="-8"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="238" height="208">
+      <vector name="origin" x="100" y="214"/>
+      <vector name="lt" x="-91" y="-162"/>
+      <vector name="rb" x="53" y="-7"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="235" height="208">
+      <vector name="origin" x="100" y="213"/>
+      <vector name="lt" x="-91" y="-162"/>
+      <vector name="rb" x="57" y="-6"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="234" height="209">
+      <vector name="origin" x="100" y="212"/>
+      <vector name="lt" x="-91" y="-162"/>
+      <vector name="rb" x="65" y="-4"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-129" y="-44"/>
+        <int name="r" value="400"/>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="87" height="39">
+          <vector name="origin" x="16" y="19"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="102" height="39">
+          <vector name="origin" x="16" y="19"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="110" height="39">
+          <vector name="origin" x="16" y="19"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="102" height="39">
+          <vector name="origin" x="16" y="19"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="87" height="78">
+          <vector name="origin" x="43" y="86"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="1" width="69" height="69">
+          <vector name="origin" x="35" y="78"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="2" width="66" height="65">
+          <vector name="origin" x="35" y="74"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="3" width="71" height="59">
+          <vector name="origin" x="36" y="70"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="4" width="72" height="62">
+          <vector name="origin" x="37" y="71"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="2"/>
+      <int name="conMP" value="10"/>
+      <int name="attackAfter" value="1050"/>
+      <int name="PADamage" value="670"/>
+      <int name="bulletSpeed" value="140"/>
+    </imgdir>
+    <canvas name="0" width="235" height="208">
+      <vector name="origin" x="100" y="211"/>
+      <vector name="lt" x="-100" y="-172"/>
+      <vector name="rb" x="69" y="-4"/>
+      <vector name="head" x="-38" y="-212"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="250" height="217">
+      <vector name="origin" x="98" y="219"/>
+      <vector name="lt" x="-90" y="-179"/>
+      <vector name="rb" x="52" y="-4"/>
+      <vector name="head" x="-28" y="-214"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="257" height="222">
+      <vector name="origin" x="95" y="226"/>
+      <vector name="lt" x="-87" y="-181"/>
+      <vector name="rb" x="54" y="-14"/>
+      <vector name="head" x="-23" y="-217"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="257" height="224">
+      <vector name="origin" x="93" y="229"/>
+      <vector name="lt" x="-84" y="-183"/>
+      <vector name="rb" x="53" y="-18"/>
+      <vector name="head" x="-18" y="-219"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="258" height="227">
+      <vector name="origin" x="89" y="232"/>
+      <vector name="lt" x="-77" y="-184"/>
+      <vector name="rb" x="63" y="-19"/>
+      <vector name="head" x="-15" y="-222"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="260" height="229">
+      <vector name="origin" x="89" y="234"/>
+      <vector name="lt" x="-76" y="-186"/>
+      <vector name="rb" x="63" y="-19"/>
+      <vector name="head" x="-12" y="-222"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="260" height="229">
+      <vector name="origin" x="89" y="234"/>
+      <vector name="lt" x="-79" y="-187"/>
+      <vector name="rb" x="62" y="-22"/>
+      <vector name="head" x="-13" y="-222"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="311" height="230">
+      <vector name="origin" x="226" y="174"/>
+      <vector name="lt" x="-156" y="-128"/>
+      <vector name="rb" x="-17" y="23"/>
+      <vector name="head" x="-96" y="-164"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="299" height="227">
+      <vector name="origin" x="224" y="172"/>
+      <vector name="lt" x="-159" y="-122"/>
+      <vector name="rb" x="-24" y="18"/>
+      <vector name="head" x="-101" y="-163"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="287" height="218">
+      <vector name="origin" x="219" y="169"/>
+      <vector name="lt" x="-164" y="-122"/>
+      <vector name="rb" x="-26" y="16"/>
+      <vector name="head" x="-103" y="-160"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="253" height="205">
+      <vector name="origin" x="152" y="185"/>
+      <vector name="lt" x="-141" y="-139"/>
+      <vector name="rb" x="20" y="8"/>
+      <vector name="head" x="-82" y="-180"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="241" height="192">
+      <vector name="origin" x="124" y="192"/>
+      <vector name="lt" x="-122" y="-159"/>
+      <vector name="rb" x="49" y="-3"/>
+      <vector name="head" x="-59" y="-193"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="235" height="208">
+      <vector name="origin" x="100" y="211"/>
+      <vector name="lt" x="-99" y="-175"/>
+      <vector name="rb" x="66" y="-7"/>
+      <vector name="head" x="-38" y="-212"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-320" y="-310"/>
+        <vector name="rb" x="-87" y="-6"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="74" height="70">
+          <vector name="origin" x="37" y="86"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="1" width="72" height="71">
+          <vector name="origin" x="37" y="86"/>
+          <int name="delay" value="60"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="2" width="69" height="71">
+          <vector name="origin" x="37" y="86"/>
+          <int name="delay" value="60"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="3" width="67" height="67">
+          <vector name="origin" x="37" y="86"/>
+          <int name="delay" value="60"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="4" width="60" height="63">
+          <vector name="origin" x="37" y="86"/>
+          <int name="delay" value="60"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="20"/>
+      <int name="magic" value="1"/>
+      <int name="attackAfter" value="960"/>
+    </imgdir>
+    <canvas name="0" width="236" height="205">
+      <vector name="origin" x="100" y="211"/>
+      <vector name="lt" x="-98" y="-177"/>
+      <vector name="rb" x="66" y="-7"/>
+      <vector name="head" x="-37" y="-213"/>
+      <string name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="311" height="206">
+      <vector name="origin" x="163" y="215"/>
+      <vector name="lt" x="-92" y="-178"/>
+      <vector name="rb" x="76" y="-14"/>
+      <vector name="head" x="-31" y="-213"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="314" height="207">
+      <vector name="origin" x="160" y="219"/>
+      <vector name="lt" x="-90" y="-175"/>
+      <vector name="rb" x="87" y="-20"/>
+      <vector name="head" x="-26" y="-213"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="307" height="206">
+      <vector name="origin" x="150" y="220"/>
+      <vector name="lt" x="-84" y="-177"/>
+      <vector name="rb" x="88" y="-24"/>
+      <vector name="head" x="-24" y="-213"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="300" height="210">
+      <vector name="origin" x="139" y="222"/>
+      <vector name="lt" x="-78" y="-179"/>
+      <vector name="rb" x="90" y="-32"/>
+      <vector name="head" x="-21" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="300" height="212">
+      <vector name="origin" x="136" y="223"/>
+      <vector name="lt" x="-80" y="-177"/>
+      <vector name="rb" x="92" y="-26"/>
+      <vector name="head" x="-20" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="298" height="213">
+      <vector name="origin" x="133" y="223"/>
+      <vector name="lt" x="-82" y="-179"/>
+      <vector name="rb" x="95" y="-25"/>
+      <vector name="head" x="-19" y="-213"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="296" height="213">
+      <vector name="origin" x="130" y="223"/>
+      <vector name="lt" x="-78" y="-179"/>
+      <vector name="rb" x="97" y="-27"/>
+      <vector name="head" x="-17" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="293" height="213">
+      <vector name="origin" x="127" y="223"/>
+      <vector name="lt" x="-78" y="-179"/>
+      <vector name="rb" x="98" y="-27"/>
+      <vector name="head" x="-18" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="315" height="230">
+      <vector name="origin" x="221" y="223"/>
+      <vector name="lt" x="-153" y="-177"/>
+      <vector name="rb" x="-6" y="-9"/>
+      <vector name="head" x="-89" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="310" height="228">
+      <vector name="origin" x="225" y="222"/>
+      <vector name="lt" x="-155" y="-173"/>
+      <vector name="rb" x="-5" y="-10"/>
+      <vector name="head" x="-92" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="303" height="225">
+      <vector name="origin" x="225" y="221"/>
+      <vector name="lt" x="-156" y="-174"/>
+      <vector name="rb" x="-2" y="-8"/>
+      <vector name="head" x="-93" y="-214"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="326" height="220">
+      <vector name="origin" x="224" y="219"/>
+      <vector name="lt" x="-142" y="-175"/>
+      <vector name="rb" x="18" y="-7"/>
+      <vector name="head" x="-81" y="-213"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="244" height="212">
+      <vector name="origin" x="131" y="215"/>
+      <vector name="lt" x="-126" y="-179"/>
+      <vector name="rb" x="35" y="-9"/>
+      <vector name="head" x="-63" y="-213"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="236" height="204">
+      <vector name="origin" x="116" y="211"/>
+      <vector name="lt" x="-115" y="-176"/>
+      <vector name="rb" x="48" y="-9"/>
+      <vector name="head" x="-53" y="-212"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="234" height="208">
+      <vector name="origin" x="100" y="212"/>
+      <vector name="lt" x="-97" y="-176"/>
+      <vector name="rb" x="65" y="-7"/>
+      <vector name="head" x="-37" y="-212"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="237" height="202">
+      <vector name="origin" x="102" y="213"/>
+      <vector name="lt" x="-98" y="-180"/>
+      <vector name="rb" x="69" y="-14"/>
+      <vector name="head" x="-37" y="-213"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="254" height="212">
+      <vector name="origin" x="110" y="220"/>
+      <vector name="lt" x="-96" y="-177"/>
+      <vector name="rb" x="73" y="-21"/>
+      <vector name="head" x="-37" y="-216"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="262" height="211">
+      <vector name="origin" x="113" y="225"/>
+      <vector name="lt" x="-98" y="-181"/>
+      <vector name="rb" x="71" y="-27"/>
+      <vector name="head" x="-37" y="-217"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="265" height="215">
+      <vector name="origin" x="115" y="228"/>
+      <vector name="lt" x="-99" y="-182"/>
+      <vector name="rb" x="70" y="-27"/>
+      <vector name="head" x="-37" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="270" height="221">
+      <vector name="origin" x="118" y="232"/>
+      <vector name="lt" x="-99" y="-182"/>
+      <vector name="rb" x="64" y="-37"/>
+      <vector name="head" x="-37" y="-219"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="273" height="223">
+      <vector name="origin" x="119" y="234"/>
+      <vector name="lt" x="-102" y="-186"/>
+      <vector name="rb" x="74" y="-35"/>
+      <vector name="head" x="-37" y="-220"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="275" height="226">
+      <vector name="origin" x="120" y="236"/>
+      <vector name="lt" x="-100" y="-186"/>
+      <vector name="rb" x="70" y="-38"/>
+      <vector name="head" x="-37" y="-219"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="278" height="239">
+      <vector name="origin" x="120" y="198"/>
+      <vector name="lt" x="-98" y="-141"/>
+      <vector name="rb" x="41" y="-3"/>
+      <vector name="head" x="-37" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="276" height="236">
+      <vector name="origin" x="119" y="195"/>
+      <vector name="lt" x="-97" y="-144"/>
+      <vector name="rb" x="43" y="-7"/>
+      <vector name="head" x="-37" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="274" height="234">
+      <vector name="origin" x="118" y="193"/>
+      <vector name="lt" x="-97" y="-144"/>
+      <vector name="rb" x="41" y="-5"/>
+      <vector name="head" x="-37" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="268" height="198">
+      <vector name="origin" x="115" y="192"/>
+      <vector name="lt" x="-96" y="-145"/>
+      <vector name="rb" x="46" y="-7"/>
+      <vector name="head" x="-37" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="264" height="202">
+      <vector name="origin" x="117" y="196"/>
+      <vector name="lt" x="-96" y="-156"/>
+      <vector name="rb" x="59" y="-5"/>
+      <vector name="head" x="-37" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="235" height="208">
+      <vector name="origin" x="100" y="210"/>
+      <vector name="lt" x="-99" y="-176"/>
+      <vector name="rb" x="65" y="-7"/>
+      <vector name="head" x="-38" y="-212"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="243" height="210">
+      <vector name="origin" x="112" y="217"/>
+      <vector name="lt" x="-108" y="-173"/>
+      <vector name="rb" x="63" y="-11"/>
+      <vector name="head" x="-45" y="-216"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="252" height="228">
+      <vector name="origin" x="122" y="222"/>
+      <vector name="lt" x="-113" y="-179"/>
+      <vector name="rb" x="52" y="-3"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="257" height="231">
+      <vector name="origin" x="129" y="225"/>
+      <vector name="lt" x="-116" y="-177"/>
+      <vector name="rb" x="26" y="-6"/>
+      <vector name="head" x="-55" y="-219"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="256" height="230">
+      <vector name="origin" x="133" y="227"/>
+      <vector name="lt" x="-122" y="-176"/>
+      <vector name="rb" x="13" y="-11"/>
+      <vector name="head" x="-61" y="-219"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="264" height="235">
+      <vector name="origin" x="137" y="228"/>
+      <vector name="lt" x="-125" y="-177"/>
+      <vector name="rb" x="20" y="-7"/>
+      <vector name="head" x="-63" y="-220"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="261" height="239">
+      <vector name="origin" x="140" y="230"/>
+      <vector name="lt" x="-127" y="-175"/>
+      <vector name="rb" x="38" y="-6"/>
+      <vector name="head" x="-66" y="-222"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="259" height="233">
+      <vector name="origin" x="141" y="232"/>
+      <vector name="lt" x="-126" y="-178"/>
+      <vector name="rb" x="36" y="-13"/>
+      <vector name="head" x="-65" y="-224"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="258" height="245">
+      <vector name="origin" x="142" y="235"/>
+      <vector name="lt" x="-129" y="-175"/>
+      <vector name="rb" x="40" y="-5"/>
+      <vector name="head" x="-68" y="-226"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="261" height="269">
+      <vector name="origin" x="143" y="262"/>
+      <vector name="lt" x="-129" y="-176"/>
+      <vector name="rb" x="14" y="-7"/>
+      <vector name="head" x="-70" y="-257"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="260" height="265">
+      <vector name="origin" x="132" y="261"/>
+      <vector name="lt" x="-122" y="-176"/>
+      <vector name="rb" x="19" y="-12"/>
+      <vector name="head" x="-56" y="-226"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="268" height="269">
+      <vector name="origin" x="130" y="266"/>
+      <vector name="lt" x="-111" y="-172"/>
+      <vector name="rb" x="29" y="-10"/>
+      <vector name="head" x="-46" y="-223"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="268" height="266">
+      <vector name="origin" x="130" y="269"/>
+      <vector name="lt" x="-102" y="-177"/>
+      <vector name="rb" x="40" y="-13"/>
+      <vector name="head" x="-39" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="264" height="188">
+      <vector name="origin" x="117" y="216"/>
+      <vector name="lt" x="-75" y="-175"/>
+      <vector name="rb" x="56" y="-32"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="236" height="208">
+      <vector name="origin" x="92" y="203"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="264" height="188">
+      <vector name="origin" x="88" y="216"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="275" height="191">
+      <vector name="origin" x="81" y="222"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="285" height="196">
+      <vector name="origin" x="82" y="223"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="264" height="202">
+      <vector name="origin" x="55" y="223"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="264" height="222">
+      <vector name="origin" x="46" y="222"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="151" height="128">
+      <vector name="origin" x="19" y="212"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="147" height="119">
+      <vector name="origin" x="-1" y="108"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="156" height="118">
+      <vector name="origin" x="5" y="107"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="166" height="119">
+      <vector name="origin" x="9" y="106"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="174" height="118">
+      <vector name="origin" x="15" y="105"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="176" height="112">
+      <vector name="origin" x="14" y="104"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="175" height="32">
+      <vector name="origin" x="16" y="33"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="沉溺于回忆的人，永远无法向前迈进……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8220005.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8220005.img.xml
@@ -1,0 +1,1032 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8220005.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="131"/>
+    <int name="maxHP" value="7600000"/>
+    <int name="maxMP" value="2500"/>
+    <int name="speed" value="-20"/>
+    <int name="PADamage" value="665"/>
+    <int name="PDDamage" value="1020"/>
+    <int name="MADamage" value="735"/>
+    <int name="MDDamage" value="1110"/>
+    <int name="acc" value="232"/>
+    <int name="eva" value="47"/>
+    <int name="exp" value="26850"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="13000"/>
+    <int name="hpRecovery" value="7000"/>
+    <int name="mpRecovery" value="220"/>
+    <string name="elemAttr" value="I2L3"/>
+    <float name="fs" value="10.0"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="23"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="145"/>
+        <int name="action" value="2"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3508"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <imgdir name="0">
+        <int name="hp" value="7000000"/>
+        <string name="0" value="呵呵呵呵！现在后悔已经太迟了！"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="203" height="233">
+      <vector name="origin" x="99" y="238"/>
+      <vector name="lt" x="-99" y="-238"/>
+      <vector name="rb" x="104" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="189" height="241">
+      <vector name="origin" x="90" y="239"/>
+      <vector name="lt" x="-90" y="-239"/>
+      <vector name="rb" x="99" y="2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="191" height="242">
+      <vector name="origin" x="92" y="240"/>
+      <vector name="lt" x="-92" y="-240"/>
+      <vector name="rb" x="99" y="2"/>
+      <vector name="head" x="-23" y="-219"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="214" height="239">
+      <vector name="origin" x="104" y="241"/>
+      <vector name="lt" x="-104" y="-241"/>
+      <vector name="rb" x="110" y="-2"/>
+      <vector name="head" x="-23" y="-220"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="195" height="245">
+      <vector name="origin" x="93" y="242"/>
+      <vector name="lt" x="-93" y="-242"/>
+      <vector name="rb" x="102" y="3"/>
+      <vector name="head" x="-23" y="-221"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="194" height="244">
+      <vector name="origin" x="94" y="243"/>
+      <vector name="lt" x="-94" y="-243"/>
+      <vector name="rb" x="100" y="1"/>
+      <vector name="head" x="-23" y="-222"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="215" height="240">
+      <vector name="origin" x="105" y="242"/>
+      <vector name="lt" x="-105" y="-242"/>
+      <vector name="rb" x="110" y="-2"/>
+      <vector name="head" x="-23" y="-221"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="195" height="245">
+      <vector name="origin" x="93" y="241"/>
+      <vector name="lt" x="-93" y="-241"/>
+      <vector name="rb" x="102" y="4"/>
+      <vector name="head" x="-23" y="-220"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="193" height="243">
+      <vector name="origin" x="93" y="240"/>
+      <vector name="lt" x="-93" y="-240"/>
+      <vector name="rb" x="100" y="3"/>
+      <vector name="head" x="-23" y="-219"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="213" height="238">
+      <vector name="origin" x="104" y="239"/>
+      <vector name="lt" x="-104" y="-239"/>
+      <vector name="rb" x="109" y="-1"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="189" height="241">
+      <vector name="origin" x="90" y="238"/>
+      <vector name="lt" x="-90" y="-238"/>
+      <vector name="rb" x="99" y="3"/>
+      <vector name="head" x="-23" y="-217"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="182" height="237">
+      <vector name="origin" x="88" y="237"/>
+      <vector name="lt" x="-88" y="-237"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="-23" y="-216"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="189" height="234">
+      <vector name="origin" x="90" y="239"/>
+      <vector name="lt" x="-90" y="-239"/>
+      <vector name="rb" x="99" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="176" height="238">
+      <vector name="origin" x="83" y="240"/>
+      <vector name="lt" x="-84" y="-240"/>
+      <vector name="rb" x="93" y="-2"/>
+      <vector name="head" x="-23" y="-219"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="168" height="238">
+      <vector name="origin" x="76" y="241"/>
+      <vector name="lt" x="-76" y="-241"/>
+      <vector name="rb" x="92" y="-3"/>
+      <vector name="head" x="-23" y="-220"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="175" height="237">
+      <vector name="origin" x="84" y="242"/>
+      <vector name="lt" x="-84" y="-242"/>
+      <vector name="rb" x="91" y="-5"/>
+      <vector name="head" x="-23" y="-221"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="184" height="239">
+      <vector name="origin" x="88" y="243"/>
+      <vector name="lt" x="-88" y="-243"/>
+      <vector name="rb" x="96" y="-4"/>
+      <vector name="head" x="-23" y="-222"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="196" height="233">
+      <vector name="origin" x="95" y="242"/>
+      <vector name="lt" x="-95" y="-242"/>
+      <vector name="rb" x="101" y="-9"/>
+      <vector name="head" x="-23" y="-221"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="189" height="234">
+      <vector name="origin" x="90" y="241"/>
+      <vector name="lt" x="-90" y="-241"/>
+      <vector name="rb" x="99" y="-7"/>
+      <vector name="head" x="-23" y="-220"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="176" height="238">
+      <vector name="origin" x="83" y="240"/>
+      <vector name="lt" x="-83" y="-240"/>
+      <vector name="rb" x="93" y="-2"/>
+      <vector name="head" x="-22" y="-219"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="168" height="238">
+      <vector name="origin" x="76" y="239"/>
+      <vector name="lt" x="-76" y="-239"/>
+      <vector name="rb" x="92" y="-1"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="175" height="237">
+      <vector name="origin" x="84" y="238"/>
+      <vector name="lt" x="-84" y="-238"/>
+      <vector name="rb" x="91" y="-1"/>
+      <vector name="head" x="-23" y="-217"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="184" height="239">
+      <vector name="origin" x="88" y="237"/>
+      <vector name="lt" x="-88" y="-237"/>
+      <vector name="rb" x="96" y="2"/>
+      <vector name="head" x="-23" y="-216"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-416" y="-300"/>
+        <vector name="rb" x="-100" y="10"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="16" height="45">
+          <vector name="origin" x="-5" y="236"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="48" height="106">
+          <vector name="origin" x="27" y="226"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="48" height="127">
+          <vector name="origin" x="27" y="237"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="56" height="147">
+          <vector name="origin" x="27" y="227"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="70" height="232">
+          <vector name="origin" x="41" y="225"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="106" height="235">
+          <vector name="origin" x="55" y="227"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="115" height="219">
+          <vector name="origin" x="65" y="217"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="110" height="193">
+          <vector name="origin" x="73" y="187"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="8" width="108" height="99">
+          <vector name="origin" x="70" y="92"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="9" width="120" height="99">
+          <vector name="origin" x="75" y="92"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="10" width="100" height="100">
+          <vector name="origin" x="36" y="96"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="11" width="68" height="67">
+          <vector name="origin" x="-4" y="88"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="12" width="63" height="49">
+          <vector name="origin" x="-7" y="76"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="13" width="58" height="42">
+          <vector name="origin" x="-13" y="78"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+        <int name="hitAfter" value="240"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1250"/>
+      <int name="magic" value="1"/>
+      <string name="elemAttr" value="I"/>
+    </imgdir>
+    <canvas name="0" width="196" height="240">
+      <vector name="origin" x="95" y="244"/>
+      <vector name="lt" x="-95" y="-244"/>
+      <vector name="rb" x="101" y="-4"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="196" height="245">
+      <vector name="origin" x="95" y="247"/>
+      <vector name="lt" x="-95" y="-247"/>
+      <vector name="rb" x="101" y="-2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="196" height="244">
+      <vector name="origin" x="95" y="246"/>
+      <vector name="lt" x="-95" y="-246"/>
+      <vector name="rb" x="101" y="-2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="196" height="243">
+      <vector name="origin" x="95" y="245"/>
+      <vector name="lt" x="-95" y="-245"/>
+      <vector name="rb" x="101" y="-2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="198" height="241">
+      <vector name="origin" x="95" y="243"/>
+      <vector name="lt" x="-95" y="-243"/>
+      <vector name="rb" x="103" y="-2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="203" height="239">
+      <vector name="origin" x="98" y="240"/>
+      <vector name="lt" x="-98" y="-240"/>
+      <vector name="rb" x="105" y="-1"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="207" height="233">
+      <vector name="origin" x="100" y="238"/>
+      <vector name="lt" x="-100" y="-238"/>
+      <vector name="rb" x="107" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="210" height="233">
+      <vector name="origin" x="102" y="238"/>
+      <vector name="lt" x="-102" y="-238"/>
+      <vector name="rb" x="108" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="211" height="233">
+      <vector name="origin" x="103" y="238"/>
+      <vector name="lt" x="-103" y="-238"/>
+      <vector name="rb" x="108" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="9" width="211" height="335">
+      <vector name="origin" x="103" y="338"/>
+      <vector name="lt" x="-103" y="-338"/>
+      <vector name="rb" x="108" y="-3"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="10" width="211" height="328">
+      <vector name="origin" x="103" y="330"/>
+      <vector name="lt" x="-103" y="-330"/>
+      <vector name="rb" x="108" y="-2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="11" width="210" height="237">
+      <vector name="origin" x="103" y="238"/>
+      <vector name="lt" x="-103" y="-238"/>
+      <vector name="rb" x="107" y="-1"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="208" height="326">
+      <vector name="origin" x="102" y="337"/>
+      <vector name="lt" x="-102" y="-337"/>
+      <vector name="rb" x="106" y="-11"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="13" width="206" height="399">
+      <vector name="origin" x="100" y="411"/>
+      <vector name="lt" x="-100" y="-411"/>
+      <vector name="rb" x="106" y="-12"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="14" width="159" height="226">
+      <vector name="origin" x="76" y="238"/>
+      <vector name="lt" x="-76" y="-238"/>
+      <vector name="rb" x="83" y="-12"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="15" width="159" height="306">
+      <vector name="origin" x="76" y="318"/>
+      <vector name="lt" x="-76" y="-318"/>
+      <vector name="rb" x="83" y="-12"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="16" width="156" height="338">
+      <vector name="origin" x="76" y="350"/>
+      <vector name="lt" x="-76" y="-350"/>
+      <vector name="rb" x="80" y="-12"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="17" width="134" height="226">
+      <vector name="origin" x="76" y="238"/>
+      <vector name="lt" x="-76" y="-238"/>
+      <vector name="rb" x="58" y="-12"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="18" width="134" height="226">
+      <vector name="origin" x="76" y="238"/>
+      <vector name="lt" x="-76" y="-238"/>
+      <vector name="rb" x="58" y="-12"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="19" width="134" height="226">
+      <vector name="origin" x="76" y="238"/>
+      <vector name="lt" x="-76" y="-238"/>
+      <vector name="rb" x="58" y="-12"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="20" width="134" height="226">
+      <vector name="origin" x="76" y="238"/>
+      <vector name="lt" x="-76" y="-238"/>
+      <vector name="rb" x="58" y="-12"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="21" width="134" height="226">
+      <vector name="origin" x="76" y="238"/>
+      <vector name="lt" x="-76" y="-238"/>
+      <vector name="rb" x="58" y="-12"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="22" width="201" height="233">
+      <vector name="origin" x="98" y="238"/>
+      <vector name="lt" x="-98" y="-238"/>
+      <vector name="rb" x="103" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="23" width="201" height="233">
+      <vector name="origin" x="98" y="238"/>
+      <vector name="lt" x="-98" y="-238"/>
+      <vector name="rb" x="103" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="24" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="25" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="26" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="27" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="28" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-810" y="-304"/>
+        <vector name="rb" x="-20" y="10"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="109" height="138">
+          <vector name="origin" x="55" y="127"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="106" height="184">
+          <vector name="origin" x="56" y="173"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="2" width="95" height="172">
+          <vector name="origin" x="50" y="182"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="3" width="79" height="165">
+          <vector name="origin" x="42" y="183"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="4" width="76" height="159">
+          <vector name="origin" x="41" y="182"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1710"/>
+      <int name="magic" value="1"/>
+      <string name="elemAttr" value="F"/>
+      <int name="knockback" value="1"/>
+      <int name="jumpAttack" value="1"/>
+    </imgdir>
+    <canvas name="0" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="189" height="234">
+      <vector name="origin" x="90" y="251"/>
+      <vector name="lt" x="-90" y="-251"/>
+      <vector name="rb" x="99" y="-17"/>
+      <vector name="head" x="-21" y="-231"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="176" height="238">
+      <vector name="origin" x="83" y="267"/>
+      <vector name="lt" x="-83" y="-267"/>
+      <vector name="rb" x="93" y="-29"/>
+      <vector name="head" x="-22" y="-246"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="168" height="238">
+      <vector name="origin" x="76" y="301"/>
+      <vector name="lt" x="-76" y="-301"/>
+      <vector name="rb" x="92" y="-63"/>
+      <vector name="head" x="-21" y="-280"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="175" height="237">
+      <vector name="origin" x="84" y="319"/>
+      <vector name="lt" x="-84" y="-319"/>
+      <vector name="rb" x="91" y="-82"/>
+      <vector name="head" x="-23" y="-298"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="184" height="242">
+      <vector name="origin" x="88" y="327"/>
+      <vector name="lt" x="-88" y="-327"/>
+      <vector name="rb" x="96" y="-85"/>
+      <vector name="head" x="-22" y="-303"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="196" height="237">
+      <vector name="origin" x="95" y="329"/>
+      <vector name="lt" x="-95" y="-329"/>
+      <vector name="rb" x="101" y="-92"/>
+      <vector name="head" x="-21" y="-303"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="189" height="238">
+      <vector name="origin" x="90" y="330"/>
+      <vector name="lt" x="-90" y="-330"/>
+      <vector name="rb" x="99" y="-92"/>
+      <vector name="head" x="-22" y="-305"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="189" height="237">
+      <vector name="origin" x="90" y="330"/>
+      <vector name="lt" x="-90" y="-330"/>
+      <vector name="rb" x="99" y="-93"/>
+      <vector name="head" x="-23" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="189" height="237">
+      <vector name="origin" x="90" y="330"/>
+      <vector name="lt" x="-90" y="-330"/>
+      <vector name="rb" x="99" y="-93"/>
+      <vector name="head" x="-22" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="189" height="235">
+      <vector name="origin" x="90" y="328"/>
+      <vector name="lt" x="-90" y="-328"/>
+      <vector name="rb" x="99" y="-93"/>
+      <vector name="head" x="-21" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="186" height="243">
+      <vector name="origin" x="90" y="327"/>
+      <vector name="lt" x="-90" y="-327"/>
+      <vector name="rb" x="96" y="-84"/>
+      <vector name="head" x="-23" y="-302"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="198" height="252">
+      <vector name="origin" x="95" y="328"/>
+      <vector name="lt" x="-95" y="-328"/>
+      <vector name="rb" x="103" y="-76"/>
+      <vector name="head" x="-23" y="-299"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="226" height="255">
+      <vector name="origin" x="109" y="210"/>
+      <vector name="lt" x="-109" y="-210"/>
+      <vector name="rb" x="117" y="45"/>
+      <vector name="head" x="-23" y="-177"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="242" height="254">
+      <vector name="origin" x="114" y="220"/>
+      <vector name="lt" x="-114" y="-220"/>
+      <vector name="rb" x="128" y="34"/>
+      <vector name="head" x="-23" y="-190"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="254" height="251">
+      <vector name="origin" x="120" y="217"/>
+      <vector name="lt" x="-121" y="-217"/>
+      <vector name="rb" x="134" y="34"/>
+      <vector name="head" x="-23" y="-189"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="292" height="234">
+      <vector name="origin" x="139" y="210"/>
+      <vector name="lt" x="-139" y="-210"/>
+      <vector name="rb" x="153" y="24"/>
+      <vector name="head" x="-23" y="-189"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="306" height="238">
+      <vector name="origin" x="146" y="210"/>
+      <vector name="lt" x="-147" y="-210"/>
+      <vector name="rb" x="160" y="28"/>
+      <vector name="head" x="-23" y="-189"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="173" height="238">
+      <vector name="origin" x="79" y="210"/>
+      <vector name="lt" x="-79" y="-210"/>
+      <vector name="rb" x="94" y="28"/>
+      <vector name="head" x="-22" y="-189"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="179" height="238">
+      <vector name="origin" x="85" y="210"/>
+      <vector name="lt" x="-85" y="-211"/>
+      <vector name="rb" x="94" y="28"/>
+      <vector name="head" x="-22" y="-189"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="191" height="235">
+      <vector name="origin" x="91" y="232"/>
+      <vector name="lt" x="-91" y="-232"/>
+      <vector name="rb" x="100" y="3"/>
+      <vector name="head" x="-23" y="-211"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="202" height="250">
+      <vector name="origin" x="101" y="255"/>
+      <vector name="lt" x="-101" y="-255"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="208" height="251">
+      <vector name="origin" x="107" y="256"/>
+      <vector name="lt" x="-107" y="-256"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="208" height="259">
+      <vector name="origin" x="107" y="264"/>
+      <vector name="lt" x="-107" y="-264"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="207" height="255">
+      <vector name="origin" x="106" y="260"/>
+      <vector name="lt" x="-106" y="-260"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="196" height="250">
+      <vector name="origin" x="95" y="255"/>
+      <vector name="lt" x="-96" y="-255"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="196" height="247">
+      <vector name="origin" x="95" y="252"/>
+      <vector name="lt" x="-95" y="-252"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="196" height="241">
+      <vector name="origin" x="95" y="246"/>
+      <vector name="lt" x="-95" y="-246"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="196" height="237">
+      <vector name="origin" x="95" y="242"/>
+      <vector name="lt" x="-95" y="-242"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="9" width="196" height="237">
+      <vector name="origin" x="95" y="242"/>
+      <vector name="lt" x="-95" y="-242"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="10" width="223" height="252">
+      <vector name="origin" x="109" y="248"/>
+      <vector name="lt" x="-109" y="-248"/>
+      <vector name="rb" x="114" y="4"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="11" width="221" height="250">
+      <vector name="origin" x="108" y="246"/>
+      <vector name="lt" x="-108" y="-246"/>
+      <vector name="rb" x="113" y="4"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="219" height="248">
+      <vector name="origin" x="107" y="245"/>
+      <vector name="lt" x="-107" y="-245"/>
+      <vector name="rb" x="112" y="3"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="13" width="217" height="245">
+      <vector name="origin" x="106" y="243"/>
+      <vector name="lt" x="-106" y="-243"/>
+      <vector name="rb" x="111" y="2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="14" width="215" height="244">
+      <vector name="origin" x="105" y="243"/>
+      <vector name="lt" x="-105" y="-243"/>
+      <vector name="rb" x="110" y="1"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="15" width="213" height="241">
+      <vector name="origin" x="104" y="242"/>
+      <vector name="lt" x="-104" y="-242"/>
+      <vector name="rb" x="109" y="-1"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="16" width="209" height="240">
+      <vector name="origin" x="102" y="242"/>
+      <vector name="lt" x="-102" y="-242"/>
+      <vector name="rb" x="107" y="-2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="17" width="207" height="238">
+      <vector name="origin" x="101" y="242"/>
+      <vector name="lt" x="-101" y="-242"/>
+      <vector name="rb" x="106" y="-4"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="18" width="203" height="237">
+      <vector name="origin" x="99" y="242"/>
+      <vector name="lt" x="-99" y="-242"/>
+      <vector name="rb" x="104" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="19" width="196" height="237">
+      <vector name="origin" x="95" y="242"/>
+      <vector name="lt" x="-95" y="-242"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="214" height="233">
+      <vector name="origin" x="113" y="238"/>
+      <vector name="lt" x="-113" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="204" height="233">
+      <vector name="origin" x="103" y="238"/>
+      <vector name="lt" x="-103" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="213" height="240">
+      <vector name="origin" x="104" y="238"/>
+      <vector name="lt" x="-104" y="-238"/>
+      <vector name="rb" x="109" y="2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="216" height="242">
+      <vector name="origin" x="105" y="238"/>
+      <vector name="lt" x="-105" y="-238"/>
+      <vector name="rb" x="111" y="4"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="215" height="241">
+      <vector name="origin" x="105" y="238"/>
+      <vector name="lt" x="-105" y="-238"/>
+      <vector name="rb" x="110" y="3"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="214" height="241">
+      <vector name="origin" x="104" y="238"/>
+      <vector name="lt" x="-104" y="-238"/>
+      <vector name="rb" x="110" y="3"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="213" height="239">
+      <vector name="origin" x="104" y="238"/>
+      <vector name="lt" x="-104" y="-238"/>
+      <vector name="rb" x="109" y="1"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="209" height="238">
+      <vector name="origin" x="102" y="238"/>
+      <vector name="lt" x="-102" y="-238"/>
+      <vector name="rb" x="107" y="0"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="215" height="249">
+      <vector name="origin" x="105" y="247"/>
+      <vector name="lt" x="-105" y="-248"/>
+      <vector name="rb" x="110" y="2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="215" height="249">
+      <vector name="origin" x="105" y="247"/>
+      <vector name="lt" x="-105" y="-247"/>
+      <vector name="rb" x="110" y="2"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="211" height="243">
+      <vector name="origin" x="103" y="244"/>
+      <vector name="lt" x="-103" y="-244"/>
+      <vector name="rb" x="107" y="-1"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="203" height="235">
+      <vector name="origin" x="99" y="240"/>
+      <vector name="lt" x="-99" y="-240"/>
+      <vector name="rb" x="104" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="196" height="233">
+      <vector name="origin" x="95" y="238"/>
+      <vector name="lt" x="-95" y="-238"/>
+      <vector name="rb" x="101" y="-5"/>
+      <vector name="head" x="-23" y="-218"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="209" height="244">
+      <vector name="origin" x="85" y="238"/>
+      <vector name="lt" x="-85" y="-238"/>
+      <vector name="rb" x="124" y="6"/>
+      <vector name="head" x="-9" y="-217"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="209" height="244">
+      <vector name="origin" x="85" y="238"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="228" height="254">
+      <vector name="origin" x="89" y="245"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="238" height="263">
+      <vector name="origin" x="90" y="249"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="259" height="273">
+      <vector name="origin" x="97" y="253"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="134" height="226">
+      <vector name="origin" x="43" y="254"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="134" height="226">
+      <vector name="origin" x="39" y="240"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="154" height="213">
+      <vector name="origin" x="39" y="210"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="158" height="211">
+      <vector name="origin" x="39" y="208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="159" height="209">
+      <vector name="origin" x="39" y="207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="164" height="208">
+      <vector name="origin" x="39" y="206"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="158" height="51">
+      <vector name="origin" x="33" y="50"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="158" height="28">
+      <vector name="origin" x="36" y="52"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="走在悔恨之路上的人啊……终点只会留下悔恨……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8220006.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8220006.img.xml
@@ -1,0 +1,877 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8220006.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="141"/>
+    <int name="maxHP" value="9300000"/>
+    <int name="maxMP" value="3000"/>
+    <int name="speed" value="-50"/>
+    <int name="PADamage" value="675"/>
+    <int name="PDDamage" value="1100"/>
+    <int name="MADamage" value="755"/>
+    <int name="MDDamage" value="1170"/>
+    <int name="acc" value="239"/>
+    <int name="eva" value="49"/>
+    <int name="exp" value="32865"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="15000"/>
+    <int name="hpRecovery" value="10000"/>
+    <int name="mpRecovery" value="300"/>
+    <string name="elemAttr" value="F2S3"/>
+    <float name="fs" value="10.0"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="summonType" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="100"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="128"/>
+        <int name="action" value="2"/>
+        <int name="level" value="7"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="114"/>
+        <int name="action" value="2"/>
+        <int name="level" value="9"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3515"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <imgdir name="0">
+        <int name="hp" value="7000000"/>
+        <string name="0" value="回归遗忘吧！"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="243" height="189">
+      <vector name="origin" x="104" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="221" height="189">
+      <vector name="origin" x="104" y="187"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="226" height="192">
+      <vector name="origin" x="104" y="185"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="231" height="193">
+      <vector name="origin" x="104" y="184"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="236" height="194">
+      <vector name="origin" x="104" y="186"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="247" height="189">
+      <vector name="origin" x="104" y="182"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="254" height="188">
+      <vector name="origin" x="104" y="185"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="279" height="188">
+      <vector name="origin" x="104" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="243" height="189">
+      <vector name="origin" x="104" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="221" height="190">
+      <vector name="origin" x="104" y="187"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="226" height="192">
+      <vector name="origin" x="104" y="185"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="231" height="193">
+      <vector name="origin" x="104" y="184"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="236" height="194">
+      <vector name="origin" x="104" y="186"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="247" height="189">
+      <vector name="origin" x="104" y="182"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="14" width="254" height="188">
+      <vector name="origin" x="104" y="185"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="15" width="279" height="188">
+      <vector name="origin" x="104" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="243" height="192">
+      <vector name="origin" x="104" y="190"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="221" height="188">
+      <vector name="origin" x="104" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="226" height="190">
+      <vector name="origin" x="104" y="190"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="231" height="189">
+      <vector name="origin" x="104" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="236" height="192">
+      <vector name="origin" x="104" y="190"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="247" height="188">
+      <vector name="origin" x="104" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="96" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="254" height="190">
+      <vector name="origin" x="104" y="190"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="96" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="259" height="188">
+      <vector name="origin" x="104" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-40" y="-200"/>
+        <vector name="rb" x="40" y="0"/>
+        <int name="start" value="-7"/>
+        <int name="areaCount" value="15"/>
+        <int name="attackCount" value="7"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="4" height="4">
+          <vector name="origin" x="37" y="91"/>
+          <int name="delay" value="180"/>
+        </canvas>
+        <canvas name="1" width="74" height="83">
+          <vector name="origin" x="37" y="91"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="98" height="101">
+          <vector name="origin" x="51" y="107"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="110" height="104">
+          <vector name="origin" x="49" y="114"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="100" height="108">
+          <vector name="origin" x="41" y="115"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="87" height="112">
+          <vector name="origin" x="35" y="116"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="79" height="87">
+          <vector name="origin" x="30" y="111"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="66" height="77">
+          <vector name="origin" x="26" y="106"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="67" height="125">
+          <vector name="origin" x="34" y="366"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="122" height="153">
+          <vector name="origin" x="55" y="139"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="165" height="168">
+          <vector name="origin" x="75" y="156"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="11" width="197" height="185">
+          <vector name="origin" x="91" y="172"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="12" width="241" height="189">
+          <vector name="origin" x="111" y="176"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="13" width="267" height="181">
+          <vector name="origin" x="123" y="173"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="14" width="266" height="156">
+          <vector name="origin" x="122" y="176"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="99" height="107">
+          <vector name="origin" x="50" y="98"/>
+          <int name="delay" value="240"/>
+        </canvas>
+        <canvas name="1" width="80" height="77">
+          <vector name="origin" x="38" y="75"/>
+          <int name="delay" value="240"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="4"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1260"/>
+      <int name="PADamage" value="720"/>
+    </imgdir>
+    <canvas name="0" width="247" height="196">
+      <vector name="origin" x="108" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="234" height="201">
+      <vector name="origin" x="111" y="192"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="242" height="205">
+      <vector name="origin" x="112" y="196"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="249" height="208">
+      <vector name="origin" x="113" y="198"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="256" height="210">
+      <vector name="origin" x="114" y="200"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="267" height="211">
+      <vector name="origin" x="114" y="201"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="274" height="211">
+      <vector name="origin" x="114" y="201"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="283" height="214">
+      <vector name="origin" x="116" y="193"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="262" height="212">
+      <vector name="origin" x="115" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="540"/>
+    </canvas>
+    <canvas name="9" width="241" height="210">
+      <vector name="origin" x="114" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="246" height="210">
+      <vector name="origin" x="114" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="11" width="247" height="205">
+      <vector name="origin" x="112" y="187"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="12" width="243" height="197">
+      <vector name="origin" x="108" y="185"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="13" width="247" height="192">
+      <vector name="origin" x="104" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="14" width="254" height="189">
+      <vector name="origin" x="104" y="187"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="15" width="259" height="189">
+      <vector name="origin" x="104" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-300" y="-272"/>
+        <vector name="rb" x="100" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="63" height="137">
+          <vector name="origin" x="31" y="115"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="92" height="187">
+          <vector name="origin" x="41" y="168"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="91" height="213">
+          <vector name="origin" x="51" y="194"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="90" height="187">
+          <vector name="origin" x="45" y="165"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="91" height="184">
+          <vector name="origin" x="44" y="164"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="86" height="177">
+          <vector name="origin" x="42" y="161"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="50" height="146">
+          <vector name="origin" x="43" y="137"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="960"/>
+      <int name="magic" value="1"/>
+      <string name="elemAttr" value="F"/>
+    </imgdir>
+    <canvas name="0" width="247" height="196">
+      <vector name="origin" x="108" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="329" height="201">
+      <vector name="origin" x="206" y="192"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="332" height="205">
+      <vector name="origin" x="202" y="196"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="332" height="208">
+      <vector name="origin" x="196" y="198"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="332" height="210">
+      <vector name="origin" x="190" y="200"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="344" height="211">
+      <vector name="origin" x="191" y="201"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="352" height="211">
+      <vector name="origin" x="192" y="201"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="358" height="214">
+      <vector name="origin" x="191" y="193"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="337" height="212">
+      <vector name="origin" x="190" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="313" height="210">
+      <vector name="origin" x="186" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="314" height="210">
+      <vector name="origin" x="182" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="296" height="205">
+      <vector name="origin" x="161" y="187"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="243" height="197">
+      <vector name="origin" x="108" y="185"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="247" height="192">
+      <vector name="origin" x="104" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="254" height="189">
+      <vector name="origin" x="104" y="187"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="259" height="189">
+      <vector name="origin" x="104" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="243" height="189">
+      <vector name="origin" x="104" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="221" height="189">
+      <vector name="origin" x="104" y="187"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="233" height="194">
+      <vector name="origin" x="111" y="187"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="240" height="197">
+      <vector name="origin" x="113" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="246" height="198">
+      <vector name="origin" x="114" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="258" height="199">
+      <vector name="origin" x="115" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="266" height="199">
+      <vector name="origin" x="116" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="272" height="199">
+      <vector name="origin" x="117" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="257" height="199">
+      <vector name="origin" x="118" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="236" height="199">
+      <vector name="origin" x="119" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="241" height="198">
+      <vector name="origin" x="119" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="246" height="197">
+      <vector name="origin" x="119" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="251" height="194">
+      <vector name="origin" x="119" y="187"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="260" height="188">
+      <vector name="origin" x="117" y="182"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="254" height="188">
+      <vector name="origin" x="104" y="185"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="279" height="188">
+      <vector name="origin" x="104" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="243" height="189">
+      <vector name="origin" x="104" y="189"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="234" height="200">
+      <vector name="origin" x="113" y="193"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="240" height="201">
+      <vector name="origin" x="115" y="191"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="251" height="199">
+      <vector name="origin" x="117" y="190"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="255" height="211">
+      <vector name="origin" x="118" y="201"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="261" height="214">
+      <vector name="origin" x="118" y="204"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="268" height="225">
+      <vector name="origin" x="118" y="215"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="273" height="221">
+      <vector name="origin" x="118" y="211"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="256" height="200">
+      <vector name="origin" x="117" y="190"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="234" height="200">
+      <vector name="origin" x="117" y="190"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="239" height="199">
+      <vector name="origin" x="117" y="190"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="243" height="198">
+      <vector name="origin" x="116" y="190"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="246" height="197">
+      <vector name="origin" x="114" y="190"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="254" height="192">
+      <vector name="origin" x="111" y="186"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="254" height="188">
+      <vector name="origin" x="104" y="185"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="259" height="188">
+      <vector name="origin" x="104" y="188"/>
+      <vector name="lt" x="-105" y="-189"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="236" height="201">
+      <vector name="origin" x="94" y="189"/>
+      <vector name="lt" x="-93" y="-189"/>
+      <vector name="rb" x="105" y="-1"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="236" height="201">
+      <vector name="origin" x="94" y="189"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="242" height="192">
+      <vector name="origin" x="87" y="190"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="247" height="193">
+      <vector name="origin" x="85" y="193"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="271" height="193">
+      <vector name="origin" x="84" y="193"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="242" height="189">
+      <vector name="origin" x="91" y="186"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="223" height="192">
+      <vector name="origin" x="94" y="171"/>
+      <vector name="head" x="-42" y="-192"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="231" height="194">
+      <vector name="origin" x="97" y="171"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="238" height="194">
+      <vector name="origin" x="99" y="170"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="走上遗忘之路的人啊……你必须为自己的选择负责。"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8220007.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8220007.img.xml
@@ -1,0 +1,252 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8220007.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="90"/>
+    <int name="maxHP" value="135000"/>
+    <int name="maxMP" value="190"/>
+    <int name="speed" value="-20"/>
+    <int name="PADamage" value="450"/>
+    <int name="PDDamage" value="810"/>
+    <int name="MADamage" value="540"/>
+    <int name="MDDamage" value="520"/>
+    <int name="acc" value="200"/>
+    <int name="eva" value="45"/>
+    <int name="exp" value="5500"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="2800"/>
+    <int name="hpRecovery" value="100"/>
+    <int name="mpRecovery" value="5"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <string name="elemAttr" value="F3"/>
+    <int name="summonType" value="0"/>
+    <imgdir name="speak">
+      <imgdir name="0">
+        <string name="hp" value="120000"/>
+        <string name="0" value="呵呵呵呵呵呵。"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="119" height="110">
+      <vector name="origin" x="59" y="110"/>
+      <int name="delay" value="500"/>
+      <vector name="lt" x="-59" y="-110"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+    <canvas name="1" width="120" height="105">
+      <vector name="origin" x="60" y="105"/>
+      <int name="delay" value="100"/>
+      <vector name="lt" x="-60" y="-105"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+    <canvas name="2" width="118" height="102">
+      <vector name="origin" x="59" y="102"/>
+      <int name="delay" value="100"/>
+      <vector name="lt" x="-59" y="-103"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+    <canvas name="3" width="118" height="125">
+      <vector name="origin" x="59" y="180"/>
+      <int name="delay" value="300"/>
+      <vector name="lt" x="-59" y="-180"/>
+      <vector name="rb" x="59" y="-55"/>
+      <vector name="head" x="-1" y="-170"/>
+    </canvas>
+    <canvas name="4" width="118" height="125">
+      <vector name="origin" x="59" y="160"/>
+      <int name="delay" value="100"/>
+      <vector name="lt" x="-59" y="-160"/>
+      <vector name="rb" x="59" y="-35"/>
+      <vector name="head" x="-8" y="-149"/>
+    </canvas>
+    <uol name="5" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="119" height="110">
+      <vector name="origin" x="59" y="110"/>
+      <vector name="lt" x="-59" y="-110"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="jump">
+    <canvas name="0" width="118" height="125">
+      <vector name="origin" x="59" y="125"/>
+      <vector name="lt" x="-59" y="-125"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-5" y="-112"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-250" y="-150"/>
+        <vector name="rb" x="250" y="0"/>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="32" height="42">
+          <vector name="origin" x="46" y="63"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="41" height="53">
+          <vector name="origin" x="51" y="69"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="82" height="71">
+          <vector name="origin" x="58" y="78"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="88" height="75">
+          <vector name="origin" x="59" y="80"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="90" height="71">
+          <vector name="origin" x="53" y="75"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="5" width="59" height="76">
+          <vector name="origin" x="19" y="77"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="6" width="61" height="79">
+          <vector name="origin" x="19" y="78"/>
+          <int name="delay" value="200"/>
+        </canvas>
+        <canvas name="7" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="300"/>
+        </canvas>
+        <canvas name="8" width="217" height="51">
+          <vector name="origin" x="108" y="50"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="9" width="242" height="54">
+          <vector name="origin" x="122" y="54"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="10" width="254" height="56">
+          <vector name="origin" x="129" y="58"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="11" width="209" height="53">
+          <vector name="origin" x="101" y="60"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="12" width="209" height="43">
+          <vector name="origin" x="102" y="61"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="13" width="209" height="41">
+          <vector name="origin" x="103" y="64"/>
+          <int name="delay" value="200"/>
+        </canvas>
+        <canvas name="14" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="50"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="50"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="effectAfter" value="0"/>
+      <int name="attackAfter" value="1050"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="300"/>
+    </imgdir>
+    <canvas name="0" width="118" height="102">
+      <vector name="origin" x="59" y="102"/>
+      <vector name="lt" x="-59" y="-102"/>
+      <vector name="rb" x="59" y="0"/>
+      <int name="delay" value="800"/>
+      <vector name="head" x="-11" y="-82"/>
+    </canvas>
+    <canvas name="1" width="118" height="125">
+      <vector name="origin" x="59" y="213"/>
+      <vector name="lt" x="-59" y="-213"/>
+      <vector name="rb" x="59" y="-88"/>
+      <vector name="head" x="-3" y="-201"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="2" width="118" height="125">
+      <vector name="origin" x="60" y="195"/>
+      <vector name="lt" x="-60" y="-195"/>
+      <vector name="rb" x="58" y="-70"/>
+      <int name="delay" value="50"/>
+      <vector name="head" x="-4" y="-186"/>
+    </canvas>
+    <canvas name="3" width="118" height="125">
+      <vector name="origin" x="60" y="133"/>
+      <vector name="lt" x="-60" y="-133"/>
+      <vector name="rb" x="58" y="-8"/>
+      <int name="delay" value="50"/>
+      <vector name="head" x="-8" y="-122"/>
+    </canvas>
+    <canvas name="4" width="120" height="105">
+      <vector name="origin" x="58" y="105"/>
+      <vector name="lt" x="-58" y="-105"/>
+      <vector name="rb" x="62" y="0"/>
+      <int name="delay" value="750"/>
+      <vector name="head" x="-6" y="-85"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="118" height="140">
+      <vector name="origin" x="59" y="140"/>
+      <vector name="lt" x="-59" y="-140"/>
+      <vector name="rb" x="59" y="0"/>
+      <int name="delay" value="600"/>
+      <vector name="head" x="-6" y="-127"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="120" height="140">
+      <vector name="origin" x="60" y="140"/>
+      <vector name="head" x="-6" y="-82"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="1" width="165" height="65">
+      <vector name="origin" x="82" y="61"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="174" height="64">
+      <vector name="origin" x="88" y="61"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="184" height="63">
+      <vector name="origin" x="92" y="61"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="198" height="63">
+      <vector name="origin" x="101" y="61"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="198" height="63">
+      <vector name="origin" x="101" y="61"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="300"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我还想再多玩一会儿……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8220009.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8220009.img.xml
@@ -1,0 +1,813 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8220009.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="85"/>
+    <int name="maxHP" value="110000"/>
+    <int name="maxMP" value="1000"/>
+    <int name="speed" value="-15"/>
+    <int name="PADamage" value="480"/>
+    <int name="PDDamage" value="720"/>
+    <int name="MADamage" value="520"/>
+    <int name="MDDamage" value="660"/>
+    <int name="acc" value="190"/>
+    <int name="eva" value="35"/>
+    <int name="exp" value="3180"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="3000"/>
+    <float name="fs" value="10.0"/>
+    <int name="hpRecovery" value="500"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="noregen" value="1"/>
+    <imgdir name="speak">
+      <imgdir name="0">
+        <string name="hp" value="100000"/>
+        <string name="0" value="为什么要妨碍我做生意？！"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="310" height="254">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-112" y="-254"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-31" y="-138"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="1" width="310" height="256">
+      <vector name="origin" x="156" y="256"/>
+      <vector name="lt" x="-109" y="-256"/>
+      <vector name="rb" x="101" y="0"/>
+      <vector name="head" x="-30" y="-143"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="2" width="310" height="257">
+      <vector name="origin" x="156" y="257"/>
+      <vector name="lt" x="-111" y="-257"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-31" y="-145"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="3" width="310" height="254">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-113" y="-254"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-30" y="-140"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="4" width="306" height="252">
+      <vector name="origin" x="153" y="252"/>
+      <vector name="lt" x="-111" y="-252"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-31" y="-137"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="5" width="310" height="254">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-112" y="-254"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-32" y="-139"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="6" width="310" height="258">
+      <vector name="origin" x="154" y="258"/>
+      <vector name="lt" x="-114" y="-258"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-31" y="-140"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="7" width="310" height="259">
+      <vector name="origin" x="154" y="259"/>
+      <vector name="lt" x="-113" y="-259"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-30" y="-142"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="8" width="310" height="254">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-112" y="-254"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-30" y="-139"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="9" width="306" height="252">
+      <vector name="origin" x="153" y="252"/>
+      <vector name="lt" x="-112" y="-252"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-31" y="-138"/>
+      <int name="delay" value="110"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="310" height="254">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-112" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-31" y="-139"/>
+      <int name="delay" value="220"/>
+    </canvas>
+    <canvas name="1" width="293" height="252">
+      <vector name="origin" x="148" y="252"/>
+      <vector name="lt" x="-113" y="-252"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-31" y="-138"/>
+      <int name="delay" value="220"/>
+    </canvas>
+    <canvas name="2" width="287" height="251">
+      <vector name="origin" x="145" y="251"/>
+      <vector name="lt" x="-113" y="-251"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-30" y="-137"/>
+      <int name="delay" value="220"/>
+    </canvas>
+    <canvas name="3" width="293" height="252">
+      <vector name="origin" x="148" y="252"/>
+      <vector name="lt" x="-112" y="-252"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-31" y="-138"/>
+      <int name="delay" value="220"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-303" y="-68"/>
+        <vector name="rb" x="255" y="6"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="70" height="65">
+          <vector name="origin" x="33" y="79"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="1" width="84" height="78">
+          <vector name="origin" x="40" y="89"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="2" width="89" height="85">
+          <vector name="origin" x="43" y="93"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="3" width="93" height="89">
+          <vector name="origin" x="45" y="95"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="attackAfter" value="1520"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="500"/>
+    </imgdir>
+    <canvas name="0" width="310" height="254">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-113" y="-254"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="1" width="298" height="256">
+      <vector name="origin" x="144" y="256"/>
+      <vector name="lt" x="-110" y="-256"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-20" y="-134"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="2" width="296" height="257">
+      <vector name="origin" x="142" y="257"/>
+      <vector name="lt" x="-111" y="-257"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-20" y="-135"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="3" width="296" height="258">
+      <vector name="origin" x="142" y="258"/>
+      <vector name="lt" x="-109" y="-258"/>
+      <vector name="rb" x="98" y="0"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="4" width="346" height="257">
+      <vector name="origin" x="191" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="102" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="5" width="352" height="254">
+      <vector name="origin" x="199" y="252"/>
+      <vector name="lt" x="-110" y="-252"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-20" y="-128"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="6" width="355" height="256">
+      <vector name="origin" x="200" y="254"/>
+      <vector name="lt" x="-112" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-21" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="7" width="340" height="256">
+      <vector name="origin" x="185" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="8" width="343" height="256">
+      <vector name="origin" x="188" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="97" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="9" width="344" height="256">
+      <vector name="origin" x="189" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="98" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="10" width="310" height="256">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="98" y="0"/>
+      <vector name="head" x="-19" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="11" width="310" height="254">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-110" y="-254"/>
+      <vector name="rb" x="98" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-136" y="-139"/>
+        <vector name="rb" x="146" y="6"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="42" height="56">
+          <vector name="origin" x="33" y="79"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="1" width="50" height="66">
+          <vector name="origin" x="37" y="89"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="2" width="52" height="66">
+          <vector name="origin" x="38" y="92"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="3" width="41" height="66">
+          <vector name="origin" x="31" y="93"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="4" width="41" height="63">
+          <vector name="origin" x="31" y="95"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="5" width="40" height="60">
+          <vector name="origin" x="31" y="95"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="2000"/>
+      <int name="magic" value="1"/>
+      <string name="elemAttr" value="F"/>
+    </imgdir>
+    <canvas name="0" width="310" height="254">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-19" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="1" width="298" height="256">
+      <vector name="origin" x="144" y="256"/>
+      <vector name="lt" x="-107" y="-256"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-20" y="-134"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="2" width="296" height="257">
+      <vector name="origin" x="142" y="257"/>
+      <vector name="lt" x="-109" y="-257"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-20" y="-135"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="3" width="296" height="258">
+      <vector name="origin" x="142" y="258"/>
+      <vector name="lt" x="-110" y="-258"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-20" y="-136"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="4" width="612" height="285">
+      <vector name="origin" x="309" y="282"/>
+      <vector name="lt" x="-107" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-19" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="5" width="612" height="266">
+      <vector name="origin" x="310" y="264"/>
+      <vector name="lt" x="-110" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-20" y="-128"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="6" width="612" height="256">
+      <vector name="origin" x="310" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-21" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="7" width="612" height="256">
+      <vector name="origin" x="310" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-21" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="8" width="669" height="259">
+      <vector name="origin" x="338" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="9" width="673" height="259">
+      <vector name="origin" x="348" y="254"/>
+      <vector name="lt" x="-110" y="-254"/>
+      <vector name="rb" x="98" y="-1"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="10" width="675" height="259">
+      <vector name="origin" x="351" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="99" y="-1"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="11" width="662" height="259">
+      <vector name="origin" x="336" y="254"/>
+      <vector name="lt" x="-110" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="12" width="671" height="259">
+      <vector name="origin" x="337" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="13" width="602" height="256">
+      <vector name="origin" x="304" y="254"/>
+      <vector name="lt" x="-112" y="-254"/>
+      <vector name="rb" x="99" y="0"/>
+      <vector name="head" x="-21" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="14" width="602" height="254">
+      <vector name="origin" x="304" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="98" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+    <canvas name="15" width="310" height="254">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-111" y="-254"/>
+      <vector name="rb" x="100" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="110"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-1122" y="-175"/>
+        <vector name="rb" x="-23" y="-45"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="70" height="65">
+          <vector name="origin" x="33" y="79"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="1" width="132" height="88">
+          <vector name="origin" x="88" y="89"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="2" width="145" height="85">
+          <vector name="origin" x="99" y="93"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="3" width="148" height="89">
+          <vector name="origin" x="100" y="95"/>
+          <int name="delay" value="110"/>
+        </canvas>
+        <canvas name="4" width="148" height="89">
+          <vector name="origin" x="100" y="95"/>
+          <int name="delay" value="110"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="2100"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="310" height="254">
+      <vector name="origin" x="155" y="254"/>
+      <vector name="lt" x="-155" y="-254"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-130"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="273" height="253">
+      <vector name="origin" x="141" y="253"/>
+      <vector name="lt" x="-141" y="-253"/>
+      <vector name="rb" x="132" y="0"/>
+      <vector name="head" x="-20" y="-129"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="271" height="252">
+      <vector name="origin" x="140" y="252"/>
+      <vector name="lt" x="-140" y="-252"/>
+      <vector name="rb" x="131" y="0"/>
+      <vector name="head" x="-20" y="-128"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="269" height="251">
+      <vector name="origin" x="139" y="251"/>
+      <vector name="lt" x="-139" y="-251"/>
+      <vector name="rb" x="130" y="0"/>
+      <vector name="head" x="-20" y="-127"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="310" height="306">
+      <vector name="origin" x="155" y="306"/>
+      <vector name="lt" x="-155" y="-306"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-182"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="310" height="308">
+      <vector name="origin" x="155" y="308"/>
+      <vector name="lt" x="-155" y="-308"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-184"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="310" height="309">
+      <vector name="origin" x="155" y="309"/>
+      <vector name="lt" x="-155" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="310" height="309">
+      <vector name="origin" x="155" y="309"/>
+      <vector name="lt" x="-155" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="310" height="309">
+      <vector name="origin" x="155" y="309"/>
+      <vector name="lt" x="-155" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="310" height="309">
+      <vector name="origin" x="155" y="309"/>
+      <vector name="lt" x="-155" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="310" height="309">
+      <vector name="origin" x="155" y="309"/>
+      <vector name="lt" x="-155" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="310" height="309">
+      <vector name="origin" x="155" y="309"/>
+      <vector name="lt" x="-155" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="310" height="309">
+      <vector name="origin" x="155" y="309"/>
+      <vector name="lt" x="-155" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="310" height="309">
+      <vector name="origin" x="155" y="309"/>
+      <vector name="lt" x="-155" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="14" width="1277" height="309">
+      <vector name="origin" x="1122" y="309"/>
+      <vector name="lt" x="-117" y="-312"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-159"/>
+          <vector name="rb" x="-118" y="-62"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="15" width="1277" height="306">
+      <vector name="origin" x="1122" y="306"/>
+      <vector name="lt" x="-117" y="-306"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-182"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-176"/>
+          <vector name="rb" x="-118" y="-43"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="16" width="1277" height="309">
+      <vector name="origin" x="1122" y="309"/>
+      <vector name="lt" x="-118" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-169"/>
+          <vector name="rb" x="-118" y="-50"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="17" width="1277" height="306">
+      <vector name="origin" x="1122" y="306"/>
+      <vector name="lt" x="-117" y="-306"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-182"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-169"/>
+          <vector name="rb" x="-118" y="-50"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="18" width="1277" height="309">
+      <vector name="origin" x="1122" y="309"/>
+      <vector name="lt" x="-117" y="-306"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-169"/>
+          <vector name="rb" x="-118" y="-50"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="19" width="1277" height="306">
+      <vector name="origin" x="1122" y="306"/>
+      <vector name="lt" x="-117" y="-306"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-182"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-169"/>
+          <vector name="rb" x="-118" y="-50"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="20" width="1277" height="309">
+      <vector name="origin" x="1122" y="309"/>
+      <vector name="lt" x="-118" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-169"/>
+          <vector name="rb" x="-118" y="-50"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="21" width="1277" height="306">
+      <vector name="origin" x="1122" y="306"/>
+      <vector name="lt" x="-117" y="-306"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-182"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-169"/>
+          <vector name="rb" x="-118" y="-50"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="22" width="1277" height="309">
+      <vector name="origin" x="1122" y="309"/>
+      <vector name="lt" x="-118" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-169"/>
+          <vector name="rb" x="-118" y="-50"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="23" width="1277" height="306">
+      <vector name="origin" x="1122" y="306"/>
+      <vector name="lt" x="-117" y="-306"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-21" y="-182"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-169"/>
+          <vector name="rb" x="-118" y="-65"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="24" width="1277" height="309">
+      <vector name="origin" x="1122" y="309"/>
+      <vector name="lt" x="-118" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-146"/>
+          <vector name="rb" x="-118" y="-88"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="25" width="1277" height="306">
+      <vector name="origin" x="1122" y="306"/>
+      <vector name="lt" x="-118" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-21" y="-182"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-129"/>
+          <vector name="rb" x="-118" y="-99"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="26" width="1277" height="309">
+      <vector name="origin" x="1122" y="309"/>
+      <vector name="lt" x="-118" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-185"/>
+      <int name="delay" value="150"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-1122" y="-123"/>
+          <vector name="rb" x="-118" y="-110"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <canvas name="27" width="1277" height="308">
+      <vector name="origin" x="1122" y="308"/>
+      <vector name="lt" x="-118" y="-309"/>
+      <vector name="rb" x="155" y="0"/>
+      <vector name="head" x="-20" y="-184"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="28" width="1254" height="253">
+      <vector name="origin" x="1122" y="253"/>
+      <vector name="lt" x="-111" y="-253"/>
+      <vector name="rb" x="132" y="0"/>
+      <vector name="head" x="-20" y="-129"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="29" width="1253" height="252">
+      <vector name="origin" x="1122" y="252"/>
+      <vector name="lt" x="-111" y="-252"/>
+      <vector name="rb" x="131" y="0"/>
+      <vector name="head" x="-20" y="-128"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="30" width="1208" height="251">
+      <vector name="origin" x="1078" y="251"/>
+      <vector name="lt" x="-111" y="-251"/>
+      <vector name="rb" x="130" y="0"/>
+      <vector name="head" x="-20" y="-127"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="31" width="1209" height="252">
+      <vector name="origin" x="1078" y="252"/>
+      <vector name="lt" x="-112" y="-252"/>
+      <vector name="rb" x="131" y="0"/>
+      <vector name="head" x="-21" y="-128"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="32" width="1210" height="253">
+      <vector name="origin" x="1078" y="253"/>
+      <vector name="lt" x="-111" y="-253"/>
+      <vector name="rb" x="132" y="0"/>
+      <vector name="head" x="-20" y="-129"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="301" height="288">
+      <vector name="origin" x="148" y="288"/>
+      <vector name="lt" x="-105" y="-136"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="-20" y="-144"/>
+      <string name="delay" value="500"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="301" height="288">
+      <vector name="origin" x="148" y="288"/>
+      <vector name="head" x="-57" y="-82"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="287" height="279">
+      <vector name="origin" x="148" y="279"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="266" height="264">
+      <vector name="origin" x="131" y="260"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="272" height="211">
+      <vector name="origin" x="137" y="203"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="276" height="170">
+      <vector name="origin" x="141" y="162"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="278" height="165">
+      <vector name="origin" x="143" y="157"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="279" height="169">
+      <vector name="origin" x="144" y="162"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="266" height="166">
+      <vector name="origin" x="131" y="162"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="266" height="166">
+      <vector name="origin" x="131" y="162"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="266" height="166">
+      <vector name="origin" x="131" y="162"/>
+      <vector name="head" x="-51" y="-38"/>
+      <int name="delay" value="300"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="看来今天只能打烊了。"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8300006.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8300006.img.xml
@@ -1,0 +1,1300 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8300006.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="70"/>
+    <int name="maxHP" value="570000"/>
+    <int name="maxMP" value="15000"/>
+    <int name="speed" value="30"/>
+    <int name="PADamage" value="380"/>
+    <int name="MADamage" value="380"/>
+    <int name="acc" value="210"/>
+    <int name="eva" value="12"/>
+    <int name="pushed" value="50000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="undead" value="0"/>
+    <int name="boss" value="1"/>
+    <int name="exp" value="5000"/>
+    <int name="ignoreFieldOut" value="1"/>
+    <int name="category" value="4"/>
+    <int name="firstAttack" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="145"/>
+        <int name="action" value="1"/>
+        <string name="level" value="6"/>
+        <int name="effectAfter" value="0"/>
+        <int name="skillAfter" value="1920"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="110"/>
+        <int name="action" value="2"/>
+        <string name="level" value="10"/>
+        <int name="effectAfter" value="0"/>
+        <int name="skillAfter" value="1920"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="200"/>
+        <int name="action" value="3"/>
+        <string name="level" value="177"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="128"/>
+        <int name="action" value="4"/>
+        <string name="level" value="15"/>
+        <int name="effectAfter" value="0"/>
+        <int name="skillAfter" value="1920"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="352" height="265">
+      <vector name="origin" x="192" y="298"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="1" width="343" height="293">
+      <vector name="origin" x="192" y="327"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="2" width="341" height="267">
+      <vector name="origin" x="192" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="3" width="356" height="260">
+      <vector name="origin" x="192" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="4" width="359" height="265">
+      <vector name="origin" x="192" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="5" width="354" height="285">
+      <vector name="origin" x="192" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="fly">
+    <canvas name="0" width="352" height="265">
+      <vector name="origin" x="192" y="298"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="1" width="343" height="293">
+      <vector name="origin" x="192" y="327"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="2" width="341" height="267">
+      <vector name="origin" x="192" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="3" width="356" height="260">
+      <vector name="origin" x="192" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="4" width="359" height="265">
+      <vector name="origin" x="192" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="5" width="354" height="285">
+      <vector name="origin" x="192" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-227" y="-79"/>
+        <int name="r" value="400"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="124" height="109">
+          <vector name="origin" x="62" y="97"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="96" height="98">
+          <vector name="origin" x="47" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="94" height="92">
+          <vector name="origin" x="48" y="86"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="99" height="83">
+          <vector name="origin" x="58" y="80"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="106" height="89">
+          <vector name="origin" x="60" y="84"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="211" height="91">
+          <vector name="origin" x="49" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="189" height="90">
+          <vector name="origin" x="47" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="160" height="83">
+          <vector name="origin" x="44" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <int name="bulletNumber" value="5"/>
+      <int name="bulletSpeed" value="-200"/>
+      <int name="type" value="2"/>
+      <int name="attackAfter" value="600"/>
+      <int name="magic" value="1"/>
+      <int name="conMP" value="5"/>
+    </imgdir>
+    <canvas name="0" width="359" height="293">
+      <vector name="origin" x="197" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-167" y="-295"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-30" y="-274"/>
+    </canvas>
+    <canvas name="1" width="346" height="260">
+      <vector name="origin" x="184" y="310"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-167" y="-295"/>
+      <vector name="rb" x="144" y="-64"/>
+      <vector name="head" x="-28" y="-280"/>
+    </canvas>
+    <canvas name="2" width="356" height="265">
+      <vector name="origin" x="177" y="313"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-167" y="-295"/>
+      <vector name="rb" x="144" y="-64"/>
+      <vector name="head" x="-25" y="-282"/>
+    </canvas>
+    <canvas name="3" width="362" height="285">
+      <vector name="origin" x="178" y="315"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-160" y="-305"/>
+      <vector name="rb" x="160" y="-63"/>
+      <vector name="head" x="-24" y="-282"/>
+    </canvas>
+    <canvas name="4" width="404" height="267">
+      <vector name="origin" x="304" y="264"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-241" y="-246"/>
+      <vector name="rb" x="79" y="-16"/>
+      <vector name="head" x="-102" y="-228"/>
+    </canvas>
+    <canvas name="5" width="404" height="277">
+      <vector name="origin" x="311" y="265"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-256" y="-240"/>
+      <vector name="rb" x="79" y="-7"/>
+      <vector name="head" x="-110" y="-217"/>
+    </canvas>
+    <canvas name="6" width="401" height="267">
+      <vector name="origin" x="309" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-256" y="-240"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-115" y="-212"/>
+    </canvas>
+    <canvas name="7" width="372" height="277">
+      <vector name="origin" x="291" y="260"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-256" y="-240"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-116" y="-212"/>
+    </canvas>
+    <canvas name="8" width="355" height="285">
+      <vector name="origin" x="225" y="275"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-209" y="-264"/>
+      <vector name="rb" x="112" y="-16"/>
+      <vector name="head" x="-73" y="-243"/>
+    </canvas>
+    <canvas name="9" width="354" height="285">
+      <vector name="origin" x="194" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-182" y="-288"/>
+      <vector name="rb" x="144" y="-34"/>
+      <vector name="head" x="-45" y="-265"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="hit">
+        <canvas name="0" width="121" height="136">
+          <vector name="origin" x="55" y="108"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="121" height="127">
+          <vector name="origin" x="55" y="104"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="120" height="134">
+          <vector name="origin" x="57" y="109"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="115" height="133">
+          <vector name="origin" x="59" y="110"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="107" height="132">
+          <vector name="origin" x="58" y="111"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="108" height="127">
+          <vector name="origin" x="59" y="110"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="93" height="124">
+          <vector name="origin" x="57" y="111"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="43" height="66">
+          <vector name="origin" x="50" y="106"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="8" width="59" height="62">
+          <vector name="origin" x="28" y="76"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="9" width="67" height="70">
+          <vector name="origin" x="32" y="77"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="10" width="75" height="72">
+          <vector name="origin" x="37" y="80"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="11" width="77" height="70">
+          <vector name="origin" x="38" y="81"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="12" width="66" height="69">
+          <vector name="origin" x="39" y="80"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="13" width="61" height="43">
+          <vector name="origin" x="36" y="54"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="14" width="12" height="18">
+          <vector name="origin" x="-12" y="31"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <imgdir name="range">
+        <vector name="lt" x="-988" y="-177"/>
+        <vector name="rb" x="-256" y="45"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="10"/>
+      <int name="attackAfter" value="1200"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="343" height="383">
+      <vector name="origin" x="176" y="430"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-161" y="-304"/>
+      <vector name="rb" x="161" y="-49"/>
+      <vector name="head" x="-26" y="-280"/>
+    </canvas>
+    <canvas name="1" width="341" height="378">
+      <vector name="origin" x="169" y="429"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-161" y="-304"/>
+      <vector name="rb" x="161" y="-49"/>
+      <vector name="head" x="-18" y="-283"/>
+    </canvas>
+    <canvas name="2" width="356" height="375">
+      <vector name="origin" x="166" y="429"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-161" y="-305"/>
+      <vector name="rb" x="160" y="-65"/>
+      <vector name="head" x="-16" y="-285"/>
+    </canvas>
+    <canvas name="3" width="359" height="375">
+      <vector name="origin" x="164" y="428"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-145" y="-312"/>
+      <vector name="rb" x="175" y="-65"/>
+      <vector name="head" x="-14" y="-287"/>
+    </canvas>
+    <canvas name="4" width="354" height="378">
+      <vector name="origin" x="163" y="414"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-144" y="-304"/>
+      <vector name="rb" x="176" y="-50"/>
+      <vector name="head" x="-13" y="-288"/>
+    </canvas>
+    <canvas name="5" width="352" height="365">
+      <vector name="origin" x="162" y="423"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-145" y="-305"/>
+      <vector name="rb" x="175" y="-64"/>
+      <vector name="head" x="-12" y="-289"/>
+    </canvas>
+    <canvas name="6" width="343" height="339">
+      <vector name="origin" x="161" y="398"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-145" y="-308"/>
+      <vector name="rb" x="159" y="-66"/>
+      <vector name="head" x="-11" y="-291"/>
+    </canvas>
+    <canvas name="7" width="341" height="293">
+      <vector name="origin" x="161" y="352"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-145" y="-309"/>
+      <vector name="rb" x="159" y="-65"/>
+      <vector name="head" x="-11" y="-291"/>
+    </canvas>
+    <canvas name="8" width="1135" height="343">
+      <vector name="origin" x="995" y="307"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-234" y="-245"/>
+      <vector name="rb" x="95" y="-3"/>
+      <vector name="head" x="-88" y="-230"/>
+    </canvas>
+    <canvas name="9" width="1109" height="332">
+      <vector name="origin" x="1000" y="286"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-241" y="-240"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-95" y="-226"/>
+    </canvas>
+    <canvas name="10" width="1094" height="336">
+      <vector name="origin" x="1006" y="285"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="63" y="-1"/>
+      <vector name="head" x="-102" y="-223"/>
+    </canvas>
+    <canvas name="11" width="1107" height="326">
+      <vector name="origin" x="1009" y="283"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-108" y="-225"/>
+    </canvas>
+    <canvas name="12" width="1108" height="333">
+      <vector name="origin" x="1010" y="283"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-111" y="-224"/>
+    </canvas>
+    <canvas name="13" width="1107" height="334">
+      <vector name="origin" x="1016" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-113" y="-222"/>
+    </canvas>
+    <canvas name="14" width="1105" height="327">
+      <vector name="origin" x="1018" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-116" y="-221"/>
+    </canvas>
+    <canvas name="15" width="1089" height="321">
+      <vector name="origin" x="1012" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-115" y="-219"/>
+    </canvas>
+    <canvas name="16" width="866" height="308">
+      <vector name="origin" x="791" y="280"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-116" y="-220"/>
+    </canvas>
+    <canvas name="17" width="600" height="264">
+      <vector name="origin" x="502" y="257"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-241" y="-241"/>
+      <vector name="rb" x="81" y="1"/>
+      <vector name="head" x="-107" y="-226"/>
+    </canvas>
+    <canvas name="18" width="428" height="267">
+      <vector name="origin" x="315" y="266"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-234" y="-256"/>
+      <vector name="rb" x="96" y="-1"/>
+      <vector name="head" x="-96" y="-236"/>
+    </canvas>
+    <canvas name="19" width="354" height="286">
+      <vector name="origin" x="227" y="280"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-221" y="-266"/>
+      <vector name="rb" x="112" y="-5"/>
+      <vector name="head" x="-77" y="-249"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="371" height="293">
+      <vector name="origin" x="221" y="348"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-304"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-42" y="-286"/>
+    </canvas>
+    <canvas name="1" width="366" height="276">
+      <vector name="origin" x="220" y="343"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-43" y="-296"/>
+    </canvas>
+    <canvas name="2" width="378" height="273">
+      <vector name="origin" x="217" y="342"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-43" y="-305"/>
+    </canvas>
+    <canvas name="3" width="376" height="285">
+      <vector name="origin" x="211" y="340"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-309"/>
+    </canvas>
+    <canvas name="4" width="362" height="265">
+      <vector name="origin" x="203" y="343"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-43" y="-312"/>
+    </canvas>
+    <canvas name="5" width="351" height="293">
+      <vector name="origin" x="201" y="375"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-44" y="-314"/>
+    </canvas>
+    <canvas name="6" width="348" height="268">
+      <vector name="origin" x="202" y="353"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-44" y="-314"/>
+    </canvas>
+    <canvas name="7" width="383" height="279">
+      <vector name="origin" x="222" y="360"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-44" y="-315"/>
+    </canvas>
+    <canvas name="8" width="392" height="324">
+      <vector name="origin" x="227" y="386"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-43" y="-314"/>
+    </canvas>
+    <canvas name="9" width="364" height="368">
+      <vector name="origin" x="228" y="386"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-66" y="-247"/>
+    </canvas>
+    <canvas name="10" width="365" height="368">
+      <vector name="origin" x="227" y="385"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-68" y="-245"/>
+    </canvas>
+    <canvas name="11" width="361" height="368">
+      <vector name="origin" x="227" y="384"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-68" y="-246"/>
+    </canvas>
+    <canvas name="12" width="355" height="336">
+      <vector name="origin" x="227" y="350"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-70" y="-244"/>
+    </canvas>
+    <canvas name="13" width="357" height="350">
+      <vector name="origin" x="227" y="346"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-65" y="-249"/>
+    </canvas>
+    <canvas name="14" width="378" height="337">
+      <vector name="origin" x="224" y="344"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-279"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-55" y="-260"/>
+    </canvas>
+    <canvas name="15" width="354" height="316">
+      <vector name="origin" x="195" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-46" y="-265"/>
+    </canvas>
+    <canvas name="16" width="352" height="298">
+      <vector name="origin" x="194" y="331"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-44" y="-267"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <canvas name="17" width="343" height="296">
+      <vector name="origin" x="194" y="330"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-44" y="-267"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <canvas name="18" width="341" height="294">
+      <vector name="origin" x="194" y="329"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-43" y="-265"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <canvas name="19" width="356" height="294">
+      <vector name="origin" x="194" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-43" y="-264"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <canvas name="20" width="359" height="299">
+      <vector name="origin" x="194" y="329"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-43" y="-264"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <canvas name="21" width="354" height="318">
+      <vector name="origin" x="194" y="330"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-43" y="-265"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <uol name="22" value="16"/>
+    <uol name="23" value="17"/>
+    <uol name="24" value="18"/>
+    <uol name="25" value="19"/>
+    <uol name="26" value="20"/>
+    <uol name="27" value="21"/>
+    <uol name="28" value="16"/>
+    <uol name="29" value="17"/>
+    <uol name="30" value="18"/>
+    <uol name="31" value="19"/>
+    <uol name="32" value="20"/>
+    <uol name="33" value="21"/>
+    <uol name="34" value="16"/>
+    <uol name="35" value="17"/>
+    <uol name="36" value="18"/>
+    <uol name="37" value="19"/>
+    <uol name="38" value="20"/>
+    <uol name="39" value="21"/>
+    <uol name="40" value="16"/>
+    <uol name="41" value="17"/>
+    <uol name="42" value="18"/>
+    <uol name="43" value="19"/>
+    <uol name="44" value="20"/>
+    <uol name="45" value="21"/>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="371" height="293">
+      <vector name="origin" x="220" y="362"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-304"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-42" y="-300"/>
+    </canvas>
+    <canvas name="1" width="366" height="276">
+      <vector name="origin" x="219" y="357"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-41" y="-308"/>
+    </canvas>
+    <canvas name="2" width="378" height="273">
+      <vector name="origin" x="216" y="356"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-316"/>
+    </canvas>
+    <canvas name="3" width="376" height="285">
+      <vector name="origin" x="210" y="354"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-41" y="-321"/>
+    </canvas>
+    <canvas name="4" width="362" height="265">
+      <vector name="origin" x="202" y="357"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-323"/>
+    </canvas>
+    <canvas name="5" width="351" height="293">
+      <vector name="origin" x="200" y="389"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-325"/>
+    </canvas>
+    <canvas name="6" width="348" height="268">
+      <vector name="origin" x="201" y="367"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-41" y="-327"/>
+    </canvas>
+    <canvas name="7" width="383" height="279">
+      <vector name="origin" x="221" y="374"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-42" y="-327"/>
+    </canvas>
+    <canvas name="8" width="392" height="324">
+      <vector name="origin" x="226" y="400"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-41" y="-328"/>
+    </canvas>
+    <canvas name="9" width="364" height="368">
+      <vector name="origin" x="227" y="400"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-65" y="-261"/>
+    </canvas>
+    <canvas name="10" width="365" height="368">
+      <vector name="origin" x="226" y="399"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-66" y="-259"/>
+    </canvas>
+    <canvas name="11" width="361" height="368">
+      <vector name="origin" x="226" y="398"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-66" y="-258"/>
+    </canvas>
+    <canvas name="12" width="355" height="336">
+      <vector name="origin" x="226" y="364"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-69" y="-257"/>
+    </canvas>
+    <canvas name="13" width="357" height="350">
+      <vector name="origin" x="226" y="360"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-64" y="-261"/>
+    </canvas>
+    <canvas name="14" width="378" height="337">
+      <vector name="origin" x="223" y="358"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-279"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-50" y="-270"/>
+    </canvas>
+    <canvas name="15" width="354" height="316">
+      <vector name="origin" x="194" y="342"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-44" y="-277"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill3">
+    <canvas name="0" width="371" height="293">
+      <vector name="origin" x="221" y="348"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-304"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-42" y="-284"/>
+    </canvas>
+    <canvas name="1" width="366" height="276">
+      <vector name="origin" x="220" y="343"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-42" y="-293"/>
+    </canvas>
+    <canvas name="2" width="378" height="273">
+      <vector name="origin" x="217" y="342"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-41" y="-300"/>
+    </canvas>
+    <canvas name="3" width="376" height="285">
+      <vector name="origin" x="211" y="340"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-41" y="-306"/>
+    </canvas>
+    <canvas name="4" width="362" height="265">
+      <vector name="origin" x="203" y="343"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-41" y="-309"/>
+    </canvas>
+    <canvas name="5" width="351" height="293">
+      <vector name="origin" x="201" y="375"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-43" y="-310"/>
+    </canvas>
+    <canvas name="6" width="348" height="268">
+      <vector name="origin" x="202" y="353"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-42" y="-311"/>
+    </canvas>
+    <canvas name="7" width="383" height="279">
+      <vector name="origin" x="222" y="360"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-43" y="-314"/>
+    </canvas>
+    <canvas name="8" width="392" height="324">
+      <vector name="origin" x="227" y="386"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-42" y="-314"/>
+    </canvas>
+    <canvas name="9" width="364" height="368">
+      <vector name="origin" x="228" y="386"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-64" y="-246"/>
+    </canvas>
+    <canvas name="10" width="365" height="368">
+      <vector name="origin" x="227" y="385"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-65" y="-245"/>
+    </canvas>
+    <canvas name="11" width="361" height="368">
+      <vector name="origin" x="227" y="384"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-67" y="-243"/>
+    </canvas>
+    <canvas name="12" width="355" height="336">
+      <vector name="origin" x="227" y="350"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-69" y="-240"/>
+    </canvas>
+    <canvas name="13" width="357" height="350">
+      <vector name="origin" x="227" y="346"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-64" y="-247"/>
+    </canvas>
+    <canvas name="14" width="378" height="337">
+      <vector name="origin" x="224" y="344"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-279"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-53" y="-257"/>
+    </canvas>
+    <canvas name="15" width="354" height="316">
+      <vector name="origin" x="195" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-44" y="-263"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill4">
+    <canvas name="0" width="371" height="293">
+      <vector name="origin" x="220" y="362"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-304"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-42" y="-300"/>
+    </canvas>
+    <canvas name="1" width="366" height="276">
+      <vector name="origin" x="219" y="357"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-41" y="-308"/>
+    </canvas>
+    <canvas name="2" width="378" height="273">
+      <vector name="origin" x="216" y="356"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-316"/>
+    </canvas>
+    <canvas name="3" width="376" height="285">
+      <vector name="origin" x="210" y="354"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-41" y="-321"/>
+    </canvas>
+    <canvas name="4" width="362" height="265">
+      <vector name="origin" x="202" y="357"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-323"/>
+    </canvas>
+    <canvas name="5" width="351" height="293">
+      <vector name="origin" x="200" y="389"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-325"/>
+    </canvas>
+    <canvas name="6" width="348" height="268">
+      <vector name="origin" x="201" y="367"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-41" y="-327"/>
+    </canvas>
+    <canvas name="7" width="383" height="279">
+      <vector name="origin" x="221" y="374"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-42" y="-327"/>
+    </canvas>
+    <canvas name="8" width="392" height="324">
+      <vector name="origin" x="226" y="400"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-41" y="-328"/>
+    </canvas>
+    <canvas name="9" width="364" height="368">
+      <vector name="origin" x="227" y="400"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-65" y="-261"/>
+    </canvas>
+    <canvas name="10" width="365" height="368">
+      <vector name="origin" x="226" y="399"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-66" y="-259"/>
+    </canvas>
+    <canvas name="11" width="361" height="368">
+      <vector name="origin" x="226" y="398"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-66" y="-258"/>
+    </canvas>
+    <canvas name="12" width="355" height="336">
+      <vector name="origin" x="226" y="364"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-69" y="-257"/>
+    </canvas>
+    <canvas name="13" width="357" height="350">
+      <vector name="origin" x="226" y="360"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-64" y="-261"/>
+    </canvas>
+    <canvas name="14" width="378" height="337">
+      <vector name="origin" x="223" y="358"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-279"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-50" y="-270"/>
+    </canvas>
+    <canvas name="15" width="354" height="316">
+      <vector name="origin" x="194" y="342"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-44" y="-277"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit">
+    <canvas name="0" width="343" height="294">
+      <vector name="origin" x="178" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="500"/>
+      <vector name="lt" x="-164" y="-295"/>
+      <vector name="rb" x="143" y="-59"/>
+      <vector name="head" x="-48" y="-271"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="343" height="294">
+      <vector name="origin" x="193" y="327"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-64" y="-263"/>
+    </canvas>
+    <canvas name="1" width="339" height="269">
+      <vector name="origin" x="183" y="307"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-51" y="-267"/>
+    </canvas>
+    <canvas name="2" width="352" height="259">
+      <vector name="origin" x="177" y="298"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-45" y="-266"/>
+    </canvas>
+    <canvas name="3" width="350" height="259">
+      <vector name="origin" x="170" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-266"/>
+    </canvas>
+    <canvas name="4" width="336" height="270">
+      <vector name="origin" x="160" y="289"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-264"/>
+    </canvas>
+    <canvas name="5" width="331" height="262">
+      <vector name="origin" x="151" y="291"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="6" width="322" height="294">
+      <vector name="origin" x="142" y="293"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="7" width="318" height="349">
+      <vector name="origin" x="131" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="8" width="112" height="163">
+      <vector name="origin" x="71" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="9" width="113" height="164">
+      <vector name="origin" x="71" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="10" width="111" height="162">
+      <vector name="origin" x="71" y="296"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="11" width="112" height="163">
+      <vector name="origin" x="71" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="12" width="113" height="164">
+      <vector name="origin" x="71" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-262"/>
+    </canvas>
+    <canvas name="13" width="112" height="163">
+      <vector name="origin" x="71" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="14" width="113" height="164">
+      <vector name="origin" x="71" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="15" width="111" height="162">
+      <vector name="origin" x="71" y="296"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="16" width="112" height="163">
+      <vector name="origin" x="71" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="17" width="113" height="164">
+      <vector name="origin" x="71" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-262"/>
+    </canvas>
+    <canvas name="18" width="111" height="162">
+      <vector name="origin" x="71" y="293"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-261"/>
+    </canvas>
+    <canvas name="19" width="93" height="250">
+      <vector name="origin" x="64" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-24" y="-240"/>
+    </canvas>
+    <canvas name="20" width="63" height="260">
+      <vector name="origin" x="56" y="268"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-21" y="-201"/>
+    </canvas>
+    <canvas name="21" width="56" height="297">
+      <vector name="origin" x="55" y="248"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-21" y="-201"/>
+    </canvas>
+    <canvas name="22" width="49" height="91">
+      <vector name="origin" x="55" y="235"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-21" y="-201"/>
+    </canvas>
+    <canvas name="23" width="49" height="105">
+      <vector name="origin" x="55" y="214"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-21" y="-201"/>
+    </canvas>
+    <canvas name="24" width="51" height="79">
+      <vector name="origin" x="47" y="185"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="600"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+      <vector name="head" x="-21" y="-201"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="狂妄的人类……如果以为这样就结束了，那就大错特错了。"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787125.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787125.img.xml
@@ -1,0 +1,1025 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787125.img">
+  <imgdir name="info">
+    <int name="level" value="120"/>
+    <int name="maxHP" value="999999999"/>
+    <int name="maxMP" value="999999999"/>
+    <int name="PADamage" value="1500"/>
+    <int name="MADamage" value="1500"/>
+    <int name="PDRate" value="25"/>
+    <int name="MDRate" value="25"/>
+    <int name="acc" value="300"/>
+    <string name="elemAttr" value="P2"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="500000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="magic" value="1"/>
+        <int name="attackCount" value="3"/>
+        <int name="disease" value="123"/>
+        <int name="level" value="9"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="speed" value="-10"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <int name="nonLevelCheckACC" value="1"/>
+    <int name="nonLevelCheckEVA" value="1"/>
+    <int name="notConsiderFieldSet" value="1"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="让你后悔！"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="skill">
+      <imgdir name="1">
+        <int name="skill" value="145"/>
+        <int name="action" value="2"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="0">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="23"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <int name="hpTagBgcolor" value="3"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="255" height="246">
+      <vector name="origin" x="130" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="8c24f04892a98e251afd139a9659c6a46e56a49d047d62a6a4ff07a56af93b86"/>
+    </canvas>
+    <canvas name="1" width="254" height="246">
+      <vector name="origin" x="130" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="a397d88b29437b34ac2b77bb24fe2b68d903c2da425462fef0cc388ae929c7e0"/>
+    </canvas>
+    <canvas name="2" width="255" height="233">
+      <vector name="origin" x="130" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="710572e4e40f4f2b30fc62c9c554d45da34a76d6cd9ff997fe40db1dc1ce3032"/>
+    </canvas>
+    <canvas name="3" width="255" height="239">
+      <vector name="origin" x="130" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="a45ab7142d5b3ad7dcb1a0d55a4bb790176325d5c5ed410bdd51e79d793d4071"/>
+    </canvas>
+    <canvas name="4" width="255" height="227">
+      <vector name="origin" x="130" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="e337c8706c5e4a87d0805439de9d0935e22abc260a77f4bb3b8e7e63c180c734"/>
+    </canvas>
+    <canvas name="5" width="255" height="242">
+      <vector name="origin" x="130" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="4dc0d7c2f3b4fe8f7d76c63e99456a733f826b69e833b17d5e0f495f89ba05b6"/>
+    </canvas>
+    <canvas name="6" width="255" height="252">
+      <vector name="origin" x="130" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="670b4acbafde2bba6d49683e6565cf7f3133519952e7427cea8ad4f04679818f"/>
+    </canvas>
+    <canvas name="7" width="255" height="252">
+      <vector name="origin" x="130" y="251"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="303012421928dcc70131d9fde69c7b42e7d05d7b96e8abc4a757449718c2c52b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="259" height="246">
+      <vector name="origin" x="134" y="243"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5826510ec24f7f5711bbd599b04e25c1d038529e4f48c1c0164f9f2eec15f3eb"/>
+    </canvas>
+    <canvas name="1" width="257" height="246">
+      <vector name="origin" x="133" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="f7949e6e67f2a84373187993f8398a393d6e0a4227a4b13db7350c11c5be3f9f"/>
+    </canvas>
+    <canvas name="2" width="259" height="233">
+      <vector name="origin" x="134" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="fddf24f6497bed7bc59e9a3e8b32461863b0f952f24562d659caf1ab40cbec2a"/>
+    </canvas>
+    <canvas name="3" width="260" height="227">
+      <vector name="origin" x="135" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="4d4c78629c12f2e16687d7c0719a3fae207d85ce1319f00a6048cc4e4d6619f1"/>
+    </canvas>
+    <canvas name="4" width="261" height="242">
+      <vector name="origin" x="136" y="244"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="eb129d61b881bd05455bec562ef3268ff1091cd67ce1afbd454916778c93f458"/>
+    </canvas>
+    <canvas name="5" width="260" height="252">
+      <vector name="origin" x="135" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="e32e1e7f0910d6cf1c30ddf552656d4f1bfafed075f2868bed45c8f2e69ebf1e"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-333" y="-325"/>
+        <vector name="rb" x="240" y="100"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="159" height="112">
+          <vector name="origin" x="79" y="56"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="c409463e4d926877460ade99a68718c8c0259929f05e5629eb2359c665713339"/>
+        </canvas>
+        <canvas name="1" width="192" height="187">
+          <vector name="origin" x="96" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="6fcf49cabd214dcc850c833773b3b7e0bc6eecae359f0f71ea05ee67163d1d89"/>
+        </canvas>
+        <canvas name="2" width="197" height="179">
+          <vector name="origin" x="98" y="89"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="dc5d7cbbaaaafca1fd82537438ed90720ba33e559d14a16ff4d84ed96ce9aab3"/>
+        </canvas>
+        <canvas name="3" width="205" height="223">
+          <vector name="origin" x="102" y="111"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="8bda67deca143c036410d4c046da32879e76aec265704d3ccd78fafb3400d06b"/>
+        </canvas>
+        <canvas name="4" width="198" height="210">
+          <vector name="origin" x="99" y="105"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="7be1a18ecf779ddc85ab401d7f4398e9cae0c26e002b03155265090d6f71bf69"/>
+        </canvas>
+        <canvas name="5" width="184" height="185">
+          <vector name="origin" x="92" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="d973660d13a7ad1817e94e277de76d63a71234b304bfb61d419eb5b2afe1cfb3"/>
+        </canvas>
+        <canvas name="6" width="201" height="164">
+          <vector name="origin" x="100" y="82"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="ac9dd6027cd927bc759a99e8963fe48db2e0f6cda8fbad317cbee045b98df27a"/>
+        </canvas>
+        <canvas name="7" width="198" height="145">
+          <vector name="origin" x="99" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="24d29499e6620c9a445cc38e7934dca1eb2850ea1112860eef91ed339823f4b3"/>
+        </canvas>
+        <canvas name="8" width="206" height="148">
+          <vector name="origin" x="103" y="74"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="347ac42104d245b7e017d7faa51a5b0c55d9086af6869c43c1ced777b12fc0d4"/>
+        </canvas>
+        <canvas name="9" width="207" height="161">
+          <vector name="origin" x="103" y="80"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="ac995c23eb2a2dcb95fd39106164618da3ac975aa88c3b0de06fdd94241ce773"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="720"/>
+    </imgdir>
+    <canvas name="0" width="255" height="246">
+      <vector name="origin" x="130" y="243"/>
+      <vector name="head" x="3" y="-161"/>
+      <vector name="lt" x="-128" y="-205"/>
+      <vector name="rb" x="113" y="-11"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="1" width="310" height="243">
+      <vector name="origin" x="65" y="242"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="132" y="-11"/>
+    </canvas>
+    <canvas name="2" width="315" height="241">
+      <vector name="origin" x="65" y="240"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="224" y="-7"/>
+    </canvas>
+    <canvas name="3" width="317" height="230">
+      <vector name="origin" x="65" y="229"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="229" y="-9"/>
+    </canvas>
+    <canvas name="4" width="318" height="227">
+      <vector name="origin" x="65" y="226"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="229" y="-9"/>
+    </canvas>
+    <canvas name="5" width="317" height="244">
+      <vector name="origin" x="65" y="243"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="229" y="-9"/>
+    </canvas>
+    <canvas name="6" width="317" height="252">
+      <vector name="origin" x="65" y="251"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="229" y="-9"/>
+    </canvas>
+    <canvas name="7" width="323" height="259">
+      <vector name="origin" x="65" y="242"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="236" y="-1"/>
+    </canvas>
+    <canvas name="8" width="386" height="314">
+      <vector name="origin" x="280" y="275"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="9" width="383" height="348">
+      <vector name="origin" x="279" y="322"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="10" width="381" height="343">
+      <vector name="origin" x="277" y="329"/>
+      <int name="delay" value="80"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="11" width="352" height="372">
+      <vector name="origin" x="244" y="272"/>
+      <int name="delay" value="80"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="12" width="452" height="347">
+      <vector name="origin" x="211" y="253"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="13" width="404" height="301">
+      <vector name="origin" x="273" y="275"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="14" width="408" height="314">
+      <vector name="origin" x="249" y="267"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-61" y="-215"/>
+      <vector name="rb" x="120" y="-9"/>
+    </canvas>
+    <canvas name="15" width="442" height="262">
+      <vector name="origin" x="337" y="229"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="16" width="418" height="234">
+      <vector name="origin" x="334" y="226"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="80" y="-11"/>
+    </canvas>
+    <canvas name="17" width="409" height="244">
+      <vector name="origin" x="327" y="243"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <uol name="18" value="0"/>
+    <uol name="19" value="../stand/5"/>
+    <uol name="20" value="../stand/6"/>
+    <uol name="21" value="../stand/7"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="268" height="243">
+      <vector name="origin" x="110" y="242"/>
+      <vector name="head" x="32" y="-163"/>
+      <vector name="lt" x="-112" y="-212"/>
+      <vector name="rb" x="150" y="-14"/>
+      <int name="delay" value="300"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="255" height="246">
+      <vector name="origin" x="130" y="243"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="268" height="243">
+      <vector name="origin" x="110" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="07a292263d1b5a85d258620faa49c8801fc492bf893e50bb1959c9ee64a02c15"/>
+    </canvas>
+    <canvas name="2" width="266" height="231">
+      <vector name="origin" x="106" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="b2aa446463aab979bb3705328e803e873e537c11aae966223464bb1ca59e541c"/>
+    </canvas>
+    <canvas name="3" width="267" height="237">
+      <vector name="origin" x="104" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="ca00fb56f32a27c8ed080df5e41488b8ff1dcc44f9f6b7a1373e4de4fdfdb1d4"/>
+    </canvas>
+    <canvas name="4" width="268" height="240">
+      <vector name="origin" x="103" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="7f5c70c478ff9abe59ef19612a9d105335bc33408dd266338a9347cc0e3d38ef"/>
+    </canvas>
+    <canvas name="5" width="268" height="241">
+      <vector name="origin" x="102" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="0be9b5d853296243b08f8ca4cae318ed6c1ea36945bf90ad0c23581ddd6964fc"/>
+    </canvas>
+    <canvas name="6" width="268" height="237">
+      <vector name="origin" x="101" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="6b4cc11f89c69f27152d88a289fb6ce7de6fcb7326d50a44b91485221e641a97"/>
+    </canvas>
+    <canvas name="7" width="268" height="203">
+      <vector name="origin" x="100" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="e6820ac1ed49971bb7b2e99dfa2004fab67333e78d71707504659824fa04577d"/>
+    </canvas>
+    <canvas name="8" width="268" height="203">
+      <vector name="origin" x="99" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="12eed69ebfa36119e3e50bd1b04272696576d9f500dc830ab462aa97adbdd537"/>
+    </canvas>
+    <canvas name="9" width="263" height="200">
+      <vector name="origin" x="95" y="200"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="236bdc6fe24b5a3ebf7137117275370b757e442454b53508d886151a29976e25"/>
+    </canvas>
+    <canvas name="10" width="250" height="182">
+      <vector name="origin" x="83" y="182"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="bb0c9b23cb9834fbfdea70a0110daed2d4b37f6cc48c3c35f0e7630c0cd00d36"/>
+    </canvas>
+    <canvas name="11" width="243" height="174">
+      <vector name="origin" x="78" y="176"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="a7809463bf4fcc04577e3c7e0150e50ea7f604127e9c97b64481742ae73b84df"/>
+    </canvas>
+    <canvas name="12" width="231" height="150">
+      <vector name="origin" x="72" y="155"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="5fa1a1b7acb82ec4dd86d1a9e436ece425dc44ad3b0e47c8834cea8c1f409d55"/>
+    </canvas>
+    <canvas name="13" width="213" height="141">
+      <vector name="origin" x="56" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="5dcc758b5453db87846032bf5062f8c94c82d7057652b5a8170628d77882dee4"/>
+    </canvas>
+    <canvas name="14" width="96" height="98">
+      <vector name="origin" x="-53" y="110"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="f21ff6a85910bbdb81054a1309205751b3ed97fd75b95b8ceab04bbe137c7a7d"/>
+    </canvas>
+    <canvas name="15" width="35" height="86">
+      <vector name="origin" x="-59" y="106"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="47712c61a7a39ad84e21b7f1919725512c6e7c8391a807a133beab5aad271b95"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="佩服…………"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="regen">
+    <canvas name="0" width="163" height="121">
+      <vector name="origin" x="-108" y="104"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2d5b4ce04af61635ec2842256342be576b5fc9d09e32d089603db1775e2d6e08"/>
+    </canvas>
+    <canvas name="1" width="183" height="159">
+      <vector name="origin" x="-106" y="143"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="08f18fb519dfabc13811fe5695be97446af01aa2f5a63e6169c86427900847da"/>
+    </canvas>
+    <canvas name="2" width="562" height="486">
+      <vector name="origin" x="132" y="469"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d1607ffdd39ac479c56f08212818c58b4b2770867ce6974b681a918e4b1af62d"/>
+    </canvas>
+    <canvas name="3" width="857" height="510">
+      <vector name="origin" x="429" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74611b04713129a952214114ad5f3a67e17de98025136a5bf70c02a37a4b997a"/>
+    </canvas>
+    <canvas name="4" width="845" height="498">
+      <vector name="origin" x="422" y="469"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fb1bb021cee9da8db55c8c5c8f1172a0f043cece335c05a1d9789dd99fea6efd"/>
+    </canvas>
+    <canvas name="5" width="836" height="483">
+      <vector name="origin" x="421" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2b95b0d905f9724d1aa2056a8eee544fa28f1f70a7e2fdfa94d2284aa74400d4"/>
+    </canvas>
+    <canvas name="6" width="793" height="482">
+      <vector name="origin" x="416" y="466"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a4333723be51fd634f9ab4f76f896b8ea30982a27382fd6be4f807a04cefa1a"/>
+    </canvas>
+    <canvas name="7" width="726" height="463">
+      <vector name="origin" x="357" y="452"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="558ade5df104f10e6ed67f675aabccaf2f75c176787e5773916588a909169e08"/>
+    </canvas>
+    <canvas name="8" width="533" height="444">
+      <vector name="origin" x="343" y="433"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7c8e52a0204be493c3ffe5252083c58840c290b8d61387790514b68fe5faf3cf"/>
+    </canvas>
+    <canvas name="9" width="371" height="425">
+      <vector name="origin" x="176" y="422"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1c0eb9d184e2dbced20b2eb83e8309b97b2b91f55a4d2d4978cedd3454adffab"/>
+    </canvas>
+    <canvas name="10" width="424" height="397">
+      <vector name="origin" x="248" y="338"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="16437ffb463403813a9e27257c8f5c082b8c68516e424d33b73c0fb62e4a78b1"/>
+    </canvas>
+    <canvas name="11" width="385" height="301">
+      <vector name="origin" x="198" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="de14046a00143be908f436e605e8dfe9c7d843f7fc150b902c7fe3417fcdfbca"/>
+    </canvas>
+    <canvas name="12" width="435" height="346">
+      <vector name="origin" x="171" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d217b903e9c3a334d57465863b8b45d0f878127409d006cc4ded285d34fa4622"/>
+    </canvas>
+    <canvas name="13" width="468" height="432">
+      <vector name="origin" x="257" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9d6cdb634de2ef06a774f033c000c40f2212c44eb9c33a8879bb5af81a3975eb"/>
+    </canvas>
+    <canvas name="14" width="418" height="240">
+      <vector name="origin" x="242" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9c2f93d25e7efb67d9d4db7e3cb27723cf673dbf3fb2a702f76f13b10ec808dd"/>
+    </canvas>
+    <canvas name="15" width="374" height="375">
+      <vector name="origin" x="187" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f16caff1f49e670f85b0f547367480237c2b6f650ddc9af4f1f7b96b28960a0c"/>
+    </canvas>
+    <canvas name="16" width="457" height="398">
+      <vector name="origin" x="146" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="eb168fae0855a88be358632e5efab06864084c789f062199d7dd29d879ed9f24"/>
+    </canvas>
+    <canvas name="17" width="423" height="463">
+      <vector name="origin" x="228" y="317"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="25d8dbc5b1beef9695158c7dcdebf7d320124f865851554e3a7bdd218e5403d7"/>
+    </canvas>
+    <canvas name="18" width="386" height="400">
+      <vector name="origin" x="210" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8dc822b25525620eae6286f9182b0282a35ad1c8bbc099332b90c348fd3f360e"/>
+    </canvas>
+    <canvas name="19" width="458" height="430">
+      <vector name="origin" x="143" y="278"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9b99e5dbae7486f643c20ca1b8a195714f7d7220cfd5c24d62d06d7cfdaa552c"/>
+    </canvas>
+    <canvas name="20" width="549" height="530">
+      <vector name="origin" x="260" y="390"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bbbf94179d8b8de33deec454905df9212420d786aea06e6f273da8914efc6003"/>
+    </canvas>
+    <canvas name="21" width="440" height="308">
+      <vector name="origin" x="245" y="222"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="819b547a07bed2178b0cd455eef186d9e58325fd178dc9e0d5f94dfd5bc136b4"/>
+    </canvas>
+    <canvas name="22" width="350" height="334">
+      <vector name="origin" x="162" y="282"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="20dada7a61f6c5acbd6656669dcb8dae0cad77f9535a411b279f811d06bce934"/>
+    </canvas>
+    <canvas name="23" width="396" height="360">
+      <vector name="origin" x="182" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d96817664341ec31615119c3317afbf8880e068e4a419138bdcec93f798ef245"/>
+    </canvas>
+    <canvas name="24" width="396" height="376">
+      <vector name="origin" x="180" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b477aa9892b05065b53d32944572f8ef9961091856c3824d38e2b4057924f1e6"/>
+    </canvas>
+    <canvas name="25" width="383" height="382">
+      <vector name="origin" x="175" y="305"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="648519edf45df8cdd8fad397642263f24e6588d0ce13f9245c81facd50df75b4"/>
+    </canvas>
+    <canvas name="26" width="382" height="382">
+      <vector name="origin" x="174" y="305"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3d7f0258801842983faf3bf462aa409d698b50ad544062bbeaf54b5ac8c4ae5c"/>
+    </canvas>
+    <canvas name="27" width="378" height="378">
+      <vector name="origin" x="172" y="303"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c40b980575aa2ba43279d47360b01fd65b19248ef865c329badfa6dd741c2ec6"/>
+    </canvas>
+    <canvas name="28" width="331" height="348">
+      <vector name="origin" x="172" y="289"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5c4328408b58d5d5514b3ecd6db47a086ec840925686dbb066f87e43cad0154e"/>
+    </canvas>
+    <canvas name="29" width="330" height="350">
+      <vector name="origin" x="173" y="291"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="eacd10b2ce0d59556d84827a3203808f8fa794e0ca1c2a2468508fa846d7cfa4"/>
+    </canvas>
+    <canvas name="30" width="320" height="320">
+      <vector name="origin" x="166" y="278"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="52a1aa3c869999c01c57dcc287b33e0bf3d36e7a6c33fa42d8de8e733792fdda"/>
+    </canvas>
+    <canvas name="31" width="315" height="315">
+      <vector name="origin" x="168" y="280"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d5f9010cc7551da209e8350e452458be2cc6a21b838c3db9f6e6c33f7464dce2"/>
+    </canvas>
+    <canvas name="32" width="258" height="252">
+      <vector name="origin" x="130" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b5c1514bc0d9509834b975f692178e6d9c6290fae67fef647c03a560699e7a11"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="为了伟大的主人！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="130" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="901f9a18a5774272e940f79aef08e21b822a59ada9b58099f5657c0d68239f0e"/>
+    </canvas>
+    <canvas name="1" width="380" height="328">
+      <vector name="origin" x="178" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="64226e1352f93ccfd53500ce559a456e2d1e0d407198ae2580ca611898806311"/>
+    </canvas>
+    <canvas name="2" width="376" height="324">
+      <vector name="origin" x="176" y="275"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="ccbe7757472f8329d059c5392da84b920e37338abf59d9a2e01cda535b300c03"/>
+    </canvas>
+    <canvas name="3" width="368" height="372">
+      <vector name="origin" x="172" y="300"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="117a182fd3e404959d642da2e6c348bd31f04b3bce5968b99b62945b3fdd3ab8"/>
+    </canvas>
+    <canvas name="4" width="332" height="384">
+      <vector name="origin" x="153" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="982c0e745ab202102d1cf496436ad798b830d05475341f8db99cbbbdc1e50175"/>
+    </canvas>
+    <canvas name="5" width="328" height="380">
+      <vector name="origin" x="151" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="33d005df1b1c233c81f36aea8db08d7b6ebf26dc290a19a227445773a3f7e520"/>
+    </canvas>
+    <canvas name="6" width="372" height="376">
+      <vector name="origin" x="174" y="301"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="e4705e1ccf799791860b81c6ae50f84f5e47a8dfb109f060b223afc042eda796"/>
+    </canvas>
+    <canvas name="7" width="384" height="368">
+      <vector name="origin" x="180" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3ffbaa78e566b4ab5f29938435588be76e529ce0560569f13b82219951a0fd87"/>
+    </canvas>
+    <canvas name="8" width="320" height="420">
+      <vector name="origin" x="151" y="419"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="a5aa40bd1965c1a7de17b55bdaf3915e76a5029a6e913f3d9e821e8b3ba8da3e"/>
+    </canvas>
+    <canvas name="9" width="288" height="408">
+      <vector name="origin" x="139" y="404"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3b9b8982c46c37e2f4ae57c4d401830ba50ee04479ebdd5b2f5270cda9553982"/>
+    </canvas>
+    <canvas name="10" width="284" height="408">
+      <vector name="origin" x="135" y="405"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3b4427253e23567cc876ac29ec814621d4c1746ae92dc9ed51b79a3db84cce4a"/>
+    </canvas>
+    <canvas name="11" width="288" height="408">
+      <vector name="origin" x="136" y="407"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="0cc610047d56064385ab70e1b9f9a88af8aed8897de1545140d3279a8a3e4a03"/>
+    </canvas>
+    <canvas name="12" width="288" height="404">
+      <vector name="origin" x="136" y="407"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="ba3c0c83652d48fb231eab1144a342840d6986eb32c5f0ae7c7e96e5f5ebf6b9"/>
+    </canvas>
+    <canvas name="13" width="284" height="372">
+      <vector name="origin" x="134" y="405"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="b42ef4f024df8e6aa9e9022404c02a0865acba6378c6c14ccbf979eef31a476f"/>
+    </canvas>
+    <canvas name="14" width="256" height="356">
+      <vector name="origin" x="130" y="379"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="79f3cc244f4682245a6a3e792995c78d1070336c89de9c1d6ce17769851e0804"/>
+    </canvas>
+    <canvas name="15" width="256" height="372">
+      <vector name="origin" x="130" y="376"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="b7b6a04e3861269039b384cb41f321be60cf46d99466f3392516fb0ec215984e"/>
+    </canvas>
+    <uol name="16" value="../stand/5"/>
+    <uol name="17" value="../stand/6"/>
+    <uol name="18" value="../stand/7"/>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="别再耍这些小把戏了……"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="130" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="901f9a18a5774272e940f79aef08e21b822a59ada9b58099f5657c0d68239f0e"/>
+    </canvas>
+    <canvas name="1" width="380" height="328">
+      <vector name="origin" x="178" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="64226e1352f93ccfd53500ce559a456e2d1e0d407198ae2580ca611898806311"/>
+    </canvas>
+    <canvas name="2" width="376" height="324">
+      <vector name="origin" x="176" y="275"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="ccbe7757472f8329d059c5392da84b920e37338abf59d9a2e01cda535b300c03"/>
+    </canvas>
+    <canvas name="3" width="368" height="372">
+      <vector name="origin" x="172" y="300"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="117a182fd3e404959d642da2e6c348bd31f04b3bce5968b99b62945b3fdd3ab8"/>
+    </canvas>
+    <canvas name="4" width="332" height="384">
+      <vector name="origin" x="153" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="982c0e745ab202102d1cf496436ad798b830d05475341f8db99cbbbdc1e50175"/>
+    </canvas>
+    <canvas name="5" width="328" height="380">
+      <vector name="origin" x="151" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="33d005df1b1c233c81f36aea8db08d7b6ebf26dc290a19a227445773a3f7e520"/>
+    </canvas>
+    <canvas name="6" width="372" height="376">
+      <vector name="origin" x="174" y="301"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="e4705e1ccf799791860b81c6ae50f84f5e47a8dfb109f060b223afc042eda796"/>
+    </canvas>
+    <canvas name="7" width="384" height="368">
+      <vector name="origin" x="180" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3ffbaa78e566b4ab5f29938435588be76e529ce0560569f13b82219951a0fd87"/>
+    </canvas>
+    <canvas name="8" width="320" height="420">
+      <vector name="origin" x="151" y="419"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="a5aa40bd1965c1a7de17b55bdaf3915e76a5029a6e913f3d9e821e8b3ba8da3e"/>
+    </canvas>
+    <canvas name="9" width="288" height="408">
+      <vector name="origin" x="139" y="404"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3b9b8982c46c37e2f4ae57c4d401830ba50ee04479ebdd5b2f5270cda9553982"/>
+    </canvas>
+    <canvas name="10" width="284" height="408">
+      <vector name="origin" x="135" y="405"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3b4427253e23567cc876ac29ec814621d4c1746ae92dc9ed51b79a3db84cce4a"/>
+    </canvas>
+    <canvas name="11" width="288" height="408">
+      <vector name="origin" x="136" y="407"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="0cc610047d56064385ab70e1b9f9a88af8aed8897de1545140d3279a8a3e4a03"/>
+    </canvas>
+    <canvas name="12" width="288" height="404">
+      <vector name="origin" x="136" y="407"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="ba3c0c83652d48fb231eab1144a342840d6986eb32c5f0ae7c7e96e5f5ebf6b9"/>
+    </canvas>
+    <canvas name="13" width="284" height="372">
+      <vector name="origin" x="134" y="405"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="b42ef4f024df8e6aa9e9022404c02a0865acba6378c6c14ccbf979eef31a476f"/>
+    </canvas>
+    <canvas name="14" width="256" height="356">
+      <vector name="origin" x="130" y="379"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="79f3cc244f4682245a6a3e792995c78d1070336c89de9c1d6ce17769851e0804"/>
+    </canvas>
+    <canvas name="15" width="256" height="372">
+      <vector name="origin" x="130" y="376"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="b7b6a04e3861269039b384cb41f321be60cf46d99466f3392516fb0ec215984e"/>
+    </canvas>
+    <uol name="16" value="../stand/5"/>
+    <uol name="17" value="../stand/6"/>
+    <uol name="18" value="../stand/7"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787126.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787126.img.xml
@@ -1,0 +1,551 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787126.img">
+  <imgdir name="info">
+    <int name="level" value="10"/>
+    <int name="maxHP" value="500"/>
+    <int name="maxMP" value="0"/>
+    <int name="PADamage" value="10"/>
+    <int name="PDDamage" value="10"/>
+    <int name="PDRate" value="1"/>
+    <int name="MADamage" value="10"/>
+    <int name="MDDamage" value="10"/>
+    <int name="MDRate" value="1"/>
+    <int name="acc" value="0"/>
+    <int name="eva" value="0"/>
+    <int name="pushed" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="0"/>
+    <int name="summonType" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="bodyAttack" value="0"/>
+    <int name="fixedDamage" value="1"/>
+    <int name="individualReward" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="ignoreFieldOut" value="1"/>
+    <int name="explosiveReward" value="1"/>
+    <int name="removeAfter" value="360000"/>
+    <int name="boss" value="1"/>
+    <int name="speed" value="-40"/>
+    <imgdir name="speak">
+      <imgdir name="0">
+        <int name="hp" value="1649"/>
+        <string name="0" value="请让我恢复原来的姿态吧！勇者大人！"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+    <int name="onlyNormalAttack" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="252" height="335">
+      <vector name="origin" x="138" y="334"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="21700974f8bf0eb26a811b3316c06f2d29cf13bbd8a184eb5711f3eced135db6"/>
+    </canvas>
+    <canvas name="1" width="260" height="339">
+      <vector name="origin" x="150" y="338"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="74c80dbbb1005cb9d35edcb22bf6968f6f01f1b7b89fd0597ec3b1ec1bc3b407"/>
+    </canvas>
+    <canvas name="2" width="268" height="335">
+      <vector name="origin" x="158" y="334"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="5c0e4a18515b275c20f9c6def0bcd92ffd7019d22e1aaaa54a7e1cbe1a283b26"/>
+    </canvas>
+    <canvas name="3" width="236" height="319">
+      <vector name="origin" x="118" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="23c512a46ff5e3a6512aa7aab5678e7f952b85d8ed2a3d49b59220780a565c50"/>
+    </canvas>
+    <canvas name="4" width="176" height="315">
+      <vector name="origin" x="94" y="314"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="389acc18a2346512ba51add8fb1db094b0cc5b8e3a56cb74d42d221d54eae97c"/>
+    </canvas>
+    <canvas name="5" width="204" height="319">
+      <vector name="origin" x="130" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="14339c0eb86ced079bf71ff0f9b520b1273a467d7c6fb93004495b06bd701215"/>
+    </canvas>
+    <canvas name="6" width="228" height="319">
+      <vector name="origin" x="146" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="7354379894103d4fe0274be2c6b58545270f01250d17abf03cceabab7cc9ed35"/>
+    </canvas>
+    <canvas name="7" width="236" height="319">
+      <vector name="origin" x="98" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="61ea2ba32231a09f84eac4386adf39dcf97213bd8e942811393de9b2b78193c6"/>
+    </canvas>
+    <canvas name="8" width="236" height="323">
+      <vector name="origin" x="82" y="322"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="da667621d11b0a055a3ba5a1f625d3da88d6de1285747d26c916d13753350790"/>
+    </canvas>
+    <canvas name="9" width="176" height="315">
+      <vector name="origin" x="18" y="314"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="10" width="204" height="319">
+      <vector name="origin" x="98" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="11" width="228" height="319">
+      <vector name="origin" x="138" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="15"/>
+      <string name="0" value="请让我恢复原来的姿态吧！勇者大人！"/>
+      <string name="1" value="喂！请救救我啊～！！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="232" height="324">
+      <vector name="origin" x="115" y="324"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="5cafe798c74ff494e9ccb944b25eeb5bc06da6ee587ce1f005e20dd00dcdd653"/>
+    </canvas>
+    <canvas name="1" width="216" height="320">
+      <vector name="origin" x="99" y="320"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="4c9392ce466ed568da8db90854e405f1b4e74af72a3e98b33344d698a0ba4191"/>
+    </canvas>
+    <canvas name="2" width="216" height="324">
+      <vector name="origin" x="99" y="324"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="f2e5532d31c36fe61b187c1315f2f7b6d328488d46551f020c77e1c877ab12b9"/>
+    </canvas>
+    <canvas name="3" width="236" height="328">
+      <vector name="origin" x="123" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="04c9026b7a55b46a51adc75e7226c49dbe77fd0f509d5502e710975fcdcc053b"/>
+    </canvas>
+    <canvas name="4" width="240" height="316">
+      <vector name="origin" x="143" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="7ef69a04c4d380fb8311cd5de9300aa06b41b1d1eb007e92b7bfad5fb01bcc53"/>
+    </canvas>
+    <canvas name="5" width="236" height="324">
+      <vector name="origin" x="111" y="324"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="38c57922577283ca970c12ea9a8d40a4f7bf348bc508ab3bd5967cbc415c020c"/>
+    </canvas>
+    <canvas name="6" width="236" height="324">
+      <vector name="origin" x="83" y="324"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="0cdfc4f70b115f0e9a2950fcfc8893b761df4bbf5214b72788894b97041102dd"/>
+    </canvas>
+    <canvas name="7" width="236" height="316">
+      <vector name="origin" x="107" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="4846e83d60f76965d31a4ae2ddcb83ac7def91e90afac5dc9ab4ccfbc395809e"/>
+    </canvas>
+    <canvas name="8" width="176" height="312">
+      <vector name="origin" x="27" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="1044cf513ae40f68fbe78c1745d1e96291c20b7c4569ba7a4468075c48bf8a60"/>
+    </canvas>
+    <canvas name="9" width="204" height="316">
+      <vector name="origin" x="63" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="2cb962ecc822cab6da8abc793533944c2e9d459cf09dcd287013f6f8abc53f94"/>
+    </canvas>
+    <canvas name="10" width="228" height="312">
+      <vector name="origin" x="107" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="4706f6db66073862fbf4668e0676d79dca3e50898590d52da03dd4ed7bf0d769"/>
+    </canvas>
+    <canvas name="11" width="228" height="308">
+      <vector name="origin" x="107" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="cce9f7fcc716382db69ecd31ed1826db7829e30b86cf04e4bf23a03e288405b6"/>
+    </canvas>
+    <canvas name="12" width="216" height="320">
+      <vector name="origin" x="103" y="320"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="13" width="236" height="328">
+      <vector name="origin" x="127" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="14" width="240" height="316">
+      <vector name="origin" x="147" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="15" width="236" height="316">
+      <vector name="origin" x="111" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="43bdee24bb984baf66e9d3d506ad6aa5920ff542bf47231fdb0beecff40fa8fd"/>
+    </canvas>
+    <canvas name="16" width="248" height="312">
+      <vector name="origin" x="119" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="97b15a5968f863da21abb39d4e7eba32a9b4f0dceb2f79a34779f029c25e5850"/>
+    </canvas>
+    <canvas name="17" width="244" height="312">
+      <vector name="origin" x="119" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="8d03ffe71b87ba470d6cdde49a37a01847ff3d6fb6c23a21d9fe019f3a713201"/>
+    </canvas>
+    <canvas name="18" width="232" height="300">
+      <vector name="origin" x="103" y="300"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="6f5b1e22a7a08e342440116b5143cfdbc2b6850184ffa03f41241f3e60fcc604"/>
+    </canvas>
+    <canvas name="19" width="264" height="312">
+      <vector name="origin" x="99" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="d75063ce484782086f8bfd1e7a1ee66b18427e96304358c1b65890dde517a481"/>
+    </canvas>
+    <canvas name="20" width="252" height="308">
+      <vector name="origin" x="123" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="aeaf519ea14bcd1ecb1154604fbe6f30f40fad0664dde82cc031b44b91f0c130"/>
+    </canvas>
+    <canvas name="21" width="264" height="316">
+      <vector name="origin" x="127" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="d1dc836e5085c7c1b94d786f16c149e65f7f3e97aa1d5f1698d3e585be5ae03c"/>
+    </canvas>
+    <canvas name="22" width="240" height="308">
+      <vector name="origin" x="131" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="f845179e24cab4241f2d172e63ad19306342f64f75e17e5776f887a9c98c393a"/>
+    </canvas>
+    <canvas name="23" width="264" height="316">
+      <vector name="origin" x="127" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="24" width="216" height="320">
+      <vector name="origin" x="95" y="320"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="8368e04ad97252d7896704bb947009438dd4b69d4dd6014c7dee049bc018215b"/>
+    </canvas>
+    <canvas name="25" width="216" height="324">
+      <vector name="origin" x="95" y="324"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="5fb0e8e81e5ae5323a9d4a63da18415bdc5d4174bceb63e05b021113993c6012"/>
+    </canvas>
+    <canvas name="26" width="216" height="320">
+      <vector name="origin" x="95" y="320"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="27" width="236" height="316">
+      <vector name="origin" x="71" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="28" width="264" height="316">
+      <vector name="origin" x="127" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="29" width="252" height="308">
+      <vector name="origin" x="119" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="30" width="240" height="316">
+      <vector name="origin" x="171" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="31" width="260" height="316">
+      <vector name="origin" x="135" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="46207cd9d0afdf4dc6b3d85a4e283d4b0c3a99b7f55316246b191e98d8ef69dd"/>
+    </canvas>
+    <canvas name="32" width="236" height="308">
+      <vector name="origin" x="103" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="9d0b54d373ce2e8249c1a3d2b1fa36010dd1e25dc783bceb65956deaf7460056"/>
+    </canvas>
+    <canvas name="33" width="236" height="316">
+      <vector name="origin" x="123" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="34" width="252" height="308">
+      <vector name="origin" x="111" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="35" width="240" height="308">
+      <vector name="origin" x="123" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="36" width="264" height="316">
+      <vector name="origin" x="119" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="37" width="248" height="312">
+      <vector name="origin" x="123" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="38" width="236" height="328">
+      <vector name="origin" x="131" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="248" height="312">
+      <vector name="origin" x="118" y="327"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <int name="delay" value="120"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="5235befd95593a19a2f2e5eed85cbfdee952b6fe99b8cb88490a819ef2d3a665"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="296" height="344">
+      <vector name="origin" x="138" y="344"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d250972e1702238d617c6f6773cf393afd40817a9b2505ae50d03d6fb7077959"/>
+    </canvas>
+    <canvas name="1" width="288" height="364">
+      <vector name="origin" x="94" y="380"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c8c06db5287fec1610ce7424aab73dc86748c19ea691334d84ef81d580b1154e"/>
+    </canvas>
+    <canvas name="2" width="316" height="356">
+      <vector name="origin" x="70" y="394"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="840be8ddf174224f7eea6c83b7304e7acc750d15fc3516aed608dde62601f820"/>
+    </canvas>
+    <canvas name="3" width="296" height="344">
+      <vector name="origin" x="30" y="394"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="330ec8cbbad2ab0893646c88801fb1cb855a07e88a83e3f4eb5ad6a278704047"/>
+    </canvas>
+    <canvas name="4" width="288" height="364">
+      <vector name="origin" x="-6" y="392"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="da7b7690971a3811e1e4833a2a0e3e8d369eac84f7d40fb2e1a0e23f21f328c0"/>
+    </canvas>
+    <canvas name="5" width="316" height="356">
+      <vector name="origin" x="-22" y="392"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6cdad95124b95cd562180c364cfd83aa4b171a801fee8445d001e82167accc81"/>
+    </canvas>
+    <canvas name="6" width="296" height="344">
+      <vector name="origin" x="-70" y="380"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="0e63844a7470823087ad723dd08671b26aae2b936afbe0f84b9e339e56c62fbb"/>
+    </canvas>
+    <canvas name="7" width="288" height="364">
+      <vector name="origin" x="-82" y="368"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="bc4d79a27b30eba1b45fe7f0174f2566428cda96bd1dfd97effee102c03929fc"/>
+    </canvas>
+    <canvas name="8" width="1" height="1">
+      <vector name="origin" x="-91" y="368"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787127.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787127.img.xml
@@ -1,0 +1,1598 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787127.img">
+  <imgdir name="info">
+    <int name="level" value="100"/>
+    <int name="maxHP" value="999999999"/>
+    <int name="maxMP" value="50000"/>
+    <int name="speed" value="5"/>
+    <int name="PADamage" value="1500"/>
+    <int name="MADamage" value="1500"/>
+    <int name="PDRate" value="25"/>
+    <int name="MDRate" value="25"/>
+    <int name="acc" value="600"/>
+    <string name="elemAttr" value="P2"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="500000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="magic" value="1"/>
+        <int name="disease" value="0"/>
+        <int name="level" value="0"/>
+        <int name="attackCount" value="3"/>
+        <int name="cooltime" value="2500"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <int name="nonLevelCheckACC" value="1"/>
+    <int name="nonLevelCheckEVA" value="1"/>
+    <int name="notConsiderFieldSet" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="100"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="128"/>
+        <int name="action" value="1"/>
+        <int name="level" value="7"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="9"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="让你后悔！"/>
+      </imgdir>
+    </imgdir>
+    <int name="hpTagBgcolor" value="3"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="161" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="bd427aaaea1847c666479be67792b05b06beb82bb32632a7126ded955f2afb71"/>
+    </canvas>
+    <canvas name="1" width="256" height="248">
+      <vector name="origin" x="161" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="951a0963998c1de1183445b160e0fb78b804f77e6859b5f8a97c7d9fe248b179"/>
+    </canvas>
+    <canvas name="2" width="256" height="236">
+      <vector name="origin" x="161" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="0606df1357becbb92ed8164123bc4f0c50a453d8bb2f2d862054175d3d7c2215"/>
+    </canvas>
+    <canvas name="3" width="256" height="244">
+      <vector name="origin" x="161" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="d9b9deb1cfdc029c3cbda2a2e5f276a46e7cdbbb368a849a4ae7e20b570b4124"/>
+    </canvas>
+    <canvas name="4" width="256" height="232">
+      <vector name="origin" x="161" y="228"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="b5946b5908a1bebf8155ee04ef507f02822b574efc8adaf0ba87c2b359af4f00"/>
+    </canvas>
+    <canvas name="5" width="256" height="244">
+      <vector name="origin" x="161" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="76172f894f9bb377f75cb5dbd73523dc8ad5ac286d9ae09c43ac9a989d4115d6"/>
+    </canvas>
+    <canvas name="6" width="256" height="256">
+      <vector name="origin" x="161" y="253"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="0a004e609478e64d284d0e81e28ffe7973a48b60160b8dff11459d97dcee615e"/>
+    </canvas>
+    <canvas name="7" width="256" height="256">
+      <vector name="origin" x="161" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="893a803240bb06adb568714125dbd3f44c7760592f9f95af1bd8acddb6f9f057"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="以为能从我面前逃走吗？你凭什么这么想？愚蠢的低等生物……你以为我是谁……"/>
+    </imgdir>
+    <canvas name="0" width="260" height="248">
+      <vector name="origin" x="165" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="255c88d1e614078a57f14fe65da5a8c0363b43fab7f9065a68c7de09e49ca76d"/>
+    </canvas>
+    <canvas name="1" width="260" height="248">
+      <vector name="origin" x="164" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="b144c1da77dd8c1aef8a512d17ba7fa541241b2ea00ccd3eea2b19fd87c0b5b7"/>
+    </canvas>
+    <canvas name="2" width="260" height="236">
+      <vector name="origin" x="165" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="e9d065cdda0860d58faf577d05fbe5dc5630f82172f5042a373728095c6dee32"/>
+    </canvas>
+    <canvas name="3" width="260" height="232">
+      <vector name="origin" x="166" y="228"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="47cec7d12cdaeb8b24206a4af4ef5c9d6d40e2d6777def038deed603affd6e98"/>
+    </canvas>
+    <canvas name="4" width="264" height="244">
+      <vector name="origin" x="167" y="244"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="ed4e7b0f0b05665e4acc22dd8cac3067641f03ee9cb249c1f1ab705a76939107"/>
+    </canvas>
+    <canvas name="5" width="260" height="256">
+      <vector name="origin" x="166" y="253"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="0318b92874568c35819660d8c424265d2759e872ec94ddedc0e635b899629aef"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-627" y="-597"/>
+        <vector name="rb" x="582" y="246"/>
+      </imgdir>
+      <int name="attackAfter" value="2520"/>
+      <int name="effectAfter" value="900"/>
+      <imgdir name="hit">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="49" y="63"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f22fe7714033f8f8e781056f7d0a203d0efd708c2d7f218c66e5f45f9db1578c"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="1" height="1">
+          <vector name="origin" x="49" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9f9bc70c590a7bdcc02e62d83c1efb977987ce36e0a0093eee4ce234347cf93f"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="1" height="1">
+          <vector name="origin" x="48" y="52"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4e868d8208e74fac1e6077a048e57546cde70ca76bb5096f2ee69951155d91f8"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="1" height="1">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1fcc1e04e096ffd8b07dde8ab85432d434e24ccd9221fef3a50595ab13b14809"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="1" height="1">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f72900dbb32c47a09453725348ddf4122a2bef2260d3e52d6e6aafba0563564c"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="49" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e20c38698a34cc81e858072970fbc265563bc47aa08b567546b3c895638d5246"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="23" height="45">
+          <vector name="origin" x="16" y="181"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="24" height="48">
+          <vector name="origin" x="16" y="184"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="25" height="49">
+          <vector name="origin" x="16" y="185"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="114" height="138">
+          <vector name="origin" x="56" y="147"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="117" height="139">
+          <vector name="origin" x="59" y="147"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="5" width="133" height="133">
+          <vector name="origin" x="65" y="134"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="6" width="136" height="134">
+          <vector name="origin" x="67" y="134"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="7" width="136" height="134">
+          <vector name="origin" x="67" y="135"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="8" width="134" height="133">
+          <vector name="origin" x="66" y="135"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="9" width="128" height="130">
+          <vector name="origin" x="60" y="135"/>
+          <int name="delay" value="180"/>
+        </canvas>
+        <canvas name="10" width="252" height="258">
+          <vector name="origin" x="128" y="192"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="11" width="246" height="250">
+          <vector name="origin" x="125" y="188"/>
+          <int name="delay" value="140"/>
+        </canvas>
+        <canvas name="12" width="246" height="250">
+          <vector name="origin" x="125" y="188"/>
+          <int name="delay" value="150"/>
+        </canvas>
+      </imgdir>
+    </imgdir>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+    <uol name="24" value="../stand/6"/>
+    <uol name="25" value="../stand/7"/>
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="在这伟大的力量下燃烧吧！和这个世界一起！哈哈哈哈哈！"/>
+      <string name="1" value="化为灰烬吧！哈哈哈哈哈哈！"/>
+    </imgdir>
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="161" y="243"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="443f7e9b9f6c3ed07c35e9b6dbcc8ba2808e2f92a4abd68351396b1f33dd9c83"/>
+    </canvas>
+    <canvas name="1" width="268" height="248">
+      <vector name="origin" x="175" y="246"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="fb24c914f53bcca82b22d44eb9c7c4449acff5ea6ac4536d8f8ec5ae8fe4efb3"/>
+    </canvas>
+    <canvas name="2" width="240" height="252">
+      <vector name="origin" x="146" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="375d944f4a6074552542141e61b03b96eb33ea2713b37fa24561834659e99437"/>
+    </canvas>
+    <canvas name="3" width="256" height="256">
+      <vector name="origin" x="160" y="258"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="ecaa56224c4334cd21deb97029b49c4abf19cea8d8ed74697be03e052aadd710"/>
+    </canvas>
+    <canvas name="4" width="260" height="288">
+      <vector name="origin" x="164" y="290"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="4ac0b9bbe1404a7141819b9347f1573462612dc140a0f186d200e1c6a6f4f09b"/>
+    </canvas>
+    <canvas name="5" width="252" height="296">
+      <vector name="origin" x="155" y="296"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="cf5342c67bf6bfea01e09acea31824bbe9beefc48ded3334a1eb54a66c3f11c6"/>
+    </canvas>
+    <canvas name="6" width="256" height="292">
+      <vector name="origin" x="160" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="32aa4a59c0e86a68433fc8d157ef9efb46e57a76d595fa7541fb8261495186a5"/>
+    </canvas>
+    <canvas name="7" width="244" height="296">
+      <vector name="origin" x="149" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="cd2dfd0e0985e56ad9574a48c44216b74f3238a62509c8a64004a23f64b8c253"/>
+    </canvas>
+    <canvas name="8" width="244" height="296">
+      <vector name="origin" x="149" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="cd7398cd61559adbd4bcd60fb739cc1014813c00745005ead3dec75fde4406c2"/>
+    </canvas>
+    <canvas name="9" width="244" height="292">
+      <vector name="origin" x="149" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="9ac969c4db107878ae55dfa6157d5c7bb0c8cc23112e028b2f7ac4f41ed78526"/>
+    </canvas>
+    <canvas name="10" width="320" height="356">
+      <vector name="origin" x="188" y="348"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="c94d2ad080d4a962d4915be307d3f170e1f8fee4fcaa85b28d742f1484d711d6"/>
+    </canvas>
+    <canvas name="11" width="304" height="348">
+      <vector name="origin" x="170" y="339"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="7656f96fb9fa88e362bb47c74b469ce6da6c4c1c326db674a8cff8f8dbe1db76"/>
+    </canvas>
+    <canvas name="12" width="304" height="348">
+      <vector name="origin" x="170" y="342"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="5a5c8fa93f2d10c6467fa890ff4a76dace10923e3c1da9b475dc4baa36da5a42"/>
+    </canvas>
+    <canvas name="13" width="304" height="348">
+      <vector name="origin" x="170" y="343"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="2ba0304fa47453642386edbb3656da20c1847b375faa4a796e90a0324b9b2c82"/>
+    </canvas>
+    <canvas name="14" width="304" height="348">
+      <vector name="origin" x="169" y="344"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="500268ad257514073d05b3f37337e62c4c8ed21e3a1ec7d41e293641b597c269"/>
+    </canvas>
+    <canvas name="15" width="300" height="348">
+      <vector name="origin" x="167" y="345"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="97eac791e961e878107ffd9cd256b1423cd5a56d7463be1408b3ce6c9a85b8eb"/>
+    </canvas>
+    <canvas name="16" width="244" height="328">
+      <vector name="origin" x="147" y="345"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="8eae3d8f3f91654aacca2bf5d512e45799836e98f2458a865c8d6ebaa5d07836"/>
+    </canvas>
+    <canvas name="17" width="272" height="316">
+      <vector name="origin" x="175" y="336"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="3d044a6be5326d21125c5373e6b796e0d8cc36f4da8834ff32d717c5db003924"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="不可能！不可能！"/>
+    </imgdir>
+    <canvas name="0" width="268" height="244">
+      <vector name="origin" x="110" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="32" y="-163"/>
+      <vector name="lt" x="-112" y="-212"/>
+      <vector name="rb" x="150" y="-14"/>
+      <int name="delay" value="300"/>
+      <string name="_hash" value="474f053c65a85581388b238f9c0291503544fc394ea2e5fef687488163d7d55a"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="你竟敢！你！你！你！不可能！我怎么会输！不可能！"/>
+    </imgdir>
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="130" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="61b6f4efb51896b9f57a98fe28f3f35363dbb3a4d0728c83f134683dbef216dc"/>
+    </canvas>
+    <canvas name="1" width="268" height="244">
+      <vector name="origin" x="110" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+      <string name="_inlink" value="hit1/0"/>
+    </canvas>
+    <canvas name="2" width="268" height="232">
+      <vector name="origin" x="106" y="230"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="a1b6b0c38bd998aa4648fa41a2d3290676ca319e263c37e313f6f25e4064469c"/>
+    </canvas>
+    <canvas name="3" width="268" height="240">
+      <vector name="origin" x="104" y="236"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="fbf90f79c1e015a2f3daf253bb292bed85ce37c9b3a64c67573c1a543e45f3ab"/>
+    </canvas>
+    <canvas name="4" width="268" height="244">
+      <vector name="origin" x="103" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="765e749105e33ea28ba053deb5c024d0143291e7c20950a83e7c930b8aa525e2"/>
+    </canvas>
+    <canvas name="5" width="268" height="244">
+      <vector name="origin" x="102" y="240"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="8efbfe202d95b3874454dd633999efce8ed1bb241ab30548729d8291f6886d3b"/>
+    </canvas>
+    <canvas name="6" width="268" height="240">
+      <vector name="origin" x="101" y="236"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="ba5ce48495fa17cf045cca8a0f313d80b66e7244bc94bc974750953f4466b60c"/>
+    </canvas>
+    <canvas name="7" width="268" height="204">
+      <vector name="origin" x="100" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="1c0dc1f2de266f43a38e6421e15e439d64d5d2d62f275e00537db74ef3170bfb"/>
+    </canvas>
+    <canvas name="8" width="268" height="208">
+      <vector name="origin" x="97" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="85962e12ccbcf0adba8d48b3133a0fadb22bd508f2e755ae42f115a310c192a1"/>
+    </canvas>
+    <canvas name="9" width="252" height="200">
+      <vector name="origin" x="81" y="200"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="f7a5ac42c0be621139c078f763ec0266751d04584d8d7ccd01549eb7a0260f35"/>
+    </canvas>
+    <canvas name="10" width="232" height="184">
+      <vector name="origin" x="64" y="182"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="a99eb2ff64f2e3b15f1b356ecf9e399514fbd34a311b74ff5b85dce6e383837a"/>
+    </canvas>
+    <canvas name="11" width="220" height="176">
+      <vector name="origin" x="52" y="176"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="41defa07fc4dc50f571e274447d9c3b18bf22a76f75f698ba322ddaf3c440496"/>
+    </canvas>
+    <canvas name="12" width="172" height="152">
+      <vector name="origin" x="10" y="155"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="769558f583c365edcd68f00e604e851d93c12340bcf492d653f1f2e66d6ce1fa"/>
+    </canvas>
+    <canvas name="13" width="160" height="144">
+      <vector name="origin" x="3" y="150"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="e8054507a9e49558dc89a400d25a636f835650de107b68a82fa190ee1753d0ec"/>
+    </canvas>
+    <canvas name="14" width="96" height="100">
+      <vector name="origin" x="-53" y="110"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="099d21c3aa7e6dee09618c11a597cd9ea17041306a68e2a26057f9e86c855f2c"/>
+    </canvas>
+    <canvas name="15" width="36" height="88">
+      <vector name="origin" x="-59" y="106"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="03f6f6f4ee0aba23be5fac43d0cbd1f26f70281d0fd4640431c34a3ca5bdf0c9"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="regen">
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="看来又有不知恐惧的家伙出现了。就让你们见识我的力量，在这伟大的力量面前屈服吧！"/>
+    </imgdir>
+    <canvas name="0" width="164" height="124">
+      <vector name="origin" x="-97" y="104"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="383006fadb41017b717bfdbb3df14b22dbf09873bb2d7257279340cc43f89731"/>
+    </canvas>
+    <canvas name="1" width="184" height="160">
+      <vector name="origin" x="-95" y="143"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a9c43056e2849d974d54bff5025d8e4156bf559f74735889f1ebf7fe2b3e85d"/>
+    </canvas>
+    <canvas name="2" width="564" height="488">
+      <vector name="origin" x="143" y="469"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c23bac0ad00bfbce57b25fe6e214fed99751d2273970bfbf853303a9e40aae38"/>
+    </canvas>
+    <canvas name="3" width="860" height="512">
+      <vector name="origin" x="440" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3692c45cb927feaece7e9464eee47c777c442fe724b8330cca9635abf67d96bd"/>
+    </canvas>
+    <canvas name="4" width="848" height="500">
+      <vector name="origin" x="433" y="469"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="10fe4b2574c04d0fe40e877f10086bf6cec53982abc34d751ec03ea31237ba36"/>
+    </canvas>
+    <canvas name="5" width="836" height="484">
+      <vector name="origin" x="432" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a4b66cc52c70d612c84928ad0f12c17d70581e0e814a025f5ea033bc353e301f"/>
+    </canvas>
+    <canvas name="6" width="796" height="484">
+      <vector name="origin" x="427" y="466"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="355dba27120226e8005ba1987e3779f9429d572ab2476a6a6c4f7451be7ac131"/>
+    </canvas>
+    <canvas name="7" width="728" height="464">
+      <vector name="origin" x="368" y="452"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a6efbbb2e26dba3125476dff15fc9a4882855d5988719112a45d55de638964b4"/>
+    </canvas>
+    <canvas name="8" width="536" height="444">
+      <vector name="origin" x="354" y="433"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bca5f386756cd000cd09f717a820de4c508f0fe5b8c72b2fc090bfede87cd4a4"/>
+    </canvas>
+    <canvas name="9" width="372" height="428">
+      <vector name="origin" x="187" y="422"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dbd5718714d9918b6f0afb1e8f7e1ea8bbcdd8dfa3b9a1e3676fbbf9074baf62"/>
+    </canvas>
+    <canvas name="10" width="424" height="400">
+      <vector name="origin" x="259" y="338"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="638552a138ab2073144ecd62f0bdf02364c408e2560764ae59e796bf57c5a06d"/>
+    </canvas>
+    <canvas name="11" width="388" height="304">
+      <vector name="origin" x="209" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bff550983c2f3359481fc4f0a85ec8c6b2bd7e11b731f087a1fe1556a6a1d10e"/>
+    </canvas>
+    <canvas name="12" width="436" height="348">
+      <vector name="origin" x="182" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ea20ffa0329d7e33ebd9598d08bab9225fec7159737e659050fb48d0f3639acf"/>
+    </canvas>
+    <canvas name="13" width="468" height="432">
+      <vector name="origin" x="268" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="853dcd7913494e31f66aff413dd159426338d78a211b2fb8dce9851321fbb366"/>
+    </canvas>
+    <canvas name="14" width="420" height="240">
+      <vector name="origin" x="253" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c14307c39a05cb48072d524ae381a2663f5ca5c863ba1f1888dc2a4feaf056a8"/>
+    </canvas>
+    <canvas name="15" width="376" height="376">
+      <vector name="origin" x="198" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fa075d29d4a81444fd67a51f2f29a562a6e8b09c8dcc78e73d62934f02eec42b"/>
+    </canvas>
+    <canvas name="16" width="460" height="400">
+      <vector name="origin" x="157" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d0dbc7361eae8cdf8f1bde04e77c68d207a84fec95632596013b6fc5a79e9cac"/>
+    </canvas>
+    <canvas name="17" width="424" height="464">
+      <vector name="origin" x="239" y="317"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="520d6f97cb7d618000772ed2162c362779f223f6795fd53730eee954a8bf8e0f"/>
+    </canvas>
+    <canvas name="18" width="388" height="400">
+      <vector name="origin" x="221" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45fb2f1330ab604313a7cea5bc42cb9f7e2e83cfbc90b2b19059f70df8a87273"/>
+    </canvas>
+    <canvas name="19" width="460" height="432">
+      <vector name="origin" x="154" y="278"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0454cde7197ece210169fbcac3ebb1ea744b8e1eb53e704ded9da47d6aca9237"/>
+    </canvas>
+    <canvas name="20" width="552" height="532">
+      <vector name="origin" x="271" y="390"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cac5f25b8fb7821a34341e64abec071609752bcd3993afbdf7b76d95f6e5f99c"/>
+    </canvas>
+    <canvas name="21" width="440" height="308">
+      <vector name="origin" x="256" y="222"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bbbda1b3256cf1cd7f6d0b559370af092201c4bb620bf8f4683cbd532f819cdd"/>
+    </canvas>
+    <canvas name="22" width="352" height="336">
+      <vector name="origin" x="173" y="282"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a37748adbb655dc8f3e8f1e76ce9a670bad12d0cd58489e47c1debcd6b2b2e71"/>
+    </canvas>
+    <canvas name="23" width="396" height="360">
+      <vector name="origin" x="193" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7595dc6eb03d4b684a39f403306f80cb9941deafc5ed566710db40d55a697a6b"/>
+    </canvas>
+    <canvas name="24" width="396" height="376">
+      <vector name="origin" x="191" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b55f08ba541ff2d2b48b1d78e683f587a825c7d33d2261e98ac1986748e002b3"/>
+    </canvas>
+    <canvas name="25" width="384" height="384">
+      <vector name="origin" x="186" y="305"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bd1a894b26c17c38d62c2d3c8e421c68caf00f1773dc4771760d9cc740e34191"/>
+    </canvas>
+    <canvas name="26" width="384" height="384">
+      <vector name="origin" x="185" y="305"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e1634ea15dc79210137c22479ba9aa77f7a7298672af8476da60a22e4090dc2b"/>
+    </canvas>
+    <canvas name="27" width="380" height="380">
+      <vector name="origin" x="183" y="303"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c3fa7b2710c328f3a0a5152177725f97fbb4de004ab0b4b9578aa353c8c59951"/>
+    </canvas>
+    <canvas name="28" width="332" height="348">
+      <vector name="origin" x="183" y="289"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="81015d10a202430bfc86fa524726b4710a52f5d2d84825f7fb425c07f6689ef3"/>
+    </canvas>
+    <canvas name="29" width="332" height="352">
+      <vector name="origin" x="184" y="291"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8dcb22e042dc12ed16fd01af950da50e1d7290b25b4c5f35f200040bee56ef7c"/>
+    </canvas>
+    <canvas name="30" width="320" height="320">
+      <vector name="origin" x="177" y="278"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ecf51634b6c189de16798cecdb0f4ba6d421bff4d8192aa086380275c6b38920"/>
+    </canvas>
+    <canvas name="31" width="316" height="316">
+      <vector name="origin" x="179" y="280"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1152a8f37d7fb58712f803b4a1f721b6ecbb561cd027ace0ac2862b267265622"/>
+    </canvas>
+    <canvas name="32" width="260" height="256">
+      <vector name="origin" x="131" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="00e3fdacedc92990e3d4dd771684d8bbb70b2467f4cf43c2015316f84ef160ed"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-570" y="-645"/>
+        <vector name="rb" x="603" y="171"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="100" height="128">
+          <vector name="origin" x="49" y="63"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="965aebbf037df2db2238fd06c80659dcccd2aaa3217afda4039a32b3beabe400"/>
+        </canvas>
+        <canvas name="1" width="100" height="124">
+          <vector name="origin" x="49" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="15982111885848b17a5328515e925d50886c1a549cb1fd7d6556f9fd5e059112"/>
+        </canvas>
+        <canvas name="2" width="104" height="108">
+          <vector name="origin" x="50" y="52"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5fbc2ac381a9e65736876dbaa03e333a5cbbfba0217046dc75e37f7e154fd131"/>
+        </canvas>
+        <canvas name="3" width="104" height="92">
+          <vector name="origin" x="51" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="70056b82e35774211e06cc98209213efe560ea9bcc564a9ceef5f197e175f883"/>
+        </canvas>
+        <canvas name="4" width="104" height="92">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="36c394d69b6d8b4856dfada0fb9133dbfc62ff3e7863edbd72da5fa1dd1b8e74"/>
+        </canvas>
+        <canvas name="5" width="100" height="88">
+          <vector name="origin" x="49" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="92360631ff8eb213b6add343b43e27969831853ae5a655c387b78596408e154c"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="2610"/>
+      <int name="effectAfter" value="990"/>
+      <imgdir name="effect">
+        <canvas name="0" width="110" height="140">
+          <vector name="origin" x="53" y="140"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="1" width="124" height="140">
+          <vector name="origin" x="61" y="140"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="2" width="132" height="142">
+          <vector name="origin" x="64" y="142"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="3" width="132" height="142">
+          <vector name="origin" x="64" y="142"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="4" width="132" height="140">
+          <vector name="origin" x="64" y="142"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="5" width="132" height="138">
+          <vector name="origin" x="64" y="142"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="6" width="134" height="139">
+          <vector name="origin" x="65" y="143"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="7" width="132" height="136">
+          <vector name="origin" x="64" y="142"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="8" width="114" height="125">
+          <vector name="origin" x="52" y="131"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="9" width="21" height="113">
+          <vector name="origin" x="9" y="122"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="10" width="3" height="53">
+          <vector name="origin" x="0" y="103"/>
+          <int name="delay" value="95"/>
+        </canvas>
+      </imgdir>
+    </imgdir>
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="161" y="241"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="78fe704193ae1d25bad9e69f8ffb6cca0950316631b4de7fed38112aee032bb9"/>
+    </canvas>
+    <canvas name="1" width="268" height="264">
+      <vector name="origin" x="168" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="cc8cf2eb9a12ff8cfcaf39524dc68173d44369e8fca7ebad03c257c03e6c9235"/>
+    </canvas>
+    <canvas name="2" width="232" height="252">
+      <vector name="origin" x="128" y="229"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="5a60fd42c640b8c62b114675225c2784741d0f8545016a7a7a10f23793c007c0"/>
+    </canvas>
+    <canvas name="3" width="232" height="264">
+      <vector name="origin" x="128" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="9bf363e074210560447ba375c4353da981e1817e6657ce6d91a223ee8041f3f9"/>
+    </canvas>
+    <canvas name="4" width="232" height="256">
+      <vector name="origin" x="129" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="5d92981afe7d59260603170335ecc31accf76fd2a72634f02117288986e1553a"/>
+    </canvas>
+    <canvas name="5" width="236" height="272">
+      <vector name="origin" x="130" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="b7a67ff5808ded2a6fb9b89becd8dfe804ce714a88c4a63f761a8bfbafedcd9a"/>
+    </canvas>
+    <canvas name="6" width="232" height="284">
+      <vector name="origin" x="129" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="f46fe352bbfb1771e23ecf539d8bcb649f6a988f2fb2623d25c915594df06d48"/>
+    </canvas>
+    <canvas name="7" width="232" height="280">
+      <vector name="origin" x="127" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="e41f48b769c8d7ff54ef10d1c3db1700188dd421adc62386b61fe3302567db11"/>
+    </canvas>
+    <canvas name="8" width="228" height="272">
+      <vector name="origin" x="125" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="559aa2a9f70cd4e22b81dbdaee021a46b62b62b7e848cdb2a3c1e9e2836ee3f4"/>
+    </canvas>
+    <canvas name="9" width="224" height="272">
+      <vector name="origin" x="124" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="cf8332d9c9d1db0295748ae23d383f0ec3540ae16e5b978c90c9c1d8eed1beac"/>
+    </canvas>
+    <canvas name="10" width="228" height="256">
+      <vector name="origin" x="124" y="229"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="8d2de386936a84a9d6f9f075ffa6cce0ab5d287030732e55925848f09028fb3c"/>
+    </canvas>
+    <canvas name="11" width="308" height="328">
+      <vector name="origin" x="168" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="54f0b3eaea571388a06e6cc1e5991f618e5aa97da5229bc3b1351226119b8677"/>
+    </canvas>
+    <canvas name="12" width="304" height="348">
+      <vector name="origin" x="168" y="317"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="18c5721ff3c7e74df40d5a13a1b1bf5f1781024d7a14f3c6385b6494e0b72b4a"/>
+    </canvas>
+    <canvas name="13" width="304" height="352">
+      <vector name="origin" x="168" y="322"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="a1f99e048ead3997e6ee2c4d96d7777fc565c775294afbe2deed91ba2b209e89"/>
+    </canvas>
+    <canvas name="14" width="304" height="356">
+      <vector name="origin" x="168" y="325"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="e8474758a497d3d8ed56d24db516a199e57f3bc057c38582b12e014d03d53add"/>
+    </canvas>
+    <canvas name="15" width="304" height="352">
+      <vector name="origin" x="167" y="326"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="c358b2e93c047f1395b5b90c4f1ddfed2ceea5907f2505fdb1cb510cc9837c31"/>
+    </canvas>
+    <canvas name="16" width="300" height="348">
+      <vector name="origin" x="165" y="327"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="029987b54b21eb920698b111d13f47bbec5e59fdd85c61cf00356859ebd4050b"/>
+    </canvas>
+    <canvas name="17" width="224" height="308">
+      <vector name="origin" x="121" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="38168422525371e01ac0503e07a743e71002bcb80cf273a1df8affb8de3d0b85"/>
+    </canvas>
+    <canvas name="18" width="272" height="280">
+      <vector name="origin" x="168" y="271"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="8c801cfecdcc1d282f00de6ed00a99301d843941c5bec884961a0fca53ebb8bf"/>
+    </canvas>
+    <uol name="19" value="../stand/0"/>
+    <uol name="20" value="../stand/1"/>
+    <uol name="21" value="../stand/2"/>
+    <uol name="22" value="../stand/3"/>
+    <uol name="23" value="../stand/4"/>
+    <uol name="24" value="../stand/5"/>
+    <uol name="25" value="../stand/6"/>
+    <uol name="26" value="../stand/7"/>
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="冻结吧！这可笑的世界！"/>
+      <string name="1" value="啊哈哈哈哈哈哈哈哈哈哈哈哈！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-584" y="-900"/>
+        <vector name="rb" x="592" y="48"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="156" height="204">
+          <vector name="origin" x="78" y="101"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="df0c08c9cb4cd67ce2fd5ac6b8871e86afcaab3d2be771bc331682ea9ce2831b"/>
+        </canvas>
+        <canvas name="1" width="168" height="168">
+          <vector name="origin" x="84" y="84"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e8cbe781ec7017c52de7c613964eea9ebff0db72e69f8f2e65a8418f98542843"/>
+        </canvas>
+        <canvas name="2" width="176" height="176">
+          <vector name="origin" x="86" y="87"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="c99bf4b6a89d58c848bba5a6f0e6c8270c4882b502f6898e274d4a736456476a"/>
+        </canvas>
+        <canvas name="3" width="172" height="172">
+          <vector name="origin" x="86" y="86"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4e571f43378a791b61e02dde80c1476f958f6aa28b96d150c4efbf309af2e65d"/>
+        </canvas>
+        <canvas name="4" width="172" height="172">
+          <vector name="origin" x="86" y="86"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="2d2b130ca964fcb48d51ab67b7a244b4998bc36c9d29113edfca4fa46965be62"/>
+        </canvas>
+        <canvas name="5" width="172" height="172">
+          <vector name="origin" x="86" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="63d19520e356bf3a42ccab1b1acb46d360374f283bc4bb7ca4d5b84579f6aa23"/>
+        </canvas>
+        <canvas name="6" width="144" height="144">
+          <vector name="origin" x="71" y="71"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8d4d606ffb78257cd85cc863d6926e397750d3c112b6662b0c297cb5ff65f675"/>
+        </canvas>
+        <canvas name="7" width="140" height="136">
+          <vector name="origin" x="68" y="68"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="72f874ed8dc1224abf628797e028b94f5a494020cc5aff624f578253c8ff3585"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1890"/>
+      <int name="effectAfter" value="990"/>
+      <imgdir name="effect">
+        <canvas name="0" width="162" height="142">
+          <vector name="origin" x="82" y="120"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="165" height="153">
+          <vector name="origin" x="85" y="131"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="166" height="159">
+          <vector name="origin" x="78" y="140"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="180" height="181">
+          <vector name="origin" x="78" y="162"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="162" height="205">
+          <vector name="origin" x="69" y="186"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="159" height="216">
+          <vector name="origin" x="70" y="197"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="142" height="202">
+          <vector name="origin" x="65" y="188"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="162" height="210">
+          <vector name="origin" x="73" y="194"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="176" height="193">
+          <vector name="origin" x="73" y="193"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="165" height="145">
+          <vector name="origin" x="73" y="198"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="171" height="173">
+          <vector name="origin" x="72" y="202"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+    </imgdir>
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="161" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+    </canvas>
+    <canvas name="1" width="268" height="244">
+      <vector name="origin" x="175" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="209c7e1f6af03aabd74ce3c84eb77884cc72518db1d5ab2d12a16785209a62a6"/>
+    </canvas>
+    <canvas name="2" width="224" height="236">
+      <vector name="origin" x="127" y="233"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="5d3bcb103f556ca9dc794de52ad2557f4c898ffd3e46ee9cd0d3c1210ddaf726"/>
+    </canvas>
+    <canvas name="3" width="208" height="240">
+      <vector name="origin" x="114" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="640193e4bd9675242acb323a190fa912b1384a2c14e9e55d9d728aa847588977"/>
+    </canvas>
+    <canvas name="4" width="224" height="280">
+      <vector name="origin" x="128" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="b558d1dc825752bcb7db6d75113f54bec95d8d2148011e88ed0a39a7d56dd9d0"/>
+    </canvas>
+    <canvas name="5" width="248" height="284">
+      <vector name="origin" x="141" y="282"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="faaaa97213e0e766202dd28e9247f9b28fdaae230f3c79448187847b8e9d7fdf"/>
+    </canvas>
+    <canvas name="6" width="264" height="284">
+      <vector name="origin" x="151" y="282"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="0304b0a998faf19a2fa1f81af3c8fa291a7cc191421b715d4edfc0be637fdd5d"/>
+    </canvas>
+    <canvas name="7" width="320" height="312">
+      <vector name="origin" x="184" y="309"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="982084f06f695832aced6edadd9dc079fe18c7f8a6d612577050be5afc029703"/>
+    </canvas>
+    <canvas name="8" width="324" height="316">
+      <vector name="origin" x="187" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="08381d07d9b2a094ebb35bf2b2ac5dfd708ec1d521d34d20c0df58243ccf1735"/>
+    </canvas>
+    <canvas name="9" width="324" height="316">
+      <vector name="origin" x="187" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="5cdc90aa4ce335cb7c58fa5953006047c6508154e141ef2fdf4f513f4ff16dc7"/>
+    </canvas>
+    <canvas name="10" width="336" height="324">
+      <vector name="origin" x="195" y="317"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="44fc135f382de5a7a56bbb1578fdffb6ae9421497bc64693840159d682d3e079"/>
+    </canvas>
+    <canvas name="11" width="388" height="364">
+      <vector name="origin" x="242" y="344"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="bac336f5696480eba768cb5094d1c1862c468873dbfa4b7cffb91fae981d7e8a"/>
+    </canvas>
+    <canvas name="12" width="404" height="416">
+      <vector name="origin" x="242" y="402"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="8dc737e354632c7d7018081a091c426f1c46eaf10b9befc23cfea72ff599bce4"/>
+    </canvas>
+    <canvas name="13" width="456" height="416">
+      <vector name="origin" x="253" y="408"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="6d6419d5084f1e6ce845f1e98647b8552ec1b44629d29420a4ba80cd0217d913"/>
+    </canvas>
+    <canvas name="14" width="472" height="420">
+      <vector name="origin" x="262" y="411"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="9e661b433683c05fdf8243c6b38820e06a08b14ff6a1e75ebc8cf1da0dcea83d"/>
+    </canvas>
+    <canvas name="15" width="480" height="416">
+      <vector name="origin" x="266" y="412"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="7b58786140c032741f1a8672f2298b29bf5067d4ffecf966aaf004ba2ef4e6f8"/>
+    </canvas>
+    <canvas name="16" width="480" height="420">
+      <vector name="origin" x="266" y="413"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="fc8f88b656f9776f021aed16842fa79979998814354325661ac39b602b3104bb"/>
+    </canvas>
+    <canvas name="17" width="476" height="340">
+      <vector name="origin" x="263" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="944560ebc78370f63eded4db3ccd384cedc4c54c9b64d341e34758ee7201743f"/>
+    </canvas>
+    <canvas name="18" width="464" height="276">
+      <vector name="origin" x="258" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="0b19357b61333b6b24fac8820c21ba50a8a5c10af9b81c3f24e413ee6ffe90f0"/>
+    </canvas>
+    <uol name="19" value="../stand/0"/>
+    <uol name="20" value="../stand/1"/>
+    <uol name="21" value="../stand/2"/>
+    <uol name="22" value="../stand/3"/>
+    <uol name="23" value="../stand/4"/>
+    <uol name="24" value="../stand/5"/>
+    <uol name="25" value="../stand/6"/>
+    <uol name="26" value="../stand/7"/>
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="我将掌控世上所有魔法！在光芒面前消失吧！"/>
+      <string name="1" value="啊哈哈哈哈哈哈哈哈哈哈哈哈！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="这样如何，哈哈哈哈！"/>
+      <string name="1" value="吃我这一招！"/>
+    </imgdir>
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="161" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_outlink" value="Mob/9303131.img/attack1/0"/>
+    </canvas>
+    <canvas name="1" width="268" height="244">
+      <vector name="origin" x="175" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="44525d70458ba03c2c201835f66dcc143181bb2e78d8f47c8f777644329aef81"/>
+    </canvas>
+    <canvas name="2" width="224" height="232">
+      <vector name="origin" x="130" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="44d11bb6ce4a65db7488184ed2b22c9206477782377bbaf14013e8f987e30c66"/>
+    </canvas>
+    <canvas name="3" width="216" height="228">
+      <vector name="origin" x="122" y="228"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="478250de271aaa3439754d708b7e56a9a68db309a2fa8193513a5d8ba1b7c2e0"/>
+    </canvas>
+    <canvas name="4" width="216" height="240">
+      <vector name="origin" x="122" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="8fe9b0fabb8f05bcaf5076e46d6aaca165b3088f6f44f4e324b6c8b1bb78b4d0"/>
+    </canvas>
+    <canvas name="5" width="216" height="252">
+      <vector name="origin" x="121" y="253"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="3f427e1ce586bb831f36fa092fbc4cb5b4ca2150c39eeed4d348d8d19e308a46"/>
+    </canvas>
+    <canvas name="6" width="216" height="252">
+      <vector name="origin" x="120" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="ff3699b8174c90a37d0060f4a523a25cb131ca3ba83dd6d1628f0e9bdf3be7b1"/>
+    </canvas>
+    <canvas name="7" width="216" height="244">
+      <vector name="origin" x="119" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="2644cec5c879cfecad9f66432357ab823b277679009e3b22b6d8ea941c48ca41"/>
+    </canvas>
+    <canvas name="8" width="212" height="244">
+      <vector name="origin" x="118" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="ffe396a90e084625e0ddfee061016d3346bda89ff277ced45596cd3194e5e5d5"/>
+    </canvas>
+    <canvas name="9" width="212" height="232">
+      <vector name="origin" x="117" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="f343f83d4836bdde634eb9e80f0ba29d45215f013da1c8a1b5dd232ba0e361ee"/>
+    </canvas>
+    <canvas name="10" width="212" height="240">
+      <vector name="origin" x="116" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="a629d2e11bfa3de386e1c5a60e285289c046a51a143124cc2ea332e3a36d933c"/>
+    </canvas>
+    <canvas name="11" width="212" height="228">
+      <vector name="origin" x="115" y="228"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="7ffe1c9b041c33afdaf867f446f1ac5b7018c1d56cfef566289785cee81d0935"/>
+    </canvas>
+    <canvas name="12" width="208" height="252">
+      <vector name="origin" x="114" y="253"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="6fb33064b45871e6767f0e637b32ec29ae1dade0c07e6d9330ed7fc3c98798eb"/>
+    </canvas>
+    <canvas name="13" width="248" height="288">
+      <vector name="origin" x="154" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="156206cf35e0f3a4ef4ec52f5cb96b4c1925524092391480e0bfe4db6e33fbe8"/>
+    </canvas>
+    <canvas name="14" width="256" height="268">
+      <vector name="origin" x="161" y="256"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="676a115da7a0734ca0c8091c7229017351e465f121a8591abee83310d675f0fa"/>
+    </canvas>
+    <canvas name="15" width="256" height="268">
+      <vector name="origin" x="160" y="259"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="e7ccfb17de2f025bc77b886abc6276c4adb2ce76ab374e7ed254e349e6bec4a9"/>
+    </canvas>
+    <canvas name="16" width="244" height="264">
+      <vector name="origin" x="150" y="261"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="e8d8d62c2513597d339a5b38727264da299421f8e32f8d46e341bc8fb7e02c24"/>
+    </canvas>
+    <canvas name="17" width="248" height="268">
+      <vector name="origin" x="151" y="263"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="3f1bca2bd12ab666539c3e9704d86cf1051bb857dfba5c5f248d117ab6687a4c"/>
+    </canvas>
+    <canvas name="18" width="244" height="260">
+      <vector name="origin" x="150" y="263"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="7fe96770e5851dc16dd60a44be4175edd516c461a7ad046d1a71b5c97cad192c"/>
+    </canvas>
+    <canvas name="19" width="244" height="260">
+      <vector name="origin" x="149" y="263"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="a1c46c708c26d240b8179dcb5b477acf06fe9722b6245fdf92f82125372523a9"/>
+    </canvas>
+    <canvas name="20" width="240" height="260">
+      <vector name="origin" x="146" y="260"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="7317f100cd6b3158db0fc40b73e9f56278efd26ee8dcb575cb25a0ba984ea8bd"/>
+    </canvas>
+    <canvas name="21" width="272" height="252">
+      <vector name="origin" x="175" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="987ef4288e5f79b6009ef3de2cf32be2e0ac98cca312ad11803f8f1eb54df67c"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787128.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787128.img.xml
@@ -1,0 +1,999 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787128.img">
+  <imgdir name="info">
+    <int name="level" value="100"/>
+    <int name="maxHP" value="999999999"/>
+    <int name="maxMP" value="50000"/>
+    <int name="speed" value="5"/>
+    <int name="PADamage" value="1500"/>
+    <int name="MADamage" value="1500"/>
+    <int name="PDRate" value="25"/>
+    <int name="MDRate" value="25"/>
+    <int name="acc" value="600"/>
+    <string name="elemAttr" value="P2"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="500000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="magic" value="1"/>
+        <int name="rush" value="1"/>
+        <int name="knockback" value="1"/>
+        <int name="ignoreStance" value="100"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <int name="nonLevelCheckACC" value="1"/>
+    <int name="nonLevelCheckEVA" value="1"/>
+    <int name="notConsiderFieldSet" value="1"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="让你后悔！"/>
+      </imgdir>
+    </imgdir>
+    <int name="hpTagBgcolor" value="3"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="202" height="242">
+      <vector name="origin" x="77" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9af6f81a1ab95b0e0c4f55c0a53f8f2f635bcfd706301d4aa995e5d4a9c4eb0d"/>
+    </canvas>
+    <canvas name="1" width="201" height="243">
+      <vector name="origin" x="77" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d707327d6bee4545ec95ccd3f4fcf6c1161d673f7efe94cf565c66bc1768c124"/>
+    </canvas>
+    <canvas name="2" width="202" height="230">
+      <vector name="origin" x="77" y="230"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7c83ff901cb3faea57d33cb638db973498aa1a1f5dbcce932d5cb9575a2b3d26"/>
+    </canvas>
+    <canvas name="3" width="202" height="237">
+      <vector name="origin" x="77" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e07750e90046d1a1960344001286c5ec26199031caed0b7459d7d54ab248df3f"/>
+    </canvas>
+    <canvas name="4" width="202" height="225">
+      <vector name="origin" x="77" y="228"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0954b0fa686369d05d9a4f11861be60a4d8f32a99a877d9b255771130b576b99"/>
+    </canvas>
+    <canvas name="5" width="202" height="239">
+      <vector name="origin" x="77" y="243"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d920cb060a062489fe62e53f4a31d791a706134036615cbf43cc3865b51fdd76"/>
+    </canvas>
+    <canvas name="6" width="202" height="250">
+      <vector name="origin" x="77" y="253"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f9a152963ba5d59af7a05ce5cd81c504df234d1466f8162465f897f0d325e64c"/>
+    </canvas>
+    <canvas name="7" width="202" height="250">
+      <vector name="origin" x="77" y="252"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8cba5c517a90c09bb5b0b450d4af4f962e97f64b025b53c19687eb24ce9137e9"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="206" height="242">
+      <vector name="origin" x="81" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b979d6cde026396b625c94835b84c71850af63340493b43ad85c3834827557e3"/>
+    </canvas>
+    <canvas name="1" width="204" height="243">
+      <vector name="origin" x="80" y="241"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c0ac3dac95654d89e3cefe605bc60e7fb30e1366fa057b68f3e816809f197f56"/>
+    </canvas>
+    <canvas name="2" width="206" height="230">
+      <vector name="origin" x="81" y="230"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dd3bb5d40ed54f37310bb2e142075fc3d883308a7144ee760926e37cdac1c02d"/>
+    </canvas>
+    <canvas name="3" width="207" height="225">
+      <vector name="origin" x="82" y="228"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3d98aa4231cf6b5a9b8b2774ba8979cabed08ecfd557233ee2730a775fffdac6"/>
+    </canvas>
+    <canvas name="4" width="208" height="239">
+      <vector name="origin" x="83" y="244"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="aadc7791cdb288a3fab6437f1a6d3f3b83844b1abbeef5524958102ed3ad557a"/>
+    </canvas>
+    <canvas name="5" width="207" height="250">
+      <vector name="origin" x="82" y="253"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="64cc5e674d8c4e791e9555ae406b23efa6dd03267cbc0b951942a57aac11c474"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="开始追击。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-571" y="-192"/>
+        <vector name="rb" x="0" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="98" height="126">
+          <vector name="origin" x="49" y="63"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0be27986f4af3a6f70bf4ea8c24f71ea70101ce9e65a5817f8feb627bd01bec6"/>
+        </canvas>
+        <canvas name="1" width="99" height="124">
+          <vector name="origin" x="49" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b2115db9d9cc4575ccc141471d8ff61b0a214fe3c40aa3d9e2910f02c2b74644"/>
+        </canvas>
+        <canvas name="2" width="97" height="104">
+          <vector name="origin" x="48" y="52"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="dc2b872017c48e5b213e13ce656b69ba546923e5cb27bb77d84481412e8eea62"/>
+        </canvas>
+        <canvas name="3" width="100" height="91">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b01695807d8d166acafb60143a1f19ebd757f62d1e2f54007a77bbaee82fc8f2"/>
+        </canvas>
+        <canvas name="4" width="101" height="91">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0636f3fbc9203b254f2d701993cc222a8583baf61e965a0d02a9bbd344e46eb7"/>
+        </canvas>
+        <canvas name="5" width="99" height="88">
+          <vector name="origin" x="49" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="718af6e4a522fe73161025ec5fbe5a46f69597acc859e037bd0378a573e8c4b8"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="attackAfter" value="780"/>
+    </imgdir>
+    <canvas name="0" width="202" height="242">
+      <vector name="origin" x="77" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="e6476f77cb542b59cacfa41762e1e7290317fa3e8b3fb648bd7bfe0ad95ffb73"/>
+    </canvas>
+    <canvas name="1" width="255" height="240">
+      <vector name="origin" x="148" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="bf7b09da821e6ed8bf5d43339982965be49e6ac315c62b78dfa3f9217e93bd4a"/>
+    </canvas>
+    <canvas name="2" width="258" height="240">
+      <vector name="origin" x="149" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="78c202668b3421033468c3a2f3943cecd502114c559b71f64937445ca3eb5b71"/>
+    </canvas>
+    <canvas name="3" width="261" height="228">
+      <vector name="origin" x="150" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="54734a5c538e8df9f1a3d2e826d0f711788ff24a87ffe4e888fea580845c76df"/>
+    </canvas>
+    <canvas name="4" width="263" height="237">
+      <vector name="origin" x="151" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="0b7cfd9a9f7eaebe6e7ab8bd382be3f2b748d6c349c1e00c2520c5202e55de86"/>
+    </canvas>
+    <canvas name="5" width="263" height="226">
+      <vector name="origin" x="151" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="b306af63eab31a6a5f1f58ea3fd0883b43a4fa3bc118ce45ace549356a44e105"/>
+    </canvas>
+    <canvas name="6" width="261" height="241">
+      <vector name="origin" x="149" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="1973af609752a4a3116cfce81a35d1ddc67762b909dd582dfc8d87f7adda6b8b"/>
+    </canvas>
+    <canvas name="7" width="263" height="251">
+      <vector name="origin" x="151" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="cffadff5aa2484f24f578de5cd222e26a970692a15eff5503c1e207b22956c1f"/>
+    </canvas>
+    <canvas name="8" width="263" height="270">
+      <vector name="origin" x="151" y="249"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="13c9a2cbd1ef43aa38754b7173c261c46fc31d8d581d3d9a9cc28c70cc9874c6"/>
+    </canvas>
+    <canvas name="9" width="263" height="258">
+      <vector name="origin" x="151" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="5360aacafb9719c59698760e3a0946126e0e9fb4c78e27ba4dec653bb1ac7b67"/>
+    </canvas>
+    <canvas name="10" width="261" height="254">
+      <vector name="origin" x="150" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="65ae2616de6dea6566c569297628af03bc24ec0284902ec86a858328712aa952"/>
+    </canvas>
+    <canvas name="11" width="260" height="240">
+      <vector name="origin" x="149" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="a9f25ea830ead9c9979097cda2843c230ee92a8b0ddcb7dd9784b4033f4e9da5"/>
+    </canvas>
+    <canvas name="12" width="255" height="243">
+      <vector name="origin" x="148" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="80aeaf08de5aaba6a0ae139e427161da4ba1f53b704ae773edb2d0341cc95893"/>
+    </canvas>
+    <canvas name="13" width="593" height="176">
+      <vector name="origin" x="193" y="155"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="82" y="-116"/>
+      <vector name="lt" x="-194" y="-157"/>
+      <vector name="rb" x="398" y="19"/>
+      <string name="_hash" value="ade621a108c79ecbbc322ab70193822eea48140caeee928d5cd4eb6217711546"/>
+    </canvas>
+    <canvas name="14" width="595" height="222">
+      <vector name="origin" x="198" y="211"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-194" y="-157"/>
+      <vector name="rb" x="398" y="19"/>
+      <string name="_hash" value="3ca45c00decc1cfc64834dcc0ab9ebe68530174c61f8040529ddec2ba54e9a9b"/>
+    </canvas>
+    <canvas name="15" width="339" height="222">
+      <vector name="origin" x="209" y="211"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-206" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="492b7a29819a026a5620819b4ad86f18d8db8e1c33454d8178b8147442c8fe11"/>
+    </canvas>
+    <canvas name="16" width="343" height="210">
+      <vector name="origin" x="211" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="da979da6dddacdb7155c6b23856e41e31d713883ee55f527d8104961d08d4a35"/>
+    </canvas>
+    <canvas name="17" width="335" height="219">
+      <vector name="origin" x="207" y="208"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="70d5c1f37acd19ba89787389e80cac7ff71360f34ab39dffcc844eb8ff190992"/>
+    </canvas>
+    <canvas name="18" width="336" height="208">
+      <vector name="origin" x="208" y="197"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="3b81d891c78a9c48aef0122e4f08e8e79372dc74492214a69f8584782cca1117"/>
+    </canvas>
+    <canvas name="19" width="334" height="223">
+      <vector name="origin" x="209" y="212"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="9455a3b0c431291399ce787cc4a916ed0f1e1bb9be9794ed8707e300e299a195"/>
+    </canvas>
+    <canvas name="20" width="335" height="233">
+      <vector name="origin" x="209" y="222"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="214f7371a02a3c93a5f5eac40e26e638a54000445e1efdcb74f345c0cd857faf"/>
+    </canvas>
+    <canvas name="21" width="335" height="232">
+      <vector name="origin" x="209" y="221"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="33d1d76421b32dbd2a9093f4e453898a4874f7947e614b11281a791107ecdeb8"/>
+    </canvas>
+    <canvas name="22" width="335" height="222">
+      <vector name="origin" x="209" y="211"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="2287f67b576cf55ab251a38d5460bae23f70df33aaf161267a6042bf1ed7f0e5"/>
+    </canvas>
+    <canvas name="23" width="335" height="222">
+      <vector name="origin" x="209" y="211"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="f6c1d84d74e86ccd0f4d6f016fc8bfe7904b7051c59c7cbfe4c42d3d0b9b8574"/>
+    </canvas>
+    <canvas name="24" width="293" height="210">
+      <vector name="origin" x="167" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-121" y="-152"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="8d3f195e2e96210c14c5d92a780d547f50ec2954b1d72dc3869e557d3807af60"/>
+    </canvas>
+    <canvas name="25" width="250" height="219">
+      <vector name="origin" x="125" y="208"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-123" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="0cd6e7a6cad3c16fc29d8bef29603aebd927e2d60f7e3e4aa7f14d069da61b9b"/>
+    </canvas>
+    <canvas name="26" width="251" height="208">
+      <vector name="origin" x="125" y="197"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-84" y="-151"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="d0d37cd3226c21b089326085f1174e2a9bb60c357249b496901b9ae6ec18bbac"/>
+    </canvas>
+    <uol name="32" value="../stand/5"/>
+    <uol name="33" value="../stand/6"/>
+    <uol name="34" value="../stand/7"/>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="发现目标。"/>
+      <string name="1" value="开始攻击。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="215" height="243">
+      <vector name="origin" x="57" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="32" y="-163"/>
+      <vector name="lt" x="-57" y="-216"/>
+      <vector name="rb" x="150" y="-14"/>
+      <int name="delay" value="300"/>
+      <string name="_hash" value="2841e714edf29d7c5cf569b13bbaaaacdc8a9c8be09aed05af5e4aad97f178cf"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="损伤轻微。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="202" height="242">
+      <vector name="origin" x="77" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="ff60285aaf9135506d27c4ccfe8c5ec2d0fcf85ba37a4b91e3f58cbb7680960c"/>
+    </canvas>
+    <canvas name="1" width="215" height="243">
+      <vector name="origin" x="57" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="213" height="231">
+      <vector name="origin" x="53" y="230"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="16cb5586737c7e4c22a8e3c74b01c226c839d14174c78707374dd97d63643ce7"/>
+    </canvas>
+    <canvas name="3" width="214" height="236">
+      <vector name="origin" x="51" y="236"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="8fc1ad55aee619ca485ba1de982160b500122f2d5d2cd15e06ce33f480fc7d91"/>
+    </canvas>
+    <canvas name="4" width="215" height="239">
+      <vector name="origin" x="50" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="0e65ed47cbb1698fcffd5d2c5e62c6587110b4659dda6bf29a52874d5d35af8a"/>
+    </canvas>
+    <canvas name="5" width="215" height="240">
+      <vector name="origin" x="49" y="240"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="e0de94986fdb296c05f0e6225329b34736094563ea13a910c90b2688a950bf4b"/>
+    </canvas>
+    <canvas name="6" width="215" height="236">
+      <vector name="origin" x="48" y="236"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="424950f9dd5717c683ce5adc6854d8df70e79b710107b8f731642351f76717cf"/>
+    </canvas>
+    <canvas name="7" width="215" height="202">
+      <vector name="origin" x="47" y="202"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="debcd4abb4977553fd92f738374c4c45e7c112380798d8a5507062f6871bf94e"/>
+    </canvas>
+    <canvas name="8" width="215" height="202">
+      <vector name="origin" x="46" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="58c0e04cd3941598c3737d260ff6d7bd8573ccf748c4c2b0f8b41e704220ace6"/>
+    </canvas>
+    <canvas name="9" width="213" height="200">
+      <vector name="origin" x="45" y="200"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="d182be7835f50156e2e1b58494facc676159a0967913b46d94aafe6ca153e229"/>
+    </canvas>
+    <canvas name="10" width="210" height="182">
+      <vector name="origin" x="43" y="182"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="aa547b4b896793e7e2d489e04c094757085b37dbffd49bf8d0f3c59372669ef9"/>
+    </canvas>
+    <canvas name="11" width="200" height="174">
+      <vector name="origin" x="35" y="176"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="df7a6e802c6870d7a17a7ea7b3413f07b6e0eeb43bf4582c743ac39609d71e75"/>
+    </canvas>
+    <canvas name="12" width="187" height="150">
+      <vector name="origin" x="28" y="155"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="5eb24184e5903aeb7a000088fc72aafd5238acd4a3987b18cca87c297c47b253"/>
+    </canvas>
+    <canvas name="13" width="160" height="141">
+      <vector name="origin" x="3" y="150"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="79c11bc2a11013764e63316e433236ba84844af677f13e69f54b0f655b736b40"/>
+    </canvas>
+    <canvas name="14" width="96" height="98">
+      <vector name="origin" x="-53" y="110"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="71c2d51f154349c7b471154e2f30becb4c00da6ac0f6946ed5d49a68c4649129"/>
+    </canvas>
+    <canvas name="15" width="35" height="86">
+      <vector name="origin" x="-59" y="106"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="7a00cc8a984c5fac82290df21e764bf3a766e883b0bbf73478d89c1a528c0981"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="……任务失败。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="regen">
+    <canvas name="0" width="163" height="121">
+      <vector name="origin" x="-104" y="103"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="57a89999d9c0bbccccf4dba3f28db80650922d400b5fd32b95a3dc589d4d4204"/>
+    </canvas>
+    <canvas name="1" width="183" height="159">
+      <vector name="origin" x="-102" y="142"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f109b72f34a4ec6cccfcede898555aa03d6ad743e6ce67df8d307268edf94d08"/>
+    </canvas>
+    <canvas name="2" width="562" height="486">
+      <vector name="origin" x="136" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f6129f7d5eda7c22e85d20f6680eaa5bddd883a577679f44c1adacf6471cd228"/>
+    </canvas>
+    <canvas name="3" width="857" height="510">
+      <vector name="origin" x="433" y="466"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4b7b7f746e27173490d2c29020e3383be44f48b4c7b6a56fd1812db3b1cacd5f"/>
+    </canvas>
+    <canvas name="4" width="845" height="498">
+      <vector name="origin" x="426" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="73c48f904bfa996f484daf6c8bd75d3a906e6062ee8b7e4d59be08fd1d6c7e26"/>
+    </canvas>
+    <canvas name="5" width="836" height="483">
+      <vector name="origin" x="425" y="466"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a3555d08b8389f19a2490e8be341f8f8228b48bdda7f4d83ab0afee9e8f80edb"/>
+    </canvas>
+    <canvas name="6" width="793" height="482">
+      <vector name="origin" x="420" y="465"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="367742ee8378daa836e08608ba3349af345609bb246ea091ff41100141c7cff4"/>
+    </canvas>
+    <canvas name="7" width="726" height="463">
+      <vector name="origin" x="361" y="451"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fec84c56d448e65e2a0e31fd2913c2dc6f404c45aa00cf3e6b4ef90c3e8582e8"/>
+    </canvas>
+    <canvas name="8" width="533" height="444">
+      <vector name="origin" x="347" y="432"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c433019575a8293f68bf5d497c8307b0875e3bc1489e41a5f78da90008f5d996"/>
+    </canvas>
+    <canvas name="9" width="371" height="425">
+      <vector name="origin" x="180" y="421"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="12b043fa95704094cc4d1ca782547374c4f63ffd5723d29ff5144de5a81330b4"/>
+    </canvas>
+    <canvas name="10" width="424" height="397">
+      <vector name="origin" x="252" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="737d3ae9a0a82a1283ae699caffedd979865c726fa0d518927c30329fe7c3842"/>
+    </canvas>
+    <canvas name="11" width="385" height="301">
+      <vector name="origin" x="202" y="291"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3fe014c7c50355cf66baedf861914fe6e6c6e5606ec432fb8f5ccfbb7cc39c2b"/>
+    </canvas>
+    <canvas name="12" width="435" height="346">
+      <vector name="origin" x="175" y="336"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="817edc2561f595d5bf87b0d73809a08d6567dd22bcd50c101f5cbdc72f5823fc"/>
+    </canvas>
+    <canvas name="13" width="468" height="432">
+      <vector name="origin" x="261" y="273"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="60cfae5e25ee9ea73e02aa18bf179b839abf90428ccaf52f1567f41098c00225"/>
+    </canvas>
+    <canvas name="14" width="418" height="240">
+      <vector name="origin" x="246" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0800c3544486ee85cdd938afb4d869540c78865845d66ea95a21b96a3c5c1fda"/>
+    </canvas>
+    <canvas name="15" width="374" height="375">
+      <vector name="origin" x="191" y="233"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="320aea99666789b5e2c9453c9d8b60d19deea4ebe881b82d64eb0e710a01afdf"/>
+    </canvas>
+    <canvas name="16" width="457" height="398">
+      <vector name="origin" x="150" y="229"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce133fbad599f9d399b999a71b5c8bee6c23af208c6fa65041493411fe64b313"/>
+    </canvas>
+    <canvas name="17" width="423" height="463">
+      <vector name="origin" x="232" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ec2ae9eda06e0dfe6a8de9f698c3b98c006ace578801a165bcae046d32e6a27a"/>
+    </canvas>
+    <canvas name="18" width="386" height="400">
+      <vector name="origin" x="214" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="989119d8252ce7ee95da633b0dc3a363b45d7d6160d3012c50aa98758eb641be"/>
+    </canvas>
+    <canvas name="19" width="458" height="430">
+      <vector name="origin" x="147" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4e810ebaf36c9a92dedebd4d97e32537140de05248428e0b0243612250861ac9"/>
+    </canvas>
+    <canvas name="20" width="549" height="530">
+      <vector name="origin" x="264" y="389"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dfa1626cb67e07c0956715b1b6ed1839ab4aa62e1b4184e5c66e51b001a89b87"/>
+    </canvas>
+    <canvas name="21" width="440" height="308">
+      <vector name="origin" x="249" y="221"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="47494a0455d55c3d0164b5a72a29dfe443e9bc4634a00e4ea1ba106b464d77c4"/>
+    </canvas>
+    <canvas name="22" width="350" height="334">
+      <vector name="origin" x="166" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2e4c7101635614718ce9bef2b741a50d6d8f49e0996c515b82eb369efe87b643"/>
+    </canvas>
+    <canvas name="23" width="396" height="360">
+      <vector name="origin" x="186" y="293"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1b9d151601fa15ff30357903d418982976fa617dc61e3be2c1482124b09fe79c"/>
+    </canvas>
+    <canvas name="24" width="396" height="376">
+      <vector name="origin" x="184" y="301"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="197f3e82f73eeff1e3bcca3dab42a1edc10ad9c409fa4ed2fa5c7836862fac54"/>
+    </canvas>
+    <canvas name="25" width="383" height="382">
+      <vector name="origin" x="179" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f7f16428a721af3cf533eb8f7da6936aea1b95ec84897d22943b11f26e7d7fed"/>
+    </canvas>
+    <canvas name="26" width="382" height="382">
+      <vector name="origin" x="178" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b54486a9a83b72f88eb27c05cca20338798fd924439c83f752a452dfc9f2c494"/>
+    </canvas>
+    <canvas name="27" width="378" height="378">
+      <vector name="origin" x="176" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="906e8f4447fea7af6ae5893ac8951af516766c8672ddcdcc0fe812e92b887fd4"/>
+    </canvas>
+    <canvas name="28" width="331" height="348">
+      <vector name="origin" x="176" y="288"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c3091841a62e6db3a8726d5292b654262a294250118f7b9ca95a757f9ce8cfd8"/>
+    </canvas>
+    <canvas name="29" width="330" height="350">
+      <vector name="origin" x="177" y="290"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8aed8ede89e93a648dec20fa05072377156a880cd95393ab201df2a7fe0d884e"/>
+    </canvas>
+    <canvas name="30" width="320" height="320">
+      <vector name="origin" x="170" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="405d5a1e019623c8a31b11fc8c150609039331b24beef9f31f552f52517cd49c"/>
+    </canvas>
+    <canvas name="31" width="315" height="315">
+      <vector name="origin" x="172" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2834a375ab9ae8471180ead3d94b768fb3b757b6f05aba9a15a8b7620267eaef"/>
+    </canvas>
+    <canvas name="32" width="206" height="251">
+      <vector name="origin" x="78" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="16a0c5e3bd363e9cc7492dd9d51837fbf9cdc11f85297fbb68d875d65cb819eb"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="发现目标。开始清除行动。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack2">
+    <canvas name="0" width="204" height="244">
+      <vector name="origin" x="77" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d14494a3b5675b9bda2f6f1112b96aa344d46788b7756a2ef26d6e6c685936fc"/>
+    </canvas>
+    <canvas name="1" width="448" height="244">
+      <vector name="origin" x="351" y="229"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-16" y="-139"/>
+      <vector name="lt" x="-348" y="-151"/>
+      <vector name="rb" x="86" y="1"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="18c1627de5c43ae47e4d191c70fd3addb86d8de87449e31947a2563e1a360a2b"/>
+    </canvas>
+    <canvas name="2" width="456" height="232">
+      <vector name="origin" x="362" y="214"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-28" y="-133"/>
+      <vector name="lt" x="-247" y="-165"/>
+      <vector name="rb" x="86" y="1"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="936b495391185a95f60bb070cefc7d6ec1c35b6ecc3e43c525fe8bf8b88df162"/>
+    </canvas>
+    <canvas name="3" width="468" height="244">
+      <vector name="origin" x="370" y="226"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-28" y="-133"/>
+      <vector name="lt" x="-309" y="-189"/>
+      <vector name="rb" x="86" y="1"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="38f6ebee6965fea8e5d633292f68c2299358a4395ca53a1d8e58bb258e4cf6d9"/>
+    </canvas>
+    <canvas name="4" width="464" height="232">
+      <vector name="origin" x="360" y="213"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-6" y="-136"/>
+      <vector name="lt" x="-326" y="-187"/>
+      <vector name="rb" x="86" y="1"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="ba58596e713d25a12c13a85dd2b9845d8908baeb0d6e5c30b1028501b6c5e331"/>
+    </canvas>
+    <canvas name="5" width="444" height="244">
+      <vector name="origin" x="367" y="228"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-46" y="-140"/>
+      <vector name="lt" x="-361" y="-138"/>
+      <vector name="rb" x="69" y="-1"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="b1f64c29d9c980dd18b6b1b6fbe16ea77acb6b0d8459b0867686dc1edc148e13"/>
+    </canvas>
+    <canvas name="6" width="460" height="236">
+      <vector name="origin" x="377" y="235"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-54" y="-127"/>
+      <vector name="lt" x="-373" y="-137"/>
+      <vector name="rb" x="74" y="-9"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="e0fe7302c9321080d0d2d285f6c0330fd29052008349c688fadf048c85488a2b"/>
+    </canvas>
+    <canvas name="7" width="448" height="256">
+      <vector name="origin" x="390" y="247"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-79" y="-139"/>
+      <vector name="lt" x="-376" y="-136"/>
+      <vector name="rb" x="50" y="-4"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="3a41850f9d5dc56a022748c0e518a82d5195743d33f4a3ce6e1cb34d2d0af11e"/>
+    </canvas>
+    <canvas name="8" width="424" height="252">
+      <vector name="origin" x="401" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-95" y="-142"/>
+      <vector name="lt" x="-398" y="-155"/>
+      <vector name="rb" x="15" y="-4"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="414e8762f8afcb082d0686cf01b48af08e97a0dcac74eddaaf3a7cb1bf600efd"/>
+    </canvas>
+    <canvas name="9" width="424" height="256">
+      <vector name="origin" x="405" y="245"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-95" y="-144"/>
+      <vector name="lt" x="-402" y="-160"/>
+      <vector name="rb" x="14" y="-4"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="48df81bc8051a488aad258aef74ca41c1d0f1ca2bebe784f1cce771e759d80c5"/>
+    </canvas>
+    <canvas name="10" width="380" height="244">
+      <vector name="origin" x="361" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-101" y="-145"/>
+      <vector name="lt" x="-216" y="-142"/>
+      <vector name="rb" x="13" y="-5"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="70f041254bdbf5354371fb0f04b3bb78509519f568aae157c08feecfbe6434e7"/>
+    </canvas>
+    <canvas name="11" width="202" height="242">
+      <vector name="origin" x="170" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-88" y="-156"/>
+      <vector name="lt" x="-170" y="-161"/>
+      <vector name="rb" x="23" y="-9"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="202" height="239">
+      <vector name="origin" x="140" y="243"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="13" width="202" height="250">
+      <vector name="origin" x="109" y="253"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="14" width="202" height="250">
+      <vector name="origin" x="77" y="252"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <uol name="15" value="../stand/6"/>
+    <uol name="16" value="../stand/7"/>
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-471" y="-192"/>
+        <vector name="rb" x="0" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="98" height="126">
+          <vector name="origin" x="49" y="63"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0be27986f4af3a6f70bf4ea8c24f71ea70101ce9e65a5817f8feb627bd01bec6"/>
+        </canvas>
+        <canvas name="1" width="99" height="124">
+          <vector name="origin" x="49" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b2115db9d9cc4575ccc141471d8ff61b0a214fe3c40aa3d9e2910f02c2b74644"/>
+        </canvas>
+        <canvas name="2" width="97" height="104">
+          <vector name="origin" x="48" y="52"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="dc2b872017c48e5b213e13ce656b69ba546923e5cb27bb77d84481412e8eea62"/>
+        </canvas>
+        <canvas name="3" width="100" height="91">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b01695807d8d166acafb60143a1f19ebd757f62d1e2f54007a77bbaee82fc8f2"/>
+        </canvas>
+        <canvas name="4" width="101" height="91">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0636f3fbc9203b254f2d701993cc222a8583baf61e965a0d02a9bbd344e46eb7"/>
+        </canvas>
+        <canvas name="5" width="99" height="88">
+          <vector name="origin" x="49" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="718af6e4a522fe73161025ec5fbe5a46f69597acc859e037bd0378a573e8c4b8"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="attackAfter" value="780"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787129.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787129.img.xml
@@ -1,0 +1,935 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787129.img">
+  <imgdir name="info">
+    <int name="level" value="100"/>
+    <int name="maxHP" value="999999999"/>
+    <int name="mpRecovery" value="10000"/>
+    <int name="PADamage" value="1500"/>
+    <int name="MADamage" value="1500"/>
+    <int name="PDRate" value="25"/>
+    <int name="MDRate" value="25"/>
+    <int name="acc" value="600"/>
+    <string name="elemAttr" value="P2"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="500000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="2"/>
+        <int name="conMP" value="1"/>
+        <int name="magic" value="1"/>
+        <int name="disease" value="122"/>
+        <int name="level" value="18"/>
+        <int name="bulletSpeed" value="700"/>
+        <int name="attackCount" value="2"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="speed" value="5"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <int name="nonLevelCheckACC" value="1"/>
+    <int name="nonLevelCheckEVA" value="1"/>
+    <int name="notConsiderFieldSet" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="123"/>
+        <int name="action" value="1"/>
+        <int name="level" value="5"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="让你后悔！"/>
+      </imgdir>
+    </imgdir>
+    <int name="hpTagBgcolor" value="3"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="225" height="248">
+      <vector name="origin" x="100" y="244"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="79ca2ec48344ab18770db140448badc8d9f5bb0de305abe27087b8d4766f161f"/>
+    </canvas>
+    <canvas name="1" width="224" height="247">
+      <vector name="origin" x="100" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="3bcf0b871f98606500bdf953274f082342661517393d8983f8c04531da713c52"/>
+    </canvas>
+    <canvas name="2" width="225" height="234">
+      <vector name="origin" x="100" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="2577232515851fafa34e7db4f1be256ce42816c58620259cfd3176ba4772b7ce"/>
+    </canvas>
+    <canvas name="3" width="225" height="240">
+      <vector name="origin" x="100" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="713ef6aab3e4d5369163148c50f6dd09c76811f1343d3ab05728cc6ba4073365"/>
+    </canvas>
+    <canvas name="4" width="225" height="228">
+      <vector name="origin" x="100" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="8754730aa52722e181aa5d79a6b2b880c6796df8b50c3d38142a0db98da998d5"/>
+    </canvas>
+    <canvas name="5" width="225" height="242">
+      <vector name="origin" x="100" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="cca465d244097d605f8889ee2cba7d8e2560789f2235dcc472a466b6eb86fb82"/>
+    </canvas>
+    <canvas name="6" width="225" height="252">
+      <vector name="origin" x="100" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="e6c65f892d2d7b52d9a7beb44d3caad24d52ec6a8f92ecfe03314a5299d99733"/>
+    </canvas>
+    <canvas name="7" width="225" height="253">
+      <vector name="origin" x="100" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="3bc433e96c3d690744cb2c507ee86ee14e3b33fada9f71370379b6c013f0c1aa"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="追逐逃跑的猎物，也是乐趣之一。"/>
+    </imgdir>
+    <canvas name="0" width="226" height="246">
+      <vector name="origin" x="101" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3eeffa970f29a2863097777b6919aca828788232e331728c368eabb311fd7d8e"/>
+    </canvas>
+    <canvas name="1" width="224" height="247">
+      <vector name="origin" x="100" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="6b84a97e5a9ac6fbccfda7a0c54d3f1218a4b899b27ccddc48351cc7e82d1b8b"/>
+    </canvas>
+    <canvas name="2" width="226" height="234">
+      <vector name="origin" x="101" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="cd7d6ee7407ad2e334f13f6f504ad135b11c7c511b9c6d52455539aebf54387d"/>
+    </canvas>
+    <canvas name="3" width="227" height="228">
+      <vector name="origin" x="102" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="25b58d6be8d401356cd7b1c9ea9f3dd6bb4a15af514deffabd6fe2bd9e965f89"/>
+    </canvas>
+    <canvas name="4" width="228" height="242">
+      <vector name="origin" x="103" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="a55aa9106f052051cdf14d65484f0880f7048a6dcc3333d289109fed35b46612"/>
+    </canvas>
+    <canvas name="5" width="227" height="252">
+      <vector name="origin" x="102" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="5bcf3d4befac0fa239c6d22b00f22883e2e3569856d80585e1be461bd837357b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="咳……"/>
+    </imgdir>
+    <canvas name="0" width="228" height="251">
+      <vector name="origin" x="70" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="300"/>
+      <vector name="head" x="47" y="-157"/>
+      <vector name="lt" x="-47" y="-183"/>
+      <vector name="rb" x="150" y="-14"/>
+      <string name="_hash" value="4b76eadd3da9bb5afd0e6a3435c041eec53975ebdb81938750808241ef91dec3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="我太大意了，不能就这样结束……"/>
+      <string name="1" value="竟被猎物击中要害……"/>
+    </imgdir>
+    <canvas name="0" width="225" height="248">
+      <vector name="origin" x="100" y="244"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="9" y="-158"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="319644088fa89730261a06b0d8359484d60e8caa04dd39a74e6a2e52eced1cfa"/>
+    </canvas>
+    <canvas name="1" width="228" height="251">
+      <vector name="origin" x="70" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="048bad989af1c25e7ae439fca2af4cb51f8b016b1ebb8277513ddf1bcffaeda7"/>
+    </canvas>
+    <canvas name="2" width="226" height="239">
+      <vector name="origin" x="66" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="c9c6d90e34bc086d03778051db1cd39d29a7b2df4f272c1fa7be38f65c41445b"/>
+    </canvas>
+    <canvas name="3" width="227" height="245">
+      <vector name="origin" x="64" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="bbe95c381369f53e157e402f86a78dfb9443118aec1920a62365ef5fd84baf47"/>
+    </canvas>
+    <canvas name="4" width="228" height="248">
+      <vector name="origin" x="63" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="c322d84f117a3d5ec3a7d46ebdca54bc2e81b770c299c612562dc9033b80fb8b"/>
+    </canvas>
+    <canvas name="5" width="228" height="249">
+      <vector name="origin" x="62" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="c8a4055ff352a1d11b2a96cae51413f76db7741b7b1168c5787cb58dd2a81787"/>
+    </canvas>
+    <canvas name="6" width="228" height="245">
+      <vector name="origin" x="61" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="52d727d71147f8dfeb0f8b1ca5074e4137c26f1bab2ef306b7a288bebf5b8b22"/>
+    </canvas>
+    <canvas name="7" width="228" height="211">
+      <vector name="origin" x="60" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="03ccfcbbc45e29a913574d7b62ac4e3a7a2bb4f681a7231c04f15e604c7d233b"/>
+    </canvas>
+    <canvas name="8" width="228" height="211">
+      <vector name="origin" x="59" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="1a3d22b1d0af8da7e65b2d4f817a462d23267109cfc778502beed26ec34d4213"/>
+    </canvas>
+    <canvas name="9" width="224" height="209">
+      <vector name="origin" x="56" y="200"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="71fef80464d3d6a7b1970646d9123d49e340fdeb0ed8b09f06614bbd22874b82"/>
+    </canvas>
+    <canvas name="10" width="214" height="186">
+      <vector name="origin" x="47" y="182"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="2f1d3cac376b5fe82e03b116895817b70bafee6921fd1277628cd673ea9fddff"/>
+    </canvas>
+    <canvas name="11" width="196" height="179">
+      <vector name="origin" x="31" y="176"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="22bc197b44f80c6d6038322422c1f526f28ecfa8788113e2f2ec1de0570c1f54"/>
+    </canvas>
+    <canvas name="12" width="177" height="150">
+      <vector name="origin" x="18" y="155"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="4e5889b77638472ac007dd05dbeb926dc84fecaae8dd4eb22a9aade6d584fb6b"/>
+    </canvas>
+    <canvas name="13" width="162" height="141">
+      <vector name="origin" x="5" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="ab88f085490fa4eec4ea305753927560f329ff2d4bc0463cf18ee43139de58c2"/>
+    </canvas>
+    <canvas name="14" width="96" height="98">
+      <vector name="origin" x="-53" y="110"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="158a723fe3a93a5be88b64a7759f121ec0a13cc9c24e1ec868a47d67a709b4a4"/>
+    </canvas>
+    <canvas name="15" width="35" height="86">
+      <vector name="origin" x="-59" y="106"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="e3c11fdda7e8d36ac6bb08408225b5401d1e3837b42833d39efbcb04a971b527"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="regen">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="猎物出现了。"/>
+      <string name="1" value="开始狩猎吧。"/>
+    </imgdir>
+    <canvas name="0" width="163" height="121">
+      <vector name="origin" x="-104" y="105"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bcf3f049a42ecff3a35fce04ad578177ee96a2c63c9fffd6a6ca447d0b9277fe"/>
+    </canvas>
+    <canvas name="1" width="183" height="159">
+      <vector name="origin" x="-102" y="144"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="eab0b5f10900dfbefa707435a14cfcdf1abee3f86df647afb8f719a80d73bb52"/>
+    </canvas>
+    <canvas name="2" width="562" height="486">
+      <vector name="origin" x="136" y="470"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a1aac6031e70dfa9a0fd0f1bdc145d61b1e2bed8579d8cc3543d847cb807ff75"/>
+    </canvas>
+    <canvas name="3" width="857" height="510">
+      <vector name="origin" x="433" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e04ab1b777e398d3fd96c80eb990d6e78880bf91ccce52c2de23e40b5cf2be16"/>
+    </canvas>
+    <canvas name="4" width="845" height="498">
+      <vector name="origin" x="426" y="470"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="aafda4f5f91d5ada9cb0b8ec027695b10a47a1ab906ea9e226dd5c8f50ad713d"/>
+    </canvas>
+    <canvas name="5" width="836" height="483">
+      <vector name="origin" x="425" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9181f27f7303f76736bb814bed9baa01ade9e20b84230188b626503f77076322"/>
+    </canvas>
+    <canvas name="6" width="793" height="482">
+      <vector name="origin" x="420" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1198cb880c3226498fac1830f936e57883f4423ce34b6306cbbeed5d74012e6c"/>
+    </canvas>
+    <canvas name="7" width="726" height="463">
+      <vector name="origin" x="361" y="453"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ed00d92ead6c917199914f5c26aa575f22207b939a1a364d229e57a8f5b1b364"/>
+    </canvas>
+    <canvas name="8" width="533" height="444">
+      <vector name="origin" x="347" y="434"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="829ae55e68098eb5961b3ac05d041e6ab9b7141641b7a7d9a4ad8bc6b7e75408"/>
+    </canvas>
+    <canvas name="9" width="371" height="425">
+      <vector name="origin" x="180" y="423"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="28b068dc401f59886f3d43b83a1c3db9a8d8500c2664b7dd92100cbcb3b6886b"/>
+    </canvas>
+    <canvas name="10" width="424" height="397">
+      <vector name="origin" x="252" y="339"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b47747bed5e698b54ea9135629f6ae7dca7c01558ca814b487fa23f5212d7385"/>
+    </canvas>
+    <canvas name="11" width="385" height="301">
+      <vector name="origin" x="202" y="293"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="011318b3090b0cfa57808cf4c02df432d452ff194a9d5d6f8f8bdba02a02a3d0"/>
+    </canvas>
+    <canvas name="12" width="435" height="346">
+      <vector name="origin" x="175" y="338"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b946e26788820a0da621c7aec3e4e5d62f50360fdccd4ed204249bcb161d8d52"/>
+    </canvas>
+    <canvas name="13" width="468" height="432">
+      <vector name="origin" x="261" y="275"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d568063e2c8d85e2002604808c248b6181f1f6c94b2a8accbb46ae9811849269"/>
+    </canvas>
+    <canvas name="14" width="418" height="240">
+      <vector name="origin" x="246" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0c86470e1fe4da7b95ad5ef3330a411a7e8bab494edd60c644d1275caa5f0297"/>
+    </canvas>
+    <canvas name="15" width="374" height="375">
+      <vector name="origin" x="191" y="235"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e1b55dc1e3e422f01db08aa3e35d4f110d6567cdf2b760907cf75ea298a9f4f8"/>
+    </canvas>
+    <canvas name="16" width="457" height="398">
+      <vector name="origin" x="150" y="231"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9fa9403b0d86c50282862171c7527e50bc10bd114e1f8ac2b801d41522a73079"/>
+    </canvas>
+    <canvas name="17" width="423" height="463">
+      <vector name="origin" x="232" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="258e8e2bee9bf8670113ea7de8dd5b37b0a2e93e3ee475b1dd10c16a6ad2ca6d"/>
+    </canvas>
+    <canvas name="18" width="386" height="400">
+      <vector name="origin" x="214" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="176eb124744931f1c5b1b991897cc203beace44aa6dc091aa97e2796502985dc"/>
+    </canvas>
+    <canvas name="19" width="458" height="430">
+      <vector name="origin" x="147" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c5eb7d31f2808fa35f3f95adb2f1e94bfc46c65fba3b232831378239f17a5a8d"/>
+    </canvas>
+    <canvas name="20" width="549" height="530">
+      <vector name="origin" x="264" y="391"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="66c1224d9e63b9d0e17d5b0c62081132cda169368985d9cf9aca318a2d234171"/>
+    </canvas>
+    <canvas name="21" width="440" height="308">
+      <vector name="origin" x="249" y="223"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b98e4ac2c23608ac95391c584d8e526cdc05e927c3b93571514e837bd8833a27"/>
+    </canvas>
+    <canvas name="22" width="350" height="334">
+      <vector name="origin" x="166" y="283"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="227bf706372c9fe38beb6a589dd33e82777b88259166b616dc586a51eaec4fb6"/>
+    </canvas>
+    <canvas name="23" width="396" height="360">
+      <vector name="origin" x="186" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="146f1da4afafda906b376875c9af89a6302fa02c9c802225630f0a75dd68471a"/>
+    </canvas>
+    <canvas name="24" width="396" height="376">
+      <vector name="origin" x="184" y="303"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7c93142dd2dcb54c8ea55d8d566d893c019217f88205731f52aff203cacf522b"/>
+    </canvas>
+    <canvas name="25" width="383" height="382">
+      <vector name="origin" x="179" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a892d9fbbac39ef66f5e57c3ead605d9980dcff123cd2bbc1802231b277944ee"/>
+    </canvas>
+    <canvas name="26" width="382" height="382">
+      <vector name="origin" x="178" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3815f0942328c1ed019f0df9d265510e9a99c15d11dc2bde76e8eff096b70be3"/>
+    </canvas>
+    <canvas name="27" width="378" height="378">
+      <vector name="origin" x="176" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8d7d49eadf1947dffea2caf3843073f241687f4323ed1f030c05b382ce89a27b"/>
+    </canvas>
+    <canvas name="28" width="331" height="348">
+      <vector name="origin" x="176" y="290"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="06a36f38e484372b98717c6b124e6e9773aec073fe1275669f41816c09370d07"/>
+    </canvas>
+    <canvas name="29" width="330" height="350">
+      <vector name="origin" x="177" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="38123f4c9f010f29958d1f06c48b7f5eb61fccbf5a290d94a12294b1e8042b5d"/>
+    </canvas>
+    <canvas name="30" width="320" height="320">
+      <vector name="origin" x="170" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="152d4c1dae67f0102dc1ebec3ed82246b0fe3758709c4b31a3740f1554cc6607"/>
+    </canvas>
+    <canvas name="31" width="315" height="315">
+      <vector name="origin" x="172" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="47d51e1009a5ac4384bff16df563ae1461eb6667336892beb8d7ca541a010cc9"/>
+    </canvas>
+    <canvas name="32" width="228" height="254">
+      <vector name="origin" x="100" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cf3996bc1912816a29514f8bc3f96af15c71c21591326d8d678dbdce047d1318"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="我的箭绝对不会放过猎物。"/>
+    </imgdir>
+    <canvas name="0" width="228" height="248">
+      <vector name="origin" x="100" y="244"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="14" y="-163"/>
+      <vector name="lt" x="-78" y="-185"/>
+      <vector name="rb" x="113" y="-11"/>
+      <int name="delay" value="60"/>
+      <string name="_hash" value="b2adc10333e6b827c51e6dc5a1aaf61125312cbe2b373f401e0612a80621b2e9"/>
+    </canvas>
+    <canvas name="1" width="228" height="248">
+      <vector name="origin" x="83" y="263"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="34" y="-175"/>
+      <vector name="lt" x="-46" y="-189"/>
+      <vector name="rb" x="133" y="-28"/>
+      <string name="_hash" value="ff256d2efbd8827d3ecd33c64552d2942ad6c2117f55aec1afa766eb904556d0"/>
+    </canvas>
+    <canvas name="2" width="240" height="232">
+      <vector name="origin" x="85" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="47" y="-171"/>
+      <vector name="lt" x="-37" y="-182"/>
+      <vector name="rb" x="141" y="-23"/>
+      <string name="_hash" value="9e63105163b6f822d76f6f3442433be4c868db7727cf3e320ce35cd2b6fb4ade"/>
+    </canvas>
+    <canvas name="3" width="244" height="228">
+      <vector name="origin" x="86" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="93f5e4bbf4760eb20220b9b15090ddebf4376b9d0e007f147ff1ec342a103ee9"/>
+    </canvas>
+    <canvas name="4" width="244" height="260">
+      <vector name="origin" x="86" y="247"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="a4bfe561a7dae4998b59bd5763dfb6549adf1dbfcaefc3cdc937849738dcd5f0"/>
+    </canvas>
+    <canvas name="5" width="344" height="288">
+      <vector name="origin" x="184" y="256"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="a4f117097d0a5456b57176cefa7172a1a74ff2ac3806d5c55b553c7110462ce8"/>
+    </canvas>
+    <canvas name="6" width="336" height="280">
+      <vector name="origin" x="176" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="68cdd7de4af7062d56f7f22452507db5279d5f02a898e3d8c1ab5ae7adb2651a"/>
+    </canvas>
+    <canvas name="7" width="300" height="280">
+      <vector name="origin" x="142" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="9d12447a5cb2b4713cb8227ecf0e53baa9310e9f0145807dd0ed64a9f06be2a1"/>
+    </canvas>
+    <canvas name="8" width="340" height="248">
+      <vector name="origin" x="181" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="9ba7487a67d9ca7401992554313695310addd1cb10b7d037a74f4069bf651cba"/>
+    </canvas>
+    <canvas name="9" width="300" height="244">
+      <vector name="origin" x="142" y="232"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="49972a087da143ebdba3be6f47d2c9aad54103ce931ec0ea636ba0e0e31f9ebf"/>
+    </canvas>
+    <canvas name="10" width="276" height="268">
+      <vector name="origin" x="116" y="246"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="e4a9f9b13f0f3838d1b7f06ad8c4ee37c4dba3f1fcb21ea55c97b40ee2b1513e"/>
+    </canvas>
+    <canvas name="11" width="276" height="288">
+      <vector name="origin" x="116" y="256"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="333bbbce3f3b508f0ec7ebd64539d9d2945a1ffced523e585d6485828dfee5a4"/>
+    </canvas>
+    <canvas name="12" width="276" height="284">
+      <vector name="origin" x="115" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="da19e1e288420baac6270193bd948af831a90f641e85dd38e14638f12b10a143"/>
+    </canvas>
+    <canvas name="13" width="272" height="284">
+      <vector name="origin" x="113" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="a399407948d3fcb27d5f4680594ec05c1ce9afe2a8bf5f4bc716b3625c102ab5"/>
+    </canvas>
+    <canvas name="14" width="272" height="272">
+      <vector name="origin" x="112" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="8921ada9598d9bab8920a2d75e80e064f4080c43df0dd4ef30b9157fe5080833"/>
+    </canvas>
+    <canvas name="15" width="336" height="296">
+      <vector name="origin" x="177" y="248"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="ee00495474e1ddc68e787d0cdc4c0e8b714804bf7e13ad2071cedae61ee287f6"/>
+    </canvas>
+    <canvas name="16" width="336" height="284">
+      <vector name="origin" x="176" y="246"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="bbbab73b2a7a167ee11275136a7be9bc28953255cc1332ad7ad7d4ca29fc5d0d"/>
+    </canvas>
+    <canvas name="17" width="336" height="284">
+      <vector name="origin" x="176" y="256"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="dec3d11dd75a9d8ab335159ebe084cf923c2d631d1b14e56325b3d97e4303351"/>
+    </canvas>
+    <canvas name="18" width="340" height="280">
+      <vector name="origin" x="179" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="cffa55bf8b6aa0fecf5c9b506e47e8f82493942e5ffd3312d468ea0a64ee4202"/>
+    </canvas>
+    <canvas name="19" width="256" height="276">
+      <vector name="origin" x="95" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="ca794f94ffc6b298b2328f6606c70200d6e7e71de7051e9532ec70e3ccc14f3d"/>
+    </canvas>
+    <canvas name="20" width="212" height="264">
+      <vector name="origin" x="55" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="9dc3fb5cc2bfe9f4ba0aee2403ed3271e01d2e5dab373c4b30fe2e3dddd13e0b"/>
+    </canvas>
+    <canvas name="21" width="212" height="264">
+      <vector name="origin" x="68" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="30" y="-181"/>
+      <vector name="lt" x="-58" y="-190"/>
+      <vector name="rb" x="132" y="-26"/>
+      <string name="_hash" value="0c6d1c64e27fa4262277161d03b8ee8a4c049e8a08035dc72d2cc9b30b157c3e"/>
+    </canvas>
+    <canvas name="22" width="212" height="272">
+      <vector name="origin" x="78" y="261"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="21" y="-186"/>
+      <vector name="lt" x="-72" y="-200"/>
+      <vector name="rb" x="124" y="-31"/>
+      <string name="_hash" value="83599e08fe61b39cb9206d1a26171fcf8da164425f08c8187f06c12185b82847"/>
+    </canvas>
+    <uol name="23" value="../stand/4"/>
+    <uol name="24" value="../stand/5"/>
+    <uol name="25" value="../stand/6"/>
+    <uol name="26" value="../stand/7"/>
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-50" y="-100"/>
+        <int name="r" value="700"/>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="188" height="59">
+          <vector name="origin" x="94" y="29"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="1" width="204" height="55">
+          <vector name="origin" x="94" y="27"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="2" width="188" height="51">
+          <vector name="origin" x="94" y="25"/>
+          <int name="delay" value="150"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="200" height="245">
+          <vector name="origin" x="93" y="124"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="1" width="222" height="229">
+          <vector name="origin" x="102" y="118"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="2" width="225" height="254">
+          <vector name="origin" x="102" y="131"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="3" width="228" height="268">
+          <vector name="origin" x="102" y="138"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="4" width="134" height="274">
+          <vector name="origin" x="65" y="141"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="5" width="22" height="222">
+          <vector name="origin" x="11" y="112"/>
+          <int name="delay" value="150"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="660"/>
+      <int name="type" value="2"/>
+      <int name="magic" value="1"/>
+      <int name="bulletSpeed" value="200"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="228" height="248">
+      <vector name="origin" x="100" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cd652ea06aaded2e72afb169a5db3a2bc0070b09de9aaafd0b61aabdc5d7672f"/>
+    </canvas>
+    <canvas name="1" width="236" height="408">
+      <vector name="origin" x="100" y="391"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b94e3e6db458a555dbcd96426cf7633f877f1ecba7d05232f30503a181638c7f"/>
+    </canvas>
+    <canvas name="2" width="240" height="416">
+      <vector name="origin" x="100" y="396"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="be0d30dfb92b0306d086442d52833b9e1d2541bd88f9a5d3ebdc6354a63cbd02"/>
+    </canvas>
+    <canvas name="3" width="240" height="420">
+      <vector name="origin" x="103" y="395"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2bac2e9c6d307c2115c8fc21f1b27de2e17acd80e2f890a6d27f8c3ec5e4c377"/>
+    </canvas>
+    <canvas name="4" width="228" height="404">
+      <vector name="origin" x="100" y="379"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="674be33523464aa3c00d88e74f564f0fbb8cf4a2faec79d48a95fcfdab0e597f"/>
+    </canvas>
+    <canvas name="5" width="228" height="368">
+      <vector name="origin" x="100" y="342"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4f827b3663f28cf79f0b7d3a64bf321fa2ef4c18528d5bee0c35295e7bc2125e"/>
+    </canvas>
+    <canvas name="6" width="228" height="368">
+      <vector name="origin" x="100" y="342"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cdd0556f1a283306fafe5da4e0c652a3d97b332323d97d92102766f82180d401"/>
+    </canvas>
+    <canvas name="7" width="228" height="372">
+      <vector name="origin" x="100" y="341"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3ea5c4b06acd49cd9b1444395a4fff2d9e6f4efa4020eb68120b250cc1a1d783"/>
+    </canvas>
+    <canvas name="8" width="216" height="360">
+      <vector name="origin" x="88" y="355"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ae2842860106bb94cb8ac83b86f1667dc49baa1e934e9cacbb46081b295c0e8c"/>
+    </canvas>
+    <canvas name="9" width="220" height="376">
+      <vector name="origin" x="94" y="373"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2ccb349a268f70e23bdab295d864d25e1647194c7d12a2b8ad4f96b437d1027b"/>
+    </canvas>
+    <canvas name="10" width="220" height="388">
+      <vector name="origin" x="95" y="384"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d8b1e716d000e04cc4aedbb0d771f1136ea2165b6fd1652e10730baf072d6e1e"/>
+    </canvas>
+    <canvas name="11" width="224" height="396">
+      <vector name="origin" x="96" y="390"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="058f75dec752fb37463894ee70aabcccc8888fa1950a54c9f0ca20bd22679eef"/>
+    </canvas>
+    <canvas name="12" width="224" height="392">
+      <vector name="origin" x="96" y="393"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5e0cb4feb1f890ff1d1beeeec1b4a29a9224800920e6eb0dd66a71ba074e5186"/>
+    </canvas>
+    <canvas name="13" width="220" height="372">
+      <vector name="origin" x="95" y="393"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4c2b033687f0b2124a474f1ace55ba64d9cdf1f7d304ff0d433ac4372be9e8bc"/>
+    </canvas>
+    <canvas name="14" width="228" height="396">
+      <vector name="origin" x="100" y="395"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e9a2c5d35ec8e33260339e622d5f0eb30ab6a7f6a74180aa4b344e878602e1ec"/>
+    </canvas>
+    <canvas name="15" width="228" height="392">
+      <vector name="origin" x="100" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="32273fd3bb30cf2467c9b714863eb408863c8a18061c0678d0e866542125a34b"/>
+    </canvas>
+    <uol name="19" value="../stand/4"/>
+    <uol name="20" value="../stand/5"/>
+    <uol name="21" value="../stand/6"/>
+    <uol name="22" value="../stand/7"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787130.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787130.img.xml
@@ -1,0 +1,955 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787130.img">
+  <imgdir name="info">
+    <int name="level" value="100"/>
+    <int name="maxHP" value="999999999"/>
+    <int name="maxMP" value="50000"/>
+    <int name="PADamage" value="1500"/>
+    <int name="MADamage" value="1500"/>
+    <int name="PDRate" value="25"/>
+    <int name="MDRate" value="25"/>
+    <int name="acc" value="600"/>
+    <string name="elemAttr" value="P2"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="500000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="1"/>
+        <int name="magic" value="1"/>
+        <int name="fixDamR" value="5"/>
+        <int name="attackCount" value="5"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="speed" value="5"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <int name="nonLevelCheckACC" value="1"/>
+    <int name="nonLevelCheckEVA" value="1"/>
+    <int name="notConsiderFieldSet" value="1"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+    <int name="hpTagBgcolor" value="3"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="185" height="242">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="fc9ba56bd94044025cb23122cc7c18019ab6b127d335227baae967595db34058"/>
+    </canvas>
+    <canvas name="1" width="184" height="243">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="8ca880e17973af3bc04bb9801b5885c0b4b13c2a880c7a2f321d90a728e3cee8"/>
+    </canvas>
+    <canvas name="2" width="185" height="230">
+      <vector name="origin" x="60" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="39b07ffe23d3de3dbdf39612b3a8a7428bc00512314eedcd3f0aba1c1532991b"/>
+    </canvas>
+    <canvas name="3" width="185" height="236">
+      <vector name="origin" x="60" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="3ca4fcc2af804a418916aa29ea4c12d10747c348c49dc9fb83b0b0a8e7ce27ad"/>
+    </canvas>
+    <canvas name="4" width="185" height="224">
+      <vector name="origin" x="60" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="9ea35b5fc28e1ba36b6e07d19072b2d16aaa9f17efc008d0ffde294303d07952"/>
+    </canvas>
+    <canvas name="5" width="185" height="238">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="bcf8b5043707e3646ee59e436d925e0e742df347bef3871bef767f4449fe834b"/>
+    </canvas>
+    <canvas name="6" width="185" height="248">
+      <vector name="origin" x="60" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="f4b2b4a5a01d5657713b0fc633e071adfcd31060b9993c74f7c24249d73e6189"/>
+    </canvas>
+    <canvas name="7" width="185" height="249">
+      <vector name="origin" x="60" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="157a37f103e90ecee3680d88fc4a9aa3a24cef2e1e9bd7c3d080bd3e6c5fd443"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="喂，别逃。"/>
+    </imgdir>
+    <canvas name="0" width="191" height="242">
+      <vector name="origin" x="66" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cb8226ccf54c5d1ee37977b088889c89b7ccfbbe32d07882ff6dcba827734e92"/>
+    </canvas>
+    <canvas name="1" width="189" height="243">
+      <vector name="origin" x="65" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="4a7f1cb18c80851737756763511b50f4e97ff420265382c4f5123322eebc5165"/>
+    </canvas>
+    <canvas name="2" width="191" height="230">
+      <vector name="origin" x="66" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="09a39671bde8f7da801d1c358652fc43bec0ea8802a66ed4cb8f05295044aab3"/>
+    </canvas>
+    <canvas name="3" width="192" height="224">
+      <vector name="origin" x="67" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="acb1f5f96440bfee8fafab7c8f920ccdfd4533faac0151cfe9091cee1c3b4bf8"/>
+    </canvas>
+    <canvas name="4" width="193" height="238">
+      <vector name="origin" x="68" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="e7e22eb3ebe9037c2a3c09013ed07c3a016141f75445e6cdd534fcf89833b078"/>
+    </canvas>
+    <canvas name="5" width="192" height="248">
+      <vector name="origin" x="67" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="976504d6d5e81faf508107861a1528a2ac35cec101e4309322e6615d4a7c1fe1"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-435" y="-228"/>
+        <vector name="rb" x="190" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="115" height="118">
+          <vector name="origin" x="57" y="59"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="9d86bbdebb64d57f7f8ffde218b880c9a2eda0d1dfd0277b8c047d8bb531c2bb"/>
+        </canvas>
+        <canvas name="1" width="143" height="162">
+          <vector name="origin" x="71" y="81"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="3ebace547aea903279411e7c1a409df81a7db270dc4d6851c34a6006b5f9132e"/>
+        </canvas>
+        <canvas name="2" width="140" height="164">
+          <vector name="origin" x="70" y="82"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="5078d0b2b67c9737b7d81d440cb521ad865d440b6a024c706820f329048aacd1"/>
+        </canvas>
+        <canvas name="3" width="148" height="148">
+          <vector name="origin" x="74" y="74"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="605c6e7fb994ad9c4b7233763db479794bcd3b0eb3f29b16ea2449d268fa7c88"/>
+        </canvas>
+        <canvas name="4" width="133" height="141">
+          <vector name="origin" x="66" y="70"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6a1f159386ca9886b7ecc61065351e365235754d7d2fce15773ca85320bf61d9"/>
+        </canvas>
+        <canvas name="5" width="174" height="230">
+          <vector name="origin" x="87" y="115"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="53492d2bd78373169a20bf30a158e53734ed9529182a0c912c00b400fbf5441c"/>
+        </canvas>
+        <canvas name="6" width="243" height="225">
+          <vector name="origin" x="121" y="112"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="bbbd8a95fe48a471f4cf82d2197da4d20c2c2880d41b02bb1b5bdd01bce75942"/>
+        </canvas>
+        <canvas name="7" width="239" height="214">
+          <vector name="origin" x="119" y="107"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6ffc3e05f2df48ed119738ae0625ccdaf93636c1d4e91e8e321fd8702413aab5"/>
+        </canvas>
+        <canvas name="8" width="227" height="194">
+          <vector name="origin" x="113" y="97"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="266171cffb2c739b18cecea0ec70ddd50680c1d88f7c05fb8d3d89e5d1c4406d"/>
+        </canvas>
+        <canvas name="9" width="200" height="164">
+          <vector name="origin" x="100" y="82"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="f15b3c8af5876dfedd42bf5e0f0a5dd230aac7f7891ec2a3bbc7f592f1e9f0e4"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="120"/>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="拳击拳击拳击！"/>
+      <string name="1" value="果然战斗就该正面交锋！"/>
+    </imgdir>
+    <canvas name="0" width="185" height="242">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-61" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="6b25f3e402af7e8679c7966a8e5433074f8b0b985acecf32f18ef636a2ba3be4"/>
+    </canvas>
+    <canvas name="1" width="441" height="270">
+      <vector name="origin" x="257" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-23" y="-159"/>
+      <vector name="lt" x="-82" y="-159"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="cd006a056ee26e365a512167cc286e2091db1bc78079495b4ca963838b2787b6"/>
+    </canvas>
+    <canvas name="2" width="485" height="260">
+      <vector name="origin" x="284" y="229"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-30" y="-159"/>
+      <vector name="lt" x="-88" y="-158"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="4b1abdcb8b5d330b610d4ab85b62830c823dcfce493e5768467dd77adfaf2d21"/>
+    </canvas>
+    <canvas name="3" width="504" height="274">
+      <vector name="origin" x="305" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-35" y="-159"/>
+      <vector name="lt" x="-95" y="-158"/>
+      <vector name="rb" x="80" y="-5"/>
+      <string name="_hash" value="1c8248dca779c715f92e01cae4f5026589f8d4dd3ca6e3f7c74b94a2b2798094"/>
+    </canvas>
+    <canvas name="4" width="532" height="317">
+      <vector name="origin" x="322" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-30" y="-159"/>
+      <vector name="lt" x="-94" y="-158"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="d793b1b180a671c265ac9fd4a59bf17d1ed66edfcd35d0ae5c19c019e7a48b7c"/>
+    </canvas>
+    <canvas name="5" width="530" height="264">
+      <vector name="origin" x="310" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="21" y="-158"/>
+      <vector name="lt" x="-35" y="-158"/>
+      <vector name="rb" x="153" y="-6"/>
+      <string name="_hash" value="809607fe1a2d4014dc521442bf431d40eed55ab80d04741c1ba0b0d98f2ee756"/>
+    </canvas>
+    <canvas name="6" width="640" height="329">
+      <vector name="origin" x="373" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-10" y="-157"/>
+      <vector name="lt" x="-114" y="-156"/>
+      <vector name="rb" x="104" y="-5"/>
+      <string name="_hash" value="20a2614efbbc29f3a13793f3c6645eaa27796d20e4a50e870f141a432c91493e"/>
+    </canvas>
+    <canvas name="7" width="672" height="331">
+      <vector name="origin" x="421" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-26" y="-159"/>
+      <vector name="lt" x="-134" y="-158"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="f3124c327948be5960b6b19b8a508a145eb52b15dc9887c178e251f5d73dbfff"/>
+    </canvas>
+    <canvas name="8" width="675" height="319">
+      <vector name="origin" x="436" y="229"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-37" y="-160"/>
+      <vector name="lt" x="-138" y="-159"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="ad3c2b3ab7003fadbb6983598374055e7a32807e05be04e4daf922ac9633538b"/>
+    </canvas>
+    <canvas name="9" width="667" height="300">
+      <vector name="origin" x="436" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-38" y="-159"/>
+      <vector name="lt" x="-135" y="-157"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="dfc398da8bd980d7a0c1aad0e833331228143a28f627b2293eb1821bf91a1052"/>
+    </canvas>
+    <canvas name="10" width="651" height="318">
+      <vector name="origin" x="415" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="-38" y="-159"/>
+      <vector name="lt" x="-143" y="-161"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="c1d4b6c2fd6f424e6b8812d91ed8f7eba9e6942a19cf0dee0c15fd36c61d778e"/>
+    </canvas>
+    <canvas name="11" width="185" height="224">
+      <vector name="origin" x="89" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <canvas name="12" width="185" height="238">
+      <vector name="origin" x="70" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <canvas name="13" width="185" height="248">
+      <vector name="origin" x="60" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <canvas name="14" width="185" height="249">
+      <vector name="origin" x="60" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="有两下子！"/>
+      <string name="1" value="还挺不错嘛。"/>
+    </imgdir>
+    <canvas name="0" width="200" height="243">
+      <vector name="origin" x="42" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="300"/>
+      <vector name="head" x="47" y="-157"/>
+      <vector name="lt" x="-40" y="-164"/>
+      <vector name="rb" x="150" y="-14"/>
+      <string name="_hash" value="5daa75c8f71eeb9ad3c9196029b39825f78e33323c6b1254ad037f707cd494a0"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="哈哈……这还真有意思……"/>
+      <string name="1" value="下次再说……"/>
+    </imgdir>
+    <canvas name="0" width="185" height="242">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="8eff19a074671b027a87c118d653646ec0453ef55b6bd30642ec99fc08139cdd"/>
+    </canvas>
+    <canvas name="1" width="200" height="243">
+      <vector name="origin" x="42" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="198" height="231">
+      <vector name="origin" x="38" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="e8db6d4a3a287932088fcd760e265bfa1ae030abf5dfbf65501e2c3481da384e"/>
+    </canvas>
+    <canvas name="3" width="199" height="236">
+      <vector name="origin" x="36" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="e74f9a99ce5cf1ecf8747361f94b43fdfbe01dbe4f3fffcc31afe69f42ab1de5"/>
+    </canvas>
+    <canvas name="4" width="200" height="239">
+      <vector name="origin" x="35" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="5f89070096c05f04831d1854f239fe67a98b490f91779062bc8c34fb0e9855ab"/>
+    </canvas>
+    <canvas name="5" width="200" height="240">
+      <vector name="origin" x="34" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="78ae5d69b216143abce1bcf5b9fe075d2ecd3db2d2f83958e15459196cd5c59c"/>
+    </canvas>
+    <canvas name="6" width="200" height="236">
+      <vector name="origin" x="33" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="1ccf042d952d64139f253a0f18ef3eb9340835990c326c2265eb513a3a442e4f"/>
+    </canvas>
+    <canvas name="7" width="200" height="202">
+      <vector name="origin" x="32" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="72864690ff5f729fabd3983461ebcfb552b83ca7be3ef24fa5b2beb5279aec26"/>
+    </canvas>
+    <canvas name="8" width="199" height="202">
+      <vector name="origin" x="30" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="a0c76146479a450270bb0b4fc9b663d7f16751281db0f399b6ef6c8afbe29750"/>
+    </canvas>
+    <canvas name="9" width="195" height="200">
+      <vector name="origin" x="27" y="200"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="7b900e327ea9d7d1046f6697b048f66e9f54615f90750e25f8a728633b1a9e46"/>
+    </canvas>
+    <canvas name="10" width="188" height="182">
+      <vector name="origin" x="21" y="182"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="7dde0e84c5e76d44d56dd65c5d327baff7a42515663109872607872064edd6ff"/>
+    </canvas>
+    <canvas name="11" width="180" height="174">
+      <vector name="origin" x="15" y="176"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="f9615ffda2d9f8c8300dfba8ce7dad3b34733eb13400a743b96b5f3520b67ae1"/>
+    </canvas>
+    <canvas name="12" width="164" height="150">
+      <vector name="origin" x="5" y="155"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="1f21c670619af9a830b28198b6dd44bf4a16ee26a6067890d2440532905a66bb"/>
+    </canvas>
+    <canvas name="13" width="134" height="141">
+      <vector name="origin" x="-23" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="3e1584e9160683f37b7826d65595f04b3d544741428fab15e5684cef17942b9c"/>
+    </canvas>
+    <canvas name="14" width="96" height="98">
+      <vector name="origin" x="-53" y="110"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="aafe0ced749eb915c875fc6bd30419a5ae860cf70873765859d044027eafac7a"/>
+    </canvas>
+    <canvas name="15" width="35" height="86">
+      <vector name="origin" x="-59" y="106"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="3f23ee118356dc364bf5f273ef98188d4f45151e8eef7b577a2b0c757e8adbf5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="regen">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="好了，陪你们玩玩吧。"/>
+    </imgdir>
+    <canvas name="0" width="163" height="121">
+      <vector name="origin" x="-104" y="105"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="91c2ee9ab467f619ae8675a5b3b699520b806eab61ef0a69f9dbe6bf9b8c2793"/>
+    </canvas>
+    <canvas name="1" width="183" height="159">
+      <vector name="origin" x="-102" y="144"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1976a5d2184c9f9154544109512c6b9af08407390d161cfa6acc696b412af23e"/>
+    </canvas>
+    <canvas name="2" width="562" height="486">
+      <vector name="origin" x="136" y="470"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c2a7b07b1de4791293acc483c79376b9362b008864adf8cebe60aa0da4c34955"/>
+    </canvas>
+    <canvas name="3" width="857" height="510">
+      <vector name="origin" x="433" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="02fdb09232f268255af3be55eef84d5c555b8ff7d7444699581e6690f9679d90"/>
+    </canvas>
+    <canvas name="4" width="845" height="498">
+      <vector name="origin" x="426" y="470"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fc165ebe1a21759319692592572806dae139f04b6e97ecc70216912eb3d4ddec"/>
+    </canvas>
+    <canvas name="5" width="836" height="483">
+      <vector name="origin" x="425" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a52d3106302948e49156b0cedd836c19fa39e9dea15880917717df4436704879"/>
+    </canvas>
+    <canvas name="6" width="793" height="482">
+      <vector name="origin" x="420" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="820e0a2d2536ddf12b3e1ca30acf05aed9a78ef6189a6d8750b9dc5ab74a16af"/>
+    </canvas>
+    <canvas name="7" width="726" height="463">
+      <vector name="origin" x="361" y="453"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4409c657b01d9195ac2f9d2fd9d776331d6b1984485a8f55181b183c1ad4e069"/>
+    </canvas>
+    <canvas name="8" width="533" height="444">
+      <vector name="origin" x="347" y="434"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="71a9659753612fcf010c031004a245b8ef68b27f5917d7b9f527efe65368a99f"/>
+    </canvas>
+    <canvas name="9" width="371" height="425">
+      <vector name="origin" x="180" y="423"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="be68aea284fc195787a7b09ec9df9fd707e3b4bc7e0a8bdcbf0284541d6f7b31"/>
+    </canvas>
+    <canvas name="10" width="424" height="397">
+      <vector name="origin" x="252" y="339"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="99d8297ced2be46c98e9f7b7f2ebfa05aa634fcae0670ee30117895b299f58a3"/>
+    </canvas>
+    <canvas name="11" width="385" height="301">
+      <vector name="origin" x="202" y="293"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5e5a197f1b4ec2bdd82b3aa4e4458eb594df2f46c21524bbdafe38a426f3734d"/>
+    </canvas>
+    <canvas name="12" width="435" height="346">
+      <vector name="origin" x="175" y="338"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="54cf206ecaa96801253da4a884a166d0de3acc7c5c5d9cb2605a7d27be78d44a"/>
+    </canvas>
+    <canvas name="13" width="468" height="432">
+      <vector name="origin" x="261" y="275"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f47b24f453020aebb0d04e4f5b18210dd014b0cbdabcf70e2f68dc1f7adfff82"/>
+    </canvas>
+    <canvas name="14" width="418" height="240">
+      <vector name="origin" x="246" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="01d6048e047f4f3f0e9cc8f1b3b0c61a71cf059e72f4525b62a81526414476fc"/>
+    </canvas>
+    <canvas name="15" width="374" height="375">
+      <vector name="origin" x="191" y="235"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fe35198d1192f0b2c2423eeec44a4a2d6dd01c577dddc35fd90468d5d714ebcf"/>
+    </canvas>
+    <canvas name="16" width="457" height="398">
+      <vector name="origin" x="150" y="231"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fe2728f8d7c7e3d7e6156bc49bef0b73470d6e53e7df39a01177123965402a47"/>
+    </canvas>
+    <canvas name="17" width="423" height="463">
+      <vector name="origin" x="232" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7a4afd4837bbf03d263f606a74c83ce39eb576d27c4ac54b28c72183a704a4a2"/>
+    </canvas>
+    <canvas name="18" width="386" height="400">
+      <vector name="origin" x="214" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6afdd054e97e20ccd20c2d29a370e96ea75da95e59e2162b19925583368452a9"/>
+    </canvas>
+    <canvas name="19" width="458" height="430">
+      <vector name="origin" x="147" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fcbc1d497400841218f69f842c2ff11c939ded189291b6f9e74443cf0e24c6bc"/>
+    </canvas>
+    <canvas name="20" width="549" height="530">
+      <vector name="origin" x="264" y="391"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7b837f5d967d04bff2b3b22d0fc80e065630d7dc82097cafad36ec77a828a802"/>
+    </canvas>
+    <canvas name="21" width="440" height="308">
+      <vector name="origin" x="249" y="223"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cd1082839f33c179d2ab468e78475f7dac95aaf9baa7a915cd131572d4290fbc"/>
+    </canvas>
+    <canvas name="22" width="350" height="334">
+      <vector name="origin" x="166" y="283"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="576ff27217b5f08c1c7189941c31b431539d776a9dfc1fd335e6ca42b92c7864"/>
+    </canvas>
+    <canvas name="23" width="396" height="360">
+      <vector name="origin" x="186" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="02c536f8d1b0309b9072e700e6f907e405b21171ab49b171d2c54502ccbf7104"/>
+    </canvas>
+    <canvas name="24" width="396" height="376">
+      <vector name="origin" x="184" y="303"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c789cd0e023022ed247ce8f791b47bc668079bb6a397c4f85584b63be551bd2e"/>
+    </canvas>
+    <canvas name="25" width="383" height="382">
+      <vector name="origin" x="179" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="24db6f24fc260ddc8b4f2efd69bb7f4a2dfa694be87c3e308f89c4cad4042a54"/>
+    </canvas>
+    <canvas name="26" width="382" height="382">
+      <vector name="origin" x="178" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="643135538586b9035f9fd736b3340a40d62077a2a0d4c799f0de2384cee4c071"/>
+    </canvas>
+    <canvas name="27" width="378" height="378">
+      <vector name="origin" x="176" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="98d74aa139e963df272005156e82d767f465322b90833cf71306622b0fa8e04f"/>
+    </canvas>
+    <canvas name="28" width="331" height="348">
+      <vector name="origin" x="176" y="290"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="be98dfc1b485b249771faf3ca6d7765d89ca61417ae249625661dd73383311cc"/>
+    </canvas>
+    <canvas name="29" width="330" height="350">
+      <vector name="origin" x="177" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fddab123b8bd0a608448445886c37262dd257f5e47137dacef1d95af4ac803ce"/>
+    </canvas>
+    <canvas name="30" width="320" height="320">
+      <vector name="origin" x="170" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d60774dd0af428efb7b76ebfa8c56c3f7d9a174ab367334b59d53b6a9449a5fe"/>
+    </canvas>
+    <canvas name="31" width="315" height="315">
+      <vector name="origin" x="172" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8f99880f25f2a66ef8bcc98901e48b7b0131e6e8ae11763a7f6f38f5e6e15776"/>
+    </canvas>
+    <canvas name="32" width="190" height="250">
+      <vector name="origin" x="62" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="48683e2e74032776cbbec17ac480e8a53d92a4876d29a0b62c4c873ce305d7fe"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="爆头！"/>
+    </imgdir>
+    <canvas name="0" width="188" height="244">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <canvas name="1" width="232" height="256">
+      <vector name="origin" x="77" y="245"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="42" y="-153"/>
+      <vector name="lt" x="-69" y="-153"/>
+      <vector name="rb" x="142" y="-2"/>
+      <string name="_hash" value="214537a5cc36de5d151a10c4f9d689540c196d105b123da5de1c6177544ac1ca"/>
+    </canvas>
+    <canvas name="2" width="232" height="244">
+      <vector name="origin" x="71" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="49" y="-153"/>
+      <vector name="lt" x="-63" y="-153"/>
+      <vector name="rb" x="151" y="-2"/>
+      <string name="_hash" value="f8db04b9b68b730585a724931bf43ba474d7568604bddfbbbea5e757d558c66b"/>
+    </canvas>
+    <canvas name="3" width="328" height="244">
+      <vector name="origin" x="166" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="51" y="-152"/>
+      <vector name="lt" x="-61" y="-153"/>
+      <vector name="rb" x="149" y="-2"/>
+      <string name="_hash" value="b8b515c48a5c2f450d8d119984291e175a9b3a826a3f6a4305fec1c1787354e9"/>
+    </canvas>
+    <canvas name="4" width="360" height="244">
+      <vector name="origin" x="196" y="233"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="50" y="-153"/>
+      <vector name="lt" x="-63" y="-151"/>
+      <vector name="rb" x="153" y="-1"/>
+      <string name="_hash" value="adc0cb94e8e34478f0052ca7ff2dbd8e648fc591b6b757a8fc0a84a735e4b4a6"/>
+    </canvas>
+    <canvas name="5" width="356" height="240">
+      <vector name="origin" x="189" y="231"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="51" y="-154"/>
+      <vector name="lt" x="-60" y="-153"/>
+      <vector name="rb" x="151" y="-2"/>
+      <string name="_hash" value="8ab19516c08e02325c9480e9a43a4ff4801492d43a6922d2149afa2c5a6d15a6"/>
+    </canvas>
+    <canvas name="6" width="352" height="248">
+      <vector name="origin" x="185" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-59" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="258386dbd7b797a83b954934171db3b244bccb7e1f82d6e297989162956caa63"/>
+    </canvas>
+    <canvas name="7" width="344" height="256">
+      <vector name="origin" x="177" y="245"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-59" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="5edd8f9fbd413cbc185417bde1570b03c6abe6ed6c6cda4e810e7a5925329933"/>
+    </canvas>
+    <canvas name="8" width="328" height="244">
+      <vector name="origin" x="161" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-59" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="9c580e5fa29a90b9df257e68eca3fb4a4be744c86c1e7672547ad7eeb2b7a180"/>
+    </canvas>
+    <canvas name="9" width="320" height="244">
+      <vector name="origin" x="154" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-59" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="4a3e083512c203bddc7e5e494cb1f23a5dc27412f10c910442e6761d188c0f9c"/>
+    </canvas>
+    <canvas name="10" width="288" height="232">
+      <vector name="origin" x="121" y="223"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-59" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="e91e6c206bff96edba103a21511757d61eb1444c752b4081528daa33b04c72f8"/>
+    </canvas>
+    <canvas name="11" width="344" height="232">
+      <vector name="origin" x="153" y="221"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="81" y="-155"/>
+      <vector name="lt" x="-143" y="-156"/>
+      <vector name="rb" x="176" y="-2"/>
+      <string name="_hash" value="f5eaf3bdf8af3ca13d6e2eaff8911ad830589f54c6515a1cee918d233fd5db65"/>
+    </canvas>
+    <canvas name="12" width="364" height="248">
+      <vector name="origin" x="165" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-157" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="a2b3d3aee0f878622b454496f8fa6aa385319a4c3da23294129abf4b815d1655"/>
+    </canvas>
+    <canvas name="13" width="372" height="256">
+      <vector name="origin" x="169" y="244"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="87" y="-152"/>
+      <vector name="lt" x="-157" y="-150"/>
+      <vector name="rb" x="189" y="-2"/>
+      <string name="_hash" value="330dacea6074288362e9f41c3dfae1ef81564d30e6ad6f56c5f187b865a375d4"/>
+    </canvas>
+    <canvas name="14" width="376" height="244">
+      <vector name="origin" x="172" y="235"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="86" y="-153"/>
+      <vector name="lt" x="-9" y="-153"/>
+      <vector name="rb" x="190" y="-3"/>
+      <string name="_hash" value="74e276b3d4579d23f957ed0ef2c3e3bb9cc85201d417dcf8b25c97edf1106eb4"/>
+    </canvas>
+    <canvas name="15" width="376" height="244">
+      <vector name="origin" x="173" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="86" y="-153"/>
+      <vector name="lt" x="0" y="-153"/>
+      <vector name="rb" x="190" y="-3"/>
+      <string name="_hash" value="ec0df6b8d0dc410405bdf40fac51bc1eefd9dca5cf0bed4b551396dc64196b92"/>
+    </canvas>
+    <canvas name="16" width="212" height="232">
+      <vector name="origin" x="10" y="223"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="86" y="-153"/>
+      <vector name="lt" x="-5" y="-152"/>
+      <vector name="rb" x="190" y="-3"/>
+      <string name="_hash" value="cc2c425e688dd55b8416aec87cecb2356867ce1adc0c9d377e6618bd48e3c680"/>
+    </canvas>
+    <canvas name="17" width="188" height="244">
+      <vector name="origin" x="8" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <canvas name="18" width="188" height="244">
+      <vector name="origin" x="44" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <uol name="19" value="../stand/5"/>
+    <uol name="20" value="../stand/7"/>
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-435" y="-228"/>
+        <vector name="rb" x="190" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="76" height="76">
+          <vector name="origin" x="57" y="59"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="9d86bbdebb64d57f7f8ffde218b880c9a2eda0d1dfd0277b8c047d8bb531c2bb"/>
+        </canvas>
+        <canvas name="1" width="92" height="92">
+          <vector name="origin" x="71" y="81"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="3ebace547aea903279411e7c1a409df81a7db270dc4d6851c34a6006b5f9132e"/>
+        </canvas>
+        <canvas name="2" width="112" height="116">
+          <vector name="origin" x="70" y="82"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="5078d0b2b67c9737b7d81d440cb521ad865d440b6a024c706820f329048aacd1"/>
+        </canvas>
+        <canvas name="3" width="116" height="120">
+          <vector name="origin" x="74" y="74"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="605c6e7fb994ad9c4b7233763db479794bcd3b0eb3f29b16ea2449d268fa7c88"/>
+        </canvas>
+        <canvas name="4" width="120" height="124">
+          <vector name="origin" x="66" y="70"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6a1f159386ca9886b7ecc61065351e365235754d7d2fce15773ca85320bf61d9"/>
+        </canvas>
+        <canvas name="5" width="120" height="124">
+          <vector name="origin" x="87" y="115"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="53492d2bd78373169a20bf30a158e53734ed9529182a0c912c00b400fbf5441c"/>
+        </canvas>
+        <canvas name="6" width="120" height="124">
+          <vector name="origin" x="121" y="112"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="bbbd8a95fe48a471f4cf82d2197da4d20c2c2880d41b02bb1b5bdd01bce75942"/>
+        </canvas>
+        <canvas name="7" width="120" height="124">
+          <vector name="origin" x="119" y="107"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6ffc3e05f2df48ed119738ae0625ccdaf93636c1d4e91e8e321fd8702413aab5"/>
+        </canvas>
+        <canvas name="8" width="120" height="124">
+          <vector name="origin" x="113" y="97"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="266171cffb2c739b18cecea0ec70ddd50680c1d88f7c05fb8d3d89e5d1c4406d"/>
+        </canvas>
+        <canvas name="9" width="120" height="124">
+          <vector name="origin" x="100" y="82"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="f15b3c8af5876dfedd42bf5e0f0a5dd230aac7f7891ec2a3bbc7f592f1e9f0e4"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="120"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787131.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787131.img.xml
@@ -1,0 +1,570 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787131.img">
+  <imgdir name="move">
+    <canvas name="0" width="74" height="82">
+      <vector name="origin" x="34" y="90"/>
+      <vector name="head" x="-14" y="-72"/>
+      <vector name="lt" x="-34" y="-90"/>
+      <vector name="rb" x="40" y="-8"/>
+      <string name="_hash" value="628620a3281b39c6f6950a9e9d248bb8f2ab015f0872bee190b11b197fd75cb8"/>
+    </canvas>
+    <canvas name="1" width="73" height="83">
+      <vector name="origin" x="34" y="91"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-34" y="-91"/>
+      <vector name="rb" x="39" y="-8"/>
+      <string name="_hash" value="9c764b528fdbd20872accec2f77da838d84f9eec697eba7fcc926637cb934feb"/>
+    </canvas>
+    <canvas name="2" width="71" height="86">
+      <vector name="origin" x="34" y="93"/>
+      <vector name="head" x="-14" y="-75"/>
+      <vector name="lt" x="-34" y="-93"/>
+      <vector name="rb" x="37" y="-7"/>
+      <string name="_hash" value="a799ec13f86d4dc086f82c5559abfba1c50a5d4de3a25c9071e4e9b623201edc"/>
+    </canvas>
+    <canvas name="3" width="72" height="86">
+      <vector name="origin" x="34" y="94"/>
+      <vector name="head" x="-14" y="-76"/>
+      <vector name="lt" x="-34" y="-94"/>
+      <vector name="rb" x="38" y="-8"/>
+      <string name="_hash" value="351677378cada20ca80e4ee74d19bd8a320e33752d65bcbb08d918bfee207ddd"/>
+    </canvas>
+    <canvas name="4" width="72" height="84">
+      <vector name="origin" x="34" y="93"/>
+      <vector name="head" x="-14" y="-75"/>
+      <vector name="lt" x="-34" y="-93"/>
+      <vector name="rb" x="38" y="-9"/>
+      <string name="_hash" value="4d72fda183f0c7eded0da21816b198c1c7c81d51450ea55cc434da78b27ed8c6"/>
+    </canvas>
+    <canvas name="5" width="73" height="82">
+      <vector name="origin" x="34" y="91"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-34" y="-91"/>
+      <vector name="rb" x="39" y="-9"/>
+      <string name="_hash" value="0e2333cb35e28ce79a5f1dbbe12c9b4098c19de2e66e16e8dcce638d944a3603"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="76" height="88">
+      <vector name="origin" x="36" y="90"/>
+      <vector name="head" x="-14" y="-72"/>
+      <vector name="lt" x="-36" y="-90"/>
+      <vector name="rb" x="40" y="-2"/>
+      <string name="_hash" value="c49776a4f63086b60fae4ddcbacd7107b96867f42d4e560c62998b255a1d9e23"/>
+    </canvas>
+    <canvas name="1" width="75" height="87">
+      <vector name="origin" x="36" y="91"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-36" y="-91"/>
+      <vector name="rb" x="39" y="-4"/>
+      <string name="_hash" value="b8cffb7c439cfef7fd21653c79418c374e02eff3b4ce02a49e6919de3fef6a8a"/>
+    </canvas>
+    <canvas name="2" width="74" height="87">
+      <vector name="origin" x="36" y="92"/>
+      <vector name="head" x="-14" y="-74"/>
+      <vector name="lt" x="-36" y="-92"/>
+      <vector name="rb" x="38" y="-5"/>
+      <string name="_hash" value="c933af444c65403c423b100e1b5ae7737e8c693af64645e0a76c55ccb8554bdd"/>
+    </canvas>
+    <canvas name="3" width="73" height="88">
+      <vector name="origin" x="36" y="93"/>
+      <vector name="head" x="-14" y="-75"/>
+      <vector name="lt" x="-36" y="-93"/>
+      <vector name="rb" x="37" y="-5"/>
+      <string name="_hash" value="36191bf243c863a2428926be45db263e155aa3a0b6a9cd2f63a203d8cddf064a"/>
+    </canvas>
+    <canvas name="4" width="74" height="87">
+      <vector name="origin" x="36" y="92"/>
+      <vector name="head" x="-14" y="-74"/>
+      <vector name="lt" x="-36" y="-92"/>
+      <vector name="rb" x="38" y="-5"/>
+      <string name="_hash" value="bc6b13d51f81c4e68aba971025138185cfe12422810abda790d449dec7037165"/>
+    </canvas>
+    <canvas name="5" width="75" height="87">
+      <vector name="origin" x="36" y="91"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-36" y="-91"/>
+      <vector name="rb" x="39" y="-4"/>
+      <string name="_hash" value="bb6579525f818beb44a9b841de716eb0b7336099473d8b8a3f8229456a036b60"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="hit">
+        <canvas name="0" width="61" height="48">
+          <vector name="origin" x="30" y="24"/>
+          <vector name="lt" x="-30" y="-24"/>
+          <vector name="rb" x="31" y="24"/>
+          <string name="_hash" value="ff0efbcf0b18f8503163b3479695ac8ad9e0f6dcf973a25c7b56a7f2459ac707"/>
+        </canvas>
+        <canvas name="1" width="81" height="80">
+          <vector name="origin" x="29" y="56"/>
+          <vector name="lt" x="-29" y="-56"/>
+          <vector name="rb" x="52" y="24"/>
+          <string name="_hash" value="faef409b2c5cd95f40cc7d2814c64cd539245de97464b4a07b614d1d2981a1f0"/>
+        </canvas>
+        <canvas name="2" width="91" height="82">
+          <vector name="origin" x="49" y="58"/>
+          <vector name="lt" x="-49" y="-58"/>
+          <vector name="rb" x="42" y="24"/>
+          <string name="_hash" value="0c9434c3b6c5d20de376bb7320af7c4c68d634e20145e7dc52c399663480a357"/>
+        </canvas>
+        <canvas name="3" width="90" height="84">
+          <vector name="origin" x="48" y="60"/>
+          <vector name="lt" x="-48" y="-60"/>
+          <vector name="rb" x="42" y="24"/>
+          <string name="_hash" value="3cbca20aabaef328ad79121975216ed0e1c96a530f41a7fa45abe0fc21119bba"/>
+        </canvas>
+        <canvas name="4" width="92" height="92">
+          <vector name="origin" x="50" y="70"/>
+          <vector name="lt" x="-50" y="-70"/>
+          <vector name="rb" x="42" y="22"/>
+          <string name="_hash" value="00787162f54bfa2f81bca14bbe8c98bbcf83cfa74edafd65f89f5da75dcfa88d"/>
+        </canvas>
+        <canvas name="5" width="92" height="86">
+          <vector name="origin" x="50" y="70"/>
+          <vector name="lt" x="-50" y="-70"/>
+          <vector name="rb" x="42" y="16"/>
+          <string name="_hash" value="0529d2fa22961d9c20384b3cbbc43ecea6309726a7aa2241515eaa2fdd1cb81b"/>
+        </canvas>
+        <canvas name="6" width="53" height="76">
+          <vector name="origin" x="51" y="70"/>
+          <vector name="lt" x="-51" y="-70"/>
+          <vector name="rb" x="2" y="6"/>
+          <string name="_hash" value="d7daac9bde5ab9866ffc3d8c03d8420173fdfec97752f272706c6c5306cab424"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="attackAfter" value="1320"/>
+      <imgdir name="range">
+        <vector name="lt" x="-333" y="-325"/>
+        <vector name="rb" x="240" y="100"/>
+      </imgdir>
+    </imgdir>
+    <canvas name="0" width="76" height="88">
+      <vector name="origin" x="36" y="90"/>
+      <vector name="head" x="-14" y="-72"/>
+      <vector name="lt" x="-36" y="-90"/>
+      <vector name="rb" x="40" y="-2"/>
+      <string name="_inlink" value="stand/0"/>
+    </canvas>
+    <canvas name="1" width="122" height="102">
+      <vector name="origin" x="45" y="106"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-45" y="-106"/>
+      <vector name="rb" x="77" y="-4"/>
+      <string name="_hash" value="3536c51d260f142f2f7ad40a27d4d5679e4a5bf7e9e30fc70e7c109c2b7a1062"/>
+    </canvas>
+    <canvas name="2" width="109" height="96">
+      <vector name="origin" x="38" y="101"/>
+      <vector name="head" x="-14" y="-74"/>
+      <vector name="lt" x="-38" y="-101"/>
+      <vector name="rb" x="71" y="-5"/>
+      <string name="_hash" value="72ca84875f46259fda6ba7c8d83a578193ef3a4104cd4b5953c6be5558ba9f5e"/>
+    </canvas>
+    <canvas name="3" width="104" height="91">
+      <vector name="origin" x="37" y="97"/>
+      <vector name="head" x="-14" y="-76"/>
+      <vector name="lt" x="-37" y="-97"/>
+      <vector name="rb" x="67" y="-6"/>
+      <string name="_hash" value="4b5bbae813df785a441bc480327af8553f9fd4200f4beafe03e6a3b534414b9f"/>
+    </canvas>
+    <canvas name="4" width="99" height="87">
+      <vector name="origin" x="35" y="97"/>
+      <vector name="head" x="-14" y="-79"/>
+      <vector name="lt" x="-35" y="-97"/>
+      <vector name="rb" x="64" y="-10"/>
+      <string name="_hash" value="7d72fcfc62ccef5e68bc92d15939f06bbb1819c9291de9c871c391be3151f2a9"/>
+    </canvas>
+    <canvas name="5" width="75" height="87">
+      <vector name="origin" x="34" y="101"/>
+      <vector name="head" x="-14" y="-83"/>
+      <vector name="lt" x="-34" y="-101"/>
+      <vector name="rb" x="41" y="-14"/>
+      <string name="_hash" value="93f2582ef97f69337346310dfe6f8b71c58e212fc4582ea019881fb272eedc31"/>
+    </canvas>
+    <canvas name="6" width="130" height="106">
+      <vector name="origin" x="90" y="104"/>
+      <vector name="head" x="-14" y="-86"/>
+      <vector name="lt" x="-90" y="-104"/>
+      <vector name="rb" x="40" y="2"/>
+      <string name="_hash" value="118f0176b19717a9c317d6ec4d1826510c56924ecc42494e485a6ee017722992"/>
+    </canvas>
+    <canvas name="7" width="277" height="107">
+      <vector name="origin" x="238" y="105"/>
+      <vector name="head" x="-14" y="-87"/>
+      <vector name="lt" x="-238" y="-105"/>
+      <vector name="rb" x="39" y="2"/>
+      <string name="_hash" value="31c89813648fedae9b7ec1cec0cf8c57d962c21056541a987a6d603d31721f05"/>
+    </canvas>
+    <canvas name="8" width="335" height="108">
+      <vector name="origin" x="297" y="106"/>
+      <vector name="head" x="-14" y="-88"/>
+      <vector name="lt" x="-297" y="-106"/>
+      <vector name="rb" x="38" y="2"/>
+      <string name="_hash" value="a410ba284d45e73cfe22ab93737557ea9da6fbcaca10153e1b9bb386353e2fb7"/>
+    </canvas>
+    <canvas name="9" width="322" height="107">
+      <vector name="origin" x="285" y="105"/>
+      <vector name="head" x="-14" y="-87"/>
+      <vector name="lt" x="-285" y="-105"/>
+      <vector name="rb" x="37" y="2"/>
+      <string name="_hash" value="dfac6fe6dfb787b289ea570d7ea0e3aa5b1df792f843636d30e4e6eee74deb11"/>
+    </canvas>
+    <canvas name="10" width="332" height="162">
+      <vector name="origin" x="294" y="161"/>
+      <vector name="head" x="-14" y="-86"/>
+      <vector name="lt" x="-294" y="-161"/>
+      <vector name="rb" x="38" y="1"/>
+      <string name="_hash" value="889fba822226331f5ff7dcb1e0e6ac6473dbb3f23b6e3438b6b917a24d04900b"/>
+    </canvas>
+    <canvas name="11" width="344" height="200">
+      <vector name="origin" x="305" y="199"/>
+      <vector name="head" x="-14" y="-84"/>
+      <vector name="lt" x="-305" y="-199"/>
+      <vector name="rb" x="39" y="1"/>
+      <string name="_hash" value="c25a3a1f5ad07dae41633633d5eba8c01aec909c1a9a081dc86998debf65b6ac"/>
+    </canvas>
+    <canvas name="12" width="350" height="158">
+      <vector name="origin" x="310" y="157"/>
+      <vector name="head" x="-14" y="-81"/>
+      <vector name="lt" x="-310" y="-157"/>
+      <vector name="rb" x="40" y="1"/>
+      <string name="_hash" value="84f613ac5e796a2b2ad65646523b7c640dd0593c7c35cc66f37ad0a8ac0cea94"/>
+    </canvas>
+    <canvas name="13" width="334" height="159">
+      <vector name="origin" x="295" y="158"/>
+      <vector name="head" x="-14" y="-77"/>
+      <vector name="lt" x="-295" y="-158"/>
+      <vector name="rb" x="39" y="1"/>
+      <string name="_hash" value="4b38595a17476079c94a5892bb7fc62f190d611a4099ca5ad3d22b3cb8fa6535"/>
+    </canvas>
+    <canvas name="14" width="333" height="164">
+      <vector name="origin" x="295" y="163"/>
+      <vector name="head" x="-14" y="-75"/>
+      <vector name="lt" x="-295" y="-163"/>
+      <vector name="rb" x="38" y="1"/>
+      <string name="_hash" value="10c0e68dc9933402a171eb58cb2553aa69dadf469b6ee8838487d8acde281e04"/>
+    </canvas>
+    <canvas name="15" width="307" height="164">
+      <vector name="origin" x="270" y="163"/>
+      <vector name="head" x="-14" y="-74"/>
+      <vector name="lt" x="-270" y="-163"/>
+      <vector name="rb" x="37" y="1"/>
+      <string name="_hash" value="b8e549757135c3d6996ef0340f7ae92c6cc5800bba61c280535f4091c0ebd0d9"/>
+    </canvas>
+    <canvas name="16" width="303" height="161">
+      <vector name="origin" x="265" y="160"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-265" y="-160"/>
+      <vector name="rb" x="38" y="1"/>
+      <string name="_hash" value="c5c912b0ff12033599edecdf67ac72ab028d951244dcce33616542b29add4234"/>
+    </canvas>
+    <canvas name="17" width="75" height="87">
+      <vector name="origin" x="36" y="90"/>
+      <vector name="head" x="-14" y="-72"/>
+      <vector name="lt" x="-36" y="-90"/>
+      <vector name="rb" x="39" y="-3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="76" height="88">
+      <vector name="origin" x="36" y="90"/>
+      <vector name="head" x="-14" y="-72"/>
+      <vector name="lt" x="-36" y="-90"/>
+      <vector name="rb" x="40" y="-2"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="77" height="103">
+      <vector name="origin" x="38" y="108"/>
+      <vector name="head" x="-14" y="-74"/>
+      <vector name="lt" x="-38" y="-108"/>
+      <vector name="rb" x="39" y="-5"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="920b7afb1b45f5efe4f9c3c4b98ec3d3807573cf309a34ec655baf45f22da4e0"/>
+    </canvas>
+    <canvas name="2" width="81" height="89">
+      <vector name="origin" x="40" y="97"/>
+      <vector name="head" x="-14" y="-77"/>
+      <vector name="lt" x="-40" y="-97"/>
+      <vector name="rb" x="41" y="-8"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="324b7f69ceb764171767f6425b78bc7ecd55bf443380201b3806b079f0ff9dee"/>
+    </canvas>
+    <canvas name="3" width="85" height="101">
+      <vector name="origin" x="42" y="99"/>
+      <vector name="head" x="-14" y="-81"/>
+      <vector name="lt" x="-42" y="-99"/>
+      <vector name="rb" x="43" y="2"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3c053b508b11d693a8ebfd2f39b0e93cb55191cf839f8d1f3828acac389f7da3"/>
+    </canvas>
+    <canvas name="4" width="89" height="112">
+      <vector name="origin" x="44" y="107"/>
+      <vector name="head" x="-14" y="-89"/>
+      <vector name="lt" x="-44" y="-107"/>
+      <vector name="rb" x="45" y="5"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6660ec98be1e30f7d87229f14e1d97da5dc0e38eb83b2a5923b1b27126e652c1"/>
+    </canvas>
+    <canvas name="5" width="93" height="121">
+      <vector name="origin" x="46" y="117"/>
+      <vector name="head" x="-14" y="-99"/>
+      <vector name="lt" x="-46" y="-117"/>
+      <vector name="rb" x="47" y="4"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fccd1fa592614aaeb65dc8d60c3830eb0f8806d648a7c90d1c6ba1221b786591"/>
+    </canvas>
+    <canvas name="6" width="97" height="127">
+      <vector name="origin" x="48" y="123"/>
+      <vector name="head" x="-14" y="-105"/>
+      <vector name="lt" x="-48" y="-123"/>
+      <vector name="rb" x="49" y="4"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dbf9d6d6d0012292303a4ee906ff13656eebeca0962900a9b040893fe04498d2"/>
+    </canvas>
+    <canvas name="7" width="103" height="136">
+      <vector name="origin" x="51" y="126"/>
+      <vector name="head" x="-14" y="-108"/>
+      <vector name="lt" x="-51" y="-126"/>
+      <vector name="rb" x="52" y="10"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="199959138e821d5c48ceea019209e9c4a6ff1d26664a2d232a1b1a3b3fc6e7dd"/>
+    </canvas>
+    <canvas name="8" width="107" height="139">
+      <vector name="origin" x="53" y="128"/>
+      <vector name="head" x="-14" y="-110"/>
+      <vector name="lt" x="-53" y="-128"/>
+      <vector name="rb" x="54" y="11"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0a42efef17c74412aafea98f45af84f0925b2366c12a00236e5a7104362e01c0"/>
+    </canvas>
+    <canvas name="9" width="113" height="131">
+      <vector name="origin" x="56" y="129"/>
+      <vector name="head" x="-14" y="-111"/>
+      <vector name="lt" x="-56" y="-129"/>
+      <vector name="rb" x="57" y="2"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="44fd71a73d10e5243c97f83ab860abba5041a5f19f028465bffce5e60425ffa3"/>
+    </canvas>
+    <canvas name="10" width="125" height="145">
+      <vector name="origin" x="62" y="130"/>
+      <vector name="head" x="-14" y="-112"/>
+      <vector name="lt" x="-62" y="-130"/>
+      <vector name="rb" x="63" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="572e5bf19da1da84a234de1f37ef248c2ab18282fcec44fdac424ae41351b650"/>
+    </canvas>
+    <canvas name="11" width="163" height="296">
+      <vector name="origin" x="81" y="275"/>
+      <vector name="head" x="-14" y="-112"/>
+      <vector name="lt" x="-81" y="-275"/>
+      <vector name="rb" x="82" y="21"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0aabbb31efa735bbea969b270707de1e16ffd236caeaa5504f307501ad5851ee"/>
+    </canvas>
+    <canvas name="12" width="141" height="303">
+      <vector name="origin" x="70" y="285"/>
+      <vector name="head" x="-14" y="-112"/>
+      <vector name="lt" x="-70" y="-285"/>
+      <vector name="rb" x="71" y="18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ac6867882bc45392160dfbf0f7373d7fa05167fd83b30224c1192dafa5768a47"/>
+    </canvas>
+    <canvas name="13" width="137" height="310">
+      <vector name="origin" x="68" y="285"/>
+      <vector name="head" x="-14" y="-111"/>
+      <vector name="lt" x="-68" y="-285"/>
+      <vector name="rb" x="69" y="25"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="51f0e6836ea2c23e921830e08815242970dc68558f546777b89377c4986e3479"/>
+    </canvas>
+    <canvas name="14" width="138" height="300">
+      <vector name="origin" x="68" y="271"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-68" y="-271"/>
+      <vector name="rb" x="70" y="29"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="96b81a0956ee76f18f51e5b47245accd88488023f985ce1456b8574ca4fc4e25"/>
+    </canvas>
+    <canvas name="15" width="141" height="275">
+      <vector name="origin" x="68" y="247"/>
+      <vector name="head" x="-14" y="-106"/>
+      <vector name="lt" x="-68" y="-247"/>
+      <vector name="rb" x="73" y="28"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0bbe17c920ad4e0a2674ba351766c1d9bc2c585e9ae9d2ff741b92152ea07d3b"/>
+    </canvas>
+    <canvas name="16" width="144" height="275">
+      <vector name="origin" x="67" y="246"/>
+      <vector name="head" x="-14" y="-102"/>
+      <vector name="lt" x="-67" y="-246"/>
+      <vector name="rb" x="77" y="29"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f1423c5e82e2cf978fab70edbb6b6c588e77897e84b1ff92c9349533b2cbe6b2"/>
+    </canvas>
+    <canvas name="17" width="133" height="210">
+      <vector name="origin" x="66" y="199"/>
+      <vector name="head" x="-14" y="-97"/>
+      <vector name="lt" x="-66" y="-199"/>
+      <vector name="rb" x="67" y="11"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c77e9b7d4569c337b0e97e4f2cc9ecfc20fee35ca57642a053767cc937a9bbf5"/>
+    </canvas>
+    <canvas name="18" width="142" height="82">
+      <vector name="origin" x="64" y="109"/>
+      <vector name="head" x="-14" y="-91"/>
+      <vector name="lt" x="-64" y="-109"/>
+      <vector name="rb" x="78" y="-27"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a417855e33339c2aa8fc814b62b8ea73c54ffa7b896a8ae460d197ff738584d6"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="95" height="103">
+      <vector name="origin" x="42" y="111"/>
+      <vector name="head" x="-6" y="-80"/>
+      <vector name="lt" x="-42" y="-111"/>
+      <vector name="rb" x="53" y="-8"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="f633fa95ea6dc080fcc3c09dd7e31010be8668c4cabf9eb8edea05ec4364f042"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="95" height="103">
+      <vector name="origin" x="33" y="111"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="82" height="88">
+      <vector name="origin" x="20" y="97"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="01a7efa78e48640eb65ad86cf962fb11c148932a993dac31d9a0788eeeedc949"/>
+    </canvas>
+    <canvas name="2" width="68" height="81">
+      <vector name="origin" x="2" y="90"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f2dd2f5010ac6db981cd081698c5b43b9950c319968e8adf471488530f9b9a54"/>
+    </canvas>
+    <canvas name="3" width="68" height="81">
+      <vector name="origin" x="-1" y="90"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ff2ed666fbcd9a34e9f33034de97744375c2cb802ad3bc09c44319c2d63d7eaf"/>
+    </canvas>
+    <canvas name="4" width="134" height="99">
+      <vector name="origin" x="33" y="94"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bedcfb1f30c1fd803e5768f3df35cef41297af372fecce35b6da9c887c542f61"/>
+    </canvas>
+    <canvas name="5" width="131" height="139">
+      <vector name="origin" x="28" y="128"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="06acf086cf0327f79587e9fcbd246a477dd779ec21ad53b6161749ed69e34b9c"/>
+    </canvas>
+    <canvas name="6" width="119" height="136">
+      <vector name="origin" x="21" y="132"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ec3b27d89f38a6f8bdd2251582b9d34ea714c3507be23d16985925b023ac482c"/>
+    </canvas>
+    <canvas name="7" width="98" height="129">
+      <vector name="origin" x="12" y="132"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="725c80e5a4925680a8eb7dd59d06f58c6c92e4ab2d56b53169cb369b70085d38"/>
+    </canvas>
+    <canvas name="8" width="96" height="126">
+      <vector name="origin" x="10" y="133"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="530fdbec6c693b86116fb2530e335e5f343d418e6b7686a15646b394dccba9f6"/>
+    </canvas>
+    <canvas name="9" width="62" height="92">
+      <vector name="origin" x="-4" y="93"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f3fb963fc078ae070f34f999fffb790a7ae1662eb00e77e684c3351c7f135d1d"/>
+    </canvas>
+    <canvas name="10" width="52" height="87">
+      <vector name="origin" x="-8" y="90"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d94ef025c321517d6707c566d8dfad88fb019cef9fd7f2d67a1af75353bf409a"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="这只是前菜呢～"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="info">
+    <int name="level" value="120"/>
+    <int name="maxHP" value="1500000"/>
+    <int name="maxMP" value="999999999"/>
+    <int name="PADamage" value="300"/>
+    <int name="MADamage" value="300"/>
+    <int name="acc" value="300"/>
+    <int name="eva" value="30"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="300000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="magic" value="1"/>
+        <int name="attackCount" value="3"/>
+        <int name="disease" value="123"/>
+        <int name="level" value="9"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="speed" value="30"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="让你后悔！"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="18"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="110"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="140"/>
+        <int name="action" value="1"/>
+        <int name="level" value="12"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="revive">
+      <int name="0" value="8787137"/>
+      <int name="1" value="8787137"/>
+      <int name="2" value="8787137"/>
+      <int name="3" value="8787137"/>
+      <int name="4" value="8787137"/>
+      <int name="5" value="8787161"/>
+      <int name="6" value="8787137"/>
+      <int name="7" value="8787137"/>
+      <int name="8" value="8787137"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787148.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787148.img.xml
@@ -1,0 +1,257 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787148.img">
+  <imgdir name="stand">
+    <canvas name="0" width="199" height="267">
+      <vector name="origin" x="114" y="267"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-267"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="92296f27eade5010ac1ed7107c3e2d575e943557945a74dd49bda682e7e49870"/>
+    </canvas>
+    <canvas name="1" width="199" height="266">
+      <vector name="origin" x="114" y="266"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-266"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="951af802f91ab83b8700966d5670dae997380ae3a37e5fec3c9a736ccf5b19fb"/>
+    </canvas>
+    <canvas name="2" width="199" height="267">
+      <vector name="origin" x="114" y="267"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-267"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="ddda466ade9b271a4d8118e1d9b4bf6b12b2dc12b62be40f63062e7bfacd68b1"/>
+    </canvas>
+    <canvas name="3" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="8017382a12f25e58ae3a135a0fd3e1d1d4680b2949833e49580e7abfa4e3f003"/>
+    </canvas>
+    <canvas name="4" width="199" height="269">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="338ab1efafc6ac019bf0e5d6038f7866a86fd6746d006a714c144e4f0ba81eb1"/>
+    </canvas>
+    <canvas name="5" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="71dcae9511ad31579b130e6661388f3b27fb992b72a0891e47335dc00c503bf1"/>
+    </canvas>
+    <canvas name="6" width="199" height="267">
+      <vector name="origin" x="114" y="267"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-267"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="50a18de487e93aa7b9f37ed3df42e705bcceb54b8b89a9783caba5466f8076d6"/>
+    </canvas>
+    <canvas name="7" width="199" height="266">
+      <vector name="origin" x="114" y="266"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-266"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="9343dc529c14bdb26e874c6f96db88f0af473db306d0dc1fe31162820be99458"/>
+    </canvas>
+    <canvas name="8" width="199" height="267">
+      <vector name="origin" x="114" y="267"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-267"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="e8ff0bd7ce308076f8915b9b21a6268fce3ed8c6d32e2c7101f61566b0b2fdfe"/>
+    </canvas>
+    <canvas name="9" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="2a9bb2657d008b88821ecb8c3206965ed52abc5cc68e4277ed5ae5bdb066a76c"/>
+    </canvas>
+    <canvas name="10" width="199" height="269">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="52dcf42b9f460299482ebd9d559803e62bc46407ac5d8e42153e909cc6a9a040"/>
+    </canvas>
+    <canvas name="11" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="37f49bafdbf6b289508efdb48c3d748ca2e962df30c9634eaf689604c262f51b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="11ed2431d7f0fb054f792b11cabe2e1c2ffd8ec10dde4bd5ae9949d0290ce376"/>
+    </canvas>
+    <canvas name="1" width="199" height="269">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="bf39cc5ab85cba52060e6b30eb0a563862a595ddc13a02706eb77206c0f165c1"/>
+    </canvas>
+    <canvas name="2" width="199" height="269">
+      <vector name="origin" x="114" y="270"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-270"/>
+      <vector name="rb" x="85" y="-1"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="b17df7f444630664483e9d9ca190a43ca5618fed6c7c327280f5f3c4aa39ed38"/>
+    </canvas>
+    <canvas name="3" width="199" height="268">
+      <vector name="origin" x="114" y="271"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-271"/>
+      <vector name="rb" x="85" y="-3"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="98cc69eb55f06519743940c509d3b05988b3b703d107ac2cd15f8ea292177ede"/>
+    </canvas>
+    <canvas name="4" width="199" height="267">
+      <vector name="origin" x="114" y="270"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-270"/>
+      <vector name="rb" x="85" y="-3"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="6a2edc96c6bea18774a527d3e64ef8684771cfc1ecf494946a87777354d5b8b7"/>
+    </canvas>
+    <canvas name="5" width="199" height="268">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="-1"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="4eaed9b5cba4eb409c932e2be65577d2f4ed1c27c8b224de33de5b268dca35a7"/>
+    </canvas>
+    <canvas name="6" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="710a897f6bb4fe87768b55978bad6c9b6b719a24d4dd653d6f6cb92341b3805f"/>
+    </canvas>
+    <canvas name="7" width="199" height="269">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="9b7c70d45fdc45e9aaff47ecb867a10bbeaa8c39112606f5c964a90fbce7ce75"/>
+    </canvas>
+    <canvas name="8" width="199" height="269">
+      <vector name="origin" x="114" y="270"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-270"/>
+      <vector name="rb" x="85" y="-1"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="8f58f453749ffa5d582a6c4b579d8c78b2dc74c541518624f329e0ce9a17bfb4"/>
+    </canvas>
+    <canvas name="9" width="199" height="268">
+      <vector name="origin" x="114" y="271"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-271"/>
+      <vector name="rb" x="85" y="-3"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="4ef91d5c356b1be2dfc5c284712d8f64dc1fa5232e064771de97c5286c37ac2e"/>
+    </canvas>
+    <canvas name="10" width="199" height="267">
+      <vector name="origin" x="114" y="270"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-270"/>
+      <vector name="rb" x="85" y="-3"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="1308c651011217d15b0667ad8279e816f812b7417de4955f03ae028df6c96a32"/>
+    </canvas>
+    <canvas name="11" width="199" height="268">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="-1"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="91fd53542a970c6ad3cf154b1106f84d1512da2cdf0e942a2037e9ece051c53f"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="235" height="329">
+      <vector name="origin" x="125" y="329"/>
+      <vector name="head" x="-26" y="-256"/>
+      <vector name="lt" x="-125" y="-329"/>
+      <vector name="rb" x="110" y="0"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="59cd2f0069263309fe15798f415865c2d35e91d8d502834d0f39c6f96500ba6b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="199" height="278">
+      <vector name="origin" x="114" y="278"/>
+      <vector name="head" x="-28" y="-256"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="199" height="298">
+      <vector name="origin" x="104" y="298"/>
+      <vector name="head" x="-28" y="-256"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="别急着走呀～客人，主菜准备上桌了！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="info">
+    <int name="level" value="120"/>
+    <int name="maxHP" value="2000000"/>
+    <int name="maxMP" value="999999999"/>
+    <int name="PADamage" value="350"/>
+    <int name="MADamage" value="400"/>
+    <int name="acc" value="300"/>
+    <string name="elemAttr" value="P2H2F2I2S2L2D2"/>
+    <int name="eva" value="30"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="300000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="speed" value="30"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="让你后悔！"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="revive">
+      <int name="0" value="8787149"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787154.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787154.img.xml
@@ -1,0 +1,371 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787154.img">
+  <imgdir name="info">
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="2"/>
+      </imgdir>
+    </imgdir>
+    <int name="level" value="130"/>
+    <int name="maxHP" value="2000000"/>
+    <int name="maxMP" value="50000"/>
+    <int name="speed" value="50"/>
+    <int name="PADamage" value="380"/>
+    <int name="PDDamage" value="235"/>
+    <int name="MADamage" value="400"/>
+    <int name="MDDamage" value="245"/>
+    <int name="acc" value="930"/>
+    <int name="eva" value="30"/>
+    <int name="pushed" value="5000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="87"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="1"/>
+    <string name="elemAttr" value="S3"/>
+    <string name="mobType" value="1N"/>
+    <int name="firstAttack" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="让你后悔！"/>
+      </imgdir>
+    </imgdir>
+    <int name="boss" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="111" height="108">
+      <vector name="origin" x="46" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="460e24c469d66f2b704168f5b80e494e3911b5eada9db889fd4736af5b113577"/>
+    </canvas>
+    <canvas name="1" width="111" height="107">
+      <vector name="origin" x="46" y="107"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="46f6bef0782fe0783f268fd6f1c636bfcf16063f91bec9f1c75ef9f9dc465ae4"/>
+    </canvas>
+    <canvas name="2" width="111" height="108">
+      <vector name="origin" x="46" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+    </canvas>
+    <canvas name="3" width="110" height="109">
+      <vector name="origin" x="46" y="109"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="d64775c23f9a259b9440779297dea5230a425c23a2c4356667aec54a7749f729"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="107" height="109">
+      <vector name="origin" x="42" y="109"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="43e324252edc699c98a69569ad4a222213a0986231a422e9a33d83899e847549"/>
+    </canvas>
+    <canvas name="1" width="123" height="107">
+      <vector name="origin" x="54" y="107"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="d8b56a2826c6ac87374353bfad4201c23d25d2f3a14c6aefef51e51d196a7a22"/>
+    </canvas>
+    <canvas name="2" width="115" height="108">
+      <vector name="origin" x="50" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="178f33af5a5eef4b78cfd2aa092308d0a59e22f527ed341a0f251cdb827d537d"/>
+    </canvas>
+    <canvas name="3" width="104" height="109">
+      <vector name="origin" x="42" y="109"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="6997b376e2060ef93cd1969a2754005831246950047c9d9697a149cbb480dd43"/>
+    </canvas>
+    <canvas name="4" width="95" height="107">
+      <vector name="origin" x="34" y="107"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="70b4fa155884506fde27c20f562ee4021ce7cf177907f00ca2a129bd54c37a4c"/>
+    </canvas>
+    <canvas name="5" width="98" height="108">
+      <vector name="origin" x="36" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="cdf8838f5f687d0770f7db763a9dc0ea200268bcefdcc4fbff5c692aaeacca81"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <int name="attackAfter" value="840"/>
+      <imgdir name="range">
+        <int name="r" value="300"/>
+        <vector name="sp" x="-116" y="-65"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="122" height="135">
+          <vector name="origin" x="62" y="68"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="06fdb5903a7bc5d2385008ad1b4e2959b23236314faaf5b29aabff9892fde576"/>
+        </canvas>
+        <canvas name="1" width="129" height="123">
+          <vector name="origin" x="66" y="70"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="725f75613d738d6551df9d91e6f66fd76b819418c5bf246971f69938d79075e9"/>
+        </canvas>
+        <canvas name="2" width="148" height="135">
+          <vector name="origin" x="81" y="79"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="d11d4965c52d76ba6014335a2ddd71105f7a859c98ac73df8c225a33b7bbd42d"/>
+        </canvas>
+        <canvas name="3" width="148" height="123">
+          <vector name="origin" x="78" y="69"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="4b7d0009b3dfd94c6cdb081f0a9873660a882326e8b9b65bb0cc1d04e12d667d"/>
+        </canvas>
+        <canvas name="4" width="157" height="120">
+          <vector name="origin" x="83" y="72"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="bf0a508067ee5d9c7dfcf6950a35e1a62a7092ecbda3b34af617db560767329b"/>
+        </canvas>
+        <canvas name="5" width="145" height="120">
+          <vector name="origin" x="70" y="72"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="21aee41be529b867e4983f6d43ac1301d3e0ab65bbd457bc29f4d417c1213d10"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="123" height="77">
+          <vector name="origin" x="62" y="32"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="ecb450a00dc08bd12e49a64ce4d9c93c541642a4d46bb37e49271a3830b6deef"/>
+        </canvas>
+        <canvas name="1" width="104" height="101">
+          <vector name="origin" x="54" y="53"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f57dc456b8fb1f8e6df8b8f9264fc3891fb0822078b866e9a328595f8431e580"/>
+        </canvas>
+        <canvas name="2" width="122" height="122">
+          <vector name="origin" x="61" y="58"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="12155a1ba5549812be2471592c013d1b9a8debc03d4c772588f341ae3f1cece8"/>
+        </canvas>
+      </imgdir>
+      <int name="bulletSpeed" value="250"/>
+      <int name="conMP" value="3"/>
+      <int name="type" value="2"/>
+    </imgdir>
+    <canvas name="0" width="111" height="108">
+      <vector name="origin" x="46" y="108"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="1894c2911a5a2b15061c1199cd20fac8c42bda7c49476d586585377bc0fd52fe"/>
+    </canvas>
+    <canvas name="1" width="149" height="176">
+      <vector name="origin" x="48" y="166"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="90657cf3500703d44984fefa66fa5b400b671be3c0b9a7205a89a26a61c2eac2"/>
+    </canvas>
+    <canvas name="2" width="153" height="178">
+      <vector name="origin" x="45" y="167"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="d5458cfe377ceaad956e6898ce2ba8e25ffe484a5d20daee77c1d93538d2f62a"/>
+    </canvas>
+    <canvas name="3" width="155" height="181">
+      <vector name="origin" x="45" y="168"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="fcc7f000de4d974152a3d7d7bb7ae2979d1ef11fddb656faf251482790d0ddd5"/>
+    </canvas>
+    <canvas name="4" width="154" height="181">
+      <vector name="origin" x="44" y="168"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="d609aebfa8cadf68c2adb06e72147aa4de4c0948e1765818b76c4415896d4ac8"/>
+    </canvas>
+    <canvas name="5" width="154" height="180">
+      <vector name="origin" x="43" y="167"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="da9b25c5d6ea83ffc695e40f62ec821d72fbbce9d0996bbaba5b1f0bf3b81c5d"/>
+    </canvas>
+    <canvas name="6" width="155" height="180">
+      <vector name="origin" x="43" y="167"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="fc1ca39bfa1ce2253d6fa53e734e4693260dced4e6937bac9945be66ca04d6e1"/>
+    </canvas>
+    <canvas name="7" width="184" height="130">
+      <vector name="origin" x="125" y="117"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="a14d3276fb0a43f5aa43db1f4da080b804764cdcd866f5b9f7c3195f96daf604"/>
+    </canvas>
+    <canvas name="8" width="185" height="123">
+      <vector name="origin" x="121" y="110"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="56ebf347f1f5eb4e6a541d063240f6d9056da7ef582fb78c1a7e22649ceb6230"/>
+    </canvas>
+    <canvas name="9" width="167" height="125">
+      <vector name="origin" x="122" y="110"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="9802722a4b8d615a1ad854d2f31541ffd7681aed6a63a55c91b96f4c372f8210"/>
+    </canvas>
+    <canvas name="10" width="170" height="119">
+      <vector name="origin" x="120" y="108"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="61999ccf4e7fefb9f649567d5a1d4d32eddd8cccee6a22745e8bb356ba9f3399"/>
+    </canvas>
+    <canvas name="11" width="172" height="117">
+      <vector name="origin" x="119" y="107"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="8f8985fd382ba62dfaba567bf0cad2d9577dcf4627c7fb4ec369cdfd21d8c94b"/>
+    </canvas>
+    <canvas name="12" width="111" height="108">
+      <vector name="origin" x="46" y="108"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="108" height="119">
+      <vector name="origin" x="44" y="119"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="e72df47a892297cd0570ba2702f6c53cd5bc9574c822aa3cdb08291a47d638ec"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="111" height="108">
+      <vector name="origin" x="46" y="108"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="c94d2aede301c6bf27da2695bca5729fabc8bffb9b68263aa6460ef6a2af7e2a"/>
+    </canvas>
+    <canvas name="1" width="117" height="119">
+      <vector name="origin" x="38" y="119"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="f5b68d1488d52ad971520642d2a9c638b724fd31cd65e474324a61b82c38a5c5"/>
+    </canvas>
+    <canvas name="2" width="122" height="113">
+      <vector name="origin" x="44" y="113"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="4c762a282b3059dda8936aa6eed7967bd984835f15ffae6c233047b5336deeb5"/>
+    </canvas>
+    <canvas name="3" width="123" height="108">
+      <vector name="origin" x="47" y="108"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="6a0e80d64033fb0251d722add81421d61d7f84e5d13454579307fa20f3edf3fa"/>
+    </canvas>
+    <canvas name="4" width="97" height="103">
+      <vector name="origin" x="19" y="103"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="fead3b15af1c6b152bca208cf6bfab5bfc5ac4d5fa3af21a7c5577122b8dab18"/>
+    </canvas>
+    <canvas name="5" width="97" height="103">
+      <vector name="origin" x="18" y="103"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="6" width="142" height="115">
+      <vector name="origin" x="26" y="105"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="365519ff842c6fe161872ab79b986a8af09b2a608f91cc9159ad9a4190600ec9"/>
+    </canvas>
+    <canvas name="7" width="158" height="117">
+      <vector name="origin" x="33" y="107"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="7413e5070321eea2a61df710da3bd753255f9f62518d9d52af57dd8757069c61"/>
+    </canvas>
+    <canvas name="8" width="164" height="120">
+      <vector name="origin" x="36" y="110"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="77df9b89e3e393e5917c33d3d7b107fee85900c9c70160c8817959bb240b8d17"/>
+    </canvas>
+    <canvas name="9" width="167" height="124">
+      <vector name="origin" x="37" y="114"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="06a6e07fe28b65ed32a6ab4695e117c36bc269463780883f5c1872cd86dc0e4d"/>
+    </canvas>
+    <canvas name="10" width="169" height="129">
+      <vector name="origin" x="38" y="119"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="24dae18ec9e399d32a86b3e9e465f7b5bce128e9cbbdd68cb7e02ba7bb7ef0b2"/>
+    </canvas>
+    <canvas name="11" width="93" height="99">
+      <vector name="origin" x="21" y="122"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="28bdb79325ad8a271eb5232615acd1b1cb5affb8cefa8c35dd5555629db2d297"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="招……招待不周。"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787155.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787155.img.xml
@@ -1,0 +1,157 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787155.img">
+  <imgdir name="stand">
+    <canvas name="0" width="89" height="96">
+      <vector name="origin" x="48" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-42" y="-86"/>
+      <vector name="head" x="-9" y="-82"/>
+      <vector name="rb" x="36" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="ae75c61c3692244fed0bd90a8074293d6c917896929b79b9214636871ef35332"/>
+    </canvas>
+    <canvas name="1" width="89" height="96">
+      <vector name="origin" x="47" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-41" y="-86"/>
+      <vector name="head" x="-7" y="-82"/>
+      <vector name="rb" x="37" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="7d51fca313281b0eb78d637a6f5e0398c180ff2ffa1d6495955366f182744d9b"/>
+    </canvas>
+    <canvas name="2" width="89" height="96">
+      <vector name="origin" x="46" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-40" y="-86"/>
+      <vector name="head" x="-5" y="-82"/>
+      <vector name="rb" x="38" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="c4fca248c488048566b3676a734515fbc5b161b28471738a1188f824cbd4bb54"/>
+    </canvas>
+    <canvas name="3" width="89" height="96">
+      <vector name="origin" x="47" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-41" y="-86"/>
+      <vector name="head" x="-7" y="-82"/>
+      <vector name="rb" x="37" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="95f448d0a0707b9db556cc28de7b98c67467c411bc78e5c8e8bd29508e861e56"/>
+    </canvas>
+    <canvas name="4" width="89" height="96">
+      <vector name="origin" x="48" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-42" y="-86"/>
+      <vector name="head" x="-9" y="-82"/>
+      <vector name="rb" x="35" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="5ae246f07e477bbeafc74bdbd54dd201d6f09d540e8e770ee949019c12af20da"/>
+    </canvas>
+    <canvas name="5" width="89" height="96">
+      <vector name="origin" x="49" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-44" y="-86"/>
+      <vector name="head" x="-11" y="-82"/>
+      <vector name="rb" x="35" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="ec6c9e8cf1a1c2fba4cb1b737bad0c7561f194609da5a7384f6b2d82a0999334"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="93" height="108">
+      <vector name="origin" x="44" y="109"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-31" y="-90"/>
+      <vector name="head" x="3" y="-83"/>
+      <vector name="rb" x="50" y="0"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="567a9c1e4fb9c90ca6bce795f5a0b73d73212e9a196a72721b2f428639a5712e"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="99" height="108">
+      <vector name="origin" x="50" y="109"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="2" y="-83"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="96e921770abca91eb9833799506d946df53df1b245b87262156dafa03b494876"/>
+    </canvas>
+    <canvas name="1" width="98" height="102">
+      <vector name="origin" x="52" y="105"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-83"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="a772d5e1b2c9a5cb8c669b5c0ff24c1f2b986d19a9ed2c270d3957e315ea8626"/>
+    </canvas>
+    <canvas name="2" width="112" height="96">
+      <vector name="origin" x="63" y="100"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="7" y="-84"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="d2b2765f0022db31d8a131f5cdd992755fe9d3bb698cd6fc6ee7238a710f6e61"/>
+    </canvas>
+    <canvas name="3" width="118" height="94">
+      <vector name="origin" x="65" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="10" y="-83"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="212288307ec4f7ed9fdb5c69dcdb393633b41668bdc3e1e2cfca6eb36bdbea4c"/>
+    </canvas>
+    <canvas name="4" width="120" height="94">
+      <vector name="origin" x="65" y="94"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="12" y="-80"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="ce6b690a8dcf503def4ffdffe8dcb00be621aee389c0e8f7326a06a570236f39"/>
+    </canvas>
+    <canvas name="5" width="121" height="94">
+      <vector name="origin" x="65" y="91"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="13" y="-77"/>
+      <int name="delay" value="300"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+      <string name="_hash" value="2de3aaa626b2818f047e5a4569a90c2ae2606cf134b0ff5657139f4e418c7a82"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="鍑嗗涓婅彍鍟︼紒锛侊紒"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="105"/>
+    <int name="maxHP" value="100000"/>
+    <int name="maxMP" value="100"/>
+    <int name="speed" value="-20"/>
+    <int name="PADamage" value="130"/>
+    <int name="PDDamage" value="160"/>
+    <int name="MADamage" value="165"/>
+    <int name="MDDamage" value="160"/>
+    <int name="acc" value="140"/>
+    <int name="eva" value="10"/>
+    <int name="exp" value="800"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="300"/>
+    <string name="elemAttr" value="I2F2L2H2"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="revive">
+      <int name="0" value="8787132"/>
+      <int name="1" value="8787132"/>
+      <int name="2" value="8787132"/>
+      <int name="3" value="8787132"/>
+      <int name="4" value="8787132"/>
+      <int name="5" value="8787132"/>
+      <int name="6" value="8787132"/>
+      <int name="7" value="8787132"/>
+      <int name="8" value="8787156"/>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="让你后悔！"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787178.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787178.img.xml
@@ -1,0 +1,539 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787178.img">
+  <imgdir name="move">
+    <canvas name="0" width="48" height="76">
+      <vector name="origin" x="31" y="76"/>
+      <vector name="lt" x="-31" y="-76"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="420e4adee3b34d61d0c297c74301b0662b876fcc93fc0647315a02f75f102d56"/>
+    </canvas>
+    <canvas name="1" width="48" height="77">
+      <vector name="origin" x="34" y="77"/>
+      <vector name="lt" x="-31" y="-76"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fdd1927391a95d0e5ef718482b7a4a3ab44e4f983221a391ba256bb500ea13ca"/>
+    </canvas>
+    <canvas name="2" width="48" height="76">
+      <vector name="origin" x="34" y="76"/>
+      <vector name="lt" x="-31" y="-76"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="87b58567962e4091438bac50be60429144621fd03c31742f67d18ad15a0475d6"/>
+    </canvas>
+    <canvas name="3" width="48" height="77">
+      <vector name="origin" x="32" y="77"/>
+      <vector name="lt" x="-31" y="-76"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a21f520a9be747778289bb7c9de01c9da7cf14f7df7df2e1166fa5cba9fbc58d"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="12b96a1ec4f82043d2982a22e36ba196916e6d8a2b77c881b607b9296d185020"/>
+    </canvas>
+    <canvas name="1" width="49" height="75">
+      <vector name="origin" x="24" y="75"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b846732a38cb9215ce4b3516b537170fb132b4554dae2b0406543e4298f5bda1"/>
+    </canvas>
+    <canvas name="2" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="48" height="78">
+      <vector name="origin" x="27" y="78"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="328a5dbe03347b7dca59e5ee7ef4ad045709123b4d2b82cf97e36db4d35b1cae"/>
+    </canvas>
+    <canvas name="4" width="48" height="77">
+      <vector name="origin" x="28" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c549b9a131bdd60d657b6b75a7b804036069699f862187c4d1038514070491d2"/>
+    </canvas>
+    <canvas name="5" width="49" height="75">
+      <vector name="origin" x="29" y="75"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3e067372532efc0e548f9703311cecf6531750dda56b9c6b39d2e09be77f838c"/>
+    </canvas>
+    <canvas name="6" width="48" height="77">
+      <vector name="origin" x="28" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="48" height="78">
+      <vector name="origin" x="26" y="78"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="49" height="75">
+      <vector name="origin" x="24" y="75"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="48" height="78">
+      <vector name="origin" x="27" y="78"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="48" height="77">
+      <vector name="origin" x="28" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="49" height="75">
+      <vector name="origin" x="29" y="75"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="48" height="78">
+      <vector name="origin" x="28" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="48" height="78">
+      <vector name="origin" x="26" y="78"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="48" height="76">
+      <vector name="origin" x="24" y="76"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4bde60bb6983244684382504d29fb7a7f284d8d46eab815b7d670632e63c6c0e"/>
+    </canvas>
+    <canvas name="17" width="48" height="76">
+      <vector name="origin" x="23" y="76"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="de19dde62123393a9fc1fb81ec3482a76cc3692908d5248ef8feccade241f4b5"/>
+    </canvas>
+    <canvas name="18" width="48" height="76">
+      <vector name="origin" x="24" y="76"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a029e661b4d3ef2c115ee5c976233e430344c06b4e0ae5aff469306113088fb5"/>
+    </canvas>
+    <canvas name="19" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="258d8ee8ddf85707ad2d37c966f046238933530116e6857882f079a82c3fa913"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="71" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <vector name="lt" x="-23" y="-85"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-3" y="-82"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="5fc58806e7bbd51b6cde7daa046329ed542951421933462ef788571d2b0568f2"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="48" height="77">
+      <vector name="origin" x="27" y="77"/>
+      <vector name="head" x="-8" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="71" height="84">
+      <vector name="origin" x="54" y="93"/>
+      <vector name="head" x="-12" y="-91"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="73" height="87">
+      <vector name="origin" x="56" y="91"/>
+      <vector name="head" x="-12" y="-85"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="00736e9dad51bd5b0dc76c6b3148e3db4b2eddc0985709a7c95d3f487d9785eb"/>
+    </canvas>
+    <canvas name="3" width="50" height="74">
+      <vector name="origin" x="34" y="74"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6f487fccd4dbeb722c97ab806f836d4a9d428f46949cf4d907a88feb45ae9193"/>
+    </canvas>
+    <canvas name="4" width="50" height="73">
+      <vector name="origin" x="34" y="73"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="086765faf40f6cd644ae83360886e95319d4f2d89436c1ef035d760d0bb2ff3e"/>
+    </canvas>
+    <canvas name="5" width="50" height="74">
+      <vector name="origin" x="34" y="74"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="50" height="73">
+      <vector name="origin" x="34" y="73"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d1c8b0ce884d0d89118c690d1f0348a242cf81b62459a8bf2dc7a4a5b0feddc3"/>
+    </canvas>
+    <canvas name="7" width="50" height="74">
+      <vector name="origin" x="34" y="74"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f974925437bae7719ce92ce3ab3ccf21bcbd6253bfef3e193e35091a135400b3"/>
+    </canvas>
+    <canvas name="8" width="50" height="73">
+      <vector name="origin" x="34" y="73"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1a12c771acf7859aa05d6636466d229f7d9d84ff2a6a75c6382b2725cde017b1"/>
+    </canvas>
+    <canvas name="9" width="50" height="74">
+      <vector name="origin" x="34" y="74"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f2a28ea2e01079463c70e87b1c3113e4aef1d0f4cb53e1f3682ffcf791aa351e"/>
+    </canvas>
+    <canvas name="10" width="50" height="73">
+      <vector name="origin" x="34" y="73"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="37fcd278494720c6600f0f9e49fb4ca24dda196a59e044779cd5e0ae59136744"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="哼～还没结束呢！！我会在屋顶等你。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-291" y="-146"/>
+        <vector name="rb" x="72" y="1"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="137" height="106">
+          <vector name="origin" x="75" y="92"/>
+          <int name="delay" value="100"/>
+          <string name="_hash" value="53fe57e191c187c8e2bbe1d82a71b618409a30b9b718dc03416d6f95a7c5db05"/>
+        </canvas>
+        <canvas name="1" width="145" height="104">
+          <vector name="origin" x="80" y="92"/>
+          <int name="delay" value="100"/>
+          <string name="_hash" value="1a9cce56ee81acc0c5c9a73f7ad040b5da67a4180a9de599e3f04eefe95e426d"/>
+        </canvas>
+        <canvas name="2" width="206" height="111">
+          <vector name="origin" x="94" y="98"/>
+          <int name="delay" value="100"/>
+          <string name="_hash" value="5f3167922d261220ba52f5aa73766d9c0f6920ef7ed203641c1ed28201eea6ec"/>
+        </canvas>
+        <canvas name="3" width="189" height="83">
+          <vector name="origin" x="88" y="78"/>
+          <int name="delay" value="100"/>
+          <string name="_hash" value="561b503ea3f81b005d1be6ccd7aa470ed4d24a31eda8f321c681b59a8f844654"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="600"/>
+    </imgdir>
+    <canvas name="0" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <string name="_hash" value="0b0773f01e0f929812676344c5e74e92ff106c7d98822a5d8ab7d0d4e2a756f9"/>
+    </canvas>
+    <canvas name="1" width="49" height="76">
+      <vector name="origin" x="27" y="75"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-27" y="-75"/>
+      <vector name="rb" x="22" y="1"/>
+      <vector name="head" x="-8" y="-78"/>
+      <string name="_hash" value="f94a5aa68493a9bc70227cee70c52b9b83bf17cf0855f7ea4fb4beacaabdaadd"/>
+    </canvas>
+    <canvas name="2" width="48" height="76">
+      <vector name="origin" x="27" y="74"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-27" y="-74"/>
+      <vector name="rb" x="22" y="2"/>
+      <vector name="head" x="-8" y="-77"/>
+      <string name="_hash" value="08baf5ffd0f514311b59615dbbdeabeb3bf2f0fbb9919ea3e62b951f302a6d95"/>
+    </canvas>
+    <canvas name="3" width="56" height="74">
+      <vector name="origin" x="20" y="74"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-20" y="-74"/>
+      <vector name="rb" x="36" y="0"/>
+      <vector name="head" x="7" y="-77"/>
+      <string name="_hash" value="c7dadeb9fc76cde30a38fd2c7fa035266631ae845200f892f0fb01787f524de6"/>
+    </canvas>
+    <canvas name="4" width="160" height="94">
+      <vector name="origin" x="95" y="93"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-33" y="-81"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="5" y="-80"/>
+      <string name="_hash" value="b71fddf11dc9585cdd264a08386f3e47a02c11ad54a40a8a945ef815ec7505ea"/>
+    </canvas>
+    <canvas name="5" width="165" height="120">
+      <vector name="origin" x="110" y="119"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-33" y="-81"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="5" y="-80"/>
+      <string name="_hash" value="014f80b85f2ecee66c2dd8b8507772491bcd245b6ad9cb8f054ff20c84fa852a"/>
+    </canvas>
+    <canvas name="6" width="165" height="118">
+      <vector name="origin" x="131" y="118"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-33" y="-81"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="5" y="-80"/>
+      <string name="_hash" value="2330f5e31245da02a9cce01cd75681f251f0e76e2e1f9799229bd27aa42af9af"/>
+    </canvas>
+    <canvas name="7" width="116" height="125">
+      <vector name="origin" x="81" y="125"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-33" y="-81"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="5" y="-80"/>
+      <string name="_hash" value="9f17736be05670a47fa86191789370cf6f83b7bf975478be4664e172391774cc"/>
+    </canvas>
+    <canvas name="8" width="119" height="112">
+      <vector name="origin" x="82" y="112"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-24" y="-80"/>
+      <vector name="rb" x="37" y="0"/>
+      <vector name="head" x="7" y="-78"/>
+      <string name="_hash" value="60ee84a080a2e1b8f38c3a987ba04157f2c7d28725900c22d4a217cff28e0bbf"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-210" y="-112"/>
+        <vector name="rb" x="62" y="23"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="109" height="126">
+          <vector name="origin" x="64" y="110"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6a45abf3e5a613a123363b0a58b760d9ef93341d7a1baa2dbe53a90c201cbf54"/>
+        </canvas>
+        <canvas name="1" width="123" height="104">
+          <vector name="origin" x="63" y="86"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="b58a22ae3b4ffc742aa47d4f09f97e6a7ede77daf5668164fb0b15e7d24ad710"/>
+        </canvas>
+        <canvas name="2" width="115" height="114">
+          <vector name="origin" x="51" y="98"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="b6eaaea178ef5ee59193e7e184e57499874c1474e72b19904e8ea1173a5a0ed7"/>
+        </canvas>
+        <canvas name="3" width="117" height="126">
+          <vector name="origin" x="53" y="110"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="5e255fd8a0266df96ae4173ef0df852e0ac25f405f683ec2181e81d76b17defd"/>
+        </canvas>
+        <canvas name="4" width="120" height="124">
+          <vector name="origin" x="56" y="109"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="67e786b009fe0d1848d69e2cfbcac80130a5202d5d9ee0fc91876d5db771261f"/>
+        </canvas>
+        <canvas name="5" width="113" height="87">
+          <vector name="origin" x="56" y="88"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="f174142b4540c58306a7b7e453ebb00554a739991ac242c1b654052543f167c4"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="720"/>
+    </imgdir>
+    <canvas name="0" width="52" height="77">
+      <vector name="origin" x="29" y="77"/>
+      <vector name="lt" x="-29" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2c61b6512347cac16c460bf69c757123caf6946e15dd3838e52ac1388dcd1356"/>
+    </canvas>
+    <canvas name="1" width="53" height="75">
+      <vector name="origin" x="29" y="75"/>
+      <vector name="lt" x="-29" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a9bce25fe0dc3a87c281c1330d408e605abb785af25d69620be3411fb3f18392"/>
+    </canvas>
+    <canvas name="2" width="59" height="79">
+      <vector name="origin" x="36" y="75"/>
+      <vector name="lt" x="-29" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="29b5de526a406855f6fd4b27ecea640fc3b004119d9769a1db24485a9ed9ee99"/>
+    </canvas>
+    <canvas name="3" width="65" height="93">
+      <vector name="origin" x="42" y="75"/>
+      <vector name="lt" x="-29" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="426e3090f129a08b12b8ccb6babdc934a5ba55cb36e42e5875226056fb2c128a"/>
+    </canvas>
+    <canvas name="4" width="63" height="87">
+      <vector name="origin" x="40" y="75"/>
+      <vector name="lt" x="-29" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a9b04d78a7c4a1a93ee4b11615e8fdbba4b2b8f58c07197b2ce8f2f44625ffd4"/>
+    </canvas>
+    <canvas name="5" width="51" height="77">
+      <vector name="origin" x="32" y="77"/>
+      <vector name="lt" x="-32" y="-77"/>
+      <vector name="rb" x="19" y="0"/>
+      <vector name="head" x="-10" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3e362b75ce071ba6dfb0d42254a3927b71666d7590af3a46fb76a1be9f6f5f5f"/>
+    </canvas>
+    <canvas name="6" width="95" height="78">
+      <vector name="origin" x="78" y="78"/>
+      <vector name="lt" x="-54" y="-78"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8f27cf525eae747562ea0489cf32e5b8f8dc33d6d7c66b90949f12e5313e971b"/>
+    </canvas>
+    <canvas name="7" width="136" height="128">
+      <vector name="origin" x="117" y="115"/>
+      <vector name="lt" x="-32" y="-77"/>
+      <vector name="rb" x="19" y="0"/>
+      <vector name="head" x="-10" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f6a69e63bad3dab1d07a22e21707e495070f6f637608fc2a3ab599a42189868e"/>
+    </canvas>
+    <canvas name="8" width="141" height="115">
+      <vector name="origin" x="121" y="107"/>
+      <vector name="lt" x="-54" y="-78"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2df77589fbe387286c087d0973510014dcb78c3916304cab54b67e2ee12f1688"/>
+    </canvas>
+    <canvas name="9" width="129" height="126">
+      <vector name="origin" x="110" y="114"/>
+      <vector name="lt" x="-32" y="-77"/>
+      <vector name="rb" x="19" y="0"/>
+      <vector name="head" x="-10" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="44bfc058cb7fbd176d4eec3aead5f068f919a14f0fd95d332203d816078c044f"/>
+    </canvas>
+    <canvas name="10" width="134" height="110">
+      <vector name="origin" x="117" y="104"/>
+      <vector name="lt" x="-54" y="-78"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f28c87da6df48edc2ccc1fbf5c16cff42c891db754523cb8ee2ea58815137b51"/>
+    </canvas>
+    <canvas name="11" width="145" height="118">
+      <vector name="origin" x="125" y="108"/>
+      <vector name="lt" x="-32" y="-77"/>
+      <vector name="rb" x="19" y="0"/>
+      <vector name="head" x="-10" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5bd3ce94e1706d3b81ce6aa9d1aaea024878d93e70b1f3eadfaf3036467c8a69"/>
+    </canvas>
+    <canvas name="12" width="61" height="78">
+      <vector name="origin" x="39" y="78"/>
+      <vector name="lt" x="-28" y="-78"/>
+      <vector name="rb" x="22" y="0"/>
+      <vector name="head" x="-7" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="64da4914b8a8401725cd8ceef007650fef0dfeb98b72fea9cb20770f4b0e6165"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="180"/>
+    <int name="maxHP" value="4000000"/>
+    <int name="maxMP" value="8000"/>
+    <int name="speed" value="30"/>
+    <int name="PADamage" value="800"/>
+    <int name="PDDamage" value="920"/>
+    <int name="MADamage" value="700"/>
+    <int name="MDDamage" value="750"/>
+    <int name="acc" value="888"/>
+    <int name="eva" value="70"/>
+    <int name="exp" value="100000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="80000"/>
+    <float name="fs" value="10.0"/>
+    <int name="hpRecovery" value="500"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787179.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787179.img.xml
@@ -1,0 +1,550 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787179.img">
+  <imgdir name="move">
+    <canvas name="0" width="83" height="87">
+      <vector name="origin" x="55" y="86"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1898e5f83eb1cb6648c818dab5e23bcf861906aeccd9a0a443ddf9a63e86747f"/>
+    </canvas>
+    <canvas name="1" width="86" height="85">
+      <vector name="origin" x="58" y="84"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dd63c946ac2ee508236ca61ba65641fea196f63700f899d4923a8c93d16648b9"/>
+    </canvas>
+    <canvas name="2" width="83" height="87">
+      <vector name="origin" x="55" y="86"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="14a1b2f0a418b2173a45ea5fcaf80f781754e8c7ccd5af73ae3caffc3af52ef0"/>
+    </canvas>
+    <canvas name="3" width="81" height="88">
+      <vector name="origin" x="53" y="87"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f640725a3005f02477a41b4a30bbe357a08ff2382aae5e55b8e345e7f47fb0ef"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="83" height="88">
+      <vector name="origin" x="53" y="87"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e3742038950d70997f268297943f7fc553f52793dbb8c9b8272d631c79324e6e"/>
+    </canvas>
+    <canvas name="1" width="83" height="86">
+      <vector name="origin" x="53" y="85"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="97a22ecd1ff29367f294feba7d87d90511910f23d09a27f509f8661cd7610be0"/>
+    </canvas>
+    <canvas name="2" width="83" height="88">
+      <vector name="origin" x="53" y="87"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="215eefc49399aa18d0e3712d2c76dacfc845dcfa9223a1585439c1df3d85086a"/>
+    </canvas>
+    <canvas name="3" width="82" height="89">
+      <vector name="origin" x="53" y="88"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="82583c4c226bc252df7026a827358548f3ca4daee92a2c7dafbf78eccdd809e3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="92" height="88">
+      <vector name="origin" x="43" y="87"/>
+      <vector name="lt" x="-44" y="-88"/>
+      <vector name="rb" x="50" y="1"/>
+      <vector name="head" x="-17" y="-85"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="a81cf292182137d7cc74008a892275fca8d6541f7428eee98eb4417f48d02ec3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="86" height="88">
+      <vector name="origin" x="42" y="87"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3c4f212e229675eba5c050ca325fbe6662340dcdbee152fd404b453d5db4d73d"/>
+    </canvas>
+    <canvas name="1" width="83" height="88">
+      <vector name="origin" x="41" y="87"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f57ef084fa97fe409ba26ec2614cba616980efe52ca146d10b90eee2980408d8"/>
+    </canvas>
+    <canvas name="2" width="96" height="86">
+      <vector name="origin" x="28" y="81"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5ae5c1c7bbbb1c1b33cc38d77e0d8891bee5829e946d5a7efb408b6b32f303e1"/>
+    </canvas>
+    <canvas name="3" width="105" height="89">
+      <vector name="origin" x="32" y="84"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d61d6674f21637d5f485328d1296efb60bd748174286a83f551c9dcd00e9a9f2"/>
+    </canvas>
+    <canvas name="4" width="107" height="87">
+      <vector name="origin" x="32" y="83"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3aed8c6ba6627805294c7aafd3f4a5d59551cf9ec1497125463158cd79609a75"/>
+    </canvas>
+    <canvas name="5" width="109" height="84">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5206d2c7bdf97a23188d963c9bb2831c1c6bd0c55f1af34cc1c7194f454814f5"/>
+    </canvas>
+    <canvas name="6" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7d8d96a15738735e22a38e75bf6af59de60ef1b94b1e389049359a41c9e1ef53"/>
+    </canvas>
+    <canvas name="7" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f2f0b2ee379c0d6c218d16f7bffc3b60b0dc5a41ff13bd1b98dc818b455ab9cf"/>
+    </canvas>
+    <canvas name="8" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="40026ffac9862ccf1dc8dc7556e5d9c16b4d61f8ea57a4e88151a01083b568cf"/>
+    </canvas>
+    <canvas name="9" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cf7c5005119fb56a67cc7a92ce1b3fa2eb57b920742d12049e83cb674aacc0f5"/>
+    </canvas>
+    <canvas name="10" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a06a9959e9b98f23b974631b176196c521d718a4b6341723e8a2a7b6848f5179"/>
+    </canvas>
+    <canvas name="11" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="06d9f3da506a7a84b5fdc4ed395b4c400fdec816f61ecece92c5e6e6f11d154a"/>
+    </canvas>
+    <canvas name="12" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="3a461c0f7c95d8984df0723355568116312d49a05334514d6fb61e6837efc580"/>
+    </canvas>
+    <canvas name="13" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="1d2a05d7fba139804cbe0d6356739abc2d9efc2c3af6e0df23ae0eda8b485637"/>
+    </canvas>
+    <canvas name="14" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="e762aae19d4d38075dbcc18e13c94c92f1666c2ead808f2af768864652d5af47"/>
+    </canvas>
+    <canvas name="15" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="aede0bd33ad6ee4aa602f484c26b81d1b06659e27ab8f560ebcaa4849095d881"/>
+    </canvas>
+    <canvas name="18" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="f49423846ee434adea0f7c7062536b8141a4acd2d08f1e58e517a2db9a0deb4f"/>
+    </canvas>
+    <canvas name="19" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="fa97d46d6a710cc1c17f126ada5ec788b89baa39edaaf59771946fd99c514af1"/>
+    </canvas>
+    <canvas name="20" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="f0c1aa3acc117a73064a40692260fd631f57db4f155228853f668a64bf1c943a"/>
+    </canvas>
+    <canvas name="21" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="3493748479e30b561222683f926b4eb8a22846851cd8724adf5e50499187baa5"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="哼～还没结束呢！！我会在屋顶等你。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-291" y="-146"/>
+        <vector name="rb" x="72" y="1"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="70" height="68">
+          <vector name="origin" x="35" y="67"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="4e3535ceecee873a87488f6693e58934e69f77d82260a1a1051e362caa101fdc"/>
+        </canvas>
+        <canvas name="1" width="118" height="155">
+          <vector name="origin" x="51" y="116"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="f7a7a8d418de5119d19ea2c5fb44d8eb04cfce4bdc4d939c59b3f5850e02366e"/>
+        </canvas>
+        <canvas name="2" width="164" height="153">
+          <vector name="origin" x="86" y="114"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="2b4e7308e6616deb1dd5a09149601e4d86eba68567c2c2b20f113e5d5dd9a266"/>
+        </canvas>
+        <canvas name="3" width="164" height="151">
+          <vector name="origin" x="86" y="112"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6b95dba9a7437225a56c2b85f254cd3cf5796b57087fa4103537315b7e72fe7d"/>
+        </canvas>
+        <canvas name="4" width="153" height="132">
+          <vector name="origin" x="81" y="107"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="a925f554f7f750233cdf915c6da4e2e8810c7319321cd944d1bbd53b853f3d4d"/>
+        </canvas>
+        <canvas name="5" width="155" height="132">
+          <vector name="origin" x="83" y="107"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="9df74b9dbde2c11dba0a3890b95b4a9fe6b4501b7f47eb5cdec2bf2c7b49257c"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="960"/>
+    </imgdir>
+    <canvas name="0" width="170" height="181">
+      <vector name="origin" x="107" y="139"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="2ba0ae038391ef8e136b0d263c897df377a659713029ffd11ae04658b57bdc48"/>
+    </canvas>
+    <canvas name="1" width="122" height="166">
+      <vector name="origin" x="70" y="117"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="89432ba48111ed41427a035b68d04ffe74f8a7a87aa39039250f53bfdeae80d7"/>
+    </canvas>
+    <canvas name="2" width="150" height="130">
+      <vector name="origin" x="87" y="88"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="448b002724a759152289c72b399dd8d4dbf1462f6cf46780c22702f96da1b7f7"/>
+    </canvas>
+    <canvas name="3" width="154" height="192">
+      <vector name="origin" x="75" y="166"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="a38676471c7ef59ad1cb0578c34681c59eb616ba3b5976edf07d8a3427e290cb"/>
+    </canvas>
+    <canvas name="4" width="161" height="120">
+      <vector name="origin" x="101" y="111"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="a28c55b4a30e34359a3a4d97bd9583668b7efbf9bcbd6d8a97bf26109b35ba67"/>
+    </canvas>
+    <canvas name="5" width="100" height="86">
+      <vector name="origin" x="53" y="85"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="3605dd1b01a3d7da4a9b27260ecc2f5ad1b97adda800de74eedaa06a2ab07611"/>
+    </canvas>
+    <canvas name="6" width="83" height="85">
+      <vector name="origin" x="57" y="84"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-58" y="-85"/>
+      <vector name="rb" x="27" y="1"/>
+      <vector name="head" x="-26" y="-79"/>
+      <string name="_hash" value="7686de38416d486ed36e96494e07903e0cd25e71954d31384dee7e372538e9e4"/>
+    </canvas>
+    <canvas name="7" width="235" height="169">
+      <vector name="origin" x="146" y="146"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <string name="_hash" value="9f2e9fecab38d213d7a3e1249368bb1c1b12e464ad9cfef450f4f0e2cafdb7b2"/>
+    </canvas>
+    <canvas name="8" width="287" height="165">
+      <vector name="origin" x="169" y="142"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <string name="_hash" value="cba20203be235e7371a650904cf1a30bf7979ab3057ca4f539c63982c741613e"/>
+    </canvas>
+    <canvas name="9" width="312" height="171">
+      <vector name="origin" x="186" y="144"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <string name="_hash" value="c8f97deec1669eea0619c9056596c4c561252ee8df2c52fb51d4627a2fabf629"/>
+    </canvas>
+    <canvas name="10" width="339" height="174">
+      <vector name="origin" x="206" y="146"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <string name="_hash" value="1f09ea164b9bfde4966e34f86fec218d98136d9122313707d2115b15709e7c98"/>
+    </canvas>
+    <canvas name="11" width="360" height="168">
+      <vector name="origin" x="229" y="142"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <string name="_hash" value="756129d499a07b569bb915137d2f876ae6cdbeffa9b300c6c68f7da8b4c29135"/>
+    </canvas>
+    <canvas name="12" width="371" height="164">
+      <vector name="origin" x="245" y="144"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="08e2a08f0a0cf721e8f1950967518ea21b95d7b38bf3c1473497858f9b8e564a"/>
+    </canvas>
+    <canvas name="13" width="295" height="148">
+      <vector name="origin" x="265" y="144"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0ea5b4eabde5397c3a40649ad983dd7477eed542593a0460185c85cf4b109132"/>
+    </canvas>
+    <canvas name="14" width="316" height="143">
+      <vector name="origin" x="286" y="140"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="aeb134f3dbf0f39cf0228f3c57399a23adf8d46297ba6c78df963c53f462c7e1"/>
+    </canvas>
+    <canvas name="15" width="327" height="138">
+      <vector name="origin" x="298" y="137"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1e63335cea2431a053adbb4f46cb38937fbe9349f9777068e66215f776f19c68"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-210" y="-112"/>
+        <vector name="rb" x="62" y="23"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="83" height="77">
+          <vector name="origin" x="74" y="75"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="fe8e961636db6d411931c6e63ea7ed4414bf81f07aa09cae69a3d7d05d5d5f13"/>
+        </canvas>
+        <canvas name="1" width="134" height="94">
+          <vector name="origin" x="81" y="71"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6925815909794625ae0066db2548b80bb72484d673a62ce0b7b86194e7c23feb"/>
+        </canvas>
+        <canvas name="2" width="143" height="121">
+          <vector name="origin" x="85" y="102"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="a9e228684ee84cea9089d2c914596e8fa34018f5f9ab7f9317d18555f96d8667"/>
+        </canvas>
+        <canvas name="3" width="111" height="128">
+          <vector name="origin" x="49" y="107"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="efb473f9b387f7c76fda011ad9642c8933be5ed62fcd6fe97c9c4fe3cd057360"/>
+        </canvas>
+        <canvas name="4" width="94" height="128">
+          <vector name="origin" x="46" y="111"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="3beb1fbe5396cf9fba6d3100cbafd55cb9429cadf84aec9a49feaa07492e3681"/>
+        </canvas>
+        <canvas name="5" width="76" height="102">
+          <vector name="origin" x="49" y="81"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="351c9a1465ce0488c0d22d872cb64cbd514e3a8d3ebc7b48d655ccb65a0a9196"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="960"/>
+    </imgdir>
+    <canvas name="0" width="83" height="88">
+      <vector name="origin" x="53" y="87"/>
+      <vector name="lt" x="-54" y="-88"/>
+      <vector name="rb" x="30" y="1"/>
+      <vector name="head" x="-24" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="87" height="97">
+      <vector name="origin" x="53" y="92"/>
+      <vector name="lt" x="-54" y="-92"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="-23" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="35ae5b154985cd700b34ef2067ea8c1a5d71b42a63b04c589ef63ec852779141"/>
+    </canvas>
+    <canvas name="2" width="94" height="102">
+      <vector name="origin" x="56" y="95"/>
+      <vector name="lt" x="-54" y="-92"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="-23" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="582a6e364f462348e42c386bdd68f83b49150f58b23bd3f0938d0aca817fd1eb"/>
+    </canvas>
+    <canvas name="3" width="93" height="106">
+      <vector name="origin" x="52" y="98"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="297b009e40508b01964c6b8584a969347384d189d99b6123c9922d73c129b4f5"/>
+    </canvas>
+    <canvas name="4" width="96" height="106">
+      <vector name="origin" x="53" y="98"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="731bb3c8b6de6e94bb0456ae7725cb69d6afb87eaedc2cfc80447e9da1c2f478"/>
+    </canvas>
+    <canvas name="5" width="96" height="108">
+      <vector name="origin" x="53" y="99"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c10c706a73006e149cfc741ea11c91b61ba140b660d20b38f9266b9c6952cba8"/>
+    </canvas>
+    <canvas name="6" width="183" height="101">
+      <vector name="origin" x="153" y="92"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="174f9140e8fac9366cfb1ee5d2f1d1c1151291c7daa99664f5c0256969af15ef"/>
+    </canvas>
+    <canvas name="7" width="201" height="99">
+      <vector name="origin" x="154" y="91"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="01c524de8afff628eabec742f4f49d7295c4c6b624cc9c5f1cd9f089b8e19aef"/>
+    </canvas>
+    <canvas name="8" width="183" height="98">
+      <vector name="origin" x="153" y="91"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="30566d42cb53419601b48c57fff8017692696c4386d8e592865b818a6302e033"/>
+    </canvas>
+    <canvas name="9" width="193" height="107">
+      <vector name="origin" x="146" y="90"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2ea26c82b8731d9804e7c4cb891d4a5af0e15fdd32b9d1337058e78efee4c9b"/>
+    </canvas>
+    <canvas name="10" width="199" height="101">
+      <vector name="origin" x="145" y="85"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6f00715cac24509aa69ffab49d0b009da73115b6e378603af4036f0803faa2ba"/>
+    </canvas>
+    <canvas name="11" width="195" height="86">
+      <vector name="origin" x="143" y="85"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="95dd9055b9388873a8fb1dd276f58cef33a212dabe8a6e39496050f0ca42346a"/>
+    </canvas>
+    <uol name="12" value="5"/>
+    <uol name="13" value="4"/>
+    <uol name="14" value="3"/>
+    <uol name="15" value="2"/>
+    <uol name="16" value="1"/>
+  </imgdir>
+  <imgdir name="jump">
+    <canvas name="0" width="83" height="85">
+      <vector name="origin" x="57" y="97"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-58" y="-98"/>
+      <vector name="rb" x="26" y="-12"/>
+      <vector name="head" x="-31" y="-100"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="180"/>
+    <int name="maxHP" value="3900000"/>
+    <int name="maxMP" value="8000"/>
+    <int name="speed" value="30"/>
+    <int name="PADamage" value="800"/>
+    <int name="PDDamage" value="920"/>
+    <int name="MADamage" value="700"/>
+    <int name="MDDamage" value="750"/>
+    <int name="acc" value="688"/>
+    <int name="eva" value="65"/>
+    <int name="exp" value="100000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="hpRecovery" value="500"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8787180.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8787180.img.xml
@@ -1,0 +1,1255 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787180.img">
+  <imgdir name="stand">
+    <canvas name="0" width="115" height="86">
+      <vector name="origin" x="56" y="86"/>
+      <vector name="lt" x="-56" y="-86"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-11" y="-53"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b0c47f42552e3d57c962b27e69f917dcee4b014a4f854517cd432503b31e59e3"/>
+    </canvas>
+    <canvas name="1" width="121" height="87">
+      <vector name="origin" x="56" y="87"/>
+      <vector name="lt" x="-56" y="-87"/>
+      <vector name="rb" x="65" y="0"/>
+      <vector name="head" x="-7" y="-53"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c9735770149ba96efc0003479ab9188e4747af420408f10c240975a65252230e"/>
+    </canvas>
+    <canvas name="2" width="123" height="86">
+      <vector name="origin" x="56" y="86"/>
+      <vector name="lt" x="-56" y="-86"/>
+      <vector name="rb" x="67" y="0"/>
+      <vector name="head" x="-6" y="-52"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="21387399ca001c7d49713675de56269bb54a4f26a9a9e0889e57128d3be31b36"/>
+    </canvas>
+    <canvas name="3" width="116" height="85">
+      <vector name="origin" x="56" y="85"/>
+      <vector name="lt" x="-56" y="-85"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-11" y="-52"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="47d9ee3172ab83e0d1d15434413b05205eb8d76eb359f80c485a953395c9c2a4"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="122" height="90">
+      <vector name="origin" x="59" y="89"/>
+      <vector name="lt" x="-64" y="-89"/>
+      <vector name="rb" x="58" y="1"/>
+      <vector name="head" x="-11" y="-57"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6699f2c91583e81b7c42eac4475ccdbe50c15413d66b1b1b682167e1d98acab8"/>
+    </canvas>
+    <canvas name="1" width="117" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <vector name="lt" x="-60" y="-86"/>
+      <vector name="rb" x="57" y="1"/>
+      <vector name="head" x="-11" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="72cc07fef2d5029da94d9b359456938dcb732f5f85c1af5496e454c9924d63d2"/>
+    </canvas>
+    <canvas name="2" width="108" height="88">
+      <vector name="origin" x="57" y="87"/>
+      <vector name="lt" x="-57" y="-87"/>
+      <vector name="rb" x="51" y="1"/>
+      <vector name="head" x="-12" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3a94301c3e3a1134f0ae292c3e55ec773f3d2fd0d32c8fa8e2498d30d8ae15d"/>
+    </canvas>
+    <canvas name="3" width="107" height="90">
+      <vector name="origin" x="56" y="89"/>
+      <vector name="lt" x="-56" y="-89"/>
+      <vector name="rb" x="51" y="1"/>
+      <vector name="head" x="-12" y="-57"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="12bdd1fdf51a82610313077ebe1fdf25bb53568e407a78a9cbc1deb9ec988640"/>
+    </canvas>
+    <canvas name="4" width="115" height="91">
+      <vector name="origin" x="59" y="90"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-90"/>
+      <vector name="rb" x="56" y="1"/>
+      <vector name="head" x="-12" y="-57"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8f11ef41ccbdb23f4bc4154a36fad1333df612545e64420c37e1e757dbff7ab4"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="117" height="88">
+      <vector name="origin" x="58" y="88"/>
+      <vector name="lt" x="-58" y="-88"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-11" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bb7f7890765d6a0bd6f988de066aaca64beed8a469b23252932b23f378104fcb"/>
+    </canvas>
+    <canvas name="1" width="103" height="98">
+      <vector name="origin" x="53" y="98"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-28" y="-98"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="4" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e3f2bf31cd039f956fd17995a2bb9287cdc25b12586e00858c9259e629817eca"/>
+    </canvas>
+    <canvas name="2" width="136" height="146">
+      <vector name="origin" x="86" y="137"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-28" y="-98"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="4" y="-64"/>
+      <string name="_hash" value="7c03bc16e24b8e0ff087a6bf32b901e590af3e69f7d5d3b12bf8e40f22dd0454"/>
+    </canvas>
+    <canvas name="3" width="142" height="155">
+      <vector name="origin" x="92" y="142"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-28" y="-98"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="4" y="-64"/>
+      <string name="_hash" value="739bc4c0732333bf6aa33649bc2b69a756569a27b1d4e8156d2e39fe0e9d7d4a"/>
+    </canvas>
+    <canvas name="4" width="146" height="154">
+      <vector name="origin" x="96" y="144"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-28" y="-98"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="4" y="-64"/>
+      <string name="_hash" value="5426b26725f308692bb313e53af94d7b21ddb38f5badcaf0aa8e0c5fa07c5389"/>
+    </canvas>
+    <canvas name="5" width="142" height="146">
+      <vector name="origin" x="92" y="137"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-28" y="-98"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="4" y="-64"/>
+      <string name="_hash" value="457242ee495677b6cfa162e7f4a878cc8d35fdbabe0ff32888b6af470ad5dd59"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="117" height="88">
+      <vector name="origin" x="58" y="88"/>
+      <vector name="head" x="-11" y="-56"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="103" height="98">
+      <vector name="origin" x="53" y="97"/>
+      <vector name="head" x="3" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="136" height="146">
+      <vector name="origin" x="86" y="137"/>
+      <vector name="head" x="2" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="142" height="155">
+      <vector name="origin" x="92" y="142"/>
+      <vector name="head" x="3" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="146" height="154">
+      <vector name="origin" x="96" y="144"/>
+      <vector name="head" x="3" y="-65"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="142" height="146">
+      <vector name="origin" x="92" y="136"/>
+      <vector name="head" x="3" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="94" height="84">
+      <vector name="origin" x="37" y="80"/>
+      <vector name="head" x="9" y="-48"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="36ee7a35804990fac7466d146b53c04bc92de8d4912433e07b9fe397fcac57ad"/>
+    </canvas>
+    <canvas name="7" width="87" height="85">
+      <vector name="origin" x="25" y="81"/>
+      <vector name="head" x="9" y="-49"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e22a9405668bfc587508d3e65806d1c41e220a50ac88a38d84d7cac4ee0c021c"/>
+    </canvas>
+    <canvas name="8" width="88" height="85">
+      <vector name="origin" x="26" y="81"/>
+      <vector name="head" x="26" y="-17"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="61eef33622c24101ef3a7ac6e3bf57618d17c3897ab50832b853f2b4cbcb732e"/>
+    </canvas>
+    <canvas name="9" width="87" height="84">
+      <vector name="origin" x="25" y="80"/>
+      <vector name="head" x="9" y="-47"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="771c998f701d4e6acb1b5b84f116f29d672cef8ecbe42f78663e6e15ad4b8f5c"/>
+    </canvas>
+    <canvas name="10" width="111" height="85">
+      <vector name="origin" x="44" y="81"/>
+      <vector name="head" x="9" y="-48"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="021ca92c572b44d5c7b20ead4dae243bb0e32198d4b39af1dffe39c0f439d8f3"/>
+    </canvas>
+    <canvas name="11" width="141" height="84">
+      <vector name="origin" x="57" y="80"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="9" y="-47"/>
+      <string name="_hash" value="6895496dcc4f1649e817cb52b9cc560a39ea5abba980447ec0c9a77010a8ccd8"/>
+    </canvas>
+    <canvas name="12" width="146" height="85">
+      <vector name="origin" x="59" y="81"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="e585aecaf74a5d50aead2d842f6bff2a9a2120d9076375d067aca41164734e6c"/>
+    </canvas>
+    <canvas name="13" width="146" height="84">
+      <vector name="origin" x="59" y="80"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="08f60f4a863f3053542afd7cec74edd16b7b282ffd2499703fef60c073d637c6"/>
+    </canvas>
+    <canvas name="14" width="146" height="85">
+      <vector name="origin" x="55" y="81"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="e6d190f92935a2bdeeea8b9fde1102a6976681fa56d51edaf7e2e5b269656fff"/>
+    </canvas>
+    <canvas name="15" width="146" height="84">
+      <vector name="origin" x="58" y="80"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="6e92f3274b442d80399fc35587bd7a338081b2a8de02a0345fa03f787b932a6e"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="哼～还没结束呢！！我会在屋顶等你。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-95" y="-82"/>
+        <vector name="rb" x="60" y="1"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="92" height="125">
+          <vector name="origin" x="46" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5964f52b588e51495c01dd76a3095e4d521a9f80280dcb48ce5ecfcee331c7ee"/>
+        </canvas>
+        <canvas name="1" width="103" height="110">
+          <vector name="origin" x="51" y="55"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="3975cd08395b9ab1a0083f696f42855f9e6ede6d5aae80379917d75acba74669"/>
+        </canvas>
+        <canvas name="2" width="101" height="136">
+          <vector name="origin" x="50" y="68"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="50158431679cafeead31e810c246a6bb68151c7dea1797537786ad350ba54cc4"/>
+        </canvas>
+        <canvas name="3" width="105" height="135">
+          <vector name="origin" x="52" y="67"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="763b29ad9baaca682b4f166aacd1265a5822594fa2412d039b13ae2484b465f8"/>
+        </canvas>
+        <canvas name="4" width="112" height="146">
+          <vector name="origin" x="56" y="73"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="151c44b33a1891230c1f00b76aa384ed29fc40cb8ae9c24d4fb1479000b7918f"/>
+        </canvas>
+        <canvas name="5" width="102" height="124">
+          <vector name="origin" x="51" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="74b40413cd7d9b0edede0f0696dc50a87988abe44535d970470d4c447087c36e"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="600"/>
+    </imgdir>
+    <canvas name="0" width="115" height="87">
+      <vector name="origin" x="56" y="86"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="59" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+      <string name="_hash" value="685e9b1b3f5d9300628d52da39161a6a6fbbc7d46564f39de7b8225789e95bdb"/>
+    </canvas>
+    <canvas name="1" width="118" height="90">
+      <vector name="origin" x="60" y="89"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-89"/>
+      <vector name="rb" x="58" y="1"/>
+      <vector name="head" x="-10" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="23c36ba4b352dea2ea5bb809c5877830708e96d81ac3d7bda2213195dc332d76"/>
+    </canvas>
+    <canvas name="2" width="88" height="99">
+      <vector name="origin" x="37" y="98"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-98"/>
+      <vector name="rb" x="51" y="1"/>
+      <vector name="head" x="0" y="-63"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="709f7b6c2c7bdd7455fa3c2694fe7d3fabacc137f5ebe3a6faf2405139c33c42"/>
+    </canvas>
+    <canvas name="3" width="77" height="106">
+      <vector name="origin" x="30" y="105"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-30" y="-105"/>
+      <vector name="rb" x="47" y="1"/>
+      <vector name="head" x="2" y="-66"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="43efc94c2fa178b8fd9a86f3c67e5e9fb7a7426b1f2659f51c31c353fec356a0"/>
+    </canvas>
+    <canvas name="4" width="155" height="83">
+      <vector name="origin" x="95" y="82"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-95" y="-82"/>
+      <vector name="rb" x="60" y="1"/>
+      <vector name="head" x="-14" y="-48"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a7375189d575c5521dd1b4b62248ef0ac0613a269bca5afd8e2118b3737a1b26"/>
+    </canvas>
+    <canvas name="5" width="134" height="85">
+      <vector name="origin" x="74" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-74" y="-83"/>
+      <vector name="rb" x="60" y="2"/>
+      <vector name="head" x="-13" y="-51"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="caf562430d91a87a0fb6e9cac55c70183e1c78b96dfadc79e00857194eb2c2a5"/>
+    </canvas>
+    <canvas name="6" width="122" height="85">
+      <vector name="origin" x="64" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-64" y="-83"/>
+      <vector name="rb" x="58" y="2"/>
+      <vector name="head" x="-12" y="-49"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9cd6d158688d92c72e6a8ff0448a20168092eb3cca4ca3caf54c96148e5e0935"/>
+    </canvas>
+    <canvas name="7" width="122" height="86">
+      <vector name="origin" x="63" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-63" y="-85"/>
+      <vector name="rb" x="59" y="1"/>
+      <vector name="head" x="-11" y="-52"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fe76201215705b58f94caf467fbbce1b9f4972c42eeadce0231782d517d16888"/>
+    </canvas>
+    <uol name="8" value="../stand/0"/>
+    <uol name="9" value="../stand/1"/>
+    <uol name="10" value="../stand/2"/>
+    <uol name="11" value="../stand/3"/>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-711" y="-98"/>
+        <vector name="rb" x="726" y="-21"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="116" height="120">
+          <vector name="origin" x="51" y="66"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8ed2c3d468cd983bcb517f87c318200d199ea02900510cfbc0e3439d27daa8c2"/>
+        </canvas>
+        <canvas name="1" width="108" height="113">
+          <vector name="origin" x="54" y="56"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="2c057ef0f829620f079fb368c7d5594ca1339f33c040c387d69ffaff39cddba9"/>
+        </canvas>
+        <canvas name="2" width="117" height="119">
+          <vector name="origin" x="58" y="59"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e4c279fba43ea074b3e109d6b56bfcf684003cbd78200ebc08334c5b943c6a37"/>
+        </canvas>
+        <canvas name="3" width="125" height="129">
+          <vector name="origin" x="62" y="64"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d49a368d5430625319429ea7ca18057f147279f799d5e9740c15973b76b18e6d"/>
+        </canvas>
+        <canvas name="4" width="134" height="141">
+          <vector name="origin" x="67" y="70"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="febd73dfe38eabcab918a83d219a7a5e45cd4678ffbd93b6a2fad9432c3de54e"/>
+        </canvas>
+        <canvas name="5" width="79" height="88">
+          <vector name="origin" x="39" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="cc795793c247aeb3777e8f5c587226f20ce768ba7b236d8ee201583117431f64"/>
+        </canvas>
+        <canvas name="6" width="62" height="69">
+          <vector name="origin" x="31" y="34"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="dbf5559c52b90fc9927a9a17bb7417dddef010396c54d580e8de32502b9d8292"/>
+        </canvas>
+        <canvas name="7" width="33" height="34">
+          <vector name="origin" x="16" y="17"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="a2d2112016144bdcc85477047359db56a587c6b729f6956b8350656678c42c9b"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1560"/>
+    </imgdir>
+    <canvas name="0" width="117" height="88">
+      <vector name="origin" x="58" y="87"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-58" y="-87"/>
+      <vector name="rb" x="59" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+    </canvas>
+    <canvas name="1" width="128" height="154">
+      <vector name="origin" x="64" y="149"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-52" y="-87"/>
+      <vector name="rb" x="52" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3aa4a6c6d7887b986de9b50b059c770ff353046358079df21fb26b947327788c"/>
+    </canvas>
+    <canvas name="2" width="146" height="170">
+      <vector name="origin" x="68" y="162"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-51" y="-87"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6f6a12458da560293be289e843e87b69f297211a404789c1978277f2c26262ec"/>
+    </canvas>
+    <canvas name="3" width="150" height="159">
+      <vector name="origin" x="69" y="148"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-47" y="-87"/>
+      <vector name="rb" x="42" y="3"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c9de3e8af271c8b1e9e78916de70e944771703f465a2340d76bdb6bed01b9dfa"/>
+    </canvas>
+    <canvas name="4" width="152" height="163">
+      <vector name="origin" x="70" y="155"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-48" y="-86"/>
+      <vector name="rb" x="45" y="2"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2472d3234c6f5329ed020ca480e1279945c1905d18099a0437b54dd2fa5c3806"/>
+    </canvas>
+    <canvas name="5" width="151" height="147">
+      <vector name="origin" x="73" y="139"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-47" y="-86"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f47fd28508f2b6c474b2c187c5b00755631d01d14fe5c9884cd1a2b04cc1f61b"/>
+    </canvas>
+    <canvas name="6" width="155" height="159">
+      <vector name="origin" x="77" y="153"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-48" y="-86"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="95032a2d178ab58df57f93d3ce574ecc317859cff3b178913af5c1fc315e9232"/>
+    </canvas>
+    <canvas name="7" width="152" height="169">
+      <vector name="origin" x="77" y="163"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-47" y="-87"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5b5a4838a0c020c1f992e779bd69b4f61b949395dd9b7b74275a07f242fc3d8a"/>
+    </canvas>
+    <canvas name="8" width="149" height="171">
+      <vector name="origin" x="73" y="165"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-49" y="-86"/>
+      <vector name="rb" x="44" y="2"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7b0dba85813d6f88df935802e62c77b152da4af42cb35b3738e3b2c52f0927eb"/>
+    </canvas>
+    <canvas name="9" width="144" height="159">
+      <vector name="origin" x="67" y="153"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-47" y="-86"/>
+      <vector name="rb" x="42" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b4e99f4956e87f2135f99e79bc4ac43ea117717a632775756b3ce942ef0346e9"/>
+    </canvas>
+    <canvas name="10" width="145" height="160">
+      <vector name="origin" x="65" y="155"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-50" y="-87"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-8" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="111b18303dd8d42cd4e62786ab1380772a0f2a2a0cd81b4fcd2361e20822aed6"/>
+    </canvas>
+    <canvas name="11" width="187" height="96">
+      <vector name="origin" x="86" y="95"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1f5785057c87c223c7c0179e0669f6c2af9dfd8b7bec76af737af1c7179c3109"/>
+    </canvas>
+    <canvas name="12" width="319" height="128">
+      <vector name="origin" x="152" y="124"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ddfeb0a3c60cb9044265b2f70ad3dadd637bc5d9a463eaaea913d3450f57eb80"/>
+    </canvas>
+    <canvas name="13" width="1529" height="158">
+      <vector name="origin" x="757" y="143"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6b2189fb419c5f6fb18751025922a6853a68318fa82a628378725b5f1647731e"/>
+    </canvas>
+    <canvas name="14" width="1501" height="142">
+      <vector name="origin" x="743" y="131"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="64c552cfb6d646e1b58a623da5ac6957b2e1d37f44cb50a9ae7245b852ce6797"/>
+    </canvas>
+    <canvas name="15" width="1489" height="154">
+      <vector name="origin" x="737" y="139"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="999cfc7130a247bffe357f798007471aadabccdaee7c39237f5f6323ba861893"/>
+    </canvas>
+    <canvas name="16" width="1499" height="157">
+      <vector name="origin" x="742" y="139"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dc7abac381aa585ee59dee7f6ffc1408c87c605314df97622334d085f2e65699"/>
+    </canvas>
+    <canvas name="17" width="1507" height="109">
+      <vector name="origin" x="746" y="108"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="72" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f202a611429ed20dde74a9767760ccb24256262ade0c29f7802d754c154b2ffa"/>
+    </canvas>
+    <canvas name="18" width="1533" height="97">
+      <vector name="origin" x="759" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="72" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="da118e6d3541df760dcbbe20633edd0a568bc42102b6efa8052fd2df0e4c13b1"/>
+    </canvas>
+    <canvas name="19" width="1539" height="96">
+      <vector name="origin" x="762" y="95"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="72" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1a4494b615db3e6426cce80b7b59346945000382dca1a9ada1e3485e4417afe9"/>
+    </canvas>
+    <canvas name="20" width="1453" height="97">
+      <vector name="origin" x="719" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="72" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c38f3b9a9203832e40df9970bf9afa922d2030732555b495061b0b05a8fceaa6"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-33" y="-309"/>
+        <vector name="rb" x="41" y="0"/>
+        <int name="start" value="-4"/>
+        <int name="areaCount" value="9"/>
+        <int name="attackCount" value="4"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="78" height="75">
+          <vector name="origin" x="39" y="37"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="badd9f56e36671cea02e387e50ff957982367af578845aeb0204c6d96bf14a59"/>
+        </canvas>
+        <canvas name="1" width="76" height="68">
+          <vector name="origin" x="38" y="34"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="0e7abffa83f8639089d8a8202eb310e77879637d3da5cce1a7d8e66f6dae3514"/>
+        </canvas>
+        <canvas name="2" width="73" height="74">
+          <vector name="origin" x="36" y="37"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="6fc6f3d534d4ea6a79ccef2e2d1cbc4ec7597eb99cc9491a979a325a47dd0717"/>
+        </canvas>
+        <canvas name="3" width="76" height="68">
+          <vector name="origin" x="38" y="34"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="4" width="78" height="75">
+          <vector name="origin" x="39" y="37"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="115" height="15">
+          <vector name="origin" x="57" y="7"/>
+          <int name="delay" value="1680"/>
+          <string name="_hash" value="f90ae113b69b928cb639e4005e8a2f19f8ea9915d54c842ed822374678c927df"/>
+        </canvas>
+        <canvas name="1" width="1" height="1">
+          <vector name="origin" x="57" y="7"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack3/info/areaWarning/0"/>
+        </canvas>
+        <canvas name="2" width="121" height="22">
+          <vector name="origin" x="60" y="11"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6c786d03f298753d12d875dac7d1174123cf04aba011147cef83b5c071e05c2a"/>
+        </canvas>
+        <canvas name="3" width="125" height="36">
+          <vector name="origin" x="62" y="25"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bf75b33260b78c6a1d978b365edadb6190c34268821cf07ca7e026d992792f17"/>
+        </canvas>
+        <canvas name="4" width="125" height="37">
+          <vector name="origin" x="62" y="26"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="02648ff11488ef2177ae6d3b2eab21d2fa0cc99a881ae142568aca8cb39d8d01"/>
+        </canvas>
+        <canvas name="5" width="125" height="39">
+          <vector name="origin" x="62" y="28"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="46312c0237515d0356fb638783e8124b21ce90e8f9472445ac02b01c70ac7be4"/>
+        </canvas>
+        <canvas name="6" width="125" height="39">
+          <vector name="origin" x="62" y="28"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="475b3e0cc1be75652ba868738a3c7f25f96be2a956c26525059e9d85f92084de"/>
+        </canvas>
+        <canvas name="7" width="125" height="39">
+          <vector name="origin" x="62" y="28"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="2f6039c636e35c2d8ce5fd2980da13c1bc63c4c889601478a48ad7509e93c040"/>
+        </canvas>
+        <canvas name="8" width="125" height="40">
+          <vector name="origin" x="62" y="29"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="7668d9c65a6afb24288d5adc4cd27acfccc0ec3ae12fad91e8af35a03aeb8433"/>
+        </canvas>
+        <canvas name="9" width="161" height="350">
+          <vector name="origin" x="80" y="325"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="04459d34cc6e142d1f7322d1b3638d9154c1b16aad6127dfe90bc6e186c98f3c"/>
+        </canvas>
+        <canvas name="10" width="165" height="339">
+          <vector name="origin" x="86" y="325"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="05800a06c5156a80d9f278a69896266417f54e69ce5ba3ac02aff11290872204"/>
+        </canvas>
+        <canvas name="11" width="165" height="345">
+          <vector name="origin" x="86" y="330"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="2cec2a7f92e3865db18fa5d33559d40443c4244735cc30a5cb8a0702aae2cb29"/>
+        </canvas>
+        <canvas name="12" width="163" height="339">
+          <vector name="origin" x="82" y="325"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="fa52d87f3215e5052f55534ba9e5a277f7a417aa0e878b80318153d0fc680fa5"/>
+        </canvas>
+        <canvas name="13" width="159" height="285">
+          <vector name="origin" x="82" y="285"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1e4d2434a58092551f5bc70c66f0b827d5ebcc03586a8f988a1398b73bbf8525"/>
+        </canvas>
+        <canvas name="14" width="86" height="151">
+          <vector name="origin" x="43" y="285"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="89914a4e99f8eea4cae19231b054e786836b39e9cb0d6075bb6536d7501a1075"/>
+        </canvas>
+        <canvas name="15" width="88" height="149">
+          <vector name="origin" x="44" y="285"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="a65f4b7ff417a4cd13f4735754f2ebe3d98ca737cefc27e13d43b66dd4ec662d"/>
+        </canvas>
+        <canvas name="16" width="81" height="144">
+          <vector name="origin" x="40" y="285"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="69147b924ab412aedc58bdbe4764b20d6255a81e33b4430a9679aeb58097f714"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="2790"/>
+    </imgdir>
+    <canvas name="0" width="117" height="88">
+      <vector name="origin" x="58" y="87"/>
+      <vector name="lt" x="-54" y="-88"/>
+      <vector name="rb" x="30" y="1"/>
+      <vector name="head" x="-24" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="128" height="154">
+      <vector name="origin" x="64" y="149"/>
+      <vector name="lt" x="-54" y="-92"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="-23" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fd54515b0ad5a4252c53327e328703ef44c79e4b8558c0a4d8752eac34ffee10"/>
+    </canvas>
+    <canvas name="2" width="146" height="170">
+      <vector name="origin" x="68" y="162"/>
+      <vector name="lt" x="-54" y="-92"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="-23" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dfd5f24937ef5ecc68abadba98c979406cca16c2b8c83d1c971bf28fc89104af"/>
+    </canvas>
+    <canvas name="3" width="150" height="157">
+      <vector name="origin" x="69" y="148"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="603fe6f3498aad15a4b2e552a7bba3836127b0c997bb7e2a6dfafde4341a65b7"/>
+    </canvas>
+    <canvas name="4" width="152" height="163">
+      <vector name="origin" x="70" y="155"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ee1288610eb02e41eaf65063a5d23a0d6e332b7e00b1991b568ffb1037b06f29"/>
+    </canvas>
+    <canvas name="5" width="151" height="147">
+      <vector name="origin" x="73" y="139"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="83c965493262e16dc5a4217117fa493db44dc970d3a02d337f23108b652a0339"/>
+    </canvas>
+    <canvas name="6" width="155" height="159">
+      <vector name="origin" x="77" y="153"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8e2dc38ad54b13933afe647e103d66c3d63a81c207d42a44bba028502aefd499"/>
+    </canvas>
+    <canvas name="7" width="152" height="169">
+      <vector name="origin" x="77" y="163"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c0299b85b052dcc82d3c6d44a6fa065ba35bd562d1beb4a0a9886d96c25cdd7c"/>
+    </canvas>
+    <canvas name="8" width="149" height="171">
+      <vector name="origin" x="73" y="165"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2dba7d15ab60b5dd7d0137a7b7f66841a81a8983053dc6d23fd54ab2ebdc9b21"/>
+    </canvas>
+    <canvas name="9" width="144" height="161">
+      <vector name="origin" x="67" y="155"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a41b71af7399691f5f591496270a64cd9974c7c5f0e024557abf2623e93c663c"/>
+    </canvas>
+    <canvas name="10" width="148" height="168">
+      <vector name="origin" x="68" y="162"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a5e5d9c692172b73c95ee75d8777d93f067cb766f58dc10a396bdc8ae233c53f"/>
+    </canvas>
+    <canvas name="11" width="154" height="153">
+      <vector name="origin" x="69" y="146"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="523fb8dab9e69c6ea3209a9b8c868183219498a0f2a3833450a256f84de5d401"/>
+    </canvas>
+    <canvas name="12" width="152" height="155">
+      <vector name="origin" x="66" y="149"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="450c8c8811b4c0d8d84006f383aababe67080a48ae529bf3a65a909bee67a197"/>
+    </canvas>
+    <canvas name="13" width="144" height="136">
+      <vector name="origin" x="69" y="131"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="417bcffe132d605ade7aeedc8c5afb085961f1a0d0226701fbba1f39aeff4fbb"/>
+    </canvas>
+    <canvas name="14" width="226" height="93">
+      <vector name="origin" x="162" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8e1bc6c102c27f816ec9479991e7570296cf556ca0964bebfa2a8ed43ef22fbf"/>
+    </canvas>
+    <canvas name="15" width="270" height="88">
+      <vector name="origin" x="166" y="78"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="13f8bccc566f6f990f7ec69a780e2b4e34f309d05cd3e637338f26033550b693"/>
+    </canvas>
+    <canvas name="16" width="261" height="93">
+      <vector name="origin" x="167" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="84eb38c28cae45fb12e9e58ecf33c89fed7913824a1d234407e23615c2c908fb"/>
+    </canvas>
+    <canvas name="17" width="257" height="93">
+      <vector name="origin" x="167" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="aab8eb1264c8846aa9609e02d0591c784bf760121360e4ccd26f5a3a9fefb810"/>
+    </canvas>
+    <canvas name="18" width="216" height="88">
+      <vector name="origin" x="130" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="efa4fba21fa318ae99bd0e68328d48d23187bf4a477d57f4468b6a817be57bf2"/>
+    </canvas>
+    <canvas name="19" width="252" height="91">
+      <vector name="origin" x="167" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="40e3df5e1250762c247f727ef79f56250058292772e3235bdf29538eae6770e7"/>
+    </canvas>
+    <canvas name="20" width="135" height="90">
+      <vector name="origin" x="51" y="89"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0843fb182980ec77d4314cfa3347c922881158bdc8fbcbb588a39daadc40e894"/>
+    </canvas>
+    <canvas name="21" width="117" height="88">
+      <vector name="origin" x="58" y="87"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d02718ed1b5b880796baa331ee43b1a662be663c518a15917d6bf9c6cf5f4c67"/>
+    </canvas>
+    <canvas name="22" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="123" height="86">
+      <vector name="origin" x="61" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="123" height="86">
+      <vector name="origin" x="61" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="116" height="85">
+      <vector name="origin" x="56" y="84"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="26" width="116" height="85">
+      <vector name="origin" x="56" y="84"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="27" width="115" height="86">
+      <vector name="origin" x="56" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="28" width="115" height="86">
+      <vector name="origin" x="56" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="29" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="30" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="31" width="123" height="86">
+      <vector name="origin" x="61" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="32" width="123" height="86">
+      <vector name="origin" x="61" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="33" width="116" height="85">
+      <vector name="origin" x="56" y="84"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="34" width="116" height="85">
+      <vector name="origin" x="56" y="84"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="35" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="36" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="37" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-230" y="-144"/>
+        <vector name="rb" x="240" y="17"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="136" height="127">
+          <vector name="origin" x="68" y="63"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="b387a30765e2fe4857dd72c0b46dd5d99d8da82d87f5eb89634a50d4e4e6969d"/>
+        </canvas>
+        <canvas name="1" width="139" height="124">
+          <vector name="origin" x="69" y="62"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="791795eeff7cc632ae8384cb0933c220a89c08b52b91926e5afce3ca136ed3f7"/>
+        </canvas>
+        <canvas name="2" width="143" height="129">
+          <vector name="origin" x="71" y="64"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="b9afed6b101039a16aa1b033e70be7884ddd713bca468b5fa759093871ca9eb7"/>
+        </canvas>
+        <canvas name="3" width="168" height="124">
+          <vector name="origin" x="84" y="62"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="0fb3119eadbedffb553986408c5c5c5f77dece4034ccb321f1de04adae7c83c8"/>
+        </canvas>
+        <canvas name="4" width="174" height="72">
+          <vector name="origin" x="87" y="36"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="e1a0f4ba8cad079740b7235c3402d05b5dbd97d79380f207b89d3d147a7c43e7"/>
+        </canvas>
+        <canvas name="5" width="128" height="23">
+          <vector name="origin" x="64" y="11"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="026d25ddcbe8c5d9e2d2d1322e79d84a6941a7459a9dec075e0bc82f3f1063b3"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1200"/>
+    </imgdir>
+    <canvas name="0" width="1" height="1">
+      <vector name="origin" x="58" y="87"/>
+      <vector name="lt" x="-58" y="-87"/>
+      <vector name="rb" x="59" y="1"/>
+      <vector name="head" x="-11" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_inlink" value="hit1/0"/>
+    </canvas>
+    <canvas name="1" width="128" height="154">
+      <vector name="origin" x="64" y="149"/>
+      <vector name="lt" x="-53" y="-85"/>
+      <vector name="rb" x="53" y="1"/>
+      <vector name="head" x="-11" y="-52"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="401769c1caf411c6311dc8ee272c292f3e9c7a42df5cd7a629831c56848ab0c2"/>
+    </canvas>
+    <canvas name="2" width="146" height="170">
+      <vector name="origin" x="68" y="162"/>
+      <vector name="lt" x="-49" y="-85"/>
+      <vector name="rb" x="44" y="2"/>
+      <vector name="head" x="-11" y="-52"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="14e24acb769bf27153a77f95ca2e00cc88db528aeb299de675741a793f549c03"/>
+    </canvas>
+    <canvas name="3" width="150" height="157">
+      <vector name="origin" x="69" y="148"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="927d1446d8d620ae15ebac9a759cdd51aca908112b00f7122349aac67ba9c752"/>
+    </canvas>
+    <canvas name="4" width="152" height="163">
+      <vector name="origin" x="70" y="155"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="757a1dcd29f091223037f229cad99b96efe805d491ae4cddd14bbf474294e4b5"/>
+    </canvas>
+    <canvas name="5" width="151" height="147">
+      <vector name="origin" x="73" y="139"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4e055fc01038f1ccd9e8b2fc974a82be8f74833b4791a1d6801fb27d204b892f"/>
+    </canvas>
+    <canvas name="6" width="155" height="159">
+      <vector name="origin" x="77" y="153"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="829bd8dc4039109cf4fb259ab31cc09c650438861ca3d55c983f6e0de9b9db39"/>
+    </canvas>
+    <canvas name="7" width="152" height="174">
+      <vector name="origin" x="77" y="163"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ea7fb237c1b526a62f52294056bb98253adf391111c416e373406652ed43522d"/>
+    </canvas>
+    <canvas name="8" width="149" height="177">
+      <vector name="origin" x="73" y="165"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="eb3f901e10d9cdc913090a29f13ca20da2df30508cac858a7698db37ebb84dd4"/>
+    </canvas>
+    <canvas name="9" width="144" height="167">
+      <vector name="origin" x="67" y="153"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="30ce06aeae07639e40b60cf929a4c88f7ac1f79abc8902e20cb1c0f72221baf6"/>
+    </canvas>
+    <canvas name="10" width="145" height="170">
+      <vector name="origin" x="65" y="155"/>
+      <vector name="lt" x="-51" y="-87"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-7" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3ecd57322bbd6238441f2a5327f778e6497d8f4c73cdeeaf69285fb55a92c016"/>
+    </canvas>
+    <canvas name="11" width="344" height="178">
+      <vector name="origin" x="171" y="150"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2bb0f09675dba22a7afe9379703853dc3f15707ea6efce7d9ac3480f4982518"/>
+    </canvas>
+    <canvas name="12" width="483" height="236">
+      <vector name="origin" x="237" y="207"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3af83f6f598c43d0f73a76272b922395115198219315fb39bf48cb3accfa8b0b"/>
+    </canvas>
+    <canvas name="13" width="561" height="220">
+      <vector name="origin" x="276" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="87c207c05a537c4b2a900036ec7ac5ab06766c925532b2b3d65d3febd7387930"/>
+    </canvas>
+    <canvas name="14" width="603" height="225">
+      <vector name="origin" x="297" y="197"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4d7f8d7d9b6590ac927bd30605834bd634f1dbf033b7f69e9ed134d85620dc6"/>
+    </canvas>
+    <canvas name="15" width="601" height="220">
+      <vector name="origin" x="296" y="195"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fb3604d34a2b1cc06f64b309afacb406811590f6b25b96fa832b88774faeb3b1"/>
+    </canvas>
+    <canvas name="16" width="591" height="212">
+      <vector name="origin" x="291" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6df32e6afb60fc749530f161e3c4f7da7c1b51e287865448a5a1975f1d620eb9"/>
+    </canvas>
+    <canvas name="17" width="492" height="109">
+      <vector name="origin" x="247" y="95"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="738bac0f1bd3a02b9c55719c4aac33817dfc9218277963df765f2a4ab9beda3c"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="180"/>
+    <int name="maxHP" value="8000000"/>
+    <int name="maxMP" value="8000"/>
+    <int name="speed" value="15"/>
+    <int name="PADamage" value="850"/>
+    <int name="PDDamage" value="920"/>
+    <int name="MADamage" value="800"/>
+    <int name="MDDamage" value="750"/>
+    <int name="acc" value="999"/>
+    <int name="eva" value="70"/>
+    <int name="exp" value="180000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="hpRecovery" value="500"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8830000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8830000.img.xml
@@ -1,0 +1,1483 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8830000.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="105"/>
+    <int name="maxHP" value="4280000"/>
+    <int name="maxMP" value="30000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="480"/>
+    <int name="PDDamage" value="200"/>
+    <int name="MADamage" value="230"/>
+    <int name="MDDamage" value="320"/>
+    <int name="acc" value="250"/>
+    <int name="eva" value="12"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="50000"/>
+    <int name="hpRecovery" value="100"/>
+    <int name="mpRecovery" value="100"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="noFlip" value="1"/>
+    <int name="boss" value="1"/>
+    <string name="defaultHP" value="Unknown"/>
+    <string name="defaultMP" value="Unknown"/>
+    <int name="mobType" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="145"/>
+        <int name="action" value="1"/>
+        <int name="level" value="3"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="133"/>
+        <int name="action" value="1"/>
+        <int name="level" value="3"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="default">
+      <canvas name="0" width="253" height="217">
+        <vector name="origin" x="126" y="108"/>
+        <int name="z" value="0"/>
+      </canvas>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="1"/>
+    </imgdir>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="HPgaugeHide" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="821" height="558">
+      <vector name="origin" x="321" y="557"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-400" y="-600"/>
+        <vector name="rb" x="400" y="0"/>
+        <int name="start" value="-4"/>
+        <int name="areaCount" value="9"/>
+        <int name="attackCount" value="9"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="2640"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="1" width="32" height="61">
+          <vector name="origin" x="140" y="392"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="443" height="267">
+          <vector name="origin" x="267" y="592"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="514" height="298">
+          <vector name="origin" x="269" y="618"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="521" height="358">
+          <vector name="origin" x="270" y="670"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="524" height="364">
+          <vector name="origin" x="271" y="660"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="525" height="637">
+          <vector name="origin" x="271" y="633"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="527" height="474">
+          <vector name="origin" x="273" y="469"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="540" height="153">
+          <vector name="origin" x="273" y="148"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="541" height="151">
+          <vector name="origin" x="273" y="147"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="534" height="149">
+          <vector name="origin" x="265" y="145"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="11" width="431" height="145">
+          <vector name="origin" x="160" y="142"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="12" width="354" height="136">
+          <vector name="origin" x="82" y="134"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="13" width="353" height="72">
+          <vector name="origin" x="83" y="71"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="104" height="111">
+          <vector name="origin" x="52" y="55"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="89" height="84">
+          <vector name="origin" x="44" y="42"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="100" height="82">
+          <vector name="origin" x="50" y="41"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="117" height="95">
+          <vector name="origin" x="58" y="47"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="126" height="105">
+          <vector name="origin" x="63" y="52"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="conMP" value="5"/>
+      <int name="tremble" value="1"/>
+      <int name="attackAfter" value="3240"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="1200"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="1" width="823" height="566">
+      <vector name="origin" x="317" y="565"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="819" height="569">
+      <vector name="origin" x="312" y="568"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="815" height="571">
+      <vector name="origin" x="308" y="570"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="810" height="573">
+      <vector name="origin" x="304" y="572"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="806" height="574">
+      <vector name="origin" x="301" y="573"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="802" height="576">
+      <vector name="origin" x="298" y="575"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="798" height="578">
+      <vector name="origin" x="295" y="577"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="794" height="579">
+      <vector name="origin" x="292" y="578"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="790" height="580">
+      <vector name="origin" x="289" y="579"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="12" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="13" width="899" height="566">
+      <vector name="origin" x="391" y="565"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="14" width="886" height="565">
+      <vector name="origin" x="383" y="564"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="15" width="878" height="564">
+      <vector name="origin" x="372" y="563"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="16" width="844" height="563">
+      <vector name="origin" x="343" y="562"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="17" width="832" height="562">
+      <vector name="origin" x="328" y="561"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="18" width="819" height="561">
+      <vector name="origin" x="320" y="560"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="19" width="827" height="560">
+      <vector name="origin" x="325" y="559"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="20" width="819" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="21" width="827" height="558">
+      <vector name="origin" x="327" y="557"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="22" width="819" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="23" width="827" height="560">
+      <vector name="origin" x="325" y="559"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-733" y="-760"/>
+        <vector name="rb" x="864" y="20"/>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="4" height="4">
+          <vector name="origin" x="36" y="53"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect0">
+        <int name="effectType" value="1"/>
+        <int name="effectDistance" value="130"/>
+        <int name="randomPos" value="1"/>
+        <int name="delay" value="740"/>
+        <vector name="lt" x="-733" y="-760"/>
+        <vector name="rb" x="864" y="20"/>
+        <imgdir name="0">
+          <canvas name="0" width="126" height="97">
+            <vector name="origin" x="60" y="98"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="1" width="133" height="99">
+            <vector name="origin" x="63" y="99"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="2" width="135" height="98">
+            <vector name="origin" x="63" y="98"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="3" width="136" height="95">
+            <vector name="origin" x="62" y="95"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="4" width="136" height="100">
+            <vector name="origin" x="62" y="100"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="5" width="136" height="100">
+            <vector name="origin" x="62" y="100"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="6" width="133" height="88">
+            <vector name="origin" x="60" y="87"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="7" width="125" height="64">
+            <vector name="origin" x="57" y="64"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="8" width="53" height="29">
+            <vector name="origin" x="40" y="31"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+        </imgdir>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="83" height="60">
+          <vector name="origin" x="40" y="52"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="1" width="99" height="105">
+          <vector name="origin" x="50" y="97"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="2" width="84" height="107">
+          <vector name="origin" x="41" y="99"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="3" width="71" height="104">
+          <vector name="origin" x="41" y="101"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="4" width="72" height="104">
+          <vector name="origin" x="42" y="115"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="930"/>
+      <int name="magic" value="1"/>
+      <string name="elemAttr" value="F"/>
+    </imgdir>
+    <canvas name="0" width="821" height="558">
+      <vector name="origin" x="321" y="557"/>
+      <int name="delay" value="210"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="1" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="828" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="831" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="836" height="566">
+      <vector name="origin" x="329" y="565"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="839" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="841" height="569">
+      <vector name="origin" x="332" y="568"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="844" height="570">
+      <vector name="origin" x="333" y="569"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="827" height="565">
+      <vector name="origin" x="324" y="564"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="825" height="567">
+      <vector name="origin" x="323" y="566"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="823" height="567">
+      <vector name="origin" x="322" y="566"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="12" width="821" height="565">
+      <vector name="origin" x="321" y="564"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="13" width="823" height="567">
+      <vector name="origin" x="322" y="566"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="14" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="15" width="828" height="561">
+      <vector name="origin" x="325" y="560"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <uol name="16" value="../stand/1"/>
+    <uol name="17" value="../stand/2"/>
+    <uol name="18" value="../stand/3"/>
+    <uol name="19" value="../stand/4"/>
+    <uol name="20" value="../stand/5"/>
+    <uol name="21" value="../stand/6"/>
+    <uol name="22" value="../stand/7"/>
+    <uol name="23" value="../stand/8"/>
+    <uol name="24" value="../stand/9"/>
+    <uol name="25" value="../stand/10"/>
+    <uol name="26" value="../stand/11"/>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-57" y="-200"/>
+        <vector name="rb" x="57" y="0"/>
+        <int name="start" value="-5"/>
+        <int name="areaCount" value="11"/>
+        <int name="attackCount" value="4"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="54" height="14">
+          <vector name="origin" x="28" y="10"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="74" height="18">
+          <vector name="origin" x="36" y="14"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="79" height="57">
+          <vector name="origin" x="38" y="53"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="83" height="71">
+          <vector name="origin" x="41" y="67"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="84" height="73">
+          <vector name="origin" x="40" y="71"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="84" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="83" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="83" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="83" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="83" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="83" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="11" width="114" height="474">
+          <vector name="origin" x="54" y="472"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="12" width="125" height="478">
+          <vector name="origin" x="60" y="476"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="13" width="128" height="470">
+          <vector name="origin" x="61" y="468"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="14" width="130" height="449">
+          <vector name="origin" x="62" y="447"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="15" width="143" height="163">
+          <vector name="origin" x="73" y="142"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="16" width="150" height="123">
+          <vector name="origin" x="77" y="115"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="17" width="151" height="124">
+          <vector name="origin" x="76" y="113"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="18" width="156" height="129">
+          <vector name="origin" x="77" y="111"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="19" width="156" height="132">
+          <vector name="origin" x="76" y="109"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="20" width="156" height="103">
+          <vector name="origin" x="80" y="103"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="104" height="111">
+          <vector name="origin" x="57" y="59"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="89" height="84">
+          <vector name="origin" x="43" y="45"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="100" height="82">
+          <vector name="origin" x="49" y="40"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="117" height="95">
+          <vector name="origin" x="57" y="46"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="126" height="105">
+          <vector name="origin" x="60" y="51"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="attackAfter" value="2040"/>
+      <int name="conMP" value="10"/>
+      <int name="deadlyAttack" value="1"/>
+      <int name="PADamage" value="560"/>
+    </imgdir>
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="1" width="827" height="560">
+      <vector name="origin" x="324" y="559"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="827" height="559">
+      <vector name="origin" x="324" y="558"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="827" height="558">
+      <vector name="origin" x="324" y="557"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="827" height="557">
+      <vector name="origin" x="324" y="556"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="827" height="556">
+      <vector name="origin" x="324" y="555"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="827" height="555">
+      <vector name="origin" x="324" y="554"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="827" height="554">
+      <vector name="origin" x="324" y="553"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="827" height="553">
+      <vector name="origin" x="324" y="552"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="827" height="554">
+      <vector name="origin" x="324" y="553"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="827" height="556">
+      <vector name="origin" x="324" y="555"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="827" height="558">
+      <vector name="origin" x="324" y="557"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="12" width="827" height="559">
+      <vector name="origin" x="324" y="558"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="13" width="827" height="560">
+      <vector name="origin" x="324" y="559"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="14" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="15" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="16" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="17" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="18" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <uol name="19" value="0"/>
+    <uol name="20" value="0"/>
+    <uol name="21" value="0"/>
+    <uol name="22" value="0"/>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-482" y="-668"/>
+        <vector name="rb" x="789" y="10"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="73" height="103">
+          <vector name="origin" x="41" y="99"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="96" height="127">
+          <vector name="origin" x="53" y="116"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="106" height="137">
+          <vector name="origin" x="58" y="122"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="114" height="142">
+          <vector name="origin" x="62" y="124"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="120" height="150">
+          <vector name="origin" x="65" y="129"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="126" height="152">
+          <vector name="origin" x="68" y="130"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="156" height="110">
+          <vector name="origin" x="83" y="112"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="155" height="117">
+          <vector name="origin" x="84" y="116"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="8" width="154" height="119">
+          <vector name="origin" x="84" y="118"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="9" width="140" height="104">
+          <vector name="origin" x="75" y="111"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="10" width="73" height="58">
+          <vector name="origin" x="41" y="76"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="hitAfter" value="810"/>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="disease" value="127"/>
+      <int name="level" value="12"/>
+      <int name="magic" value="1"/>
+      <int name="attackAfter" value="1200"/>
+    </imgdir>
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="1" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="835" height="565">
+      <vector name="origin" x="328" y="564"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="837" height="566">
+      <vector name="origin" x="329" y="565"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="839" height="567">
+      <vector name="origin" x="330" y="566"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="841" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="841" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="841" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="841" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="12" width="841" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="13" width="839" height="567">
+      <vector name="origin" x="330" y="566"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="14" width="835" height="565">
+      <vector name="origin" x="328" y="564"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="15" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="16" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="3"/>
+      <string name="0" value="我要打破特里斯坦的封印。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill16">
+    <canvas name="0" width="876" height="584">
+      <vector name="origin" x="376" y="583"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="876" height="583">
+      <vector name="origin" x="376" y="582"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="876" height="581">
+      <vector name="origin" x="376" y="580"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="878" height="579">
+      <vector name="origin" x="376" y="578"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="880" height="576">
+      <vector name="origin" x="376" y="575"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="882" height="573">
+      <vector name="origin" x="376" y="572"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="883" height="569">
+      <vector name="origin" x="376" y="568"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="882" height="566">
+      <vector name="origin" x="376" y="565"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="879" height="561">
+      <vector name="origin" x="376" y="560"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="300"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="1" width="823" height="566">
+      <vector name="origin" x="317" y="565"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="819" height="569">
+      <vector name="origin" x="312" y="568"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="815" height="571">
+      <vector name="origin" x="308" y="570"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="810" height="573">
+      <vector name="origin" x="304" y="572"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="806" height="574">
+      <vector name="origin" x="301" y="573"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="802" height="576">
+      <vector name="origin" x="298" y="575"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="798" height="578">
+      <vector name="origin" x="295" y="577"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="794" height="579">
+      <vector name="origin" x="292" y="578"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="790" height="580">
+      <vector name="origin" x="289" y="579"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="785" height="582">
+      <vector name="origin" x="285" y="581"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="12" width="784" height="583">
+      <vector name="origin" x="284" y="582"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="13" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="14" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="15" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="16" width="784" height="583">
+      <vector name="origin" x="284" y="582"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="17" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="18" width="794" height="579">
+      <vector name="origin" x="292" y="578"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="19" width="802" height="576">
+      <vector name="origin" x="298" y="575"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="20" width="810" height="573">
+      <vector name="origin" x="304" y="572"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="21" width="819" height="569">
+      <vector name="origin" x="312" y="568"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="22" width="823" height="566">
+      <vector name="origin" x="317" y="565"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="特里斯坦的结界还笼罩着这个洞窟吗？我没有力量了。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="944" height="752">
+      <vector name="origin" x="441" y="560"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="944" height="752">
+      <vector name="origin" x="441" y="560"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="942" height="751">
+      <vector name="origin" x="441" y="559"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="941" height="750">
+      <vector name="origin" x="441" y="558"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="940" height="749">
+      <vector name="origin" x="441" y="557"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="939" height="748">
+      <vector name="origin" x="441" y="556"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="938" height="747">
+      <vector name="origin" x="441" y="555"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="939" height="748">
+      <vector name="origin" x="441" y="556"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="942" height="751">
+      <vector name="origin" x="441" y="559"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="945" height="758">
+      <vector name="origin" x="441" y="566"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="951" height="762">
+      <vector name="origin" x="441" y="570"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="11" width="948" height="764">
+      <vector name="origin" x="441" y="572"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="12" width="953" height="767">
+      <vector name="origin" x="441" y="575"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="13" width="950" height="769">
+      <vector name="origin" x="441" y="577"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="14" width="955" height="770">
+      <vector name="origin" x="441" y="578"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="15" width="952" height="771">
+      <vector name="origin" x="441" y="579"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="16" width="957" height="772">
+      <vector name="origin" x="441" y="580"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="17" width="954" height="773">
+      <vector name="origin" x="441" y="581"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="18" width="957" height="772">
+      <vector name="origin" x="441" y="580"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="19" width="954" height="773">
+      <vector name="origin" x="441" y="581"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="20" width="957" height="772">
+      <vector name="origin" x="441" y="580"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="21" width="954" height="773">
+      <vector name="origin" x="441" y="581"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <uol name="22" value="20"/>
+    <uol name="23" value="21"/>
+    <uol name="24" value="20"/>
+    <uol name="25" value="21"/>
+    <uol name="26" value="20"/>
+    <uol name="27" value="21"/>
+    <uol name="28" value="20"/>
+    <uol name="29" value="21"/>
+    <uol name="30" value="20"/>
+    <uol name="31" value="21"/>
+    <uol name="32" value="20"/>
+    <uol name="33" value="21"/>
+    <uol name="34" value="20"/>
+    <uol name="35" value="21"/>
+    <uol name="36" value="20"/>
+    <uol name="37" value="21"/>
+    <uol name="38" value="20"/>
+    <uol name="39" value="20"/>
+    <uol name="40" value="21"/>
+    <uol name="41" value="20"/>
+    <uol name="42" value="21"/>
+    <uol name="43" value="20"/>
+    <uol name="44" value="21"/>
+    <uol name="45" value="20"/>
+    <uol name="46" value="21"/>
+    <uol name="47" value="20"/>
+    <uol name="48" value="21"/>
+    <uol name="49" value="20"/>
+    <uol name="50" value="21"/>
+    <uol name="51" value="20"/>
+    <uol name="52" value="21"/>
+    <uol name="53" value="20"/>
+    <uol name="54" value="21"/>
+    <uol name="55" value="20"/>
+    <uol name="56" value="21"/>
+    <uol name="57" value="20"/>
+    <uol name="58" value="20"/>
+    <uol name="59" value="21"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8830001.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8830001.img.xml
@@ -1,0 +1,1130 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8830001.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="60"/>
+    <int name="maxHP" value="2640000"/>
+    <int name="maxMP" value="3000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="220"/>
+    <int name="PDDamage" value="500"/>
+    <int name="MADamage" value="360"/>
+    <int name="MDDamage" value="250"/>
+    <int name="acc" value="250"/>
+    <int name="eva" value="12"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="50000"/>
+    <int name="hpRecovery" value="100"/>
+    <int name="mpRecovery" value="100"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="noFlip" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="159"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="160"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="revive">
+      <int name="0" value="8830004"/>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="1"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="1" width="276" height="200">
+      <vector name="origin" x="377" y="208"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="2" width="276" height="203">
+      <vector name="origin" x="377" y="207"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="3" width="276" height="200">
+      <vector name="origin" x="377" y="206"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="4" width="275" height="197">
+      <vector name="origin" x="376" y="207"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="5" width="275" height="196">
+      <vector name="origin" x="376" y="208"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="6" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="7" width="276" height="200">
+      <vector name="origin" x="377" y="210"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="8" width="276" height="203">
+      <vector name="origin" x="377" y="211"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="9" width="276" height="200">
+      <vector name="origin" x="377" y="212"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="10" width="275" height="199">
+      <vector name="origin" x="376" y="211"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="11" width="275" height="198">
+      <vector name="origin" x="376" y="210"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-70" y="-100"/>
+        <vector name="rb" x="70" y="0"/>
+        <int name="start" value="-3"/>
+        <int name="areaCount" value="7"/>
+        <int name="attackCount" value="3"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="900"/>
+        </canvas>
+        <canvas name="1" width="10" height="16">
+          <vector name="origin" x="2" y="15"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="16" height="18">
+          <vector name="origin" x="8" y="17"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="34" height="21">
+          <vector name="origin" x="25" y="20"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="29" height="26">
+          <vector name="origin" x="18" y="25"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="5" width="29" height="47">
+          <vector name="origin" x="18" y="46"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="6" width="124" height="139">
+          <vector name="origin" x="67" y="133"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="7" width="134" height="134">
+          <vector name="origin" x="70" y="133"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="8" width="139" height="134">
+          <vector name="origin" x="69" y="133"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="9" width="141" height="134">
+          <vector name="origin" x="70" y="133"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="10" width="141" height="134">
+          <vector name="origin" x="69" y="133"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="11" width="140" height="132">
+          <vector name="origin" x="72" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="12" width="129" height="133">
+          <vector name="origin" x="58" y="132"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="13" width="121" height="56">
+          <vector name="origin" x="46" y="56"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="104" height="111">
+          <vector name="origin" x="57" y="59"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="89" height="84">
+          <vector name="origin" x="43" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="100" height="82">
+          <vector name="origin" x="49" y="40"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="117" height="95">
+          <vector name="origin" x="57" y="46"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="126" height="105">
+          <vector name="origin" x="60" y="51"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="attackAfter" value="1500"/>
+      <int name="conMP" value="10"/>
+      <int name="PADamage" value="560"/>
+    </imgdir>
+    <canvas name="0" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="1" width="355" height="223">
+      <vector name="origin" x="456" y="212"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="2" width="362" height="234">
+      <vector name="origin" x="463" y="215"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="3" width="365" height="239">
+      <vector name="origin" x="466" y="217"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="4" width="368" height="243">
+      <vector name="origin" x="469" y="218"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="5" width="369" height="247">
+      <vector name="origin" x="470" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="6" width="369" height="246">
+      <vector name="origin" x="470" y="218"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="7" width="369" height="248">
+      <vector name="origin" x="470" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="8" width="369" height="247">
+      <vector name="origin" x="470" y="218"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="9" width="369" height="249">
+      <vector name="origin" x="470" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="10" width="369" height="248">
+      <vector name="origin" x="470" y="218"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="11" width="368" height="250">
+      <vector name="origin" x="469" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="12" width="370" height="224">
+      <vector name="origin" x="469" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="13" width="370" height="235">
+      <vector name="origin" x="469" y="205"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="14" width="372" height="233">
+      <vector name="origin" x="471" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="15" width="377" height="230">
+      <vector name="origin" x="477" y="201"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="16" width="381" height="230">
+      <vector name="origin" x="481" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="17" width="389" height="227">
+      <vector name="origin" x="489" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="18" width="371" height="221">
+      <vector name="origin" x="471" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="19" width="369" height="216">
+      <vector name="origin" x="469" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="20" width="275" height="192">
+      <vector name="origin" x="375" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-486" y="-134"/>
+        <vector name="rb" x="-30" y="5"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="112" height="111">
+          <vector name="origin" x="49" y="104"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="81" height="109">
+          <vector name="origin" x="34" y="104"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="77" height="110">
+          <vector name="origin" x="32" y="104"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="76" height="103">
+          <vector name="origin" x="32" y="102"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="74" height="94">
+          <vector name="origin" x="34" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="55" height="82">
+          <vector name="origin" x="21" y="81"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="2400"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="274" height="402">
+      <vector name="origin" x="375" y="413"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="285" height="402">
+      <vector name="origin" x="387" y="414"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="362" height="408">
+      <vector name="origin" x="446" y="421"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="383" height="422">
+      <vector name="origin" x="457" y="434"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="389" height="431">
+      <vector name="origin" x="460" y="443"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="399" height="435">
+      <vector name="origin" x="465" y="449"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="407" height="436">
+      <vector name="origin" x="469" y="452"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="421" height="437">
+      <vector name="origin" x="473" y="454"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="430" height="440">
+      <vector name="origin" x="475" y="456"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="436" height="448">
+      <vector name="origin" x="476" y="465"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="438" height="447">
+      <vector name="origin" x="476" y="463"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="443" height="445">
+      <vector name="origin" x="478" y="462"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="443" height="455">
+      <vector name="origin" x="478" y="471"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="441" height="455">
+      <vector name="origin" x="477" y="472"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="441" height="456">
+      <vector name="origin" x="477" y="472"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="443" height="454">
+      <vector name="origin" x="478" y="471"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="443" height="445">
+      <vector name="origin" x="478" y="461"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="441" height="417">
+      <vector name="origin" x="477" y="434"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="437" height="363">
+      <vector name="origin" x="475" y="359"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="411" height="295">
+      <vector name="origin" x="462" y="291"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="453" height="264">
+      <vector name="origin" x="483" y="260"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="455" height="204">
+      <vector name="origin" x="484" y="200"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="453" height="197">
+      <vector name="origin" x="483" y="193"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="453" height="196">
+      <vector name="origin" x="483" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="453" height="196">
+      <vector name="origin" x="483" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="26" width="453" height="206">
+      <vector name="origin" x="483" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="27" width="453" height="204">
+      <vector name="origin" x="483" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="28" width="377" height="203">
+      <vector name="origin" x="445" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="275" height="214">
+      <vector name="origin" x="376" y="210"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="275" height="218">
+      <vector name="origin" x="376" y="211"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="290" height="224">
+      <vector name="origin" x="391" y="212"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="288" height="228">
+      <vector name="origin" x="389" y="213"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="288" height="230">
+      <vector name="origin" x="389" y="214"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="287" height="231">
+      <vector name="origin" x="389" y="215"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="286" height="232">
+      <vector name="origin" x="388" y="216"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="284" height="233">
+      <vector name="origin" x="386" y="217"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="285" height="236">
+      <vector name="origin" x="387" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="287" height="237">
+      <vector name="origin" x="389" y="221"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="291" height="239">
+      <vector name="origin" x="394" y="223"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="301" height="241">
+      <vector name="origin" x="404" y="226"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="304" height="244">
+      <vector name="origin" x="407" y="229"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="14" width="312" height="251">
+      <vector name="origin" x="415" y="230"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="15" width="308" height="249">
+      <vector name="origin" x="411" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="16" width="309" height="251">
+      <vector name="origin" x="412" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="17" width="309" height="249">
+      <vector name="origin" x="412" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="18" width="310" height="250">
+      <vector name="origin" x="413" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="19" width="310" height="247">
+      <vector name="origin" x="413" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="20" width="311" height="249">
+      <vector name="origin" x="414" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="21" width="312" height="250">
+      <vector name="origin" x="415" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="22" width="313" height="251">
+      <vector name="origin" x="416" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="23" width="314" height="247">
+      <vector name="origin" x="417" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="24" width="315" height="252">
+      <vector name="origin" x="418" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="25" width="316" height="249">
+      <vector name="origin" x="419" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="26" width="318" height="241">
+      <vector name="origin" x="420" y="226"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="27" width="318" height="241">
+      <vector name="origin" x="420" y="225"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="28" width="317" height="238">
+      <vector name="origin" x="419" y="223"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="29" width="308" height="235">
+      <vector name="origin" x="410" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="30" width="302" height="226">
+      <vector name="origin" x="404" y="215"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="31" width="301" height="218">
+      <vector name="origin" x="402" y="214"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="32" width="297" height="201">
+      <vector name="origin" x="398" y="213"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="33" width="275" height="200">
+      <vector name="origin" x="376" y="212"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="34" width="275" height="199">
+      <vector name="origin" x="376" y="211"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="35" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="36" width="275" height="197">
+      <vector name="origin" x="376" y="208"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="274" height="197">
+      <vector name="origin" x="375" y="209"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="346" height="230">
+      <vector name="origin" x="376" y="211"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="439" height="394">
+      <vector name="origin" x="464" y="372"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="434" height="410">
+      <vector name="origin" x="456" y="388"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="439" height="422">
+      <vector name="origin" x="459" y="401"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="445" height="411">
+      <vector name="origin" x="463" y="389"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="449" height="408">
+      <vector name="origin" x="469" y="386"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="463" height="427">
+      <vector name="origin" x="462" y="405"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="385" height="447">
+      <vector name="origin" x="452" y="425"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="385" height="449">
+      <vector name="origin" x="452" y="427"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="390" height="394">
+      <vector name="origin" x="452" y="372"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="395" height="262">
+      <vector name="origin" x="452" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="391" height="266">
+      <vector name="origin" x="452" y="244"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="391" height="270">
+      <vector name="origin" x="452" y="248"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="392" height="274">
+      <vector name="origin" x="453" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="394" height="274">
+      <vector name="origin" x="454" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="396" height="274">
+      <vector name="origin" x="455" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="396" height="274">
+      <vector name="origin" x="455" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="398" height="274">
+      <vector name="origin" x="456" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="398" height="274">
+      <vector name="origin" x="456" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="369" height="274">
+      <vector name="origin" x="442" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="369" height="256">
+      <vector name="origin" x="442" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="369" height="254">
+      <vector name="origin" x="442" y="232"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="369" height="252">
+      <vector name="origin" x="442" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="367" height="248">
+      <vector name="origin" x="441" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="367" height="242">
+      <vector name="origin" x="441" y="220"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="26" width="367" height="224">
+      <vector name="origin" x="441" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="27" width="367" height="215">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="愚蠢的新手们……竟想用这种拙劣的手段封印我……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8830003.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8830003.img.xml
@@ -1,0 +1,306 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8830003.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="0"/>
+    <int name="level" value="105"/>
+    <int name="maxHP" value="9980000"/>
+    <int name="maxMP" value="0"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="0"/>
+    <int name="PDDamage" value="0"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="0"/>
+    <int name="acc" value="0"/>
+    <int name="eva" value="0"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="3"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <string name="defaultHP" value="측정불가"/>
+    <int name="noFlip" value="1"/>
+    <string name="defaultMP" value="측정불가"/>
+    <int name="firstAttack" value="1"/>
+    <int name="disable" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="161"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="1"/>
+    </imgdir>
+    <int name="boss" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="821" height="558">
+      <vector name="origin" x="321" y="557"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="2" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="3" width="821" height="558">
+      <vector name="origin" x="321" y="557"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="4" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="5" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="6" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="7" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="8" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="9" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="10" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="11" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="12" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="13" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="14" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="15" width="821" height="558">
+      <vector name="origin" x="321" y="557"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="16" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="17" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="18" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="19" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="20" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="21" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="22" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="23" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill16">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="823" height="566">
+      <vector name="origin" x="317" y="565"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="2" width="819" height="569">
+      <vector name="origin" x="312" y="568"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="3" width="815" height="571">
+      <vector name="origin" x="308" y="570"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="4" width="810" height="573">
+      <vector name="origin" x="304" y="572"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="5" width="806" height="574">
+      <vector name="origin" x="301" y="573"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="6" width="802" height="576">
+      <vector name="origin" x="298" y="575"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="7" width="798" height="578">
+      <vector name="origin" x="295" y="577"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="8" width="794" height="579">
+      <vector name="origin" x="292" y="578"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="9" width="790" height="580">
+      <vector name="origin" x="289" y="579"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="10" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="11" width="785" height="582">
+      <vector name="origin" x="285" y="581"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="12" width="784" height="583">
+      <vector name="origin" x="284" y="582"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="13" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="14" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="15" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="16" width="784" height="583">
+      <vector name="origin" x="284" y="582"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="17" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="18" width="794" height="579">
+      <vector name="origin" x="292" y="578"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="19" width="802" height="576">
+      <vector name="origin" x="298" y="575"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="20" width="810" height="573">
+      <vector name="origin" x="304" y="572"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="21" width="819" height="569">
+      <vector name="origin" x="312" y="568"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="22" width="823" height="566">
+      <vector name="origin" x="317" y="565"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="没有什么能阻止我……黑暗已经开始蔓延……"/>
+      <string name="1" value="愚蠢！只靠一个人是赢不了的。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="4" height="4">
+      <vector name="origin" x="36" y="53"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+      <int name="delay" value="3000"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="呃……比我想象中更强！别以为你已经打败了我。被封印的力量……等那股力量归来时，我将再次统治世界。"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8830006.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8830006.img.xml
@@ -1,0 +1,137 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8830006.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="0"/>
+    <int name="level" value="1"/>
+    <int name="maxHP" value="1"/>
+    <int name="maxMP" value="0"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="0"/>
+    <int name="PDDamage" value="0"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="0"/>
+    <int name="acc" value="0"/>
+    <int name="eva" value="0"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="12"/>
+    <int name="noFlip" value="1"/>
+    <imgdir name="revive">
+      <int name="0" value="8830001"/>
+    </imgdir>
+    <int name="boss" value="1"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="1"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="367" height="215">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="367" height="215">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="366" height="211">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="366" height="220">
+      <vector name="origin" x="441" y="202"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="2" width="366" height="211">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="3" width="366" height="220">
+      <vector name="origin" x="441" y="202"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="4" width="366" height="211">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="5" width="366" height="220">
+      <vector name="origin" x="441" y="202"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="6" width="366" height="211">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="7" width="369" height="256">
+      <vector name="origin" x="441" y="208"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="8" width="369" height="274">
+      <vector name="origin" x="441" y="226"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="9" width="369" height="285">
+      <vector name="origin" x="441" y="237"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="10" width="370" height="384">
+      <vector name="origin" x="442" y="336"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="11" width="413" height="324">
+      <vector name="origin" x="485" y="276"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="12" width="370" height="297">
+      <vector name="origin" x="442" y="249"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="13" width="374" height="288">
+      <vector name="origin" x="438" y="257"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="14" width="396" height="294">
+      <vector name="origin" x="441" y="263"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="15" width="399" height="280">
+      <vector name="origin" x="442" y="264"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="16" width="436" height="281">
+      <vector name="origin" x="442" y="266"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="17" width="437" height="285">
+      <vector name="origin" x="443" y="268"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="18" width="299" height="256">
+      <vector name="origin" x="402" y="240"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="19" width="282" height="218">
+      <vector name="origin" x="384" y="229"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="20" width="276" height="207">
+      <vector name="origin" x="378" y="219"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="21" width="275" height="199">
+      <vector name="origin" x="376" y="211"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="哈哈……又想封印我？休想。我会让你见识我的力量！"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8830007.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8830007.img.xml
@@ -1,0 +1,1480 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8830007.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="84"/>
+    <int name="maxHP" value="3210000"/>
+    <int name="maxMP" value="30000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="336"/>
+    <int name="PDDamage" value="200"/>
+    <int name="MADamage" value="230"/>
+    <int name="MDDamage" value="320"/>
+    <int name="acc" value="250"/>
+    <int name="eva" value="12"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="50000"/>
+    <int name="hpRecovery" value="100"/>
+    <int name="mpRecovery" value="100"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="noFlip" value="1"/>
+    <int name="boss" value="1"/>
+    <string name="defaultHP" value="Unknown"/>
+    <string name="defaultMP" value="Unknown"/>
+    <int name="mobType" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="145"/>
+        <int name="action" value="1"/>
+        <int name="level" value="4"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="133"/>
+        <int name="action" value="1"/>
+        <int name="level" value="3"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="default">
+      <canvas name="0" width="253" height="217">
+        <vector name="origin" x="126" y="108"/>
+        <int name="z" value="0"/>
+      </canvas>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="1"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="821" height="558">
+      <vector name="origin" x="321" y="557"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-400" y="-600"/>
+        <vector name="rb" x="400" y="0"/>
+        <int name="start" value="-4"/>
+        <int name="areaCount" value="9"/>
+        <int name="attackCount" value="9"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="2640"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="1" width="32" height="61">
+          <vector name="origin" x="140" y="392"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="443" height="267">
+          <vector name="origin" x="267" y="592"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="514" height="298">
+          <vector name="origin" x="269" y="618"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="521" height="358">
+          <vector name="origin" x="270" y="670"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="524" height="364">
+          <vector name="origin" x="271" y="660"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="525" height="637">
+          <vector name="origin" x="271" y="633"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="527" height="474">
+          <vector name="origin" x="273" y="469"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="540" height="153">
+          <vector name="origin" x="273" y="148"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="541" height="151">
+          <vector name="origin" x="273" y="147"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="534" height="149">
+          <vector name="origin" x="265" y="145"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="11" width="431" height="145">
+          <vector name="origin" x="160" y="142"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="12" width="354" height="136">
+          <vector name="origin" x="82" y="134"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="13" width="353" height="72">
+          <vector name="origin" x="83" y="71"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="104" height="111">
+          <vector name="origin" x="52" y="55"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="89" height="84">
+          <vector name="origin" x="44" y="42"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="100" height="82">
+          <vector name="origin" x="50" y="41"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="117" height="95">
+          <vector name="origin" x="58" y="47"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="126" height="105">
+          <vector name="origin" x="63" y="52"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="conMP" value="5"/>
+      <int name="tremble" value="1"/>
+      <int name="attackAfter" value="3240"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="1200"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="1" width="823" height="566">
+      <vector name="origin" x="317" y="565"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="819" height="569">
+      <vector name="origin" x="312" y="568"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="815" height="571">
+      <vector name="origin" x="308" y="570"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="810" height="573">
+      <vector name="origin" x="304" y="572"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="806" height="574">
+      <vector name="origin" x="301" y="573"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="802" height="576">
+      <vector name="origin" x="298" y="575"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="798" height="578">
+      <vector name="origin" x="295" y="577"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="794" height="579">
+      <vector name="origin" x="292" y="578"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="790" height="580">
+      <vector name="origin" x="289" y="579"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="12" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="13" width="899" height="566">
+      <vector name="origin" x="391" y="565"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="14" width="886" height="565">
+      <vector name="origin" x="383" y="564"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="15" width="878" height="564">
+      <vector name="origin" x="372" y="563"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="16" width="844" height="563">
+      <vector name="origin" x="343" y="562"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="17" width="832" height="562">
+      <vector name="origin" x="328" y="561"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="18" width="819" height="561">
+      <vector name="origin" x="320" y="560"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="19" width="827" height="560">
+      <vector name="origin" x="325" y="559"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="20" width="819" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="21" width="827" height="558">
+      <vector name="origin" x="327" y="557"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="22" width="819" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="23" width="827" height="560">
+      <vector name="origin" x="325" y="559"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-733" y="-760"/>
+        <vector name="rb" x="864" y="20"/>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="4" height="4">
+          <vector name="origin" x="36" y="53"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect0">
+        <int name="effectType" value="1"/>
+        <int name="effectDistance" value="130"/>
+        <int name="randomPos" value="1"/>
+        <int name="delay" value="740"/>
+        <vector name="lt" x="-733" y="-760"/>
+        <vector name="rb" x="864" y="20"/>
+        <imgdir name="0">
+          <canvas name="0" width="126" height="97">
+            <vector name="origin" x="60" y="98"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="1" width="133" height="99">
+            <vector name="origin" x="63" y="99"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="2" width="135" height="98">
+            <vector name="origin" x="63" y="98"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="3" width="136" height="95">
+            <vector name="origin" x="62" y="95"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="4" width="136" height="100">
+            <vector name="origin" x="62" y="100"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="5" width="136" height="100">
+            <vector name="origin" x="62" y="100"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="6" width="133" height="88">
+            <vector name="origin" x="60" y="87"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="7" width="125" height="64">
+            <vector name="origin" x="57" y="64"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+          <canvas name="8" width="53" height="29">
+            <vector name="origin" x="40" y="31"/>
+            <int name="z" value="0"/>
+            <int name="delay" value="120"/>
+          </canvas>
+        </imgdir>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="83" height="60">
+          <vector name="origin" x="40" y="52"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="1" width="99" height="105">
+          <vector name="origin" x="50" y="97"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="2" width="84" height="107">
+          <vector name="origin" x="41" y="99"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="3" width="71" height="104">
+          <vector name="origin" x="41" y="101"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="4" width="72" height="104">
+          <vector name="origin" x="42" y="115"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="930"/>
+      <int name="magic" value="1"/>
+      <string name="elemAttr" value="F"/>
+    </imgdir>
+    <canvas name="0" width="821" height="558">
+      <vector name="origin" x="321" y="557"/>
+      <int name="delay" value="210"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="1" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="828" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="831" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="836" height="566">
+      <vector name="origin" x="329" y="565"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="839" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="841" height="569">
+      <vector name="origin" x="332" y="568"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="844" height="570">
+      <vector name="origin" x="333" y="569"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="827" height="565">
+      <vector name="origin" x="324" y="564"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="825" height="567">
+      <vector name="origin" x="323" y="566"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="823" height="567">
+      <vector name="origin" x="322" y="566"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="12" width="821" height="565">
+      <vector name="origin" x="321" y="564"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="13" width="823" height="567">
+      <vector name="origin" x="322" y="566"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="14" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="15" width="828" height="561">
+      <vector name="origin" x="325" y="560"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <uol name="16" value="../stand/1"/>
+    <uol name="17" value="../stand/2"/>
+    <uol name="18" value="../stand/3"/>
+    <uol name="19" value="../stand/4"/>
+    <uol name="20" value="../stand/5"/>
+    <uol name="21" value="../stand/6"/>
+    <uol name="22" value="../stand/7"/>
+    <uol name="23" value="../stand/8"/>
+    <uol name="24" value="../stand/9"/>
+    <uol name="25" value="../stand/10"/>
+    <uol name="26" value="../stand/11"/>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-57" y="-200"/>
+        <vector name="rb" x="57" y="0"/>
+        <int name="start" value="-5"/>
+        <int name="areaCount" value="11"/>
+        <int name="attackCount" value="3"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="54" height="14">
+          <vector name="origin" x="28" y="10"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="74" height="18">
+          <vector name="origin" x="36" y="14"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="79" height="57">
+          <vector name="origin" x="38" y="53"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="83" height="71">
+          <vector name="origin" x="41" y="67"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="84" height="73">
+          <vector name="origin" x="40" y="71"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="84" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="83" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="83" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="83" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="83" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="83" height="74">
+          <vector name="origin" x="42" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="11" width="114" height="474">
+          <vector name="origin" x="54" y="472"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="12" width="125" height="478">
+          <vector name="origin" x="60" y="476"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="13" width="128" height="470">
+          <vector name="origin" x="61" y="468"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="14" width="130" height="449">
+          <vector name="origin" x="62" y="447"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="15" width="143" height="163">
+          <vector name="origin" x="73" y="142"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="16" width="150" height="123">
+          <vector name="origin" x="77" y="115"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="17" width="151" height="124">
+          <vector name="origin" x="76" y="113"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="18" width="156" height="129">
+          <vector name="origin" x="77" y="111"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="19" width="156" height="132">
+          <vector name="origin" x="76" y="109"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="20" width="156" height="103">
+          <vector name="origin" x="80" y="103"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="104" height="111">
+          <vector name="origin" x="57" y="59"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="89" height="84">
+          <vector name="origin" x="43" y="45"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="100" height="82">
+          <vector name="origin" x="49" y="40"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="117" height="95">
+          <vector name="origin" x="57" y="46"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="126" height="105">
+          <vector name="origin" x="60" y="51"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="attackAfter" value="2040"/>
+      <int name="conMP" value="10"/>
+      <int name="deadlyAttack" value="1"/>
+      <int name="PADamage" value="280"/>
+    </imgdir>
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="1" width="827" height="560">
+      <vector name="origin" x="324" y="559"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="827" height="559">
+      <vector name="origin" x="324" y="558"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="827" height="558">
+      <vector name="origin" x="324" y="557"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="827" height="557">
+      <vector name="origin" x="324" y="556"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="827" height="556">
+      <vector name="origin" x="324" y="555"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="827" height="555">
+      <vector name="origin" x="324" y="554"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="827" height="554">
+      <vector name="origin" x="324" y="553"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="827" height="553">
+      <vector name="origin" x="324" y="552"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="827" height="554">
+      <vector name="origin" x="324" y="553"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="827" height="556">
+      <vector name="origin" x="324" y="555"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="827" height="558">
+      <vector name="origin" x="324" y="557"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="12" width="827" height="559">
+      <vector name="origin" x="324" y="558"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="13" width="827" height="560">
+      <vector name="origin" x="324" y="559"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="14" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="15" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="16" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="17" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="18" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <uol name="19" value="0"/>
+    <uol name="20" value="0"/>
+    <uol name="21" value="0"/>
+    <uol name="22" value="0"/>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-482" y="-668"/>
+        <vector name="rb" x="789" y="10"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="73" height="103">
+          <vector name="origin" x="41" y="99"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="96" height="127">
+          <vector name="origin" x="53" y="116"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="106" height="137">
+          <vector name="origin" x="58" y="122"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="114" height="142">
+          <vector name="origin" x="62" y="124"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="120" height="150">
+          <vector name="origin" x="65" y="129"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="126" height="152">
+          <vector name="origin" x="68" y="130"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="156" height="110">
+          <vector name="origin" x="83" y="112"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="155" height="117">
+          <vector name="origin" x="84" y="116"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="8" width="154" height="119">
+          <vector name="origin" x="84" y="118"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="9" width="140" height="104">
+          <vector name="origin" x="75" y="111"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="10" width="73" height="58">
+          <vector name="origin" x="41" y="76"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="hitAfter" value="810"/>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="disease" value="127"/>
+      <int name="level" value="12"/>
+      <int name="magic" value="1"/>
+      <int name="attackAfter" value="1200"/>
+    </imgdir>
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="1" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="835" height="565">
+      <vector name="origin" x="328" y="564"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="837" height="566">
+      <vector name="origin" x="329" y="565"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="839" height="567">
+      <vector name="origin" x="330" y="566"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="841" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="841" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="841" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="841" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="12" width="841" height="568">
+      <vector name="origin" x="331" y="567"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="13" width="839" height="567">
+      <vector name="origin" x="330" y="566"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="14" width="835" height="565">
+      <vector name="origin" x="328" y="564"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="15" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="16" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="3"/>
+      <string name="0" value="我要打破特里斯坦的封印。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill16">
+    <canvas name="0" width="876" height="584">
+      <vector name="origin" x="376" y="583"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="876" height="583">
+      <vector name="origin" x="376" y="582"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="876" height="581">
+      <vector name="origin" x="376" y="580"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="878" height="579">
+      <vector name="origin" x="376" y="578"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="880" height="576">
+      <vector name="origin" x="376" y="575"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="882" height="573">
+      <vector name="origin" x="376" y="572"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="883" height="569">
+      <vector name="origin" x="376" y="568"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="882" height="566">
+      <vector name="origin" x="376" y="565"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="879" height="561">
+      <vector name="origin" x="376" y="560"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="300"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="1" width="823" height="566">
+      <vector name="origin" x="317" y="565"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="2" width="819" height="569">
+      <vector name="origin" x="312" y="568"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="3" width="815" height="571">
+      <vector name="origin" x="308" y="570"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="4" width="810" height="573">
+      <vector name="origin" x="304" y="572"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="5" width="806" height="574">
+      <vector name="origin" x="301" y="573"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="6" width="802" height="576">
+      <vector name="origin" x="298" y="575"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="7" width="798" height="578">
+      <vector name="origin" x="295" y="577"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="8" width="794" height="579">
+      <vector name="origin" x="292" y="578"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="9" width="790" height="580">
+      <vector name="origin" x="289" y="579"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="10" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="11" width="785" height="582">
+      <vector name="origin" x="285" y="581"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="12" width="784" height="583">
+      <vector name="origin" x="284" y="582"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="13" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="14" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="15" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="16" width="784" height="583">
+      <vector name="origin" x="284" y="582"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="17" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="18" width="794" height="579">
+      <vector name="origin" x="292" y="578"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="19" width="802" height="576">
+      <vector name="origin" x="298" y="575"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="20" width="810" height="573">
+      <vector name="origin" x="304" y="572"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="21" width="819" height="569">
+      <vector name="origin" x="312" y="568"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <canvas name="22" width="823" height="566">
+      <vector name="origin" x="317" y="565"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="特里斯坦的结界还笼罩着这个洞窟吗？我没有力量了。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="944" height="752">
+      <vector name="origin" x="441" y="560"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="944" height="752">
+      <vector name="origin" x="441" y="560"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="942" height="751">
+      <vector name="origin" x="441" y="559"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="941" height="750">
+      <vector name="origin" x="441" y="558"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="940" height="749">
+      <vector name="origin" x="441" y="557"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="939" height="748">
+      <vector name="origin" x="441" y="556"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="938" height="747">
+      <vector name="origin" x="441" y="555"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="939" height="748">
+      <vector name="origin" x="441" y="556"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="942" height="751">
+      <vector name="origin" x="441" y="559"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="945" height="758">
+      <vector name="origin" x="441" y="566"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="951" height="762">
+      <vector name="origin" x="441" y="570"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="11" width="948" height="764">
+      <vector name="origin" x="441" y="572"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="12" width="953" height="767">
+      <vector name="origin" x="441" y="575"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="13" width="950" height="769">
+      <vector name="origin" x="441" y="577"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="14" width="955" height="770">
+      <vector name="origin" x="441" y="578"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="15" width="952" height="771">
+      <vector name="origin" x="441" y="579"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="16" width="957" height="772">
+      <vector name="origin" x="441" y="580"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="17" width="954" height="773">
+      <vector name="origin" x="441" y="581"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="18" width="957" height="772">
+      <vector name="origin" x="441" y="580"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="19" width="954" height="773">
+      <vector name="origin" x="441" y="581"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="20" width="957" height="772">
+      <vector name="origin" x="441" y="580"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="21" width="954" height="773">
+      <vector name="origin" x="441" y="581"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <uol name="22" value="20"/>
+    <uol name="23" value="21"/>
+    <uol name="24" value="20"/>
+    <uol name="25" value="21"/>
+    <uol name="26" value="20"/>
+    <uol name="27" value="21"/>
+    <uol name="28" value="20"/>
+    <uol name="29" value="21"/>
+    <uol name="30" value="20"/>
+    <uol name="31" value="21"/>
+    <uol name="32" value="20"/>
+    <uol name="33" value="21"/>
+    <uol name="34" value="20"/>
+    <uol name="35" value="21"/>
+    <uol name="36" value="20"/>
+    <uol name="37" value="21"/>
+    <uol name="38" value="20"/>
+    <uol name="39" value="20"/>
+    <uol name="40" value="21"/>
+    <uol name="41" value="20"/>
+    <uol name="42" value="21"/>
+    <uol name="43" value="20"/>
+    <uol name="44" value="21"/>
+    <uol name="45" value="20"/>
+    <uol name="46" value="21"/>
+    <uol name="47" value="20"/>
+    <uol name="48" value="21"/>
+    <uol name="49" value="20"/>
+    <uol name="50" value="21"/>
+    <uol name="51" value="20"/>
+    <uol name="52" value="21"/>
+    <uol name="53" value="20"/>
+    <uol name="54" value="21"/>
+    <uol name="55" value="20"/>
+    <uol name="56" value="21"/>
+    <uol name="57" value="20"/>
+    <uol name="58" value="20"/>
+    <uol name="59" value="21"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8830008.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8830008.img.xml
@@ -1,0 +1,1130 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8830008.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="60"/>
+    <int name="maxHP" value="2059200"/>
+    <int name="maxMP" value="3000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="220"/>
+    <int name="PDDamage" value="500"/>
+    <int name="MADamage" value="288"/>
+    <int name="MDDamage" value="250"/>
+    <int name="acc" value="250"/>
+    <int name="eva" value="12"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="50000"/>
+    <int name="hpRecovery" value="100"/>
+    <int name="mpRecovery" value="100"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="noFlip" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="162"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="163"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="revive">
+      <int name="0" value="8830011"/>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="1"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="1" width="276" height="200">
+      <vector name="origin" x="377" y="208"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="2" width="276" height="203">
+      <vector name="origin" x="377" y="207"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="3" width="276" height="200">
+      <vector name="origin" x="377" y="206"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="4" width="275" height="197">
+      <vector name="origin" x="376" y="207"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="5" width="275" height="196">
+      <vector name="origin" x="376" y="208"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="6" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="7" width="276" height="200">
+      <vector name="origin" x="377" y="210"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="8" width="276" height="203">
+      <vector name="origin" x="377" y="211"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="9" width="276" height="200">
+      <vector name="origin" x="377" y="212"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="10" width="275" height="199">
+      <vector name="origin" x="376" y="211"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="11" width="275" height="198">
+      <vector name="origin" x="376" y="210"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="170"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-70" y="-100"/>
+        <vector name="rb" x="70" y="0"/>
+        <int name="start" value="-3"/>
+        <int name="areaCount" value="7"/>
+        <int name="attackCount" value="3"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="900"/>
+        </canvas>
+        <canvas name="1" width="10" height="16">
+          <vector name="origin" x="2" y="15"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="16" height="18">
+          <vector name="origin" x="8" y="17"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="34" height="21">
+          <vector name="origin" x="25" y="20"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="29" height="26">
+          <vector name="origin" x="18" y="25"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="5" width="29" height="47">
+          <vector name="origin" x="18" y="46"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="6" width="124" height="139">
+          <vector name="origin" x="67" y="133"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="7" width="134" height="134">
+          <vector name="origin" x="70" y="133"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="8" width="139" height="134">
+          <vector name="origin" x="69" y="133"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="9" width="141" height="134">
+          <vector name="origin" x="70" y="133"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="10" width="141" height="134">
+          <vector name="origin" x="69" y="133"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="11" width="140" height="132">
+          <vector name="origin" x="72" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="12" width="129" height="133">
+          <vector name="origin" x="58" y="132"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="13" width="121" height="56">
+          <vector name="origin" x="46" y="56"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="104" height="111">
+          <vector name="origin" x="57" y="59"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="89" height="84">
+          <vector name="origin" x="43" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="100" height="82">
+          <vector name="origin" x="49" y="40"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="117" height="95">
+          <vector name="origin" x="57" y="46"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="126" height="105">
+          <vector name="origin" x="60" y="51"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="attackAfter" value="1500"/>
+      <int name="conMP" value="10"/>
+      <int name="PADamage" value="336"/>
+    </imgdir>
+    <canvas name="0" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="1" width="355" height="223">
+      <vector name="origin" x="456" y="212"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="2" width="362" height="234">
+      <vector name="origin" x="463" y="215"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="3" width="365" height="239">
+      <vector name="origin" x="466" y="217"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="4" width="368" height="243">
+      <vector name="origin" x="469" y="218"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="5" width="369" height="247">
+      <vector name="origin" x="470" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="6" width="369" height="246">
+      <vector name="origin" x="470" y="218"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="7" width="369" height="248">
+      <vector name="origin" x="470" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="8" width="369" height="247">
+      <vector name="origin" x="470" y="218"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="9" width="369" height="249">
+      <vector name="origin" x="470" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="10" width="369" height="248">
+      <vector name="origin" x="470" y="218"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="11" width="368" height="250">
+      <vector name="origin" x="469" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="12" width="370" height="224">
+      <vector name="origin" x="469" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="13" width="370" height="235">
+      <vector name="origin" x="469" y="205"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="14" width="372" height="233">
+      <vector name="origin" x="471" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="15" width="377" height="230">
+      <vector name="origin" x="477" y="201"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="16" width="381" height="230">
+      <vector name="origin" x="481" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="17" width="389" height="227">
+      <vector name="origin" x="489" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="18" width="371" height="221">
+      <vector name="origin" x="471" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="19" width="369" height="216">
+      <vector name="origin" x="469" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+    <canvas name="20" width="275" height="192">
+      <vector name="origin" x="375" y="203"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-486" y="-134"/>
+        <vector name="rb" x="-30" y="5"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="112" height="111">
+          <vector name="origin" x="49" y="104"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="81" height="109">
+          <vector name="origin" x="34" y="104"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="77" height="110">
+          <vector name="origin" x="32" y="104"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="76" height="103">
+          <vector name="origin" x="32" y="102"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="74" height="94">
+          <vector name="origin" x="34" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="55" height="82">
+          <vector name="origin" x="21" y="81"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="2400"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="274" height="402">
+      <vector name="origin" x="375" y="413"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="285" height="402">
+      <vector name="origin" x="387" y="414"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="362" height="408">
+      <vector name="origin" x="446" y="421"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="383" height="422">
+      <vector name="origin" x="457" y="434"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="389" height="431">
+      <vector name="origin" x="460" y="443"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="399" height="435">
+      <vector name="origin" x="465" y="449"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="407" height="436">
+      <vector name="origin" x="469" y="452"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="421" height="437">
+      <vector name="origin" x="473" y="454"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="430" height="440">
+      <vector name="origin" x="475" y="456"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="436" height="448">
+      <vector name="origin" x="476" y="465"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="438" height="447">
+      <vector name="origin" x="476" y="463"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="443" height="445">
+      <vector name="origin" x="478" y="462"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="443" height="455">
+      <vector name="origin" x="478" y="471"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="441" height="455">
+      <vector name="origin" x="477" y="472"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="441" height="456">
+      <vector name="origin" x="477" y="472"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="443" height="454">
+      <vector name="origin" x="478" y="471"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="443" height="445">
+      <vector name="origin" x="478" y="461"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="441" height="417">
+      <vector name="origin" x="477" y="434"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="437" height="363">
+      <vector name="origin" x="475" y="359"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="411" height="295">
+      <vector name="origin" x="462" y="291"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="453" height="264">
+      <vector name="origin" x="483" y="260"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="455" height="204">
+      <vector name="origin" x="484" y="200"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="453" height="197">
+      <vector name="origin" x="483" y="193"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="453" height="196">
+      <vector name="origin" x="483" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="453" height="196">
+      <vector name="origin" x="483" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="26" width="453" height="206">
+      <vector name="origin" x="483" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="27" width="453" height="204">
+      <vector name="origin" x="483" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="28" width="377" height="203">
+      <vector name="origin" x="445" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="275" height="214">
+      <vector name="origin" x="376" y="210"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="275" height="218">
+      <vector name="origin" x="376" y="211"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="290" height="224">
+      <vector name="origin" x="391" y="212"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="288" height="228">
+      <vector name="origin" x="389" y="213"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="288" height="230">
+      <vector name="origin" x="389" y="214"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="287" height="231">
+      <vector name="origin" x="389" y="215"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="286" height="232">
+      <vector name="origin" x="388" y="216"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="284" height="233">
+      <vector name="origin" x="386" y="217"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="285" height="236">
+      <vector name="origin" x="387" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="287" height="237">
+      <vector name="origin" x="389" y="221"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="291" height="239">
+      <vector name="origin" x="394" y="223"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="301" height="241">
+      <vector name="origin" x="404" y="226"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="304" height="244">
+      <vector name="origin" x="407" y="229"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="14" width="312" height="251">
+      <vector name="origin" x="415" y="230"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="15" width="308" height="249">
+      <vector name="origin" x="411" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="16" width="309" height="251">
+      <vector name="origin" x="412" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="17" width="309" height="249">
+      <vector name="origin" x="412" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="18" width="310" height="250">
+      <vector name="origin" x="413" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="19" width="310" height="247">
+      <vector name="origin" x="413" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="20" width="311" height="249">
+      <vector name="origin" x="414" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="21" width="312" height="250">
+      <vector name="origin" x="415" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="22" width="313" height="251">
+      <vector name="origin" x="416" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="23" width="314" height="247">
+      <vector name="origin" x="417" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="24" width="315" height="252">
+      <vector name="origin" x="418" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="25" width="316" height="249">
+      <vector name="origin" x="419" y="232"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="26" width="318" height="241">
+      <vector name="origin" x="420" y="226"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="27" width="318" height="241">
+      <vector name="origin" x="420" y="225"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="28" width="317" height="238">
+      <vector name="origin" x="419" y="223"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="29" width="308" height="235">
+      <vector name="origin" x="410" y="220"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="30" width="302" height="226">
+      <vector name="origin" x="404" y="215"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="31" width="301" height="218">
+      <vector name="origin" x="402" y="214"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="32" width="297" height="201">
+      <vector name="origin" x="398" y="213"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="33" width="275" height="200">
+      <vector name="origin" x="376" y="212"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="34" width="275" height="199">
+      <vector name="origin" x="376" y="211"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="35" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="36" width="275" height="197">
+      <vector name="origin" x="376" y="208"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-365" y="-139"/>
+      <vector name="rb" x="-118" y="-20"/>
+      <vector name="head" x="-251" y="-207"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="274" height="197">
+      <vector name="origin" x="375" y="209"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="275" height="197">
+      <vector name="origin" x="376" y="209"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="346" height="230">
+      <vector name="origin" x="376" y="211"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="439" height="394">
+      <vector name="origin" x="464" y="372"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="434" height="410">
+      <vector name="origin" x="456" y="388"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="439" height="422">
+      <vector name="origin" x="459" y="401"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="445" height="411">
+      <vector name="origin" x="463" y="389"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="449" height="408">
+      <vector name="origin" x="469" y="386"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="463" height="427">
+      <vector name="origin" x="462" y="405"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="385" height="447">
+      <vector name="origin" x="452" y="425"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="385" height="449">
+      <vector name="origin" x="452" y="427"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="390" height="394">
+      <vector name="origin" x="452" y="372"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="395" height="262">
+      <vector name="origin" x="452" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="391" height="266">
+      <vector name="origin" x="452" y="244"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="391" height="270">
+      <vector name="origin" x="452" y="248"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="392" height="274">
+      <vector name="origin" x="453" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="394" height="274">
+      <vector name="origin" x="454" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="396" height="274">
+      <vector name="origin" x="455" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="396" height="274">
+      <vector name="origin" x="455" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="398" height="274">
+      <vector name="origin" x="456" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="398" height="274">
+      <vector name="origin" x="456" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="369" height="274">
+      <vector name="origin" x="442" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="369" height="256">
+      <vector name="origin" x="442" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="369" height="254">
+      <vector name="origin" x="442" y="232"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="369" height="252">
+      <vector name="origin" x="442" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="367" height="248">
+      <vector name="origin" x="441" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="367" height="242">
+      <vector name="origin" x="441" y="220"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="26" width="367" height="224">
+      <vector name="origin" x="441" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="27" width="367" height="215">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="愚蠢的新手们……竟想用这种拙劣的手段封印我……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8830009.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8830009.img.xml
@@ -1,0 +1,890 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8830009.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="56"/>
+    <int name="maxHP" value="2233800"/>
+    <int name="maxMP" value="30000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="220"/>
+    <int name="PDDamage" value="250"/>
+    <int name="MADamage" value="250"/>
+    <int name="MDDamage" value="150"/>
+    <int name="acc" value="250"/>
+    <int name="eva" value="12"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="50000"/>
+    <int name="hpRecovery" value="100"/>
+    <int name="mpRecovery" value="100"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="noFlip" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <imgdir name="revive">
+      <int name="0" value="8830012"/>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="1"/>
+      <imgdir name="Index">
+        <int name="hp" value="306000"/>
+        <int name="prob" value="100"/>
+        <string name="0" value="你的实力还远远不够！"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="242" height="197">
+      <vector name="origin" x="-188" y="208"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="1" width="243" height="200">
+      <vector name="origin" x="-188" y="207"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="2" width="243" height="203">
+      <vector name="origin" x="-188" y="206"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="3" width="243" height="200">
+      <vector name="origin" x="-188" y="205"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="4" width="242" height="197">
+      <vector name="origin" x="-188" y="206"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="5" width="242" height="195">
+      <vector name="origin" x="-188" y="207"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="6" width="242" height="197">
+      <vector name="origin" x="-188" y="208"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="7" width="243" height="200">
+      <vector name="origin" x="-188" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="8" width="243" height="203">
+      <vector name="origin" x="-188" y="210"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="9" width="243" height="200">
+      <vector name="origin" x="-188" y="211"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="10" width="242" height="197">
+      <vector name="origin" x="-188" y="210"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="11" width="242" height="195">
+      <vector name="origin" x="-188" y="209"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+      <int name="delay" value="170"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-50" y="-100"/>
+        <vector name="rb" x="50" y="0"/>
+        <int name="start" value="-6"/>
+        <int name="areaCount" value="13"/>
+        <int name="attackCount" value="4"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="1170"/>
+        </canvas>
+        <canvas name="1" width="95" height="670">
+          <vector name="origin" x="49" y="648"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="2" width="139" height="669">
+          <vector name="origin" x="75" y="649"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="3" width="140" height="669">
+          <vector name="origin" x="76" y="647"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="4" width="140" height="664">
+          <vector name="origin" x="74" y="645"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="5" width="114" height="673">
+          <vector name="origin" x="58" y="654"/>
+          <int name="z" value="0"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="104" height="111">
+          <vector name="origin" x="57" y="59"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="89" height="84">
+          <vector name="origin" x="43" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="100" height="82">
+          <vector name="origin" x="49" y="40"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="117" height="95">
+          <vector name="origin" x="57" y="46"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="126" height="105">
+          <vector name="origin" x="60" y="51"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="attackAfter" value="1170"/>
+      <int name="conMP" value="10"/>
+      <int name="PADamage" value="336"/>
+    </imgdir>
+    <canvas name="0" width="242" height="197">
+      <vector name="origin" x="-188" y="208"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="1" width="372" height="225">
+      <vector name="origin" x="-188" y="208"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="2" width="381" height="236">
+      <vector name="origin" x="-186" y="211"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="3" width="386" height="242">
+      <vector name="origin" x="-184" y="214"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="4" width="389" height="247">
+      <vector name="origin" x="-183" y="216"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="5" width="392" height="250">
+      <vector name="origin" x="-181" y="217"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="6" width="395" height="254">
+      <vector name="origin" x="-179" y="219"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="7" width="392" height="251">
+      <vector name="origin" x="-181" y="217"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="8" width="394" height="254">
+      <vector name="origin" x="-179" y="219"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="9" width="392" height="252">
+      <vector name="origin" x="-181" y="217"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="10" width="394" height="255">
+      <vector name="origin" x="-179" y="219"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="11" width="390" height="253">
+      <vector name="origin" x="-181" y="217"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="12" width="391" height="255">
+      <vector name="origin" x="-179" y="219"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="13" width="371" height="227">
+      <vector name="origin" x="-199" y="191"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="14" width="373" height="227">
+      <vector name="origin" x="-199" y="191"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="15" width="378" height="226">
+      <vector name="origin" x="-199" y="191"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="16" width="386" height="223">
+      <vector name="origin" x="-196" y="190"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="17" width="402" height="234">
+      <vector name="origin" x="-189" y="202"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="18" width="379" height="226">
+      <vector name="origin" x="-189" y="202"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="19" width="378" height="221">
+      <vector name="origin" x="-189" y="202"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="20" width="317" height="192">
+      <vector name="origin" x="-189" y="202"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-817" y="-856"/>
+        <vector name="rb" x="800" y="20"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="64" height="65">
+          <vector name="origin" x="27" y="75"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="60" height="65">
+          <vector name="origin" x="27" y="76"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="68" height="62">
+          <vector name="origin" x="29" y="73"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="93" height="69">
+          <vector name="origin" x="44" y="76"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="96" height="67">
+          <vector name="origin" x="47" y="77"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="96" height="67">
+          <vector name="origin" x="47" y="77"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="96" height="67">
+          <vector name="origin" x="47" y="77"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="95" height="68">
+          <vector name="origin" x="47" y="79"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="8" width="85" height="67">
+          <vector name="origin" x="46" y="80"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="9" width="123" height="76">
+          <vector name="origin" x="55" y="65"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="10" width="111" height="83">
+          <vector name="origin" x="49" y="83"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="11" width="111" height="83">
+          <vector name="origin" x="49" y="75"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="12" width="101" height="79">
+          <vector name="origin" x="44" y="75"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="13" width="95" height="81">
+          <vector name="origin" x="41" y="75"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="hitAfter" value="810"/>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="magic" value="1"/>
+      <int name="conMP" value="1"/>
+      <int name="disease" value="132"/>
+      <int name="level" value="3"/>
+      <int name="attackAfter" value="1200"/>
+    </imgdir>
+    <canvas name="0" width="242" height="197">
+      <vector name="origin" x="-188" y="208"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="1" width="285" height="257">
+      <vector name="origin" x="-188" y="268"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="2" width="284" height="263">
+      <vector name="origin" x="-188" y="276"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="3" width="281" height="265">
+      <vector name="origin" x="-189" y="280"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="4" width="281" height="267">
+      <vector name="origin" x="-190" y="284"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="5" width="282" height="266">
+      <vector name="origin" x="-191" y="286"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="6" width="282" height="265">
+      <vector name="origin" x="-192" y="288"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="7" width="283" height="266">
+      <vector name="origin" x="-192" y="290"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="8" width="283" height="266">
+      <vector name="origin" x="-192" y="291"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="9" width="283" height="266">
+      <vector name="origin" x="-192" y="292"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="10" width="285" height="273">
+      <vector name="origin" x="-190" y="293"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="11" width="283" height="272">
+      <vector name="origin" x="-191" y="293"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="12" width="281" height="269">
+      <vector name="origin" x="-192" y="293"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="13" width="278" height="266">
+      <vector name="origin" x="-192" y="291"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="14" width="277" height="271">
+      <vector name="origin" x="-190" y="289"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="15" width="272" height="265">
+      <vector name="origin" x="-191" y="286"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="16" width="263" height="257">
+      <vector name="origin" x="-192" y="279"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="17" width="257" height="253">
+      <vector name="origin" x="-192" y="274"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="18" width="237" height="236">
+      <vector name="origin" x="-191" y="254"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="19" width="242" height="240">
+      <vector name="origin" x="-188" y="253"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="20" width="242" height="197">
+      <vector name="origin" x="-188" y="208"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="21" width="242" height="197">
+      <vector name="origin" x="-188" y="208"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="22" width="242" height="197">
+      <vector name="origin" x="-188" y="208"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="23" width="242" height="197">
+      <vector name="origin" x="-188" y="208"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="64" y="-145"/>
+        <vector name="rb" x="577" y="16"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="98" height="86">
+          <vector name="origin" x="51" y="76"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="140" height="122">
+          <vector name="origin" x="75" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="138" height="112">
+          <vector name="origin" x="72" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="153" height="124">
+          <vector name="origin" x="79" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="158" height="129">
+          <vector name="origin" x="80" y="98"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="162" height="135">
+          <vector name="origin" x="81" y="101"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1260"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="242" height="197">
+      <vector name="origin" x="-188" y="208"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="1" width="240" height="305">
+      <vector name="origin" x="-189" y="315"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="2" width="229" height="315">
+      <vector name="origin" x="-196" y="320"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="3" width="224" height="322">
+      <vector name="origin" x="-199" y="323"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="4" width="229" height="335">
+      <vector name="origin" x="-196" y="334"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="5" width="225" height="339">
+      <vector name="origin" x="-199" y="334"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="6" width="229" height="347">
+      <vector name="origin" x="-196" y="343"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="7" width="239" height="351">
+      <vector name="origin" x="-194" y="344"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="8" width="238" height="348">
+      <vector name="origin" x="-194" y="343"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="9" width="236" height="350">
+      <vector name="origin" x="-194" y="342"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="10" width="231" height="346">
+      <vector name="origin" x="-195" y="340"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="11" width="232" height="347">
+      <vector name="origin" x="-196" y="338"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="12" width="231" height="344">
+      <vector name="origin" x="-196" y="338"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="13" width="565" height="372">
+      <vector name="origin" x="-42" y="344"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="14" width="584" height="374">
+      <vector name="origin" x="-20" y="346"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="15" width="584" height="375">
+      <vector name="origin" x="-20" y="348"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="16" width="587" height="373">
+      <vector name="origin" x="-17" y="346"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="17" width="553" height="368">
+      <vector name="origin" x="-30" y="344"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+    <canvas name="18" width="273" height="367">
+      <vector name="origin" x="-171" y="343"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="217" y="-201"/>
+      <vector name="rb" x="404" y="-30"/>
+      <vector name="head" x="301" y="-212"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="242" height="197">
+      <vector name="origin" x="-153" y="208"/>
+      <int name="delay" value="100"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="243" height="197">
+      <vector name="origin" x="-187" y="208"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="346" height="229">
+      <vector name="origin" x="-84" y="209"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="2" width="439" height="392">
+      <vector name="origin" x="-79" y="370"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="3" width="434" height="408">
+      <vector name="origin" x="-76" y="386"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="4" width="439" height="421">
+      <vector name="origin" x="-74" y="399"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="5" width="445" height="409">
+      <vector name="origin" x="-72" y="387"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="6" width="449" height="406">
+      <vector name="origin" x="-74" y="384"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="7" width="463" height="425">
+      <vector name="origin" x="-53" y="403"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="8" width="385" height="445">
+      <vector name="origin" x="-121" y="423"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="9" width="385" height="447">
+      <vector name="origin" x="-121" y="425"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="10" width="390" height="392">
+      <vector name="origin" x="-116" y="370"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="11" width="395" height="260">
+      <vector name="origin" x="-111" y="238"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="12" width="391" height="264">
+      <vector name="origin" x="-115" y="242"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="13" width="391" height="268">
+      <vector name="origin" x="-115" y="246"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="14" width="392" height="272">
+      <vector name="origin" x="-115" y="250"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="15" width="394" height="272">
+      <vector name="origin" x="-114" y="250"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="16" width="395" height="272">
+      <vector name="origin" x="-114" y="250"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="17" width="396" height="272">
+      <vector name="origin" x="-113" y="250"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="18" width="398" height="272">
+      <vector name="origin" x="-112" y="250"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="19" width="398" height="272">
+      <vector name="origin" x="-112" y="250"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="20" width="368" height="272">
+      <vector name="origin" x="-128" y="250"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="21" width="368" height="254">
+      <vector name="origin" x="-128" y="232"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="22" width="368" height="252">
+      <vector name="origin" x="-128" y="230"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="23" width="368" height="250">
+      <vector name="origin" x="-128" y="228"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="24" width="367" height="246">
+      <vector name="origin" x="-128" y="224"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="25" width="367" height="240">
+      <vector name="origin" x="-128" y="218"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="26" width="367" height="222">
+      <vector name="origin" x="-128" y="200"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="27" width="367" height="213">
+      <vector name="origin" x="-128" y="191"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8830010.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8830010.img.xml
@@ -1,0 +1,311 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8830010.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="0"/>
+    <int name="level" value="80"/>
+    <int name="maxHP" value="7503000"/>
+    <int name="maxMP" value="0"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="0"/>
+    <int name="PDDamage" value="0"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="0"/>
+    <int name="acc" value="0"/>
+    <int name="eva" value="0"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="hpTagColor" value="3"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <string name="defaultHP" value="Unknown"/>
+    <int name="noFlip" value="1"/>
+    <string name="defaultMP" value="Unknown"/>
+    <int name="firstAttack" value="1"/>
+    <int name="disable" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="161"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="1"/>
+      <imgdir name="Index">
+        <int name="hp" value="1247500"/>
+        <int name="prob" value="100"/>
+        <string name="0" value="还……还没完。我会让你见识我真正的力量！"/>
+      </imgdir>
+    </imgdir>
+    <int name="boss" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="821" height="558">
+      <vector name="origin" x="321" y="557"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="2" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="3" width="821" height="558">
+      <vector name="origin" x="321" y="557"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="4" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="5" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="6" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="7" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="8" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="9" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="10" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="11" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="12" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="13" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="14" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="15" width="821" height="558">
+      <vector name="origin" x="321" y="557"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="16" width="823" height="559">
+      <vector name="origin" x="322" y="558"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="17" width="825" height="560">
+      <vector name="origin" x="323" y="559"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="18" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="19" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="20" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="21" width="833" height="564">
+      <vector name="origin" x="327" y="563"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="22" width="831" height="563">
+      <vector name="origin" x="326" y="562"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="23" width="829" height="562">
+      <vector name="origin" x="325" y="561"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill16">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="823" height="566">
+      <vector name="origin" x="317" y="565"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="2" width="819" height="569">
+      <vector name="origin" x="312" y="568"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="3" width="815" height="571">
+      <vector name="origin" x="308" y="570"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="4" width="810" height="573">
+      <vector name="origin" x="304" y="572"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="5" width="806" height="574">
+      <vector name="origin" x="301" y="573"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="6" width="802" height="576">
+      <vector name="origin" x="298" y="575"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="7" width="798" height="578">
+      <vector name="origin" x="295" y="577"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="8" width="794" height="579">
+      <vector name="origin" x="292" y="578"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="9" width="790" height="580">
+      <vector name="origin" x="289" y="579"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="10" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="11" width="785" height="582">
+      <vector name="origin" x="285" y="581"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="12" width="784" height="583">
+      <vector name="origin" x="284" y="582"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="13" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="14" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="15" width="783" height="584">
+      <vector name="origin" x="283" y="583"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="16" width="784" height="583">
+      <vector name="origin" x="284" y="582"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="17" width="786" height="581">
+      <vector name="origin" x="286" y="580"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="18" width="794" height="579">
+      <vector name="origin" x="292" y="578"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="19" width="802" height="576">
+      <vector name="origin" x="298" y="575"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="20" width="810" height="573">
+      <vector name="origin" x="304" y="572"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="21" width="819" height="569">
+      <vector name="origin" x="312" y="568"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="22" width="823" height="566">
+      <vector name="origin" x="317" y="565"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="没有什么能阻止我……黑暗已经开始蔓延……"/>
+      <string name="1" value="愚蠢！只靠一个人是赢不了的。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="4" height="4">
+      <vector name="origin" x="36" y="53"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="827" height="561">
+      <vector name="origin" x="324" y="560"/>
+      <vector name="lt" x="-138" y="-429"/>
+      <vector name="rb" x="63" y="-261"/>
+      <vector name="head" x="-61" y="-420"/>
+      <int name="delay" value="3000"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="呃……比我想象中更强！别以为你已经打败了我。被封印的力量……等那股力量归来时，我将再次统治世界。"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8830013.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8830013.img.xml
@@ -1,0 +1,137 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8830013.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="0"/>
+    <int name="level" value="1"/>
+    <int name="maxHP" value="1"/>
+    <int name="maxMP" value="0"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="0"/>
+    <int name="PDDamage" value="0"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="0"/>
+    <int name="acc" value="0"/>
+    <int name="eva" value="0"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="12"/>
+    <int name="noFlip" value="1"/>
+    <imgdir name="revive">
+      <int name="0" value="8830008"/>
+    </imgdir>
+    <int name="boss" value="1"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="1"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="367" height="215">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="367" height="215">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="366" height="211">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="366" height="220">
+      <vector name="origin" x="441" y="202"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="2" width="366" height="211">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="3" width="366" height="220">
+      <vector name="origin" x="441" y="202"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="4" width="366" height="211">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="5" width="366" height="220">
+      <vector name="origin" x="441" y="202"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="6" width="366" height="211">
+      <vector name="origin" x="441" y="193"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="7" width="369" height="256">
+      <vector name="origin" x="441" y="208"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="8" width="369" height="274">
+      <vector name="origin" x="441" y="226"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="9" width="369" height="285">
+      <vector name="origin" x="441" y="237"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="10" width="370" height="384">
+      <vector name="origin" x="442" y="336"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="11" width="413" height="324">
+      <vector name="origin" x="485" y="276"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="12" width="370" height="297">
+      <vector name="origin" x="442" y="249"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="13" width="374" height="288">
+      <vector name="origin" x="438" y="257"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="14" width="396" height="294">
+      <vector name="origin" x="441" y="263"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="15" width="399" height="280">
+      <vector name="origin" x="442" y="264"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="16" width="436" height="281">
+      <vector name="origin" x="442" y="266"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="17" width="437" height="285">
+      <vector name="origin" x="443" y="268"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="18" width="299" height="256">
+      <vector name="origin" x="402" y="240"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="19" width="282" height="218">
+      <vector name="origin" x="384" y="229"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="20" width="276" height="207">
+      <vector name="origin" x="378" y="219"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="21" width="275" height="199">
+      <vector name="origin" x="376" y="211"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="哈哈，又想封印我？休想。我会让你见识我的力量！"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8890036.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8890036.img.xml
@@ -1,0 +1,3155 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8890036.img">
+  <imgdir name="info">
+    <int name="level" value="160"/>
+    <int name="maxHP" value="210000000"/>
+    <int name="maxMP" value="100000"/>
+    <int name="mpRecovery" value="1000000"/>
+    <int name="hpRecovery" value="10000"/>
+    <int name="speed" value="100"/>
+    <int name="PADamage" value="1600"/>
+    <int name="MADamage" value="1600"/>
+    <int name="PDRate" value="100"/>
+    <int name="MDRate" value="100"/>
+    <int name="acc" value="270"/>
+    <int name="eva" value="47"/>
+    <int name="pushed" value="1000000000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <int name="explosiveReward" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="ignoreMovable" value="1"/>
+    <int name="ignoreFieldOut" value="1"/>
+    <int name="isRemoteRange" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="knockback" value="1"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="action" value="2"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="disease" value="123"/>
+        <int name="level" value="55"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="action" value="3"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="disease" value="132"/>
+        <int name="level" value="19"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="action" value="4"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="disease" value="125"/>
+        <int name="level" value="33"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="action" value="5"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="disease" value="137"/>
+        <int name="level" value="4"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="action" value="6"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="6"/>
+        <int name="tremble" value="1"/>
+        <int name="fixDamR" value="50"/>
+      </imgdir>
+      <imgdir name="6">
+        <int name="action" value="7"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="3"/>
+        <int name="conMP" value="1"/>
+        <int name="magic" value="1"/>
+        <int name="disease" value="126"/>
+        <int name="level" value="30"/>
+      </imgdir>
+      <imgdir name="7">
+        <int name="action" value="8"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="1"/>
+        <int name="magic" value="1"/>
+        <int name="deadlyAttack" value="1"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="skill">
+      <imgdir name="7">
+        <int name="skill" value="145"/>
+        <int name="action" value="6"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="0">
+        <int name="skill" value="128"/>
+        <int name="action" value="3"/>
+        <int name="level" value="8"/>
+        <int name="skillAfter" value="1760"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="128"/>
+        <int name="action" value="1"/>
+        <int name="level" value="13"/>
+        <int name="skillAfter" value="990"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="200"/>
+        <int name="action" value="2"/>
+        <int name="level" value="223"/>
+        <int name="skillAfter" value="1440"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="128"/>
+        <int name="action" value="4"/>
+        <int name="level" value="1"/>
+        <int name="skillAfter" value="1260"/>
+        <int name="effectAfter" value="1260"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="145"/>
+        <int name="action" value="6"/>
+        <int name="level" value="4"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="skill" value="200"/>
+        <int name="action" value="5"/>
+        <int name="level" value="222"/>
+        <int name="skillAfter" value="1440"/>
+        <int name="preSkillIndex" value="7"/>
+        <int name="preSkillCount" value="5"/>
+      </imgdir>
+      <imgdir name="6">
+        <int name="skill" value="128"/>
+        <int name="action" value="7"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="630"/>
+        <int name="skillAfter" value="630"/>
+      </imgdir>
+    </imgdir>
+    <int name="bodyAttack" value="1"/>
+    <int name="exp" value="0"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="aacfdac6db9941a92082d4ff149e479f91f9b7f9b17d384ad091f8446779d0bc"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="9720c408116d2ab09e8295717dc11971cbd4d77a353c168ebb28c04f746e232d"/>
+    </canvas>
+    <canvas name="10" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="cc792d53d48c07a6c8c037fbe59907615b6fc0e8107e7f22c903ad06b7d79ebf"/>
+    </canvas>
+    <canvas name="11" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="e692398e07ba283472e8fca4e7e5a26b1cd3d5578ab92a5c37ce89719d8608dc"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="4a6ef4330261092c4be1be264c84fc9267ad1b48ba59fd0169d306b570993dc9"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="4c12eb8473e722e09eec99743488c040d27f1fa9c00e7c6efafd77212894159a"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a8f58b13a489ca5850848829e359f05b8eed60ac4a1cce456a03680c644faaef"/>
+    </canvas>
+    <canvas name="5" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="210cd2abd8fb276b8e1e08abe2f19994edf8f3d0b2dc66721b81898279ac7a99"/>
+    </canvas>
+    <canvas name="6" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="7" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="69d8a175e31fd46b141b4f142401142cf79d649dbfca8b5715643c53f64be086"/>
+    </canvas>
+    <canvas name="8" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="c46972e7aa48ef79b899a102749f46d3474c84ad99a34f47e4f79b3b9d68db74"/>
+    </canvas>
+    <canvas name="9" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="1a3792b751548391d8b5a72067e2b2ac1738725f97521f973bb3266166731fa3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="5" width="200" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="ace4d88aa5fca2f30ce1aba0361e59635ec9936e0d948d34100a6b20f6adcaa6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="53f6e366da478b2bf97da582637682cba6e16f6426f884b8d7dd78e0f2b8b420"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="ea7498c7f47b52286a540fda3522c46e3eaa4477bee49736508c58a0e8eb847a"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="bcd85aa903f39e6f5211f04e64ab12f27968cebec541f04b2df1d55f7b3ccd82"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="de90f4fa91c5d222eb9a524c87f50fb11b4f1dcf5fd126d9bcdb7aa24f687f33"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="7ce12372921280cca8a391b4aeb4473e77e15d22d5fc854d965d4b8b1cb64eb5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="ed173a097e57edeabd997764a1203fe48282c6b66b5b3c63b8959d1a68ab282c"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f561de600870aed73eefd738f90fc1043bed8280371cbb166f7dee0e66ffbd53"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3a0c130666d0a065906181c8bd7ba4cd7af1486cf095678d378ef485a4546848"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="443e54e4c9419660510be8ff8bf49b240de73248fbd94c3b75eacb478cf445cc"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="e9a9f905eaf9c7e697735d27789323e85fa1f1d8c8abb0892d7675da6e5de506"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="9b1981507d06d898fde691f11b21c3f9778b978b01de082e32a5d753432e68cf"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e14184568972a6e77906e675413433f8968c5075e9541f2d258de8ad38bcbabf"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="ddaf8bd5ce82b330d7edf018fd66ca865657a04d92f7d983afd279d03821bd84"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5b965163288d1c34396f6416910f627c94261153a4bb4ef8e75d7c2b249209a6"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b468ebfb3b67e05d740ff415fbfaf1a6756f09d8c19ca9ec4d77141d3efd3752"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="c1c4886943ef4862b15d434a478a125dfa092481b1b250f91ce8c73154815684"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1c99b9631d1c854e130f4b548591d393fcd4721a089799389c82f668f3da2393"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="39566a11077d123dcbd1d0032373d33c586b9a1e65d564da880520ac97ef671a"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="91fbe439bd6ffca9eaff288b2cda1c5be611ee89d34e4ca9a3946bc35ec66fd7"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="14c22bb33a2f2c1bc0f9e138aadf315c219d4abbcb5adb96835640caf32e51cf"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7377d913b3e0e22893bcf9019a884a4c298f4bee7ec9a8c0c7fc2e10fdc263e7"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="84a10b45ceda775f338d1d62ff555ebe7ac9dfb2e0d90ebf5e42aaaba0ffa37d"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="cf92e0ffc0a2e247486e0a5f56bd7c5c44d61bccd420ef0c4c91bac8d35fe293"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7afbb566b04355530205cbf6ee22a58875587d460f6147bfb708d5bb90b0551e"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="484249c5bc3dfa1b980be5f56a3e1d93bde25ca3dec81ef9bb9ad2ae1d761260"/>
+        </canvas>
+        <canvas name="15" width="160" height="49">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7bb927d4063b5272776e83cf201a25a418f2d4b9e5f9f43bd3bf373d46db0082"/>
+        </canvas>
+        <canvas name="16" width="60" height="49">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5a3f8187e830f852440585186c0e3c6ab10225f0828dcb2144202500b17d788b"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="c06e0a1d53536be3f89cca6c459c632b72cbd79542e11ad04f9f9199008e775c"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6c9d0e2e3f6778eeaa44d9b6d34213e75a83e6c2e4b984b03ae49104300fc092"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="47d401133797d76af401f7855fe44a3b0eeb388923bf0a2dcd9ca654f2279c28"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3cdf4b8968876423893686bb285c6d0c9729de34c4c661a726135e8c52133f59"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="092042886657e04f11bcf14ef2b0f1ca5d651bd00ab9e31a2610744317b09c44"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_inlink" value="attack1/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="1" height="1">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/1"/>
+        </canvas>
+        <canvas name="2" width="1" height="1">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/2"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="642855b4259104ce2ec98dd86be97d0a0d89d72f70999abbf9579c85affbd9cb"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="88c5b7ecac32cc860d00577f6105be5b15fd9f99f5d25a6b98b9cf029d1295c5"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="dbc0d33c40fae2a166034f2ae1f50076866dfef4987fc1118baf95539e88e2a2"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bfbd90318e054646f09a5432bf3b2c765026a4905790c24904079c4773ad2928"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8bafcbfd9edb6cc910b860acff509eed800ab8674b38dda99b16612211c07cbd"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="34abb4387224c37351708a0ce1f3a5815d798b538e58c752e4281f437c688cb8"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e74d8967bce61233d379d4eb6a17f8f2aa2c1154af9a94eb8997a39c83ae024d"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="befec05e861886328728153a33ea56c55a94a2027fa05723733e0920e35e7970"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0cf7c84ca3d414cb33d6ba874928f742d29e2c61aa3b3f500359adbbb168ec5a"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="174e922c141594c39b6bddafe2f37540e97a76fd04ada23fb2cdccdbaf3a9ba8"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="131" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="80572942c58ca7a183d698294afdd76f7ecd842b34c191be6cd02f821b12ed9b"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="75651698bb1a7372b7f7a180922219def3bc52bc55203e46ee357cb93ebb4e8c"/>
+        </canvas>
+        <canvas name="15" width="160" height="49">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b102caf9e5204ca94452ea072db696e6f957bfc0ec7b7343109b1a625f66390d"/>
+        </canvas>
+        <canvas name="16" width="60" height="49">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="39b8c41a36c92e6ba1040a5574908a6a52e5bcb5e4894afa8e414f3ea400d22e"/>
+        </canvas>
+        <int name="attackAfter" value="1440"/>
+      </imgdir>
+    </imgdir>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="86d5b7f06107a433030beb76025082080374cf85322cc2c3faf62f0d226b8402"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="cf7d28621dd3989207c3164fdc7964b5148af1ce8f75a880ef45efe1b5e50033"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="405951214f0a2f370941d42229a23ebb4ceb720fb99eb5f27acedb63a86dc5a7"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="aa48d2503799de6a57c495166c73807468794a007631f7463f83b0fff6da4388"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b7ca770a9097eb89987acee55d3d7e1e4717b5649467050fa5d68b352415718b"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="0e09dc6fa57eb7be950c839c37ebbb3b4ea54332b2eedf35688245e1c39bc440"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f43ed4a87893b2f41ee84926f4d7ea92fe403907c32a9985d6f1186e7a2debd9"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d75724403e970496e4ab4e2415da47785a3b19c5512e37658199ef5be15107be"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4bef2b6e975ea3d60ac5e267b62766c8f7b69110625e31e45da7af5989bb6def"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b04182cbe58f31aa5bd77c1f7eb2e317802b5628a7f4b35e1cbc0b511c7b7259"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="685279ece87a51e566920b5a6b07a177b648822071db1c5a0f0bb5c0574cf50d"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bbeb8cddd55bdfb84063941c2da093e548fd70dc3be0116120157d7169c47fbf"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0e58a86d405c0e81f5a60736d82467c33f7b495aac1f1300cd936ae21c43d4ea"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e589c7010946da5b996d44c8b50f56bf635b42fedab0fbd3617bbd2fc696da92"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="25904a1f9dd3d353b62aabf2b47d9b04d6735dd28ceab5ed2402f6227912a08d"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0b9ef739ffb6dc0b6f89295de0f803a644f4fda8edd1a27268d80ac94c014b7d"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-9" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9fc588141e33ba8b19abbedf133417a7d698923cf1bb0f9da15aab94529bb564"/>
+        </canvas>
+        <canvas name="12" width="297" height="89">
+          <vector name="origin" x="244" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bada5098ad663279b04f71dc98ac1ba223ff01e9a3a31d47971490faaf6d6b16"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d0922c563583f11ffb5ce844c70e219a1a26e4a80a2f7243320c4a557d544715"/>
+        </canvas>
+        <canvas name="14" width="1" height="1">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/14"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack2/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="611c4a8dbfab9d22ac8ff48e21fd7068528727bf09abc328af09466c1a582590"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3f4f0e69bdaa8e05ec683ef1a26e2cec9c381ef18125e6c3369e4f3336edae07"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="e6a4ed00509cfd9864dc2e1ccbbdd53eeb1f8013dbf21938e5d3cc47c5fe5230"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6efdbddb5a7fe5c392ffc88bd51618db78f6c631c282ebbca0e37ca2d4a75d6d"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f23473659433f05ef05f07664365d638e4508aa1e14e6b15540c90275c949da4"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f551b946051b5a564a273336dcaee1db2d6e6a3a9b1a90d022638b88eae475df"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="203e25bb1fd53b1a5e7d2cd80b3f8959bbba982fcf452bad93a0915ade08a653"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4fa6ae3fc1b006099a97c27a170a757c9ff161a6855d75b7ca67e32d9e33eca1"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="ecaba8472e3eb0a8fd18e358df6a3341c54626abf6aa95f2ebd66b913ed97589"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6577098e707bf33585d998f703eeb2d5c68d7bde9483ee3e399e388e9ac2a0a9"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="24cf809e09060234dc560c73f4b5be22e1c04052d07d7c60fc7d2bc302076a64"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0a1ba0ddae1eb1c189d0d1f4a5672d6018b79891706bd5def4ffe135ed1e89c6"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="65b514b10138bef0075d47585ee11cd2e633f21a7673c03e8568e095158c9016"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9ecddc089310016cdd8526ca2c4475c881176fd78a27b350b5e29e01c9389e93"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="c7cc7584fd2ad81d23d13f2367a5636c8fff3c74d10b9ddd936632d668af2946"/>
+        </canvas>
+        <canvas name="10" width="57" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6562d65d76730ec0f5a02700d0904269484c4d97617402b09b0011f60178235e"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d3030969d95ef8f505edbb401b97716a0cff5e70e3b8724a86d457bb8cdf4fb3"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="55fc186417168611c03cca71cce0900a7ada6bd808ace00858680a6009207d1a"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="641d5ae49645769d9bd9a4d338e9737473e91d7000b40f08aaa6d0f8c94cacbb"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="a4740c7c3d1c09c98b009ed045fa3e3680c1cbcff89f058f9b6ff70a0bd18142"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack5">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b16c000e92a26c2dea7b8e9d20ac3d359248873c4e5840e11a49da15a68d9d10"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="a053dcb8c8ccd9dba6ac60a12d68d03420615738ab86e181bb752a6dab961d1b"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="c38457d5b09126168e6ad1a5729bb5fbf8be4cab63276007d1d81f83ade87069"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f1e1600924557d89e7ad9367b9481af20a79b8b4188697a18a3bb5639c22dfeb"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="db7e3f6c18a368186b4d7ae1802337f9eabc352bec2989541e05274bd431bf30"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_inlink" value="attack4/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6a97cfc259437844155a80dedf1ae6c70a537f46a7b87880a792cd1a8158e9ad"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5681468acc1da43e17b6275f84ee07a11e4cbd50db1dea71c70c0362833bf041"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8f744d8e1b573d08ded2b9d4bf9115b2da99e9dfbe9459ef12553b77e14e1e70"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="124a7cff5f9b3e2cdd9f2c88ceea049d5f8404ad97e11fe28078214bbfeb1739"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1172cb339eb469aef3c2d1830f581e352b47c0256462f0aba2c104e781433e9e"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="2131e318abd89e9aeb577d1784fe7f4df0956b310ebe558a9695493326a90211"/>
+        </canvas>
+        <canvas name="7" width="57" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bb2495273f323718c161b84b590564c26037d905385b182378b57e6a3ff3d41e"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="db4e53724ecb0d6a42336494745ebcc4d9ca254098e4e8058818d23b6f2dd1a3"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="22621db1db697143c85f915a1af45b368729a2d59f12a6b7f20d4596688d4c78"/>
+        </canvas>
+        <canvas name="10" width="57" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1f783c6758d0201b88b495104b98d4142d0cf926d17f39f8799af47e8cec90bf"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9a5750d8e4107d9d925b59ba4c6448cb0ec671ebccb604af5c34a6357dff146a"/>
+        </canvas>
+        <canvas name="12" width="298" height="90">
+          <vector name="origin" x="244" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="80169ca1211efeb069d6b6054af8f417f6e1fffc25ba37e02f807f84ce2dc5ad"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="fadd8c8de8582e094bfdcb68d3408f51cceca443bb7a7671c72fa319ef471713"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f5931134c84763e2714eeea51af1f123897a978882305f584236dad7ab4cfb9f"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack6">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-767" y="-30"/>
+        <vector name="rb" x="751" y="13"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="191" height="183">
+          <vector name="origin" x="95" y="91"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b23a4d491f7813fb2f0c8c5fa271c7fbd71514d6f56deccb866d385356b9e8fb"/>
+        </canvas>
+        <canvas name="1" width="178" height="181">
+          <vector name="origin" x="89" y="90"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f0644280d8a073519c5b0e8c7ce14811c644efc33597b73b8a454b1ef39f2271"/>
+        </canvas>
+        <canvas name="2" width="186" height="187">
+          <vector name="origin" x="93" y="93"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="8a413ffb1efa0bf652dbed94868378cab7971850178ddcf4048689aed6022851"/>
+        </canvas>
+        <canvas name="3" width="183" height="190">
+          <vector name="origin" x="91" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6ee40481205f9562f733ec7bde2d841b0ef551f4375a0764c523f43a1cdf0da9"/>
+        </canvas>
+        <canvas name="4" width="125" height="118">
+          <vector name="origin" x="62" y="59"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="53f010a10ce309a7f5d21259a86a2764f876a41f4d71b296497f6f98544a7efd"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1920"/>
+    </imgdir>
+    <canvas name="0" width="196" height="193">
+      <vector name="origin" x="89" y="185"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="a79760470787833c345ed030e861d371bfc98fee59ecfaf5c4ea0693ee9655cb"/>
+    </canvas>
+    <canvas name="1" width="196" height="194">
+      <vector name="origin" x="89" y="208"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="a872a786293da41c92db4fd28fee9526a973d17504fcba08e522d5b9112b9e6f"/>
+    </canvas>
+    <canvas name="2" width="196" height="193">
+      <vector name="origin" x="89" y="212"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="8af3419110e62ebcf50e11ba92e0e75b00360dd0fcdc9e3a7a811f67f12b8b2b"/>
+    </canvas>
+    <canvas name="3" width="394" height="290">
+      <vector name="origin" x="211" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-175"/>
+      <vector name="rb" x="101" y="-28"/>
+      <string name="_hash" value="fae816367fb7d68fa46976a01b0b2a90c1a4b5087dc671632482ad5d8cc1b784"/>
+    </canvas>
+    <canvas name="4" width="385" height="280">
+      <vector name="origin" x="207" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="090ceb9e8278e32f36a6d4c58005cb7420f32177eb4f2a4e28700bdcf560af5c"/>
+    </canvas>
+    <canvas name="5" width="362" height="260">
+      <vector name="origin" x="195" y="264"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="7773304bbfd0645c946f3818588e9c2fad40903928e5d515a47e8f2158849673"/>
+    </canvas>
+    <canvas name="6" width="201" height="182">
+      <vector name="origin" x="95" y="222"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="ff951bbb84e527c5d3f2c14381c01fbda4f71e479514326ae04f94a73702e0fe"/>
+    </canvas>
+    <canvas name="7" width="199" height="183">
+      <vector name="origin" x="92" y="218"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="9c6d73dc138e9fdabeeb9421397491e8b6d75e809555001862a920c6e07c49a3"/>
+    </canvas>
+    <canvas name="8" width="190" height="176">
+      <vector name="origin" x="89" y="215"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="e79175d8bb0431e5af92097e0bbed53fc33ffe9718ada7fbbf1b1d6e21c371cd"/>
+    </canvas>
+    <canvas name="9" width="181" height="165">
+      <vector name="origin" x="87" y="213"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="d9a0fd8f01dadf112bade5f12c183fbb6dbe97717938a53add9da2083d4f5036"/>
+    </canvas>
+    <canvas name="10" width="1" height="1">
+      <vector name="origin" x="0" y="-1"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="394" height="290">
+      <vector name="origin" x="213" y="330"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="84e520166895fc4810530c4caab159231e5c1119905a78cd0aba5cf3866f741a"/>
+    </canvas>
+    <canvas name="12" width="304" height="217">
+      <vector name="origin" x="165" y="289"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="76f064d25d2a7bac2bacdebaaf884baf83ad8c0e6b7454d2e99c2130e4fe64a4"/>
+    </canvas>
+    <canvas name="13" width="278" height="193">
+      <vector name="origin" x="139" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="b09268b9631049d8e06b7f0a2d277ae613e630723591e98ff18e02a546f95de2"/>
+    </canvas>
+    <canvas name="14" width="276" height="193">
+      <vector name="origin" x="138" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="308d00825addf25b8c031da29cdcea3754077e6411fc83224ee8d4ef71c43409"/>
+    </canvas>
+    <canvas name="15" width="198" height="193">
+      <vector name="origin" x="91" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="e87b46b78957d44a624c9decc23a053fbf2ea2af5881c50a547543d63bc0de93"/>
+    </canvas>
+    <canvas name="16" width="1171" height="293">
+      <vector name="origin" x="580" y="247"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <string name="_hash" value="45b5e536f5213f312e54946008fb535a5cbbe43892aa8fdd810954f6005c70fc"/>
+    </canvas>
+    <canvas name="17" width="1189" height="283">
+      <vector name="origin" x="589" y="238"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1ae4b7dcb55cd2a0574e8bf712d2bfe3d4cae25368639e9a96281f01b94151e0"/>
+    </canvas>
+    <canvas name="18" width="1192" height="222">
+      <vector name="origin" x="591" y="182"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e15595dd07d247c539f19ed8557a028ae80d04159782cbc34255b7713a9724c2"/>
+    </canvas>
+    <canvas name="19" width="1199" height="221">
+      <vector name="origin" x="594" y="184"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="be936249e6c16c13180ea19b769daab53c724731e851583479dab3a6e08c4b6d"/>
+    </canvas>
+    <canvas name="20" width="1199" height="193">
+      <vector name="origin" x="595" y="156"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="-4"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b91e4107908aa9d9215856c9cd3ca3d42d7fdb6ba627865e17f2ac5ba2f3ec43"/>
+    </canvas>
+    <canvas name="21" width="1195" height="193">
+      <vector name="origin" x="592" y="156"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1c2e58f311b27eb7ffb65051f54ba7c9e59b6d1fe370e057752afee8e39ea03a"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack7">
+    <canvas name="12" width="196" height="392">
+      <vector name="origin" x="89" y="392"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/>
+    </canvas>
+    <canvas name="13" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="2" width="197" height="378">
+      <vector name="origin" x="90" y="380"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86893292f87ad179cf8e47634df1bdbcfa0d2e425ba7c7899ddee73317a94fa8"/>
+    </canvas>
+    <canvas name="15" width="196" height="393">
+      <vector name="origin" x="89" y="394"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/>
+    </canvas>
+    <canvas name="16" width="196" height="362">
+      <vector name="origin" x="89" y="362"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/>
+    </canvas>
+    <canvas name="17" width="196" height="389">
+      <vector name="origin" x="89" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/>
+    </canvas>
+    <canvas name="6" width="197" height="407">
+      <vector name="origin" x="90" y="407"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="eadebb118bef62fb27cca7c5d83c9981cfea514dc7364f4f3eef5ce23bfd8c6c"/>
+    </canvas>
+    <canvas name="7" width="196" height="412">
+      <vector name="origin" x="89" y="413"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="88ff94607cac27e1e7f91cfab14280d57726d3b88c18e62e641f6d9cb1d83e4f"/>
+    </canvas>
+    <canvas name="8" width="196" height="405">
+      <vector name="origin" x="89" y="407"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="7f87b481fab16131725a601b2d643cf86c8c0602dc21a4848a66c424a41a980b"/>
+    </canvas>
+    <canvas name="9" width="196" height="392">
+      <vector name="origin" x="89" y="393"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="d8cfbd754bee92b4b8b2c44f4219d8669079eff901edfcd6d7b8f4983d807528"/>
+    </canvas>
+    <canvas name="10" width="197" height="388">
+      <vector name="origin" x="90" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="b85da2f8c68b4183c71b3bb528f62ee9d0e1de070b7c2a9b514a9d6535519156"/>
+    </canvas>
+    <canvas name="11" width="196" height="412">
+      <vector name="origin" x="89" y="411"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="a6bdf2a3dee1a24bafac31bbfbf31e885766650cf02d46bd53ea9e7884945551"/>
+    </canvas>
+    <imgdir name="info">
+      <imgdir name="screenCenter">
+        <canvas name="0" width="1366" height="606">
+          <vector name="origin" x="678" y="355"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="961c56bb5d5d7dc7ad0f9d1672c952c63239ced1d00dac9a640f75c5a8a38db3"/>
+        </canvas>
+        <canvas name="1" width="1366" height="619">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="867aa6baaaafb5a67f6449347b80e1aedadf4826eac95adcf41a1e066e655cce"/>
+        </canvas>
+        <canvas name="2" width="1366" height="623">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="896019b3a7c82240f86eb00d90d3d41c00921d259e1334e39586cdd496be8da0"/>
+        </canvas>
+        <canvas name="3" width="1366" height="607">
+          <vector name="origin" x="678" y="348"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="2b9af8374df735f89f113e445eee7291ed2c92a409c1bdcedd311a1ba8fa69f1"/>
+        </canvas>
+        <canvas name="4" width="1366" height="623">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="a99f7e4272142dcf40e9796215118c2c80f7193d5ebe14837da17fd9c7aa3a9b"/>
+        </canvas>
+        <canvas name="5" width="1366" height="630">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="49ddf77b31c2831af083047a841e6fb3b10eb0edcfc5e00c0c433cebceeba14e"/>
+        </canvas>
+        <canvas name="6" width="1366" height="611">
+          <vector name="origin" x="678" y="359"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="e39edb718b12070548efe00dd6df6b54f6bc76635772eee6ab63c220523b3592"/>
+        </canvas>
+        <canvas name="7" width="1366" height="620">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="0f81bf6ef594a4d1b589443177195ed8c061ae6727faaf5077943ea4831254af"/>
+        </canvas>
+        <canvas name="8" width="1366" height="630">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="ca4565241d69c2df61ebbd52a7872290341fa1d64eb742a70656ef668a1733c0"/>
+        </canvas>
+        <canvas name="9" width="1366" height="616">
+          <vector name="origin" x="678" y="359"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="753176c9a79a0b4bfbeb07e3c6f015593e51ff776d46c1605e04623bfc7d4f54"/>
+        </canvas>
+        <canvas name="10" width="1366" height="624">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="a4ea2e9d7c2acc943aadae7b91e89b7755272bf0776278fa636b3d1a3f79400c"/>
+        </canvas>
+        <canvas name="11" width="1366" height="630">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f95b69436294394856c442369930fa30939d076d5ca931717229bce5b2650bcc"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="1" width="176" height="192">
+          <vector name="origin" x="88" y="96"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="24297c65bd86f268e84f9da30bb28f28f6b3929df83c83ef4589743860586205"/>
+        </canvas>
+        <canvas name="2" width="165" height="192">
+          <vector name="origin" x="82" y="96"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="8ee5c4999ed66f77eec4a6891728d0caae27aab78b95d7c394b46b2dd7503c0e"/>
+        </canvas>
+        <canvas name="3" width="163" height="135">
+          <vector name="origin" x="81" y="67"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="710dd428dfead84cb3e570011283888350bc3cb4198c2276689f16c58a0159e8"/>
+        </canvas>
+        <canvas name="4" width="141" height="133">
+          <vector name="origin" x="70" y="66"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="2037b1d2981b15bc1694bd5f572014e17c6753082e8b6c109cfa4a4be7b752b7"/>
+        </canvas>
+        <canvas name="5" width="145" height="140">
+          <vector name="origin" x="72" y="70"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="65833d06e578de7367829fb27cdc203a3cec2d049cad8a50bbfa6bc4b11fa2c0"/>
+        </canvas>
+        <canvas name="6" width="149" height="152">
+          <vector name="origin" x="74" y="76"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="854a7c1bcea63d31cce503d0be743a3e307cf39768b30f4fa0330c0c627ecd51"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="range">
+        <vector name="lt" x="-680" y="-1147"/>
+        <vector name="rb" x="680" y="99"/>
+      </imgdir>
+      <int name="onlyFsm" value="1"/>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="prop" value="100"/>
+      <string name="0" value="无法阻挡的话，就只能承受了吧？"/>
+    </imgdir>
+    <canvas name="0" width="196" height="392">
+      <vector name="origin" x="89" y="392"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/>
+    </canvas>
+    <canvas name="14" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="1" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="3" width="196" height="393">
+      <vector name="origin" x="89" y="394"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/>
+    </canvas>
+    <canvas name="4" width="196" height="362">
+      <vector name="origin" x="89" y="362"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/>
+    </canvas>
+    <canvas name="5" width="196" height="389">
+      <vector name="origin" x="89" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="20" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="8" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/>
+    </canvas>
+    <canvas name="9" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/>
+    </canvas>
+    <canvas name="10" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/>
+    </canvas>
+    <canvas name="11" width="196" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/>
+    </canvas>
+    <canvas name="12" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/>
+    </canvas>
+    <canvas name="13" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/>
+    </canvas>
+    <canvas name="14" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f2b1eb2b88b053721807e0d194e5b55f1b846b5a4b6e11939b92839ec267967e"/>
+    </canvas>
+    <canvas name="15" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="09afd8d8cf124fb4db9f0fec591e6a074ce56eacfae17b8135982d3dec438343"/>
+    </canvas>
+    <canvas name="16" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="2ad898a1542d67c7969aa86fc1c9882bd40dd32a60625b28a3b016346e1e2b38"/>
+    </canvas>
+    <canvas name="17" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="065bae5b5906dd8921a4e04933afa7f9535d191d86be631af646eac30f4cad82"/>
+    </canvas>
+    <canvas name="18" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c6c3f56700e80cf51e3339a72040262411ec5986573968da20513049bd4707bd"/>
+    </canvas>
+    <canvas name="19" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="3297db2c984ffaa1befe4f0177259104027a50eeae88aa5472a5060efbe3f255"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prop" value="100"/>
+      <string name="0" value="在这股力量面前颤抖吧！"/>
+    </imgdir>
+    <canvas name="7" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/>
+    </canvas>
+    <canvas name="4" width="196" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/>
+    </canvas>
+    <canvas name="5" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/>
+    </canvas>
+    <canvas name="6" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/0"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="8b1c227836bc8294007f8ff45ce54f480d7907c0853f29319dea0b4cf614cea1"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/2"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/3"/>
+    </canvas>
+    <canvas name="4" width="196" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/4"/>
+    </canvas>
+    <canvas name="5" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/5"/>
+    </canvas>
+    <canvas name="6" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1578c13f059d956d6aeb5ca636e1d72331eac87a8e1a01fbfdc0085f424d5bbe"/>
+    </canvas>
+    <canvas name="7" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="8c437997c9158a5e1ed3dc72ff559562816d8efc8f8a1c189f2c9eb0152b1a1a"/>
+    </canvas>
+    <canvas name="8" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="26bf7cb4e392126aad1038844de35edc4adb007a480996ecef1f9b5888f8f278"/>
+    </canvas>
+    <canvas name="9" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/16"/>
+    </canvas>
+    <canvas name="10" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/17"/>
+    </canvas>
+    <canvas name="11" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/18"/>
+    </canvas>
+    <canvas name="12" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="636d5a1e1597807ad66adb0d47e00ac24e7f97d8429234c736cdb9347601f604"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill3">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="90" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1d0aac14b0085e2ec724af30e7ceeb5ff32ef5c9e2de6922614e262e656e514b"/>
+    </canvas>
+    <canvas name="1" width="196" height="205">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0270f3a6f9ceb6a83bce4ef665f0e03882a29be3faa0d4033b535baf2dd3756c"/>
+    </canvas>
+    <canvas name="2" width="196" height="213">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0d0cf54e86e131e21d9f127146d0184889794fd198db889de8157c6c2efb5f3a"/>
+    </canvas>
+    <canvas name="3" width="196" height="215">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="982b9d39aa44f124d59dd5fac3014606b9cb5c3b59a98170605a9ac9e86f4bad"/>
+    </canvas>
+    <canvas name="4" width="197" height="218">
+      <vector name="origin" x="90" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c3e340e338054e1adece96d3ba11a501ee729046720b245c7020c22d7a222f4c"/>
+    </canvas>
+    <canvas name="5" width="198" height="220">
+      <vector name="origin" x="91" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="af7f589835fd13d6b275c4cc1fe972c93d02207c7756cb4e581e41439ffa64ae"/>
+    </canvas>
+    <canvas name="6" width="197" height="214">
+      <vector name="origin" x="90" y="206"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1fe9c11f660642b36f07af486afbd56c2a2bc46edd912b7adb9ea0d6c9b70cbb"/>
+    </canvas>
+    <canvas name="7" width="197" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="400852cbca5268b0c396c6d5461fa99fa8d138d57ff64b3e6050e63f8e201151"/>
+    </canvas>
+    <canvas name="8" width="204" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0a6937e946fd7494552cb09f1965afbd21e75b91d71fb16568211e09fde987c6"/>
+    </canvas>
+    <canvas name="9" width="204" height="202">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e0efca09df704285e1cc5a59ad460c7cf3def9cc752c6f28e875106da8e6632a"/>
+    </canvas>
+    <canvas name="10" width="198" height="202">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="55eb33f9d5a8cabbc0ac37018e219811d6cbda349e3a81ed955236858876c60c"/>
+    </canvas>
+    <canvas name="11" width="199" height="204">
+      <vector name="origin" x="89" y="196"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c15a1b7a495533fbcc44b93ba70bc0e492c7e7f7427e326317f66e610412f72a"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill4">
+    <canvas name="0" width="956" height="363">
+      <vector name="origin" x="459" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="da1c9306bf191db3b9ca6446a0c50fb859cb08dc059b3093da6af1a7af6a416d"/>
+    </canvas>
+    <canvas name="1" width="974" height="371">
+      <vector name="origin" x="469" y="325"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="03ad3382983f4613b235848951dddb871f5b1407dd6869f93391e6f9a961911a"/>
+    </canvas>
+    <canvas name="2" width="962" height="377">
+      <vector name="origin" x="462" y="331"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e70a370621d4030bb0a82b3ec6f5edc55fc0f9948bf8cf19d2e3823a55d74f4a"/>
+    </canvas>
+    <canvas name="3" width="958" height="362">
+      <vector name="origin" x="460" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="afdafc77cbc62d9f1755d099ab8d661be62fe32619c2906fa0030a50bb6e5e73"/>
+    </canvas>
+    <canvas name="4" width="956" height="363">
+      <vector name="origin" x="459" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="9c3662fd377e82c8264734f8d9417e444f49d2812d4cf843ac5f3d94699f9ea6"/>
+    </canvas>
+    <canvas name="5" width="974" height="371">
+      <vector name="origin" x="469" y="325"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1c72e326b61263c5b09541c12852aee52a546bc2009f11ef94a6c6cb2784833b"/>
+    </canvas>
+    <canvas name="6" width="962" height="365">
+      <vector name="origin" x="462" y="319"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="7f0b27d216229c86b8505e63c40d382e5bd5730c492928d14bd308eb6005e020"/>
+    </canvas>
+    <canvas name="7" width="958" height="362">
+      <vector name="origin" x="460" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="abd5ca7492609f9c54319b080f892aa0cb5e714c3a1c6a35274972524483ef67"/>
+    </canvas>
+    <canvas name="8" width="956" height="363">
+      <vector name="origin" x="459" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="2de73e35ee56d9fe4f7e02459e796f0e55a451916606ff2cb280919bc9aba71a"/>
+    </canvas>
+    <canvas name="9" width="974" height="371">
+      <vector name="origin" x="469" y="325"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="01044fc53aa723c1c5d5eeef7dc12a36609cdb04326a7e8c76d19f5b3fb8444d"/>
+    </canvas>
+    <canvas name="10" width="962" height="377">
+      <vector name="origin" x="462" y="331"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="9b4c61b524397e7a9e6657a6c4225553734ee5c48353393c6bcce9a6737f690f"/>
+    </canvas>
+    <canvas name="11" width="957" height="362">
+      <vector name="origin" x="459" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="61e8a3c6f6bf6d4cca92bcf2a55f2ad4914d8287b42cad7f35783e70c112aca8"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="sleep">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="b2430fa639b89aa5288be7e776c5b288d9782c2d48f8feb6f0c988bbe56c9087"/>
+    </canvas>
+    <canvas name="1" width="196" height="199">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="cbfce70bc4aa789b671fd5e8b399b3181a9a7217c9eaf53e739ca7d73db54e67"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="622c48789a75abee11372071b4c17ac4bca3d6c331e3f2002ffb55c7812c01a3"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a1a00c60f5904e342e63e90375ef286a2dfed26169087d264a6cbba68a48637d"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="f76ed95f4848e01520006f427c3fc0d838ac7cb082e5ab7e3b2df583b5d7a01d"/>
+    </canvas>
+    <canvas name="5" width="196" height="203">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="3c8bd39163f7777ab7c09af8b678d21fe615a785b3ca0082c8ab3b33b8e39f75"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="wakeup">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="bb3a8529be1dd4f044e38b659cdcdcc31ea98e9b395b1ffeb79f9560a5069745"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="1539eb0621a8ae8ba73be693b113e5f3c4c99140f0fd21745db0f083b7015367"/>
+    </canvas>
+    <canvas name="5" width="196" height="203">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="3c8bd39163f7777ab7c09af8b678d21fe615a785b3ca0082c8ab3b33b8e39f75"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a1a00c60f5904e342e63e90375ef286a2dfed26169087d264a6cbba68a48637d"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="622c48789a75abee11372071b4c17ac4bca3d6c331e3f2002ffb55c7812c01a3"/>
+    </canvas>
+    <canvas name="1" width="196" height="199">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="cbfce70bc4aa789b671fd5e8b399b3181a9a7217c9eaf53e739ca7d73db54e67"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill5">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="fe6d85f38fadf27cb19d34d1fef7ed74b51708b21c45700339375e7f327c4d78"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="7474900d3708017e1d79cfaa0ad65b50c15866d1ab8258b1a303c610e9e0f737"/>
+    </canvas>
+    <canvas name="2" width="394" height="290">
+      <vector name="origin" x="211" y="254"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="3" width="385" height="280">
+      <vector name="origin" x="207" y="249"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="4" width="362" height="260">
+      <vector name="origin" x="195" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="5" width="201" height="182">
+      <vector name="origin" x="95" y="199"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="6" width="199" height="183">
+      <vector name="origin" x="92" y="196"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="7" width="190" height="176">
+      <vector name="origin" x="89" y="193"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_inlink" value="attack6/8"/>
+    </canvas>
+    <canvas name="8" width="181" height="165">
+      <vector name="origin" x="87" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_inlink" value="attack6/9"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill6">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="b2430fa639b89aa5288be7e776c5b288d9782c2d48f8feb6f0c988bbe56c9087"/>
+    </canvas>
+    <canvas name="1" width="196" height="199">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="cbfce70bc4aa789b671fd5e8b399b3181a9a7217c9eaf53e739ca7d73db54e67"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="622c48789a75abee11372071b4c17ac4bca3d6c331e3f2002ffb55c7812c01a3"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a1a00c60f5904e342e63e90375ef286a2dfed26169087d264a6cbba68a48637d"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="f76ed95f4848e01520006f427c3fc0d838ac7cb082e5ab7e3b2df583b5d7a01d"/>
+    </canvas>
+    <canvas name="5" width="196" height="203">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="3c8bd39163f7777ab7c09af8b678d21fe615a785b3ca0082c8ab3b33b8e39f75"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skillAfter5">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="fe6d85f38fadf27cb19d34d1fef7ed74b51708b21c45700339375e7f327c4d78"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="7474900d3708017e1d79cfaa0ad65b50c15866d1ab8258b1a303c610e9e0f737"/>
+    </canvas>
+    <canvas name="2" width="394" height="290">
+      <vector name="origin" x="211" y="254"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="3" width="385" height="280">
+      <vector name="origin" x="207" y="249"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="4" width="362" height="260">
+      <vector name="origin" x="195" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="5" width="201" height="182">
+      <vector name="origin" x="95" y="199"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="6" width="199" height="183">
+      <vector name="origin" x="92" y="196"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="7" width="190" height="176">
+      <vector name="origin" x="89" y="193"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_inlink" value="attack6/8"/>
+    </canvas>
+    <canvas name="8" width="181" height="165">
+      <vector name="origin" x="87" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_inlink" value="attack6/9"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack8">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-291" y="-103"/>
+        <vector name="rb" x="302" y="11"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="176" height="192">
+          <vector name="origin" x="88" y="96"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5b5bbf90f935698fa22ffc6c04334cad0af96e7dd4211f4a606d4d9f01e8526b"/>
+        </canvas>
+        <canvas name="1" width="165" height="192">
+          <vector name="origin" x="82" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f364f9d9613dbacb1f4ca3a01150f5587a4e7f51102e46b3cb327a5f415e5992"/>
+        </canvas>
+        <canvas name="2" width="163" height="135">
+          <vector name="origin" x="81" y="67"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="75f7941cc775149f4006ffef198de7efda1e50c809f2bac2dbb1bf28af282106"/>
+        </canvas>
+        <canvas name="3" width="141" height="133">
+          <vector name="origin" x="70" y="66"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f0d6a63a671be108aa176a9e1585dc7fcaf7f248cb2e85ffd823331564791147"/>
+        </canvas>
+        <canvas name="4" width="145" height="140">
+          <vector name="origin" x="72" y="70"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0f91d203de252aa01a9054313f809952e0194ff222870b26d548f37565acaa4d"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="74" y="73"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9f4f3d4b5d919ec75142aeeb50862ae7d41806fd7038b44a8323f00ba58716f8"/>
+          <string name="_outlink" value="Mob/9390624.img/attack2/info/hit/6"/>
+        </canvas>
+      </imgdir>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f9ff11c42be35e5e3fd109814f4e61b14dd109653833ad15bcd3335a56a891d5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="196" height="179">
+      <vector name="origin" x="89" y="171"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="029fc945fe7a87aea59c019b8a59e48364de0883dde4d4d6c540a9564507c8df"/>
+    </canvas>
+    <canvas name="2" width="192" height="164">
+      <vector name="origin" x="87" y="159"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="1220215ee1bfd503e711d2fa75cb24bbdef2174b20b30cfda11a4f2037da070c"/>
+    </canvas>
+    <canvas name="3" width="187" height="156">
+      <vector name="origin" x="86" y="157"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="8a7e19f2bffe98a8be6daa1e7043f1090cca13d46f8a3aa9ff25bb4f9938fc63"/>
+    </canvas>
+    <canvas name="4" width="175" height="151">
+      <vector name="origin" x="78" y="155"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="3b219a21f7c6625ddc68d067fffd2186ddad543e2fc7be9454c1002b9e49d860"/>
+    </canvas>
+    <canvas name="5" width="156" height="136">
+      <vector name="origin" x="69" y="156"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="086e3e5cf47d9b10c4c48aa15b38d0619c690f08e45e12c5e07d7c432decd957"/>
+    </canvas>
+    <canvas name="6" width="125" height="122">
+      <vector name="origin" x="48" y="151"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="315f1dd0e72160d042c46b73c891f65113b2b6734dbbc25c21beb6c96a1676a8"/>
+    </canvas>
+    <canvas name="7" width="65" height="47">
+      <vector name="origin" x="8" y="93"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="b828e2dc0153f7e04df420a0ddadbdbdfe8664baf63a1c4a5d8a16efdbe4df22"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300196.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300196.img.xml
@@ -1,0 +1,288 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9300196.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="65"/>
+    <int name="maxHP" value="35000"/>
+    <int name="maxMP" value="220"/>
+    <int name="speed" value="5"/>
+    <int name="PADamage" value="250"/>
+    <int name="PDDamage" value="350"/>
+    <int name="MADamage" value="380"/>
+    <int name="MDDamage" value="400"/>
+    <int name="acc" value="155"/>
+    <int name="eva" value="30"/>
+    <int name="exp" value="1500"/>
+    <int name="undead" value="1"/>
+    <int name="pushed" value="1500"/>
+    <int name="hpRecovery" value="100"/>
+    <int name="mpRecovery" value="5"/>
+    <int name="boss" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="mobType" value="7"/>
+    <int name="ignoreFieldOut" value="1"/>
+    <imgdir name="revive">
+      <int name="0" value="9300216"/>
+    </imgdir>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="115"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <int name="explosiveReward" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="118" height="102">
+      <vector name="origin" x="59" y="102"/>
+      <int name="delay" value="500"/>
+      <vector name="lt" x="-59" y="-102"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+    <canvas name="1" width="118" height="106">
+      <vector name="origin" x="60" y="105"/>
+      <int name="delay" value="100"/>
+      <vector name="lt" x="-60" y="-105"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+    <canvas name="2" width="118" height="102">
+      <vector name="origin" x="59" y="102"/>
+      <int name="delay" value="100"/>
+      <vector name="lt" x="-59" y="-103"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+    <canvas name="3" width="118" height="125">
+      <vector name="origin" x="59" y="180"/>
+      <int name="delay" value="300"/>
+      <vector name="lt" x="-59" y="-180"/>
+      <vector name="rb" x="59" y="-55"/>
+      <vector name="head" x="-1" y="-170"/>
+    </canvas>
+    <canvas name="4" width="118" height="125">
+      <vector name="origin" x="59" y="160"/>
+      <int name="delay" value="100"/>
+      <vector name="lt" x="-59" y="-160"/>
+      <vector name="rb" x="59" y="-35"/>
+      <vector name="head" x="-8" y="-149"/>
+    </canvas>
+    <uol name="5" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="118" height="99">
+      <vector name="origin" x="59" y="99"/>
+      <vector name="lt" x="-59" y="-99"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-6" y="-87"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="jump">
+    <canvas name="0" width="118" height="151">
+      <vector name="origin" x="59" y="151"/>
+      <vector name="lt" x="-59" y="-125"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-5" y="-112"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-250" y="-150"/>
+        <vector name="rb" x="250" y="0"/>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="32" height="42">
+          <vector name="origin" x="46" y="63"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="41" height="53">
+          <vector name="origin" x="51" y="69"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="82" height="71">
+          <vector name="origin" x="58" y="78"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="88" height="75">
+          <vector name="origin" x="59" y="80"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="90" height="71">
+          <vector name="origin" x="53" y="75"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="5" width="59" height="76">
+          <vector name="origin" x="19" y="77"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="6" width="61" height="79">
+          <vector name="origin" x="19" y="78"/>
+          <int name="delay" value="200"/>
+        </canvas>
+        <canvas name="7" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="300"/>
+        </canvas>
+        <canvas name="8" width="217" height="51">
+          <vector name="origin" x="108" y="50"/>
+          <int name="delay" value="100"/>
+          <int name="z" value="1"/>
+        </canvas>
+        <canvas name="9" width="242" height="54">
+          <vector name="origin" x="122" y="54"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="10" width="254" height="56">
+          <vector name="origin" x="129" y="58"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="11" width="209" height="53">
+          <vector name="origin" x="101" y="60"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="12" width="209" height="43">
+          <vector name="origin" x="102" y="61"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="13" width="209" height="41">
+          <vector name="origin" x="103" y="64"/>
+          <int name="delay" value="200"/>
+        </canvas>
+        <canvas name="14" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="50"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="50"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="effectAfter" value="0"/>
+      <int name="attackAfter" value="1050"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="300"/>
+    </imgdir>
+    <canvas name="0" width="118" height="102">
+      <vector name="origin" x="59" y="102"/>
+      <vector name="lt" x="-59" y="-102"/>
+      <vector name="rb" x="59" y="0"/>
+      <int name="delay" value="800"/>
+      <vector name="head" x="-11" y="-82"/>
+    </canvas>
+    <canvas name="1" width="118" height="125">
+      <vector name="origin" x="59" y="213"/>
+      <vector name="lt" x="-59" y="-213"/>
+      <vector name="rb" x="58" y="-90"/>
+      <vector name="head" x="-3" y="-201"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="2" width="118" height="151">
+      <vector name="origin" x="59" y="220"/>
+      <vector name="lt" x="-59" y="-220"/>
+      <vector name="rb" x="59" y="-70"/>
+      <int name="delay" value="50"/>
+      <vector name="head" x="-4" y="-186"/>
+    </canvas>
+    <canvas name="3" width="118" height="151">
+      <vector name="origin" x="59" y="157"/>
+      <vector name="lt" x="-59" y="-157"/>
+      <vector name="rb" x="58" y="-7"/>
+      <int name="delay" value="50"/>
+      <vector name="head" x="-8" y="-122"/>
+    </canvas>
+    <canvas name="4" width="120" height="105">
+      <vector name="origin" x="58" y="105"/>
+      <vector name="lt" x="-58" y="-105"/>
+      <vector name="rb" x="62" y="0"/>
+      <int name="delay" value="750"/>
+      <vector name="head" x="-6" y="-85"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="118" height="102">
+      <vector name="origin" x="59" y="102"/>
+      <vector name="lt" x="-59" y="-102"/>
+      <vector name="rb" x="59" y="0"/>
+      <int name="delay" value="800"/>
+      <vector name="head" x="-11" y="-82"/>
+    </canvas>
+    <canvas name="1" width="118" height="125">
+      <vector name="origin" x="59" y="213"/>
+      <vector name="lt" x="-59" y="-213"/>
+      <vector name="rb" x="58" y="-90"/>
+      <vector name="head" x="-3" y="-201"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="2" width="118" height="151">
+      <vector name="origin" x="59" y="220"/>
+      <vector name="lt" x="-59" y="-220"/>
+      <vector name="rb" x="59" y="-70"/>
+      <int name="delay" value="50"/>
+      <vector name="head" x="-4" y="-186"/>
+    </canvas>
+    <canvas name="3" width="118" height="151">
+      <vector name="origin" x="59" y="157"/>
+      <vector name="lt" x="-59" y="-157"/>
+      <vector name="rb" x="58" y="-7"/>
+      <int name="delay" value="50"/>
+      <vector name="head" x="-8" y="-122"/>
+    </canvas>
+    <canvas name="4" width="120" height="105">
+      <vector name="origin" x="58" y="105"/>
+      <vector name="lt" x="-58" y="-105"/>
+      <vector name="rb" x="62" y="0"/>
+      <int name="delay" value="750"/>
+      <vector name="head" x="-6" y="-85"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="118" height="161">
+      <vector name="origin" x="57" y="160"/>
+      <vector name="lt" x="-59" y="-140"/>
+      <vector name="rb" x="59" y="0"/>
+      <int name="delay" value="600"/>
+      <vector name="head" x="-6" y="-127"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="120" height="140">
+      <vector name="origin" x="60" y="140"/>
+      <vector name="head" x="-6" y="-82"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="1" width="138" height="68">
+      <vector name="origin" x="72" y="61"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="147" height="65">
+      <vector name="origin" x="76" y="57"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="154" height="65">
+      <vector name="origin" x="81" y="56"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="156" height="34">
+      <vector name="origin" x="80" y="30"/>
+      <vector name="head" x="-6" y="-42"/>
+      <int name="delay" value="450"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="死了……又死了一次……终于！"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300331.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300331.img.xml
@@ -1,0 +1,176 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9300331.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="10"/>
+    <int name="maxHP" value="10"/>
+    <int name="maxMP" value="10"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="10"/>
+    <int name="PDDamage" value="10"/>
+    <int name="MADamage" value="10"/>
+    <int name="MDDamage" value="10"/>
+    <int name="acc" value="10"/>
+    <int name="eva" value="10"/>
+    <int name="exp" value="10"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="10"/>
+    <int name="boss" value="1"/>
+    <int name="summonType" value="0"/>
+    <int name="removeAfter" value="5"/>
+    <int name="noFlip" value="1"/>
+    <imgdir name="revive">
+      <int name="0" value="9300338"/>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <string name="0" value="谢谢你救了我。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="49" height="65">
+      <vector name="origin" x="34" y="65"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-16" y="-57"/>
+    </canvas>
+    <canvas name="1" width="50" height="63">
+      <vector name="origin" x="35" y="63"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-16" y="-57"/>
+    </canvas>
+    <canvas name="2" width="54" height="60">
+      <vector name="origin" x="39" y="60"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-16" y="-57"/>
+    </canvas>
+    <canvas name="3" width="54" height="60">
+      <vector name="origin" x="39" y="60"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-16" y="-57"/>
+    </canvas>
+    <canvas name="4" width="54" height="60">
+      <vector name="origin" x="39" y="60"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-16" y="-57"/>
+    </canvas>
+    <canvas name="5" width="50" height="62">
+      <vector name="origin" x="35" y="62"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-16" y="-57"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="谢谢你。真的谢谢你。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="49" height="65">
+      <vector name="origin" x="34" y="65"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-16" y="-57"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="446" height="449">
+      <vector name="origin" x="236" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="1" width="475" height="449">
+      <vector name="origin" x="251" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="2" width="477" height="449">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="3" width="477" height="449">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="4" width="477" height="452">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="5" width="477" height="451">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="6" width="477" height="451">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="7" width="477" height="452">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="8" width="477" height="450">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="9" width="477" height="452">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="10" width="477" height="451">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="11" width="477" height="451">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="12" width="477" height="452">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="13" width="477" height="450">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="14" width="477" height="450">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="15" width="477" height="346">
+      <vector name="origin" x="252" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="16" width="475" height="240">
+      <vector name="origin" x="251" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="17" width="446" height="84">
+      <vector name="origin" x="236" y="449"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="呃……嗯……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300340.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300340.img.xml
@@ -1,0 +1,203 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9300340.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="15"/>
+    <int name="maxHP" value="100"/>
+    <int name="maxMP" value="100"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="1"/>
+    <int name="PDDamage" value="10"/>
+    <int name="MADamage" value="1"/>
+    <int name="MDDamage" value="10"/>
+    <int name="acc" value="10"/>
+    <int name="eva" value="0"/>
+    <int name="exp" value="6"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="0"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="removeAfter" value="600"/>
+    <int name="fixedDamage" value="6"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <string name="0" value="呀呼～6周年啦！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="75" height="77">
+      <vector name="origin" x="37" y="77"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-77"/>
+      <vector name="rb" x="38" y="0"/>
+      <vector name="head" x="-3" y="-75"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="82" height="80">
+      <vector name="origin" x="39" y="80"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-39" y="-80"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-5" y="-76"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="86" height="77">
+      <vector name="origin" x="37" y="77"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-77"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="-3" y="-75"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="83" height="74">
+      <vector name="origin" x="35" y="74"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-35" y="-74"/>
+      <vector name="rb" x="48" y="1"/>
+      <vector name="head" x="-1" y="-74"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="75" height="74">
+      <vector name="origin" x="34" y="74"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-34" y="-74"/>
+      <vector name="rb" x="41" y="0"/>
+      <vector name="head" x="0" y="-74"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="75" height="77">
+      <vector name="origin" x="37" y="77"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-77"/>
+      <vector name="rb" x="38" y="0"/>
+      <vector name="head" x="-3" y="-75"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="75" height="76">
+      <vector name="origin" x="37" y="76"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-77"/>
+      <vector name="rb" x="38" y="0"/>
+      <vector name="head" x="-3" y="-74"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="75" height="77">
+      <vector name="origin" x="37" y="77"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-77"/>
+      <vector name="rb" x="38" y="0"/>
+      <vector name="head" x="-3" y="-75"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="83" height="78">
+      <vector name="origin" x="45" y="78"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-45" y="-78"/>
+      <vector name="rb" x="38" y="0"/>
+      <vector name="head" x="-3" y="-76"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="75" height="77">
+      <vector name="origin" x="37" y="77"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-77"/>
+      <vector name="rb" x="38" y="0"/>
+      <vector name="head" x="-3" y="-75"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="75" height="76">
+      <vector name="origin" x="37" y="76"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-77"/>
+      <vector name="rb" x="38" y="0"/>
+      <vector name="head" x="-3" y="-74"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="75" height="77">
+      <vector name="origin" x="37" y="77"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-77"/>
+      <vector name="rb" x="38" y="0"/>
+      <vector name="head" x="-3" y="-75"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="75" height="78">
+      <vector name="origin" x="37" y="78"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-78"/>
+      <vector name="rb" x="38" y="0"/>
+      <vector name="head" x="-3" y="-76"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="jump">
+    <canvas name="0" width="82" height="80">
+      <vector name="origin" x="39" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-39" y="-83"/>
+      <vector name="rb" x="43" y="-3"/>
+      <vector name="head" x="-5" y="-79"/>
+      <int name="delay" value="300"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="96" height="91">
+      <vector name="origin" x="47" y="91"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-47" y="-91"/>
+      <vector name="rb" x="49" y="0"/>
+      <vector name="head" x="3" y="-80"/>
+      <int name="delay" value="300"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="96" height="91">
+      <vector name="origin" x="47" y="91"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="3" y="-80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="91" height="89">
+      <vector name="origin" x="47" y="89"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="3" y="-73"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="105" height="95">
+      <vector name="origin" x="61" y="95"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="4" y="-70"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="116" height="100">
+      <vector name="origin" x="71" y="100"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="4" y="-68"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="85" height="68">
+      <vector name="origin" x="40" y="68"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="4" y="-68"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="85" height="68">
+      <vector name="origin" x="40" y="68"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="4" y="-68"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="85" height="68">
+      <vector name="origin" x="40" y="68"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="4" y="-68"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <imgdir name="speak">
+      <string name="0" value="祝冒险岛6周年快乐～♥"/>
+      <int name="prob" value="100"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300349.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300349.img.xml
@@ -1,0 +1,187 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9300349.img">
+  <imgdir name="info">
+    <int name="level" value="999"/>
+    <int name="maxHP" value="99"/>
+    <int name="maxMP" value="99"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="99"/>
+    <int name="PDDamage" value="99"/>
+    <int name="MADamage" value="99"/>
+    <int name="MDDamage" value="99"/>
+    <int name="acc" value="99"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="99999"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="mobType" value="8"/>
+    <int name="removeAfter" value="5"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <uol name="7" value="0"/>
+    <uol name="8" value="1"/>
+    <uol name="9" value="2"/>
+    <uol name="10" value="3"/>
+    <uol name="11" value="4"/>
+    <uol name="12" value="5"/>
+    <uol name="13" value="6"/>
+    <uol name="14" value="0"/>
+    <uol name="15" value="1"/>
+    <uol name="16" value="2"/>
+    <uol name="17" value="3"/>
+    <uol name="18" value="4"/>
+    <uol name="19" value="5"/>
+    <uol name="20" value="6"/>
+    <canvas name="21" width="79" height="84">
+      <vector name="origin" x="45" y="101"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="22" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="23" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="24" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="25" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="26" width="79" height="84">
+      <vector name="origin" x="45" y="85"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="27" width="79" height="80">
+      <vector name="origin" x="45" y="87"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="28" width="78" height="76">
+      <vector name="origin" x="43" y="96"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="29" width="71" height="58">
+      <vector name="origin" x="36" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="30" width="56" height="32">
+      <vector name="origin" x="22" y="114"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="31" width="31" height="25">
+      <vector name="origin" x="17" y="120"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="32" width="15" height="16">
+      <vector name="origin" x="14" y="121"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prop" value="100"/>
+      <string name="0" value="我，黑色之翼的一员，收下天空之城的封印石。"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300352.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300352.img.xml
@@ -1,0 +1,187 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9300352.img">
+  <imgdir name="info">
+    <int name="level" value="999"/>
+    <int name="maxHP" value="99"/>
+    <int name="maxMP" value="99"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="99"/>
+    <int name="PDDamage" value="99"/>
+    <int name="MADamage" value="99"/>
+    <int name="MDDamage" value="99"/>
+    <int name="acc" value="99"/>
+    <int name="eva" value="99"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="9999"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="mobType" value="8"/>
+    <int name="removeAfter" value="5"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <uol name="7" value="0"/>
+    <uol name="8" value="1"/>
+    <uol name="9" value="2"/>
+    <uol name="10" value="3"/>
+    <uol name="11" value="4"/>
+    <uol name="12" value="5"/>
+    <uol name="13" value="6"/>
+    <uol name="14" value="0"/>
+    <uol name="15" value="1"/>
+    <uol name="16" value="2"/>
+    <uol name="17" value="3"/>
+    <uol name="18" value="4"/>
+    <uol name="19" value="5"/>
+    <uol name="20" value="6"/>
+    <canvas name="21" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="22" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="23" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="24" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="25" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="26" width="79" height="84">
+      <vector name="origin" x="45" y="85"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="27" width="79" height="80">
+      <vector name="origin" x="45" y="87"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="28" width="78" height="76">
+      <vector name="origin" x="43" y="96"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="29" width="71" height="58">
+      <vector name="origin" x="36" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="30" width="56" height="32">
+      <vector name="origin" x="22" y="114"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="31" width="31" height="25">
+      <vector name="origin" x="17" y="120"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="32" width="15" height="16">
+      <vector name="origin" x="14" y="121"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prop" value="100"/>
+      <string name="0" value="封印石我再次收下了。再见……"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300353.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300353.img.xml
@@ -1,0 +1,187 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9300353.img">
+  <imgdir name="info">
+    <int name="level" value="999"/>
+    <int name="maxHP" value="99"/>
+    <int name="maxMP" value="99"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="99"/>
+    <int name="PDDamage" value="99"/>
+    <int name="MADamage" value="99"/>
+    <int name="MDDamage" value="99"/>
+    <int name="acc" value="99"/>
+    <int name="eva" value="99"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="9999"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="mobType" value="8"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+    <int name="removeAfter" value="5"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <uol name="7" value="0"/>
+    <uol name="8" value="1"/>
+    <uol name="9" value="2"/>
+    <uol name="10" value="3"/>
+    <uol name="11" value="4"/>
+    <uol name="12" value="5"/>
+    <uol name="13" value="6"/>
+    <uol name="14" value="0"/>
+    <uol name="15" value="1"/>
+    <uol name="16" value="2"/>
+    <uol name="17" value="3"/>
+    <uol name="18" value="4"/>
+    <uol name="19" value="5"/>
+    <uol name="20" value="6"/>
+    <canvas name="21" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="22" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="23" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="24" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="25" width="79" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="26" width="79" height="84">
+      <vector name="origin" x="45" y="85"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="27" width="79" height="80">
+      <vector name="origin" x="45" y="87"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="28" width="78" height="76">
+      <vector name="origin" x="43" y="96"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="29" width="71" height="58">
+      <vector name="origin" x="36" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="30" width="56" height="32">
+      <vector name="origin" x="22" y="114"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="31" width="31" height="25">
+      <vector name="origin" x="17" y="120"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="32" width="15" height="16">
+      <vector name="origin" x="14" y="121"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prop" value="100"/>
+      <string name="0" value="你终究还是来了……你很不寻常。封印石我先收下了。"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9400633.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9400633.img.xml
@@ -1,0 +1,1148 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9400633.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="32"/>
+    <int name="maxHP" value="180000"/>
+    <int name="maxMP" value="500"/>
+    <int name="speed" value="30"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="hpRecovery" value="50"/>
+    <int name="PADamage" value="180"/>
+    <int name="PDDamage" value="150"/>
+    <int name="MADamage" value="180"/>
+    <int name="MDDamage" value="150"/>
+    <int name="acc" value="120"/>
+    <int name="eva" value="15"/>
+    <int name="exp" value="5250"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="800"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="ChargeCount" value="3"/>
+    <int name="AngerGauge" value="1"/>
+    <int name="publicReward" value="1"/>
+    <int name="explosiveReward" value="1"/>
+    <int name="mobType" value="1"/>
+    <int name="hpTagColor" value="3"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="168"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="169"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="1"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="134" height="157">
+      <vector name="origin" x="55" y="156"/>
+      <vector name="lt" x="-53" y="-155"/>
+      <vector name="rb" x="73" y="-4"/>
+      <vector name="head" x="13" y="-147"/>
+    </canvas>
+    <canvas name="1" width="132" height="156">
+      <vector name="origin" x="51" y="155"/>
+      <vector name="lt" x="-49" y="-151"/>
+      <vector name="rb" x="74" y="-4"/>
+      <vector name="head" x="15" y="-146"/>
+    </canvas>
+    <canvas name="2" width="132" height="156">
+      <vector name="origin" x="49" y="155"/>
+      <vector name="lt" x="-46" y="-150"/>
+      <vector name="rb" x="70" y="-3"/>
+      <vector name="head" x="17" y="-146"/>
+    </canvas>
+    <canvas name="3" width="134" height="157">
+      <vector name="origin" x="55" y="156"/>
+      <vector name="lt" x="-54" y="-153"/>
+      <vector name="rb" x="72" y="-3"/>
+      <vector name="head" x="13" y="-145"/>
+    </canvas>
+    <canvas name="4" width="133" height="158">
+      <vector name="origin" x="59" y="157"/>
+      <vector name="lt" x="-56" y="-154"/>
+      <vector name="rb" x="72" y="-3"/>
+      <vector name="head" x="8" y="-142"/>
+    </canvas>
+    <canvas name="5" width="134" height="159">
+      <vector name="origin" x="61" y="158"/>
+      <vector name="lt" x="-59" y="-156"/>
+      <vector name="rb" x="69" y="-3"/>
+      <vector name="head" x="7" y="-142"/>
+    </canvas>
+    <canvas name="6" width="132" height="159">
+      <vector name="origin" x="57" y="158"/>
+      <vector name="lt" x="-54" y="-154"/>
+      <vector name="rb" x="72" y="-4"/>
+      <vector name="head" x="11" y="-141"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="134" height="157">
+      <vector name="origin" x="55" y="156"/>
+      <vector name="lt" x="-51" y="-151"/>
+      <vector name="rb" x="72" y="-3"/>
+      <vector name="head" x="13" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="135" height="159">
+      <vector name="origin" x="58" y="158"/>
+      <vector name="lt" x="-56" y="-155"/>
+      <vector name="rb" x="71" y="-3"/>
+      <vector name="head" x="11" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="135" height="155">
+      <vector name="origin" x="60" y="154"/>
+      <vector name="lt" x="-58" y="-152"/>
+      <vector name="rb" x="70" y="-2"/>
+      <vector name="head" x="10" y="-145"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="132" height="153">
+      <vector name="origin" x="58" y="152"/>
+      <vector name="lt" x="-56" y="-149"/>
+      <vector name="rb" x="68" y="-3"/>
+      <vector name="head" x="7" y="-143"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="133" height="155">
+      <vector name="origin" x="57" y="154"/>
+      <vector name="lt" x="-54" y="-150"/>
+      <vector name="rb" x="70" y="-2"/>
+      <vector name="head" x="11" y="-145"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="169" height="214">
+      <vector name="origin" x="62" y="213"/>
+      <int name="delay" value="500"/>
+      <vector name="lt" x="-27" y="-63"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="2" y="-82"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="169" height="215">
+      <vector name="origin" x="62" y="213"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="181" height="231">
+      <vector name="origin" x="73" y="229"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="223" height="243">
+      <vector name="origin" x="108" y="238"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="242" height="251">
+      <vector name="origin" x="122" y="246"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="254" height="174">
+      <vector name="origin" x="129" y="168"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="282" height="178">
+      <vector name="origin" x="140" y="172"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="259" height="182">
+      <vector name="origin" x="134" y="176"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="277" height="140">
+      <vector name="origin" x="134" y="136"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="156" height="138">
+      <vector name="origin" x="80" y="128"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="呃……我小看你了。但我不会死去……不，我只是沉睡而已……"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-102" y="-163"/>
+        <vector name="rb" x="73" y="-3"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="81" height="92">
+          <vector name="origin" x="40" y="45"/>
+        </canvas>
+        <canvas name="1" width="111" height="144">
+          <vector name="origin" x="55" y="72"/>
+        </canvas>
+        <canvas name="2" width="128" height="98">
+          <vector name="origin" x="64" y="49"/>
+        </canvas>
+        <canvas name="3" width="136" height="80">
+          <vector name="origin" x="68" y="40"/>
+        </canvas>
+        <canvas name="4" width="136" height="59">
+          <vector name="origin" x="68" y="29"/>
+        </canvas>
+      </imgdir>
+      <int name="attachfacing" value="1"/>
+      <int name="type" value="0"/>
+      <int name="PADamage" value="200"/>
+      <int name="attackAfter" value="400"/>
+    </imgdir>
+    <canvas name="0" width="134" height="157">
+      <vector name="origin" x="59" y="156"/>
+      <vector name="lt" x="-57" y="-153"/>
+      <vector name="rb" x="69" y="-4"/>
+      <vector name="head" x="8" y="-146"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="1" width="132" height="168">
+      <vector name="origin" x="55" y="167"/>
+      <vector name="lt" x="-54" y="-164"/>
+      <vector name="rb" x="68" y="-4"/>
+      <vector name="head" x="11" y="-149"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="2" width="131" height="174">
+      <vector name="origin" x="52" y="173"/>
+      <vector name="lt" x="-48" y="-169"/>
+      <vector name="rb" x="70" y="-4"/>
+      <vector name="head" x="13" y="-151"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="3" width="129" height="180">
+      <vector name="origin" x="49" y="179"/>
+      <vector name="lt" x="-45" y="-174"/>
+      <vector name="rb" x="76" y="-2"/>
+      <vector name="head" x="15" y="-155"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="4" width="202" height="218">
+      <vector name="origin" x="106" y="217"/>
+      <vector name="lt" x="-102" y="-163"/>
+      <vector name="rb" x="73" y="-3"/>
+      <vector name="head" x="6" y="-146"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="5" width="216" height="232">
+      <vector name="origin" x="122" y="231"/>
+      <vector name="lt" x="-120" y="-163"/>
+      <vector name="rb" x="74" y="0"/>
+      <vector name="head" x="1" y="-143"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="6" width="221" height="238">
+      <vector name="origin" x="123" y="237"/>
+      <vector name="lt" x="-120" y="-145"/>
+      <vector name="rb" x="62" y="-3"/>
+      <vector name="head" x="-2" y="-141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="7" width="224" height="242">
+      <vector name="origin" x="125" y="241"/>
+      <vector name="lt" x="-88" y="-135"/>
+      <vector name="rb" x="64" y="0"/>
+      <vector name="head" x="3" y="-143"/>
+      <int name="delay" value="100"/>
+      <imgdir name="rect">
+        <imgdir name="0">
+          <vector name="lt" x="-155" y="-204"/>
+          <vector name="rb" x="-65" y="0"/>
+        </imgdir>
+        <imgdir name="1">
+          <vector name="lt" x="78" y="-205"/>
+          <vector name="rb" x="151" y="-1"/>
+        </imgdir>
+      </imgdir>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="我最喜欢欺负弱者了！哈哈！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-602" y="212"/>
+        <vector name="rb" x="62" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="49" height="46">
+          <vector name="origin" x="24" y="23"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="1" width="67" height="64">
+          <vector name="origin" x="33" y="32"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="2" width="73" height="66">
+          <vector name="origin" x="36" y="33"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="3" width="77" height="71">
+          <vector name="origin" x="38" y="35"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="4" width="81" height="75">
+          <vector name="origin" x="40" y="37"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="5" width="84" height="79">
+          <vector name="origin" x="42" y="39"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="magic" value="1"/>
+      <int name="disease" value="125"/>
+      <int name="level" value="1"/>
+      <int name="conMP" value="1"/>
+      <int name="MADamage" value="100"/>
+      <string name="elemAttr" value="S"/>
+      <int name="attackAfter" value="840"/>
+    </imgdir>
+    <canvas name="0" width="134" height="157">
+      <vector name="origin" x="53" y="156"/>
+      <vector name="lt" x="-51" y="-152"/>
+      <vector name="rb" x="71" y="-5"/>
+      <vector name="head" x="15" y="-146"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="132" height="168">
+      <vector name="origin" x="49" y="167"/>
+      <vector name="lt" x="-46" y="-163"/>
+      <vector name="rb" x="61" y="2"/>
+      <vector name="head" x="18" y="-148"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="131" height="174">
+      <vector name="origin" x="46" y="173"/>
+      <vector name="lt" x="-44" y="-168"/>
+      <vector name="rb" x="61" y="1"/>
+      <vector name="head" x="19" y="-153"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="136" height="180">
+      <vector name="origin" x="48" y="179"/>
+      <vector name="lt" x="-40" y="-176"/>
+      <vector name="rb" x="61" y="1"/>
+      <vector name="head" x="22" y="-155"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="147" height="176">
+      <vector name="origin" x="58" y="175"/>
+      <vector name="lt" x="-39" y="-159"/>
+      <vector name="rb" x="61" y="1"/>
+      <vector name="head" x="22" y="-154"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="155" height="176">
+      <vector name="origin" x="66" y="175"/>
+      <vector name="lt" x="-63" y="-150"/>
+      <vector name="rb" x="75" y="4"/>
+      <vector name="head" x="6" y="-142"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="139" height="156">
+      <vector name="origin" x="67" y="151"/>
+      <vector name="lt" x="-64" y="-143"/>
+      <vector name="rb" x="65" y="1"/>
+      <vector name="head" x="1" y="-138"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="206" height="152">
+      <vector name="origin" x="138" y="147"/>
+      <vector name="lt" x="-133" y="-112"/>
+      <vector name="rb" x="62" y="-1"/>
+      <vector name="head" x="-6" y="-132"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="325" height="146">
+      <vector name="origin" x="259" y="141"/>
+      <vector name="lt" x="-253" y="-113"/>
+      <vector name="rb" x="63" y="-1"/>
+      <vector name="head" x="-8" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="458" height="144">
+      <vector name="origin" x="394" y="139"/>
+      <vector name="lt" x="-385" y="-119"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="-9" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="560" height="144">
+      <vector name="origin" x="488" y="139"/>
+      <vector name="lt" x="-480" y="-116"/>
+      <vector name="rb" x="54" y="0"/>
+      <vector name="head" x="-9" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="608" height="153">
+      <vector name="origin" x="541" y="148"/>
+      <vector name="lt" x="-532" y="-129"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="-9" y="-129"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="631" height="166">
+      <vector name="origin" x="567" y="161"/>
+      <vector name="lt" x="-560" y="-135"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="-9" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="647" height="169">
+      <vector name="origin" x="583" y="164"/>
+      <vector name="lt" x="-578" y="-155"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="-7" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="664" height="197">
+      <vector name="origin" x="600" y="192"/>
+      <vector name="lt" x="-595" y="-181"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="-9" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="675" height="217">
+      <vector name="origin" x="610" y="212"/>
+      <vector name="lt" x="-602" y="-203"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="-7" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="678" height="223">
+      <vector name="origin" x="612" y="218"/>
+      <vector name="lt" x="-606" y="-208"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="-5" y="-132"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="667" height="224">
+      <vector name="origin" x="595" y="223"/>
+      <vector name="lt" x="-586" y="-194"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="6" y="-140"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="133" height="155">
+      <vector name="origin" x="55" y="154"/>
+      <vector name="lt" x="-53" y="-151"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="12" y="-146"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-405" y="-278"/>
+        <vector name="rb" x="400" y="-2"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="105" height="140">
+          <vector name="origin" x="51" y="121"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="1" width="109" height="153">
+          <vector name="origin" x="56" y="134"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="2" width="119" height="158">
+          <vector name="origin" x="56" y="139"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="3" width="117" height="142">
+          <vector name="origin" x="55" y="126"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="4" width="110" height="135">
+          <vector name="origin" x="55" y="128"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="5" width="105" height="135">
+          <vector name="origin" x="53" y="130"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="6" width="105" height="97">
+          <vector name="origin" x="53" y="133"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="magic" value="1"/>
+      <int name="MADamage" value="100"/>
+      <int name="AngerAttack" value="1"/>
+      <int name="disease" value="123"/>
+      <int name="level" value="16"/>
+      <int name="conMP" value="5"/>
+      <int name="attackAfter" value="600"/>
+    </imgdir>
+    <canvas name="0" width="132" height="168">
+      <vector name="origin" x="56" y="167"/>
+      <vector name="lt" x="-53" y="-162"/>
+      <vector name="rb" x="66" y="-6"/>
+      <vector name="head" x="10" y="-148"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="131" height="174">
+      <vector name="origin" x="53" y="173"/>
+      <vector name="lt" x="-51" y="-169"/>
+      <vector name="rb" x="63" y="-5"/>
+      <vector name="head" x="10" y="-153"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="129" height="180">
+      <vector name="origin" x="48" y="179"/>
+      <vector name="lt" x="-46" y="-176"/>
+      <vector name="rb" x="67" y="-7"/>
+      <vector name="head" x="15" y="-155"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="126" height="176">
+      <vector name="origin" x="44" y="175"/>
+      <vector name="lt" x="-43" y="-172"/>
+      <vector name="rb" x="67" y="-6"/>
+      <vector name="head" x="15" y="-153"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="841" height="176">
+      <vector name="origin" x="413" y="175"/>
+      <vector name="lt" x="-44" y="-170"/>
+      <vector name="rb" x="61" y="-3"/>
+      <vector name="head" x="17" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="870" height="152">
+      <vector name="origin" x="426" y="151"/>
+      <vector name="lt" x="-69" y="-145"/>
+      <vector name="rb" x="62" y="-5"/>
+      <vector name="head" x="0" y="-141"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="888" height="245">
+      <vector name="origin" x="431" y="235"/>
+      <vector name="lt" x="-427" y="-133"/>
+      <vector name="rb" x="447" y="-2"/>
+      <vector name="head" x="-5" y="-137"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="892" height="254">
+      <vector name="origin" x="433" y="248"/>
+      <vector name="lt" x="-426" y="-169"/>
+      <vector name="rb" x="415" y="-1"/>
+      <vector name="head" x="-10" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="814" height="261">
+      <vector name="origin" x="407" y="253"/>
+      <vector name="lt" x="-401" y="-216"/>
+      <vector name="rb" x="398" y="-2"/>
+      <vector name="head" x="-12" y="-132"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="843" height="246">
+      <vector name="origin" x="420" y="240"/>
+      <vector name="lt" x="-414" y="-229"/>
+      <vector name="rb" x="416" y="-2"/>
+      <vector name="head" x="-12" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="872" height="273">
+      <vector name="origin" x="436" y="268"/>
+      <vector name="lt" x="-433" y="-262"/>
+      <vector name="rb" x="430" y="-2"/>
+      <vector name="head" x="-13" y="-129"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="889" height="292">
+      <vector name="origin" x="438" y="287"/>
+      <vector name="lt" x="-433" y="-278"/>
+      <vector name="rb" x="445" y="0"/>
+      <vector name="head" x="-11" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="920" height="329">
+      <vector name="origin" x="454" y="324"/>
+      <vector name="lt" x="-446" y="-315"/>
+      <vector name="rb" x="433" y="-2"/>
+      <vector name="head" x="-11" y="-132"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="860" height="366">
+      <vector name="origin" x="421" y="364"/>
+      <vector name="lt" x="-75" y="-143"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-1" y="-140"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="856" height="387">
+      <vector name="origin" x="419" y="386"/>
+      <vector name="lt" x="-66" y="-151"/>
+      <vector name="rb" x="69" y="-5"/>
+      <vector name="head" x="4" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="20"/>
+      <string name="0" value="黑暗能量正在聚集……"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-433" y="-168"/>
+        <vector name="rb" x="433" y="14"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="118" height="116">
+          <vector name="origin" x="56" y="95"/>
+        </canvas>
+        <canvas name="1" width="129" height="124">
+          <vector name="origin" x="64" y="98"/>
+        </canvas>
+        <canvas name="2" width="138" height="132">
+          <vector name="origin" x="69" y="101"/>
+        </canvas>
+        <canvas name="3" width="140" height="138">
+          <vector name="origin" x="71" y="103"/>
+        </canvas>
+        <canvas name="4" width="142" height="138">
+          <vector name="origin" x="73" y="105"/>
+        </canvas>
+        <canvas name="5" width="83" height="139">
+          <vector name="origin" x="67" y="102"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="magic" value="1"/>
+      <int name="MADamage" value="400"/>
+      <int name="specialAttack" value="1"/>
+      <int name="disease" value="133"/>
+      <int name="level" value="1"/>
+      <int name="conMP" value="10"/>
+      <int name="tremble" value="1"/>
+      <int name="knockback" value="1"/>
+      <int name="attackAfter" value="3300"/>
+    </imgdir>
+    <canvas name="0" width="126" height="159">
+      <vector name="origin" x="48" y="158"/>
+      <vector name="lt" x="-45" y="-154"/>
+      <vector name="rb" x="65" y="-9"/>
+      <vector name="head" x="11" y="-148"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="1" width="131" height="170">
+      <vector name="origin" x="51" y="169"/>
+      <vector name="lt" x="-48" y="-164"/>
+      <vector name="rb" x="61" y="1"/>
+      <vector name="head" x="14" y="-153"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="130" height="181">
+      <vector name="origin" x="47" y="180"/>
+      <vector name="lt" x="-45" y="-174"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="17" y="-154"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="132" height="182">
+      <vector name="origin" x="48" y="181"/>
+      <vector name="lt" x="-46" y="-177"/>
+      <vector name="rb" x="62" y="1"/>
+      <vector name="head" x="17" y="-154"/>
+      <int name="delay" value="160"/>
+    </canvas>
+    <canvas name="4" width="218" height="230">
+      <vector name="origin" x="113" y="229"/>
+      <vector name="lt" x="-57" y="-171"/>
+      <vector name="rb" x="62" y="1"/>
+      <vector name="head" x="19" y="-152"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="5" width="240" height="243">
+      <vector name="origin" x="130" y="225"/>
+      <vector name="lt" x="-53" y="-173"/>
+      <vector name="rb" x="69" y="-5"/>
+      <vector name="head" x="18" y="-154"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="6" width="282" height="245">
+      <vector name="origin" x="160" y="223"/>
+      <vector name="lt" x="-51" y="-175"/>
+      <vector name="rb" x="62" y="-5"/>
+      <vector name="head" x="18" y="-154"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="7" width="284" height="245">
+      <vector name="origin" x="156" y="218"/>
+      <vector name="lt" x="-54" y="-178"/>
+      <vector name="rb" x="75" y="-2"/>
+      <vector name="head" x="17" y="-153"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="8" width="295" height="226">
+      <vector name="origin" x="163" y="202"/>
+      <vector name="lt" x="-58" y="-174"/>
+      <vector name="rb" x="77" y="0"/>
+      <vector name="head" x="17" y="-154"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="9" width="267" height="193">
+      <vector name="origin" x="135" y="184"/>
+      <vector name="lt" x="-55" y="-177"/>
+      <vector name="rb" x="74" y="-4"/>
+      <vector name="head" x="16" y="-154"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="10" width="218" height="230">
+      <vector name="origin" x="113" y="229"/>
+      <vector name="lt" x="-52" y="-181"/>
+      <vector name="rb" x="68" y="-5"/>
+      <vector name="head" x="18" y="-154"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="11" width="240" height="243">
+      <vector name="origin" x="130" y="225"/>
+      <vector name="lt" x="-57" y="-180"/>
+      <vector name="rb" x="67" y="-5"/>
+      <vector name="head" x="19" y="-156"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="12" width="292" height="422">
+      <vector name="origin" x="160" y="400"/>
+      <vector name="lt" x="-56" y="-187"/>
+      <vector name="rb" x="64" y="0"/>
+      <vector name="head" x="17" y="-156"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="13" width="300" height="428">
+      <vector name="origin" x="156" y="401"/>
+      <vector name="lt" x="-64" y="-179"/>
+      <vector name="rb" x="63" y="-1"/>
+      <vector name="head" x="20" y="-156"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="14" width="320" height="426">
+      <vector name="origin" x="163" y="402"/>
+      <vector name="lt" x="-58" y="-178"/>
+      <vector name="rb" x="68" y="-7"/>
+      <vector name="head" x="17" y="-156"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="15" width="296" height="410">
+      <vector name="origin" x="131" y="402"/>
+      <vector name="lt" x="-51" y="-175"/>
+      <vector name="rb" x="69" y="-7"/>
+      <vector name="head" x="18" y="-156"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="16" width="292" height="407">
+      <vector name="origin" x="127" y="402"/>
+      <vector name="lt" x="-67" y="-140"/>
+      <vector name="rb" x="61" y="-4"/>
+      <vector name="head" x="-2" y="-140"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="17" width="285" height="440">
+      <vector name="origin" x="124" y="408"/>
+      <vector name="lt" x="-107" y="-139"/>
+      <vector name="rb" x="86" y="-1"/>
+      <vector name="head" x="-8" y="-133"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="18" width="325" height="437">
+      <vector name="origin" x="177" y="405"/>
+      <vector name="lt" x="-122" y="-133"/>
+      <vector name="rb" x="109" y="-5"/>
+      <vector name="head" x="-10" y="-134"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="19" width="576" height="364">
+      <vector name="origin" x="283" y="327"/>
+      <vector name="lt" x="-253" y="-240"/>
+      <vector name="rb" x="223" y="-3"/>
+      <vector name="head" x="-4" y="-146"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="20" width="920" height="476">
+      <vector name="origin" x="466" y="439"/>
+      <vector name="lt" x="-442" y="-413"/>
+      <vector name="rb" x="389" y="-6"/>
+      <vector name="head" x="-9" y="-132"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="21" width="1012" height="503">
+      <vector name="origin" x="508" y="471"/>
+      <vector name="lt" x="-484" y="-448"/>
+      <vector name="rb" x="433" y="-2"/>
+      <vector name="head" x="-8" y="-134"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="22" width="1080" height="518">
+      <vector name="origin" x="539" y="481"/>
+      <vector name="lt" x="-508" y="-462"/>
+      <vector name="rb" x="517" y="1"/>
+      <vector name="head" x="-8" y="-133"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="23" width="1132" height="531">
+      <vector name="origin" x="563" y="499"/>
+      <vector name="lt" x="-491" y="-473"/>
+      <vector name="rb" x="515" y="-1"/>
+      <vector name="head" x="-11" y="-132"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="24" width="968" height="538">
+      <vector name="origin" x="500" y="507"/>
+      <vector name="lt" x="-467" y="-382"/>
+      <vector name="rb" x="445" y="-3"/>
+      <vector name="head" x="-11" y="-132"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="25" width="975" height="508">
+      <vector name="origin" x="502" y="478"/>
+      <vector name="lt" x="-461" y="-139"/>
+      <vector name="rb" x="458" y="9"/>
+      <vector name="head" x="-11" y="-133"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="26" width="976" height="516">
+      <vector name="origin" x="505" y="493"/>
+      <vector name="lt" x="-480" y="-114"/>
+      <vector name="rb" x="448" y="3"/>
+      <vector name="head" x="-9" y="-133"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="27" width="958" height="159">
+      <vector name="origin" x="499" y="151"/>
+      <vector name="lt" x="-483" y="-142"/>
+      <vector name="rb" x="440" y="0"/>
+      <vector name="head" x="0" y="-142"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="28" width="133" height="155">
+      <vector name="origin" x="61" y="154"/>
+      <vector name="lt" x="-57" y="-152"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="6" y="-147"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="黑暗能量已经全部聚集。趁还能逃，快逃吧。哈哈！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="134" height="157">
+      <vector name="origin" x="46" y="156"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-54" y="-119"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-14" y="-119"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="1" width="134" height="152">
+      <vector name="origin" x="55" y="151"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-52" y="-120"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-12" y="-120"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="2" width="131" height="152">
+      <vector name="origin" x="55" y="147"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-51" y="-122"/>
+      <vector name="rb" x="28" y="0"/>
+      <vector name="head" x="-9" y="-122"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="3" width="135" height="146">
+      <vector name="origin" x="61" y="141"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-51" y="-124"/>
+      <vector name="rb" x="28" y="0"/>
+      <vector name="head" x="-6" y="-124"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="4" width="214" height="147">
+      <vector name="origin" x="106" y="140"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-88" y="-150"/>
+      <vector name="rb" x="79" y="16"/>
+      <vector name="head" x="-7" y="-124"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="5" width="245" height="196">
+      <vector name="origin" x="129" y="175"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-94" y="-156"/>
+      <vector name="rb" x="85" y="22"/>
+      <vector name="head" x="-7" y="-122"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="6" width="282" height="203">
+      <vector name="origin" x="157" y="181"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-95" y="-157"/>
+      <vector name="rb" x="86" y="23"/>
+      <vector name="head" x="-7" y="-123"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="7" width="284" height="213">
+      <vector name="origin" x="153" y="186"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-93" y="-122"/>
+      <vector name="rb" x="84" y="24"/>
+      <vector name="head" x="-7" y="-123"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="8" width="302" height="218">
+      <vector name="origin" x="164" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-50" y="-123"/>
+      <vector name="rb" x="31" y="1"/>
+      <vector name="head" x="-6" y="-123"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="9" width="304" height="214">
+      <vector name="origin" x="161" y="198"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-49" y="-121"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-9" y="-121"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="10" width="159" height="205">
+      <vector name="origin" x="86" y="200"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-52" y="-120"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-12" y="-120"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="11" width="158" height="204">
+      <vector name="origin" x="84" y="199"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-52" y="-120"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-12" y="-120"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="12" width="161" height="197">
+      <vector name="origin" x="82" y="196"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-52" y="-120"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-12" y="-120"/>
+      <int name="delay" value="80"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="134" height="157">
+      <vector name="origin" x="46" y="156"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-54" y="-119"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-14" y="-119"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="1" width="134" height="152">
+      <vector name="origin" x="55" y="151"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-52" y="-120"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-12" y="-120"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="2" width="131" height="152">
+      <vector name="origin" x="55" y="147"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-51" y="-122"/>
+      <vector name="rb" x="28" y="0"/>
+      <vector name="head" x="-9" y="-122"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="3" width="135" height="146">
+      <vector name="origin" x="61" y="141"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-51" y="-124"/>
+      <vector name="rb" x="28" y="0"/>
+      <vector name="head" x="-6" y="-124"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="4" width="214" height="147">
+      <vector name="origin" x="106" y="140"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-88" y="-150"/>
+      <vector name="rb" x="79" y="16"/>
+      <vector name="head" x="-7" y="-124"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="5" width="245" height="202">
+      <vector name="origin" x="129" y="181"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-94" y="-156"/>
+      <vector name="rb" x="85" y="22"/>
+      <vector name="head" x="-7" y="-122"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="6" width="282" height="206">
+      <vector name="origin" x="157" y="184"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-95" y="-157"/>
+      <vector name="rb" x="86" y="23"/>
+      <vector name="head" x="-7" y="-123"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="7" width="284" height="214">
+      <vector name="origin" x="153" y="187"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-93" y="-122"/>
+      <vector name="rb" x="84" y="24"/>
+      <vector name="head" x="-7" y="-123"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="8" width="302" height="219">
+      <vector name="origin" x="164" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-50" y="-123"/>
+      <vector name="rb" x="31" y="1"/>
+      <vector name="head" x="-6" y="-123"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="9" width="304" height="214">
+      <vector name="origin" x="161" y="198"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-49" y="-121"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-9" y="-121"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="10" width="173" height="204">
+      <vector name="origin" x="100" y="199"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-52" y="-120"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-12" y="-120"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="11" width="171" height="204">
+      <vector name="origin" x="97" y="199"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-52" y="-120"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-12" y="-120"/>
+      <int name="delay" value="80"/>
+    </canvas>
+    <canvas name="12" width="174" height="200">
+      <vector name="origin" x="95" y="199"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-52" y="-120"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-12" y="-120"/>
+      <int name="delay" value="80"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="AngerGaugeEffect">
+    <canvas name="0" width="118" height="98">
+      <vector name="origin" x="53" y="78"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="118" height="99">
+      <vector name="origin" x="54" y="79"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="118" height="100">
+      <vector name="origin" x="55" y="80"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="135" height="159">
+      <vector name="origin" x="67" y="96"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="137" height="161">
+      <vector name="origin" x="69" y="97"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="138" height="161">
+      <vector name="origin" x="71" y="97"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="137" height="160">
+      <vector name="origin" x="72" y="97"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="113" height="111">
+      <vector name="origin" x="58" y="82"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="AngerGaugeAnimation">
+    <imgdir name="0">
+      <canvas name="0" width="47" height="67">
+        <vector name="origin" x="23" y="77"/>
+      </canvas>
+      <canvas name="1" width="47" height="67">
+        <vector name="origin" x="23" y="77"/>
+      </canvas>
+      <canvas name="2" width="47" height="69">
+        <vector name="origin" x="23" y="78"/>
+      </canvas>
+      <canvas name="3" width="47" height="67">
+        <vector name="origin" x="23" y="77"/>
+      </canvas>
+    </imgdir>
+    <imgdir name="1">
+      <canvas name="0" width="77" height="97">
+        <vector name="origin" x="53" y="77"/>
+      </canvas>
+      <canvas name="1" width="77" height="97">
+        <vector name="origin" x="53" y="77"/>
+      </canvas>
+      <canvas name="2" width="77" height="97">
+        <vector name="origin" x="53" y="78"/>
+      </canvas>
+      <canvas name="3" width="77" height="97">
+        <vector name="origin" x="53" y="77"/>
+      </canvas>
+    </imgdir>
+    <imgdir name="2">
+      <canvas name="0" width="118" height="97">
+        <vector name="origin" x="53" y="77"/>
+      </canvas>
+      <canvas name="1" width="118" height="98">
+        <vector name="origin" x="53" y="78"/>
+      </canvas>
+      <canvas name="2" width="118" height="97">
+        <vector name="origin" x="53" y="78"/>
+      </canvas>
+      <canvas name="3" width="118" height="98">
+        <vector name="origin" x="53" y="78"/>
+      </canvas>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9450022.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9450022.img.xml
@@ -1,0 +1,2339 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9450022.img">
+  <imgdir name="info">
+    <int name="level" value="150"/>
+    <int name="maxHP" value="1500000000"/>
+    <int name="maxMP" value="100000"/>
+    <int name="mpRecovery" value="10000"/>
+    <int name="hpRecovery" value="10000000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="1350"/>
+    <int name="MADamage" value="1400"/>
+    <int name="PDRate" value="30"/>
+    <int name="MDRate" value="20"/>
+    <int name="acc" value="999"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="199999"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="22000000"/>
+    <int name="summonType" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="128"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="145"/>
+        <int name="action" value="2"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="6" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="aacfdac6db9941a92082d4ff149e479f91f9b7f9b17d384ad091f8446779d0bc"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="9720c408116d2ab09e8295717dc11971cbd4d77a353c168ebb28c04f746e232d"/>
+    </canvas>
+    <canvas name="10" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="cc792d53d48c07a6c8c037fbe59907615b6fc0e8107e7f22c903ad06b7d79ebf"/>
+    </canvas>
+    <canvas name="11" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="e692398e07ba283472e8fca4e7e5a26b1cd3d5578ab92a5c37ce89719d8608dc"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="4a6ef4330261092c4be1be264c84fc9267ad1b48ba59fd0169d306b570993dc9"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="4c12eb8473e722e09eec99743488c040d27f1fa9c00e7c6efafd77212894159a"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a8f58b13a489ca5850848829e359f05b8eed60ac4a1cce456a03680c644faaef"/>
+    </canvas>
+    <canvas name="5" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="210cd2abd8fb276b8e1e08abe2f19994edf8f3d0b2dc66721b81898279ac7a99"/>
+    </canvas>
+    <canvas name="7" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="69d8a175e31fd46b141b4f142401142cf79d649dbfca8b5715643c53f64be086"/>
+    </canvas>
+    <canvas name="8" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="c46972e7aa48ef79b899a102749f46d3474c84ad99a34f47e4f79b3b9d68db74"/>
+    </canvas>
+    <canvas name="9" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="1a3792b751548391d8b5a72067e2b2ac1738725f97521f973bb3266166731fa3"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="aacfdac6db9941a92082d4ff149e479f91f9b7f9b17d384ad091f8446779d0bc"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="5" width="200" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="ace4d88aa5fca2f30ce1aba0361e59635ec9936e0d948d34100a6b20f6adcaa6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="53f6e366da478b2bf97da582637682cba6e16f6426f884b8d7dd78e0f2b8b420"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="ea7498c7f47b52286a540fda3522c46e3eaa4477bee49736508c58a0e8eb847a"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="bcd85aa903f39e6f5211f04e64ab12f27968cebec541f04b2df1d55f7b3ccd82"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="de90f4fa91c5d222eb9a524c87f50fb11b4f1dcf5fd126d9bcdb7aa24f687f33"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="7ce12372921280cca8a391b4aeb4473e77e15d22d5fc854d965d4b8b1cb64eb5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f9ff11c42be35e5e3fd109814f4e61b14dd109653833ad15bcd3335a56a891d5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="196" height="179">
+      <vector name="origin" x="89" y="171"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="029fc945fe7a87aea59c019b8a59e48364de0883dde4d4d6c540a9564507c8df"/>
+    </canvas>
+    <canvas name="2" width="192" height="164">
+      <vector name="origin" x="87" y="159"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="1220215ee1bfd503e711d2fa75cb24bbdef2174b20b30cfda11a4f2037da070c"/>
+    </canvas>
+    <canvas name="3" width="187" height="156">
+      <vector name="origin" x="86" y="157"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="8a7e19f2bffe98a8be6daa1e7043f1090cca13d46f8a3aa9ff25bb4f9938fc63"/>
+    </canvas>
+    <canvas name="4" width="175" height="151">
+      <vector name="origin" x="78" y="155"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="3b219a21f7c6625ddc68d067fffd2186ddad543e2fc7be9454c1002b9e49d860"/>
+    </canvas>
+    <canvas name="5" width="156" height="136">
+      <vector name="origin" x="69" y="156"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="086e3e5cf47d9b10c4c48aa15b38d0619c690f08e45e12c5e07d7c432decd957"/>
+    </canvas>
+    <canvas name="6" width="125" height="122">
+      <vector name="origin" x="48" y="151"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="315f1dd0e72160d042c46b73c891f65113b2b6734dbbc25c21beb6c96a1676a8"/>
+    </canvas>
+    <canvas name="7" width="65" height="47">
+      <vector name="origin" x="8" y="93"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="b828e2dc0153f7e04df420a0ddadbdbdfe8664baf63a1c4a5d8a16efdbe4df22"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="ed173a097e57edeabd997764a1203fe48282c6b66b5b3c63b8959d1a68ab282c"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f561de600870aed73eefd738f90fc1043bed8280371cbb166f7dee0e66ffbd53"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3a0c130666d0a065906181c8bd7ba4cd7af1486cf095678d378ef485a4546848"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="443e54e4c9419660510be8ff8bf49b240de73248fbd94c3b75eacb478cf445cc"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="e9a9f905eaf9c7e697735d27789323e85fa1f1d8c8abb0892d7675da6e5de506"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="9b1981507d06d898fde691f11b21c3f9778b978b01de082e32a5d753432e68cf"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e14184568972a6e77906e675413433f8968c5075e9541f2d258de8ad38bcbabf"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="ddaf8bd5ce82b330d7edf018fd66ca865657a04d92f7d983afd279d03821bd84"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5b965163288d1c34396f6416910f627c94261153a4bb4ef8e75d7c2b249209a6"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b468ebfb3b67e05d740ff415fbfaf1a6756f09d8c19ca9ec4d77141d3efd3752"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="c1c4886943ef4862b15d434a478a125dfa092481b1b250f91ce8c73154815684"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1c99b9631d1c854e130f4b548591d393fcd4721a089799389c82f668f3da2393"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="39566a11077d123dcbd1d0032373d33c586b9a1e65d564da880520ac97ef671a"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="91fbe439bd6ffca9eaff288b2cda1c5be611ee89d34e4ca9a3946bc35ec66fd7"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="14c22bb33a2f2c1bc0f9e138aadf315c219d4abbcb5adb96835640caf32e51cf"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7377d913b3e0e22893bcf9019a884a4c298f4bee7ec9a8c0c7fc2e10fdc263e7"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="84a10b45ceda775f338d1d62ff555ebe7ac9dfb2e0d90ebf5e42aaaba0ffa37d"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="cf92e0ffc0a2e247486e0a5f56bd7c5c44d61bccd420ef0c4c91bac8d35fe293"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7afbb566b04355530205cbf6ee22a58875587d460f6147bfb708d5bb90b0551e"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="484249c5bc3dfa1b980be5f56a3e1d93bde25ca3dec81ef9bb9ad2ae1d761260"/>
+        </canvas>
+        <canvas name="15" width="160" height="49">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7bb927d4063b5272776e83cf201a25a418f2d4b9e5f9f43bd3bf373d46db0082"/>
+        </canvas>
+        <canvas name="16" width="60" height="49">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5a3f8187e830f852440585186c0e3c6ab10225f0828dcb2144202500b17d788b"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="c06e0a1d53536be3f89cca6c459c632b72cbd79542e11ad04f9f9199008e775c"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6c9d0e2e3f6778eeaa44d9b6d34213e75a83e6c2e4b984b03ae49104300fc092"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="47d401133797d76af401f7855fe44a3b0eeb388923bf0a2dcd9ca654f2279c28"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3cdf4b8968876423893686bb285c6d0c9729de34c4c661a726135e8c52133f59"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="092042886657e04f11bcf14ef2b0f1ca5d651bd00ab9e31a2610744317b09c44"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_inlink" value="attack1/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="1" height="1">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/1"/>
+        </canvas>
+        <canvas name="2" width="1" height="1">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/2"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="642855b4259104ce2ec98dd86be97d0a0d89d72f70999abbf9579c85affbd9cb"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="88c5b7ecac32cc860d00577f6105be5b15fd9f99f5d25a6b98b9cf029d1295c5"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="dbc0d33c40fae2a166034f2ae1f50076866dfef4987fc1118baf95539e88e2a2"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bfbd90318e054646f09a5432bf3b2c765026a4905790c24904079c4773ad2928"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8bafcbfd9edb6cc910b860acff509eed800ab8674b38dda99b16612211c07cbd"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="34abb4387224c37351708a0ce1f3a5815d798b538e58c752e4281f437c688cb8"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e74d8967bce61233d379d4eb6a17f8f2aa2c1154af9a94eb8997a39c83ae024d"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="befec05e861886328728153a33ea56c55a94a2027fa05723733e0920e35e7970"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0cf7c84ca3d414cb33d6ba874928f742d29e2c61aa3b3f500359adbbb168ec5a"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="174e922c141594c39b6bddafe2f37540e97a76fd04ada23fb2cdccdbaf3a9ba8"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="131" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="80572942c58ca7a183d698294afdd76f7ecd842b34c191be6cd02f821b12ed9b"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="75651698bb1a7372b7f7a180922219def3bc52bc55203e46ee357cb93ebb4e8c"/>
+        </canvas>
+        <canvas name="15" width="160" height="49">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b102caf9e5204ca94452ea072db696e6f957bfc0ec7b7343109b1a625f66390d"/>
+        </canvas>
+        <canvas name="16" width="60" height="49">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="39b8c41a36c92e6ba1040a5574908a6a52e5bcb5e4894afa8e414f3ea400d22e"/>
+        </canvas>
+        <int name="attackAfter" value="1440"/>
+      </imgdir>
+    </imgdir>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="86d5b7f06107a433030beb76025082080374cf85322cc2c3faf62f0d226b8402"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="cf7d28621dd3989207c3164fdc7964b5148af1ce8f75a880ef45efe1b5e50033"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="405951214f0a2f370941d42229a23ebb4ceb720fb99eb5f27acedb63a86dc5a7"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="aa48d2503799de6a57c495166c73807468794a007631f7463f83b0fff6da4388"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b7ca770a9097eb89987acee55d3d7e1e4717b5649467050fa5d68b352415718b"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="0e09dc6fa57eb7be950c839c37ebbb3b4ea54332b2eedf35688245e1c39bc440"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f43ed4a87893b2f41ee84926f4d7ea92fe403907c32a9985d6f1186e7a2debd9"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d75724403e970496e4ab4e2415da47785a3b19c5512e37658199ef5be15107be"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4bef2b6e975ea3d60ac5e267b62766c8f7b69110625e31e45da7af5989bb6def"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b04182cbe58f31aa5bd77c1f7eb2e317802b5628a7f4b35e1cbc0b511c7b7259"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="685279ece87a51e566920b5a6b07a177b648822071db1c5a0f0bb5c0574cf50d"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bbeb8cddd55bdfb84063941c2da093e548fd70dc3be0116120157d7169c47fbf"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0e58a86d405c0e81f5a60736d82467c33f7b495aac1f1300cd936ae21c43d4ea"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e589c7010946da5b996d44c8b50f56bf635b42fedab0fbd3617bbd2fc696da92"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="25904a1f9dd3d353b62aabf2b47d9b04d6735dd28ceab5ed2402f6227912a08d"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0b9ef739ffb6dc0b6f89295de0f803a644f4fda8edd1a27268d80ac94c014b7d"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-9" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9fc588141e33ba8b19abbedf133417a7d698923cf1bb0f9da15aab94529bb564"/>
+        </canvas>
+        <canvas name="12" width="297" height="89">
+          <vector name="origin" x="244" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bada5098ad663279b04f71dc98ac1ba223ff01e9a3a31d47971490faaf6d6b16"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d0922c563583f11ffb5ce844c70e219a1a26e4a80a2f7243320c4a557d544715"/>
+        </canvas>
+        <canvas name="14" width="1" height="1">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/14"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack2/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="611c4a8dbfab9d22ac8ff48e21fd7068528727bf09abc328af09466c1a582590"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3f4f0e69bdaa8e05ec683ef1a26e2cec9c381ef18125e6c3369e4f3336edae07"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="e6a4ed00509cfd9864dc2e1ccbbdd53eeb1f8013dbf21938e5d3cc47c5fe5230"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6efdbddb5a7fe5c392ffc88bd51618db78f6c631c282ebbca0e37ca2d4a75d6d"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f23473659433f05ef05f07664365d638e4508aa1e14e6b15540c90275c949da4"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f551b946051b5a564a273336dcaee1db2d6e6a3a9b1a90d022638b88eae475df"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="203e25bb1fd53b1a5e7d2cd80b3f8959bbba982fcf452bad93a0915ade08a653"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4fa6ae3fc1b006099a97c27a170a757c9ff161a6855d75b7ca67e32d9e33eca1"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="ecaba8472e3eb0a8fd18e358df6a3341c54626abf6aa95f2ebd66b913ed97589"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6577098e707bf33585d998f703eeb2d5c68d7bde9483ee3e399e388e9ac2a0a9"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="24cf809e09060234dc560c73f4b5be22e1c04052d07d7c60fc7d2bc302076a64"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0a1ba0ddae1eb1c189d0d1f4a5672d6018b79891706bd5def4ffe135ed1e89c6"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="65b514b10138bef0075d47585ee11cd2e633f21a7673c03e8568e095158c9016"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9ecddc089310016cdd8526ca2c4475c881176fd78a27b350b5e29e01c9389e93"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="c7cc7584fd2ad81d23d13f2367a5636c8fff3c74d10b9ddd936632d668af2946"/>
+        </canvas>
+        <canvas name="10" width="57" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6562d65d76730ec0f5a02700d0904269484c4d97617402b09b0011f60178235e"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d3030969d95ef8f505edbb401b97716a0cff5e70e3b8724a86d457bb8cdf4fb3"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="55fc186417168611c03cca71cce0900a7ada6bd808ace00858680a6009207d1a"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="641d5ae49645769d9bd9a4d338e9737473e91d7000b40f08aaa6d0f8c94cacbb"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="a4740c7c3d1c09c98b009ed045fa3e3680c1cbcff89f058f9b6ff70a0bd18142"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack5">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b16c000e92a26c2dea7b8e9d20ac3d359248873c4e5840e11a49da15a68d9d10"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="a053dcb8c8ccd9dba6ac60a12d68d03420615738ab86e181bb752a6dab961d1b"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="c38457d5b09126168e6ad1a5729bb5fbf8be4cab63276007d1d81f83ade87069"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f1e1600924557d89e7ad9367b9481af20a79b8b4188697a18a3bb5639c22dfeb"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="db7e3f6c18a368186b4d7ae1802337f9eabc352bec2989541e05274bd431bf30"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_inlink" value="attack4/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6a97cfc259437844155a80dedf1ae6c70a537f46a7b87880a792cd1a8158e9ad"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5681468acc1da43e17b6275f84ee07a11e4cbd50db1dea71c70c0362833bf041"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8f744d8e1b573d08ded2b9d4bf9115b2da99e9dfbe9459ef12553b77e14e1e70"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="124a7cff5f9b3e2cdd9f2c88ceea049d5f8404ad97e11fe28078214bbfeb1739"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1172cb339eb469aef3c2d1830f581e352b47c0256462f0aba2c104e781433e9e"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="2131e318abd89e9aeb577d1784fe7f4df0956b310ebe558a9695493326a90211"/>
+        </canvas>
+        <canvas name="7" width="57" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bb2495273f323718c161b84b590564c26037d905385b182378b57e6a3ff3d41e"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="db4e53724ecb0d6a42336494745ebcc4d9ca254098e4e8058818d23b6f2dd1a3"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="22621db1db697143c85f915a1af45b368729a2d59f12a6b7f20d4596688d4c78"/>
+        </canvas>
+        <canvas name="10" width="57" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1f783c6758d0201b88b495104b98d4142d0cf926d17f39f8799af47e8cec90bf"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9a5750d8e4107d9d925b59ba4c6448cb0ec671ebccb604af5c34a6357dff146a"/>
+        </canvas>
+        <canvas name="12" width="298" height="90">
+          <vector name="origin" x="244" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="80169ca1211efeb069d6b6054af8f417f6e1fffc25ba37e02f807f84ce2dc5ad"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="fadd8c8de8582e094bfdcb68d3408f51cceca443bb7a7671c72fa319ef471713"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f5931134c84763e2714eeea51af1f123897a978882305f584236dad7ab4cfb9f"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack6">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-767" y="-30"/>
+        <vector name="rb" x="751" y="13"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="191" height="183">
+          <vector name="origin" x="95" y="91"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b23a4d491f7813fb2f0c8c5fa271c7fbd71514d6f56deccb866d385356b9e8fb"/>
+        </canvas>
+        <canvas name="1" width="178" height="181">
+          <vector name="origin" x="89" y="90"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f0644280d8a073519c5b0e8c7ce14811c644efc33597b73b8a454b1ef39f2271"/>
+        </canvas>
+        <canvas name="2" width="186" height="187">
+          <vector name="origin" x="93" y="93"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="8a413ffb1efa0bf652dbed94868378cab7971850178ddcf4048689aed6022851"/>
+        </canvas>
+        <canvas name="3" width="183" height="190">
+          <vector name="origin" x="91" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6ee40481205f9562f733ec7bde2d841b0ef551f4375a0764c523f43a1cdf0da9"/>
+        </canvas>
+        <canvas name="4" width="125" height="118">
+          <vector name="origin" x="62" y="59"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="53f010a10ce309a7f5d21259a86a2764f876a41f4d71b296497f6f98544a7efd"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1920"/>
+    </imgdir>
+    <canvas name="0" width="196" height="193">
+      <vector name="origin" x="89" y="185"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="a79760470787833c345ed030e861d371bfc98fee59ecfaf5c4ea0693ee9655cb"/>
+    </canvas>
+    <canvas name="1" width="196" height="194">
+      <vector name="origin" x="89" y="208"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="a872a786293da41c92db4fd28fee9526a973d17504fcba08e522d5b9112b9e6f"/>
+    </canvas>
+    <canvas name="2" width="196" height="193">
+      <vector name="origin" x="89" y="212"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="8af3419110e62ebcf50e11ba92e0e75b00360dd0fcdc9e3a7a811f67f12b8b2b"/>
+    </canvas>
+    <canvas name="3" width="394" height="290">
+      <vector name="origin" x="211" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-175"/>
+      <vector name="rb" x="101" y="-28"/>
+      <string name="_hash" value="fae816367fb7d68fa46976a01b0b2a90c1a4b5087dc671632482ad5d8cc1b784"/>
+    </canvas>
+    <canvas name="4" width="385" height="280">
+      <vector name="origin" x="207" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="090ceb9e8278e32f36a6d4c58005cb7420f32177eb4f2a4e28700bdcf560af5c"/>
+    </canvas>
+    <canvas name="5" width="362" height="260">
+      <vector name="origin" x="195" y="264"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="7773304bbfd0645c946f3818588e9c2fad40903928e5d515a47e8f2158849673"/>
+    </canvas>
+    <canvas name="6" width="201" height="182">
+      <vector name="origin" x="95" y="222"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="ff951bbb84e527c5d3f2c14381c01fbda4f71e479514326ae04f94a73702e0fe"/>
+    </canvas>
+    <canvas name="7" width="199" height="183">
+      <vector name="origin" x="92" y="218"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="9c6d73dc138e9fdabeeb9421397491e8b6d75e809555001862a920c6e07c49a3"/>
+    </canvas>
+    <canvas name="8" width="190" height="176">
+      <vector name="origin" x="89" y="215"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="e79175d8bb0431e5af92097e0bbed53fc33ffe9718ada7fbbf1b1d6e21c371cd"/>
+    </canvas>
+    <canvas name="9" width="181" height="165">
+      <vector name="origin" x="87" y="213"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="d9a0fd8f01dadf112bade5f12c183fbb6dbe97717938a53add9da2083d4f5036"/>
+    </canvas>
+    <canvas name="10" width="1" height="1">
+      <vector name="origin" x="0" y="-1"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="394" height="290">
+      <vector name="origin" x="213" y="330"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="84e520166895fc4810530c4caab159231e5c1119905a78cd0aba5cf3866f741a"/>
+    </canvas>
+    <canvas name="12" width="304" height="217">
+      <vector name="origin" x="165" y="289"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="76f064d25d2a7bac2bacdebaaf884baf83ad8c0e6b7454d2e99c2130e4fe64a4"/>
+    </canvas>
+    <canvas name="13" width="278" height="193">
+      <vector name="origin" x="139" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="b09268b9631049d8e06b7f0a2d277ae613e630723591e98ff18e02a546f95de2"/>
+    </canvas>
+    <canvas name="14" width="276" height="193">
+      <vector name="origin" x="138" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="308d00825addf25b8c031da29cdcea3754077e6411fc83224ee8d4ef71c43409"/>
+    </canvas>
+    <canvas name="15" width="198" height="193">
+      <vector name="origin" x="91" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="e87b46b78957d44a624c9decc23a053fbf2ea2af5881c50a547543d63bc0de93"/>
+    </canvas>
+    <canvas name="16" width="1171" height="293">
+      <vector name="origin" x="580" y="247"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <string name="_hash" value="45b5e536f5213f312e54946008fb535a5cbbe43892aa8fdd810954f6005c70fc"/>
+    </canvas>
+    <canvas name="17" width="1189" height="283">
+      <vector name="origin" x="589" y="238"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1ae4b7dcb55cd2a0574e8bf712d2bfe3d4cae25368639e9a96281f01b94151e0"/>
+    </canvas>
+    <canvas name="18" width="1192" height="222">
+      <vector name="origin" x="591" y="182"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e15595dd07d247c539f19ed8557a028ae80d04159782cbc34255b7713a9724c2"/>
+    </canvas>
+    <canvas name="19" width="1199" height="221">
+      <vector name="origin" x="594" y="184"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="be936249e6c16c13180ea19b769daab53c724731e851583479dab3a6e08c4b6d"/>
+    </canvas>
+    <canvas name="20" width="1199" height="193">
+      <vector name="origin" x="595" y="156"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="-4"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b91e4107908aa9d9215856c9cd3ca3d42d7fdb6ba627865e17f2ac5ba2f3ec43"/>
+    </canvas>
+    <canvas name="21" width="1195" height="193">
+      <vector name="origin" x="592" y="156"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1c2e58f311b27eb7ffb65051f54ba7c9e59b6d1fe370e057752afee8e39ea03a"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="20" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="8" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/>
+    </canvas>
+    <canvas name="9" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/>
+    </canvas>
+    <canvas name="10" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/>
+    </canvas>
+    <canvas name="11" width="196" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/>
+    </canvas>
+    <canvas name="12" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/>
+    </canvas>
+    <canvas name="13" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/>
+    </canvas>
+    <canvas name="14" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f2b1eb2b88b053721807e0d194e5b55f1b846b5a4b6e11939b92839ec267967e"/>
+    </canvas>
+    <canvas name="15" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="09afd8d8cf124fb4db9f0fec591e6a074ce56eacfae17b8135982d3dec438343"/>
+    </canvas>
+    <canvas name="16" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="2ad898a1542d67c7969aa86fc1c9882bd40dd32a60625b28a3b016346e1e2b38"/>
+    </canvas>
+    <canvas name="17" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="065bae5b5906dd8921a4e04933afa7f9535d191d86be631af646eac30f4cad82"/>
+    </canvas>
+    <canvas name="18" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c6c3f56700e80cf51e3339a72040262411ec5986573968da20513049bd4707bd"/>
+    </canvas>
+    <canvas name="19" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="3297db2c984ffaa1befe4f0177259104027a50eeae88aa5472a5060efbe3f255"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prop" value="100"/>
+      <string name="0" value="在这股力量面前颤抖吧！"/>
+    </imgdir>
+    <canvas name="7" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/>
+    </canvas>
+    <canvas name="4" width="196" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/>
+    </canvas>
+    <canvas name="5" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/>
+    </canvas>
+    <canvas name="6" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="90" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1d0aac14b0085e2ec724af30e7ceeb5ff32ef5c9e2de6922614e262e656e514b"/>
+    </canvas>
+    <canvas name="1" width="196" height="205">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0270f3a6f9ceb6a83bce4ef665f0e03882a29be3faa0d4033b535baf2dd3756c"/>
+    </canvas>
+    <canvas name="2" width="196" height="213">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0d0cf54e86e131e21d9f127146d0184889794fd198db889de8157c6c2efb5f3a"/>
+    </canvas>
+    <canvas name="3" width="196" height="215">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="982b9d39aa44f124d59dd5fac3014606b9cb5c3b59a98170605a9ac9e86f4bad"/>
+    </canvas>
+    <canvas name="4" width="197" height="218">
+      <vector name="origin" x="90" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c3e340e338054e1adece96d3ba11a501ee729046720b245c7020c22d7a222f4c"/>
+    </canvas>
+    <canvas name="5" width="198" height="220">
+      <vector name="origin" x="91" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="af7f589835fd13d6b275c4cc1fe972c93d02207c7756cb4e581e41439ffa64ae"/>
+    </canvas>
+    <canvas name="6" width="197" height="214">
+      <vector name="origin" x="90" y="206"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1fe9c11f660642b36f07af486afbd56c2a2bc46edd912b7adb9ea0d6c9b70cbb"/>
+    </canvas>
+    <canvas name="7" width="197" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="400852cbca5268b0c396c6d5461fa99fa8d138d57ff64b3e6050e63f8e201151"/>
+    </canvas>
+    <canvas name="8" width="204" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0a6937e946fd7494552cb09f1965afbd21e75b91d71fb16568211e09fde987c6"/>
+    </canvas>
+    <canvas name="9" width="204" height="202">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e0efca09df704285e1cc5a59ad460c7cf3def9cc752c6f28e875106da8e6632a"/>
+    </canvas>
+    <canvas name="10" width="198" height="202">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="55eb33f9d5a8cabbc0ac37018e219811d6cbda349e3a81ed955236858876c60c"/>
+    </canvas>
+    <canvas name="11" width="199" height="204">
+      <vector name="origin" x="89" y="196"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c15a1b7a495533fbcc44b93ba70bc0e492c7e7f7427e326317f66e610412f72a"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack7">
+    <canvas name="12" width="196" height="392">
+      <vector name="origin" x="89" y="392"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/>
+    </canvas>
+    <canvas name="13" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="2" width="197" height="378">
+      <vector name="origin" x="90" y="380"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86893292f87ad179cf8e47634df1bdbcfa0d2e425ba7c7899ddee73317a94fa8"/>
+    </canvas>
+    <canvas name="15" width="196" height="393">
+      <vector name="origin" x="89" y="394"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/>
+    </canvas>
+    <canvas name="16" width="196" height="362">
+      <vector name="origin" x="89" y="362"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/>
+    </canvas>
+    <canvas name="17" width="196" height="389">
+      <vector name="origin" x="89" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/>
+    </canvas>
+    <canvas name="6" width="197" height="407">
+      <vector name="origin" x="90" y="407"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="eadebb118bef62fb27cca7c5d83c9981cfea514dc7364f4f3eef5ce23bfd8c6c"/>
+    </canvas>
+    <canvas name="7" width="196" height="412">
+      <vector name="origin" x="89" y="413"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="88ff94607cac27e1e7f91cfab14280d57726d3b88c18e62e641f6d9cb1d83e4f"/>
+    </canvas>
+    <canvas name="8" width="196" height="405">
+      <vector name="origin" x="89" y="407"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="7f87b481fab16131725a601b2d643cf86c8c0602dc21a4848a66c424a41a980b"/>
+    </canvas>
+    <canvas name="9" width="196" height="392">
+      <vector name="origin" x="89" y="393"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="d8cfbd754bee92b4b8b2c44f4219d8669079eff901edfcd6d7b8f4983d807528"/>
+    </canvas>
+    <canvas name="10" width="197" height="388">
+      <vector name="origin" x="90" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="b85da2f8c68b4183c71b3bb528f62ee9d0e1de070b7c2a9b514a9d6535519156"/>
+    </canvas>
+    <canvas name="11" width="196" height="412">
+      <vector name="origin" x="89" y="411"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="a6bdf2a3dee1a24bafac31bbfbf31e885766650cf02d46bd53ea9e7884945551"/>
+    </canvas>
+    <imgdir name="info">
+      <imgdir name="hit">
+        <canvas name="1" width="176" height="192">
+          <vector name="origin" x="88" y="96"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="24297c65bd86f268e84f9da30bb28f28f6b3929df83c83ef4589743860586205"/>
+        </canvas>
+        <canvas name="2" width="165" height="192">
+          <vector name="origin" x="82" y="96"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="8ee5c4999ed66f77eec4a6891728d0caae27aab78b95d7c394b46b2dd7503c0e"/>
+        </canvas>
+        <canvas name="3" width="163" height="135">
+          <vector name="origin" x="81" y="67"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="710dd428dfead84cb3e570011283888350bc3cb4198c2276689f16c58a0159e8"/>
+        </canvas>
+        <canvas name="4" width="141" height="133">
+          <vector name="origin" x="70" y="66"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="2037b1d2981b15bc1694bd5f572014e17c6753082e8b6c109cfa4a4be7b752b7"/>
+        </canvas>
+        <canvas name="5" width="145" height="140">
+          <vector name="origin" x="72" y="70"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="65833d06e578de7367829fb27cdc203a3cec2d049cad8a50bbfa6bc4b11fa2c0"/>
+        </canvas>
+        <canvas name="6" width="149" height="152">
+          <vector name="origin" x="74" y="76"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="854a7c1bcea63d31cce503d0be743a3e307cf39768b30f4fa0330c0c627ecd51"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="range">
+        <vector name="lt" x="-680" y="-1147"/>
+        <vector name="rb" x="680" y="99"/>
+      </imgdir>
+      <int name="attackAfter" value="1920"/>
+    </imgdir>
+    <canvas name="0" width="196" height="392">
+      <vector name="origin" x="89" y="392"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/>
+    </canvas>
+    <canvas name="14" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="1" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="3" width="196" height="393">
+      <vector name="origin" x="89" y="394"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/>
+    </canvas>
+    <canvas name="4" width="196" height="362">
+      <vector name="origin" x="89" y="362"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/>
+    </canvas>
+    <canvas name="5" width="196" height="389">
+      <vector name="origin" x="89" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9700035.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9700035.img.xml
@@ -1,0 +1,1164 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9700035.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="62"/>
+    <int name="maxHP" value="700000"/>
+    <int name="maxMP" value="10000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="325"/>
+    <int name="PDDamage" value="400"/>
+    <int name="MADamage" value="350"/>
+    <int name="MDDamage" value="80"/>
+    <int name="acc" value="160"/>
+    <int name="eva" value="25"/>
+    <int name="pushed" value="10000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="mobType" value="7"/>
+    <int name="undead" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="hpTagColor" value="3"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <string name="level" value="167"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="121"/>
+        <int name="action" value="2"/>
+        <string name="level" value="9"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <int name="point" value="800"/>
+    <int name="ignoreFieldOut" value="1"/>
+    <string name="elemAttr" value="H2"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3845"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chataBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="700000"/>
+        <int name="prob" value="100"/>
+        <string name="0" value="入侵者们！我要把你们全都沉入海底。"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="hp" value="350000"/>
+        <int name="prob" value="100"/>
+        <string name="0" value="别小看我！我可是这艘船的大副！"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="142" height="156">
+      <vector name="origin" x="57" y="151"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="141" height="157">
+      <vector name="origin" x="56" y="151"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="142" height="156">
+      <vector name="origin" x="55" y="152"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="142" height="156">
+      <vector name="origin" x="54" y="153"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-118"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="143" height="156">
+      <vector name="origin" x="56" y="153"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-117"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="143" height="156">
+      <vector name="origin" x="57" y="152"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="140" height="156">
+      <vector name="origin" x="57" y="151"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="142" height="156">
+      <vector name="origin" x="56" y="151"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="139" height="155">
+      <vector name="origin" x="55" y="152"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="138" height="156">
+      <vector name="origin" x="54" y="153"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="139" height="155">
+      <vector name="origin" x="56" y="152"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="140" height="156">
+      <vector name="origin" x="57" y="152"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="152" height="160">
+      <vector name="origin" x="58" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="7" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="153" height="160">
+      <vector name="origin" x="60" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="93" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="152" height="160">
+      <vector name="origin" x="60" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="152" height="160">
+      <vector name="origin" x="59" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="152" height="160">
+      <vector name="origin" x="58" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="152" height="160">
+      <vector name="origin" x="58" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="153" height="160">
+      <vector name="origin" x="60" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="152" height="160">
+      <vector name="origin" x="60" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="152" height="160">
+      <vector name="origin" x="59" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="152" height="160">
+      <vector name="origin" x="58" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="153" height="168">
+      <vector name="origin" x="61" y="167"/>
+      <vector name="lt" x="-61" y="-160"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="12" y="-104"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="147" height="165">
+      <vector name="origin" x="62" y="163"/>
+      <vector name="head" x="12" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="179" height="174">
+      <vector name="origin" x="94" y="172"/>
+      <vector name="head" x="12" y="-92"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="190" height="185">
+      <vector name="origin" x="105" y="175"/>
+      <vector name="head" x="11" y="-91"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="191" height="188">
+      <vector name="origin" x="106" y="176"/>
+      <vector name="head" x="13" y="-91"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="191" height="186">
+      <vector name="origin" x="106" y="174"/>
+      <vector name="head" x="12" y="-91"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="195" height="179">
+      <vector name="origin" x="110" y="170"/>
+      <vector name="head" x="11" y="-86"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="195" height="175">
+      <vector name="origin" x="110" y="163"/>
+      <vector name="lt" x="-37" y="-56"/>
+      <vector name="rb" x="35" y="0"/>
+      <vector name="head" x="11" y="-86"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="232" height="158">
+      <vector name="origin" x="147" y="148"/>
+      <vector name="head" x="-3" y="-109"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="220" height="162">
+      <vector name="origin" x="110" y="150"/>
+      <vector name="head" x="-22" y="-140"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="216" height="203">
+      <vector name="origin" x="110" y="194"/>
+      <vector name="head" x="-3" y="-184"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="214" height="262">
+      <vector name="origin" x="110" y="250"/>
+      <vector name="head" x="31" y="-239"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="203" height="259">
+      <vector name="origin" x="110" y="250"/>
+      <vector name="head" x="34" y="-237"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="195" height="260">
+      <vector name="origin" x="110" y="248"/>
+      <vector name="head" x="34" y="-237"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="207" height="261">
+      <vector name="origin" x="110" y="250"/>
+      <vector name="head" x="34" y="-237"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="205" height="263">
+      <vector name="origin" x="110" y="252"/>
+      <vector name="head" x="34" y="-237"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="195" height="258">
+      <vector name="origin" x="110" y="249"/>
+      <vector name="head" x="34" y="-237"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="195" height="247">
+      <vector name="origin" x="110" y="238"/>
+      <vector name="head" x="34" y="-237"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="195" height="243">
+      <vector name="origin" x="110" y="234"/>
+      <vector name="head" x="34" y="-237"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="195" height="244">
+      <vector name="origin" x="110" y="235"/>
+      <vector name="head" x="34" y="-237"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="154" height="245">
+      <vector name="origin" x="73" y="239"/>
+      <vector name="head" x="34" y="-237"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="157" height="232">
+      <vector name="origin" x="75" y="243"/>
+      <vector name="head" x="34" y="-237"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="船……船长……对不起……呃啊。"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-471" y="-47"/>
+        <vector name="rb" x="119" y="3"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="110" height="46">
+          <vector name="origin" x="0" y="43"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="122" height="100">
+          <vector name="origin" x="15" y="98"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="192" height="95">
+          <vector name="origin" x="85" y="86"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="193" height="93">
+          <vector name="origin" x="88" y="84"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="138" height="94">
+          <vector name="origin" x="41" y="85"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="109" height="95">
+          <vector name="origin" x="40" y="86"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="110" height="94">
+          <vector name="origin" x="41" y="85"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="111" height="100">
+          <vector name="origin" x="48" y="88"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="8" width="122" height="113">
+          <vector name="origin" x="54" y="96"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="9" width="130" height="127">
+          <vector name="origin" x="58" y="103"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="10" width="134" height="137">
+          <vector name="origin" x="59" y="108"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1050"/>
+      <int name="magic" value="1"/>
+      <int name="jumpAttack" value="1"/>
+    </imgdir>
+    <canvas name="0" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-57" y="-145"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="8" y="-113"/>
+    </canvas>
+    <canvas name="1" width="147" height="156">
+      <vector name="origin" x="56" y="149"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-57" y="-145"/>
+      <vector name="rb" x="91" y="0"/>
+      <vector name="head" x="8" y="-113"/>
+    </canvas>
+    <canvas name="2" width="161" height="156">
+      <vector name="origin" x="54" y="149"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-57" y="-145"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="8" y="-113"/>
+    </canvas>
+    <canvas name="3" width="167" height="156">
+      <vector name="origin" x="52" y="150"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-57" y="-145"/>
+      <vector name="rb" x="115" y="0"/>
+      <vector name="head" x="8" y="-113"/>
+    </canvas>
+    <canvas name="4" width="168" height="156">
+      <vector name="origin" x="51" y="150"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-57" y="-145"/>
+      <vector name="rb" x="115" y="0"/>
+      <vector name="head" x="8" y="-113"/>
+    </canvas>
+    <canvas name="5" width="170" height="156">
+      <vector name="origin" x="51" y="150"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-51" y="-145"/>
+      <vector name="rb" x="115" y="0"/>
+      <vector name="head" x="8" y="-113"/>
+    </canvas>
+    <canvas name="6" width="174" height="156">
+      <vector name="origin" x="55" y="150"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-51" y="-145"/>
+      <vector name="rb" x="115" y="0"/>
+      <vector name="head" x="8" y="-113"/>
+    </canvas>
+    <canvas name="7" width="205" height="153">
+      <vector name="origin" x="97" y="147"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-51" y="-145"/>
+      <vector name="rb" x="69" y="0"/>
+      <vector name="head" x="8" y="-110"/>
+    </canvas>
+    <canvas name="8" width="186" height="149">
+      <vector name="origin" x="103" y="145"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-51" y="-145"/>
+      <vector name="rb" x="69" y="0"/>
+      <vector name="head" x="8" y="-110"/>
+    </canvas>
+    <canvas name="9" width="190" height="147">
+      <vector name="origin" x="105" y="144"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-51" y="-145"/>
+      <vector name="rb" x="69" y="0"/>
+      <vector name="head" x="8" y="-110"/>
+    </canvas>
+    <canvas name="10" width="157" height="151">
+      <vector name="origin" x="83" y="143"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-51" y="-145"/>
+      <vector name="rb" x="69" y="0"/>
+      <vector name="head" x="8" y="-110"/>
+    </canvas>
+    <canvas name="11" width="151" height="156">
+      <vector name="origin" x="60" y="148"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-55" y="-142"/>
+      <vector name="rb" x="91" y="0"/>
+      <vector name="head" x="8" y="-110"/>
+    </canvas>
+    <canvas name="12" width="152" height="160">
+      <vector name="origin" x="58" y="149"/>
+      <vector name="lt" x="-58" y="-143"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="9" y="-113"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="153" height="160">
+      <vector name="origin" x="60" y="149"/>
+      <vector name="lt" x="-58" y="-143"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="9" y="-113"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="14" width="152" height="160">
+      <vector name="origin" x="60" y="149"/>
+      <vector name="lt" x="-58" y="-143"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="9" y="-113"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="15" width="152" height="160">
+      <vector name="origin" x="59" y="149"/>
+      <vector name="lt" x="-58" y="-143"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="9" y="-113"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="16" width="152" height="160">
+      <vector name="origin" x="58" y="149"/>
+      <vector name="lt" x="-58" y="-143"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="9" y="-113"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-574" y="-96"/>
+        <vector name="rb" x="-17" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="69" height="37">
+          <vector name="origin" x="34" y="18"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="81" height="43">
+          <vector name="origin" x="40" y="25"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="98" height="61">
+          <vector name="origin" x="49" y="45"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="106" height="56">
+          <vector name="origin" x="52" y="39"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="33" height="28">
+          <vector name="origin" x="16" y="14"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="101" height="29">
+          <vector name="origin" x="132" y="29"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="105" height="47">
+          <vector name="origin" x="133" y="47"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="105" height="67">
+          <vector name="origin" x="133" y="67"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="107" height="91">
+          <vector name="origin" x="133" y="90"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="119" height="91">
+          <vector name="origin" x="145" y="90"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="137" height="91">
+          <vector name="origin" x="167" y="90"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="152" height="91">
+          <vector name="origin" x="199" y="90"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="159" height="91">
+          <vector name="origin" x="230" y="91"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="8" width="175" height="91">
+          <vector name="origin" x="276" y="91"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="9" width="163" height="91">
+          <vector name="origin" x="324" y="91"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="10" width="184" height="91">
+          <vector name="origin" x="388" y="91"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="11" width="185" height="91">
+          <vector name="origin" x="445" y="91"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="12" width="171" height="91">
+          <vector name="origin" x="509" y="91"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="13" width="161" height="91">
+          <vector name="origin" x="555" y="91"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="14" width="145" height="91">
+          <vector name="origin" x="580" y="91"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="15" width="131" height="88">
+          <vector name="origin" x="600" y="88"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="16" width="114" height="62">
+          <vector name="origin" x="628" y="62"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="17" width="118" height="39">
+          <vector name="origin" x="664" y="39"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="15"/>
+      <int name="attackAfter" value="1080"/>
+      <int name="effectAfter" value="0"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-57" y="-149"/>
+      <vector name="rb" x="95" y="11"/>
+      <vector name="head" x="10" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-57" y="-149"/>
+      <vector name="rb" x="95" y="11"/>
+      <vector name="head" x="12" y="-86"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="145" height="154">
+      <vector name="origin" x="54" y="148"/>
+      <vector name="lt" x="-54" y="-148"/>
+      <vector name="rb" x="91" y="6"/>
+      <vector name="head" x="14" y="-85"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="114" height="147">
+      <vector name="origin" x="34" y="145"/>
+      <vector name="lt" x="-34" y="-146"/>
+      <vector name="rb" x="79" y="2"/>
+      <vector name="head" x="13" y="-85"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="112" height="146">
+      <vector name="origin" x="32" y="144"/>
+      <vector name="lt" x="-33" y="-144"/>
+      <vector name="rb" x="80" y="2"/>
+      <vector name="head" x="18" y="-82"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="145" height="161">
+      <vector name="origin" x="58" y="159"/>
+      <vector name="lt" x="-58" y="-159"/>
+      <vector name="rb" x="87" y="2"/>
+      <vector name="head" x="-8" y="-43"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="164" height="162">
+      <vector name="origin" x="74" y="160"/>
+      <vector name="lt" x="-74" y="-160"/>
+      <vector name="rb" x="90" y="2"/>
+      <vector name="head" x="9" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="163" height="160">
+      <vector name="origin" x="73" y="158"/>
+      <vector name="lt" x="-73" y="-158"/>
+      <vector name="rb" x="90" y="2"/>
+      <vector name="head" x="6" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="163" height="162">
+      <vector name="origin" x="73" y="160"/>
+      <vector name="lt" x="-73" y="-160"/>
+      <vector name="rb" x="90" y="2"/>
+      <vector name="head" x="7" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="165" height="160">
+      <vector name="origin" x="73" y="159"/>
+      <vector name="lt" x="-73" y="-159"/>
+      <vector name="rb" x="92" y="2"/>
+      <vector name="head" x="6" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="163" height="162">
+      <vector name="origin" x="73" y="160"/>
+      <vector name="lt" x="-73" y="-161"/>
+      <vector name="rb" x="90" y="2"/>
+      <vector name="head" x="7" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="163" height="161">
+      <vector name="origin" x="73" y="160"/>
+      <vector name="lt" x="-73" y="-160"/>
+      <vector name="rb" x="90" y="1"/>
+      <vector name="head" x="4" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="164" height="161">
+      <vector name="origin" x="74" y="160"/>
+      <vector name="lt" x="-74" y="-160"/>
+      <vector name="rb" x="90" y="1"/>
+      <vector name="head" x="5" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="164" height="161">
+      <vector name="origin" x="73" y="159"/>
+      <vector name="lt" x="-73" y="-159"/>
+      <vector name="rb" x="91" y="2"/>
+      <vector name="head" x="6" y="-100"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="164" height="169">
+      <vector name="origin" x="73" y="163"/>
+      <vector name="lt" x="-73" y="-163"/>
+      <vector name="rb" x="91" y="6"/>
+      <vector name="head" x="14" y="-86"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-370" y="-150"/>
+        <vector name="rb" x="335" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="61" height="44">
+          <vector name="origin" x="-40" y="59"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="160" height="154">
+          <vector name="origin" x="67" y="60"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="126" height="130">
+          <vector name="origin" x="60" y="45"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="129" height="87">
+          <vector name="origin" x="62" y="40"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="96" height="58">
+          <vector name="origin" x="66" y="17"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="15"/>
+      <int name="attackAfter" value="1440"/>
+      <int name="effectAfter" value="0"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-57" y="-149"/>
+      <vector name="rb" x="95" y="11"/>
+      <vector name="head" x="10" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="145" height="154">
+      <vector name="origin" x="54" y="148"/>
+      <vector name="lt" x="-57" y="-149"/>
+      <vector name="rb" x="95" y="11"/>
+      <vector name="head" x="12" y="-86"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="145" height="154">
+      <vector name="origin" x="54" y="148"/>
+      <vector name="lt" x="-54" y="-148"/>
+      <vector name="rb" x="91" y="6"/>
+      <vector name="head" x="14" y="-85"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="114" height="147">
+      <vector name="origin" x="34" y="145"/>
+      <vector name="lt" x="-34" y="-146"/>
+      <vector name="rb" x="79" y="2"/>
+      <vector name="head" x="13" y="-85"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="112" height="146">
+      <vector name="origin" x="32" y="144"/>
+      <vector name="lt" x="-33" y="-144"/>
+      <vector name="rb" x="80" y="2"/>
+      <vector name="head" x="18" y="-82"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="231" height="161">
+      <vector name="origin" x="96" y="159"/>
+      <vector name="lt" x="-58" y="-159"/>
+      <vector name="rb" x="87" y="2"/>
+      <vector name="head" x="-8" y="-43"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="237" height="163">
+      <vector name="origin" x="99" y="160"/>
+      <vector name="lt" x="-74" y="-160"/>
+      <vector name="rb" x="90" y="2"/>
+      <vector name="head" x="9" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="239" height="161">
+      <vector name="origin" x="100" y="158"/>
+      <vector name="lt" x="-73" y="-158"/>
+      <vector name="rb" x="90" y="2"/>
+      <vector name="head" x="6" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="302" height="164">
+      <vector name="origin" x="124" y="160"/>
+      <vector name="lt" x="-73" y="-160"/>
+      <vector name="rb" x="90" y="2"/>
+      <vector name="head" x="7" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="365" height="166">
+      <vector name="origin" x="176" y="161"/>
+      <vector name="lt" x="-73" y="-159"/>
+      <vector name="rb" x="92" y="2"/>
+      <vector name="head" x="6" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="368" height="175">
+      <vector name="origin" x="179" y="170"/>
+      <vector name="lt" x="-73" y="-161"/>
+      <vector name="rb" x="90" y="2"/>
+      <vector name="head" x="7" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="366" height="204">
+      <vector name="origin" x="178" y="201"/>
+      <vector name="lt" x="-73" y="-160"/>
+      <vector name="rb" x="90" y="1"/>
+      <vector name="head" x="4" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="364" height="227">
+      <vector name="origin" x="178" y="225"/>
+      <vector name="lt" x="-74" y="-160"/>
+      <vector name="rb" x="90" y="1"/>
+      <vector name="head" x="5" y="-99"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="354" height="227">
+      <vector name="origin" x="176" y="225"/>
+      <vector name="lt" x="-73" y="-159"/>
+      <vector name="rb" x="91" y="2"/>
+      <vector name="head" x="6" y="-100"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="164" height="168">
+      <vector name="origin" x="73" y="162"/>
+      <vector name="lt" x="-73" y="-163"/>
+      <vector name="rb" x="91" y="6"/>
+      <vector name="head" x="14" y="-86"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="7" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="145" height="154">
+      <vector name="origin" x="54" y="148"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="93" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="114" height="147">
+      <vector name="origin" x="34" y="145"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="112" height="146">
+      <vector name="origin" x="32" y="144"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="189" height="164">
+      <vector name="origin" x="76" y="159"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="275" height="181">
+      <vector name="origin" x="121" y="174"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="278" height="189">
+      <vector name="origin" x="122" y="181"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="267" height="185">
+      <vector name="origin" x="117" y="178"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="269" height="189">
+      <vector name="origin" x="118" y="181"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="189" height="179">
+      <vector name="origin" x="76" y="172"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="187" height="152">
+      <vector name="origin" x="74" y="144"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="184" height="152">
+      <vector name="origin" x="74" y="145"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="165" height="154">
+      <vector name="origin" x="62" y="148"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="152" height="160">
+      <vector name="origin" x="58" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="7" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="153" height="160">
+      <vector name="origin" x="60" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="93" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="152" height="160">
+      <vector name="origin" x="60" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="152" height="160">
+      <vector name="origin" x="59" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="全都出来击退入侵者。这是命令！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="7" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="145" height="154">
+      <vector name="origin" x="54" y="148"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="93" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="114" height="147">
+      <vector name="origin" x="34" y="145"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="112" height="146">
+      <vector name="origin" x="32" y="144"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="202" height="164">
+      <vector name="origin" x="79" y="159"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="206" height="158">
+      <vector name="origin" x="81" y="151"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="240" height="152">
+      <vector name="origin" x="98" y="144"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="256" height="152">
+      <vector name="origin" x="106" y="145"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="265" height="152">
+      <vector name="origin" x="111" y="144"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="256" height="152">
+      <vector name="origin" x="112" y="145"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="265" height="152">
+      <vector name="origin" x="117" y="144"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="206" height="152">
+      <vector name="origin" x="81" y="145"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="202" height="154">
+      <vector name="origin" x="79" y="148"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="152" height="160">
+      <vector name="origin" x="57" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="7" y="-115"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="152" height="160">
+      <vector name="origin" x="58" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="7" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="153" height="160">
+      <vector name="origin" x="60" y="149"/>
+      <vector name="lt" x="-57" y="-150"/>
+      <vector name="rb" x="93" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="152" height="160">
+      <vector name="origin" x="60" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="152" height="160">
+      <vector name="origin" x="59" y="149"/>
+      <vector name="lt" x="-60" y="-149"/>
+      <vector name="rb" x="92" y="0"/>
+      <vector name="head" x="10" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9700037.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9700037.img.xml
@@ -1,0 +1,1287 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9700037.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="62"/>
+    <int name="maxHP" value="4000000"/>
+    <int name="maxMP" value="10000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="350"/>
+    <int name="PDDamage" value="480"/>
+    <int name="MADamage" value="330"/>
+    <int name="MDDamage" value="500"/>
+    <int name="acc" value="160"/>
+    <int name="eva" value="27"/>
+    <int name="pushed" value="99999999"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="mobType" value="7"/>
+    <int name="undead" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="point" value="1000"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <string name="level" value="166"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="134"/>
+        <int name="action" value="2"/>
+        <string name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="135"/>
+        <int name="action" value="2"/>
+        <string name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="revive">
+      <int name="0" value="9700038"/>
+    </imgdir>
+    <int name="ignoreFieldOut" value="1"/>
+    <string name="elemAttr" value="H2"/>
+    <imgdir name="speak">
+      <imgdir name="con">
+        <imgdir name="0">
+          <imgdir name="quest">
+            <int name="questID" value="3845"/>
+            <int name="state" value="2"/>
+          </imgdir>
+        </imgdir>
+      </imgdir>
+      <int name="chataBalloon" value="0"/>
+      <imgdir name="0">
+        <int name="hp" value="3900000"/>
+        <int name="prob" value="100"/>
+        <string name="0" value="竟敢毫无畏惧地闯进来！全都去死吧！！"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="hp" value="2000000"/>
+        <int name="prob" value="100"/>
+        <string name="0" value="以海军的名誉起誓，我会击败你们。"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="hp" value="800000"/>
+        <int name="prob" value="100"/>
+        <string name="0" value="这种程度还远远不够，你们这些家伙。"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="253" height="203">
+      <vector name="origin" x="151" y="194"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="253" height="204">
+      <vector name="origin" x="151" y="196"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="253" height="206">
+      <vector name="origin" x="151" y="198"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="253" height="206">
+      <vector name="origin" x="151" y="199"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="253" height="204">
+      <vector name="origin" x="151" y="198"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="253" height="202">
+      <vector name="origin" x="151" y="197"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="253" height="203">
+      <vector name="origin" x="151" y="196"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="253" height="203">
+      <vector name="origin" x="151" y="196"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="253" height="203">
+      <vector name="origin" x="151" y="194"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="251" height="204">
+      <vector name="origin" x="150" y="196"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="249" height="204">
+      <vector name="origin" x="149" y="197"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-15" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="247" height="205">
+      <vector name="origin" x="148" y="199"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-15" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="245" height="203">
+      <vector name="origin" x="147" y="197"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-15" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="247" height="203">
+      <vector name="origin" x="148" y="196"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-15" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="249" height="202">
+      <vector name="origin" x="149" y="195"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-15" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="251" height="203">
+      <vector name="origin" x="150" y="195"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-15" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="261" height="205">
+      <vector name="origin" x="134" y="197"/>
+      <vector name="lt" x="-127" y="-192"/>
+      <vector name="rb" x="111" y="0"/>
+      <vector name="head" x="-9" y="-141"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="253" height="200">
+      <vector name="origin" x="151" y="193"/>
+      <vector name="head" x="-15" y="-141"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="251" height="204">
+      <vector name="origin" x="150" y="196"/>
+      <vector name="head" x="-15" y="-141"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="249" height="204">
+      <vector name="origin" x="149" y="197"/>
+      <vector name="head" x="-15" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="247" height="205">
+      <vector name="origin" x="148" y="199"/>
+      <vector name="head" x="-14" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="245" height="203">
+      <vector name="origin" x="147" y="197"/>
+      <vector name="head" x="-14" y="-145"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="247" height="203">
+      <vector name="origin" x="148" y="196"/>
+      <vector name="head" x="-14" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="249" height="202">
+      <vector name="origin" x="149" y="195"/>
+      <vector name="head" x="-14" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="251" height="203">
+      <vector name="origin" x="150" y="195"/>
+      <vector name="head" x="-14" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="212" height="196">
+      <vector name="origin" x="51" y="185"/>
+      <vector name="head" x="76" y="-134"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="142" height="194">
+      <vector name="origin" x="-17" y="182"/>
+      <vector name="head" x="76" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="206" height="165">
+      <vector name="origin" x="21" y="154"/>
+      <vector name="head" x="76" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="210" height="189">
+      <vector name="origin" x="23" y="182"/>
+      <vector name="head" x="77" y="-155"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="214" height="210">
+      <vector name="origin" x="25" y="203"/>
+      <vector name="head" x="80" y="-178"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="221" height="238">
+      <vector name="origin" x="28" y="231"/>
+      <vector name="head" x="79" y="-206"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="227" height="259">
+      <vector name="origin" x="31" y="252"/>
+      <vector name="head" x="80" y="-223"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="229" height="267">
+      <vector name="origin" x="32" y="260"/>
+      <vector name="head" x="79" y="-233"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="141" height="280">
+      <vector name="origin" x="-12" y="273"/>
+      <vector name="head" x="78" y="-246"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="106" height="225">
+      <vector name="origin" x="-27" y="282"/>
+      <vector name="head" x="78" y="-248"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="98" height="273">
+      <vector name="origin" x="-32" y="358"/>
+      <vector name="head" x="78" y="-285"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="64" height="320">
+      <vector name="origin" x="-49" y="382"/>
+      <vector name="head" x="79" y="-303"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="44" height="366">
+      <vector name="origin" x="-59" y="384"/>
+      <vector name="head" x="79" y="-327"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="32" height="331">
+      <vector name="origin" x="-65" y="368"/>
+      <vector name="head" x="80" y="-335"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我竟然会败给这些小鬼……呃啊……"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-263" y="-192"/>
+        <vector name="rb" x="-2" y="16"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="133" height="131">
+          <vector name="origin" x="62" y="67"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="145" height="130">
+          <vector name="origin" x="66" y="71"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="136" height="128">
+          <vector name="origin" x="67" y="68"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="53" height="69">
+          <vector name="origin" x="22" y="46"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="1"/>
+      <int name="attackAfter" value="1080"/>
+      <int name="PADamage" value="430"/>
+    </imgdir>
+    <canvas name="0" width="253" height="203">
+      <vector name="origin" x="151" y="194"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-144" y="-189"/>
+      <vector name="rb" x="94" y="0"/>
+      <vector name="head" x="-13" y="-142"/>
+    </canvas>
+    <canvas name="1" width="283" height="360">
+      <vector name="origin" x="121" y="384"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-112" y="-217"/>
+      <vector name="rb" x="106" y="-32"/>
+      <vector name="head" x="8" y="-113"/>
+    </canvas>
+    <canvas name="2" width="265" height="343">
+      <vector name="origin" x="71" y="380"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-65" y="-239"/>
+      <vector name="rb" x="108" y="-40"/>
+      <vector name="head" x="10" y="-185"/>
+    </canvas>
+    <canvas name="3" width="245" height="331">
+      <vector name="origin" x="47" y="375"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-38" y="-247"/>
+      <vector name="rb" x="126" y="-48"/>
+      <vector name="head" x="13" y="-193"/>
+    </canvas>
+    <canvas name="4" width="244" height="315">
+      <vector name="origin" x="45" y="363"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-37" y="-252"/>
+      <vector name="rb" x="128" y="-55"/>
+      <vector name="head" x="8" y="-113"/>
+    </canvas>
+    <canvas name="5" width="239" height="292">
+      <vector name="origin" x="44" y="343"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-37" y="-255"/>
+      <vector name="rb" x="133" y="-58"/>
+      <vector name="head" x="15" y="-199"/>
+    </canvas>
+    <canvas name="6" width="228" height="271">
+      <vector name="origin" x="43" y="324"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-37" y="-256"/>
+      <vector name="rb" x="133" y="-59"/>
+      <vector name="head" x="18" y="-201"/>
+    </canvas>
+    <canvas name="7" width="207" height="218">
+      <vector name="origin" x="42" y="273"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-33" y="-259"/>
+      <vector name="rb" x="136" y="-62"/>
+      <vector name="head" x="17" y="-203"/>
+    </canvas>
+    <canvas name="8" width="186" height="216">
+      <vector name="origin" x="42" y="271"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-33" y="-258"/>
+      <vector name="rb" x="136" y="-60"/>
+      <vector name="head" x="16" y="-203"/>
+    </canvas>
+    <canvas name="9" width="346" height="237">
+      <vector name="origin" x="259" y="209"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-112" y="-144"/>
+      <vector name="rb" x="74" y="15"/>
+      <vector name="head" x="-61" y="-110"/>
+    </canvas>
+    <canvas name="10" width="341" height="234">
+      <vector name="origin" x="257" y="208"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-112" y="-144"/>
+      <vector name="rb" x="74" y="15"/>
+      <vector name="head" x="-61" y="-110"/>
+    </canvas>
+    <canvas name="11" width="341" height="237">
+      <vector name="origin" x="258" y="212"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-93" y="-141"/>
+      <vector name="rb" x="91" y="23"/>
+      <vector name="head" x="-43" y="-100"/>
+    </canvas>
+    <canvas name="12" width="347" height="195">
+      <vector name="origin" x="257" y="171"/>
+      <vector name="lt" x="-93" y="-141"/>
+      <vector name="rb" x="91" y="23"/>
+      <vector name="head" x="-43" y="-100"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="351" height="188">
+      <vector name="origin" x="242" y="165"/>
+      <vector name="lt" x="-97" y="-138"/>
+      <vector name="rb" x="67" y="30"/>
+      <vector name="head" x="-47" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="344" height="188">
+      <vector name="origin" x="234" y="165"/>
+      <vector name="lt" x="-90" y="-143"/>
+      <vector name="rb" x="72" y="20"/>
+      <vector name="head" x="-41" y="-103"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="253" height="199">
+      <vector name="origin" x="157" y="182"/>
+      <vector name="lt" x="-145" y="-174"/>
+      <vector name="rb" x="86" y="4"/>
+      <vector name="head" x="-16" y="-130"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="253" height="203">
+      <vector name="origin" x="151" y="194"/>
+      <vector name="lt" x="-139" y="-184"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-13" y="-142"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="251" height="204">
+      <vector name="origin" x="150" y="196"/>
+      <vector name="lt" x="-139" y="-182"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-13" y="-142"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="249" height="204">
+      <vector name="origin" x="149" y="197"/>
+      <vector name="lt" x="-138" y="-182"/>
+      <vector name="rb" x="88" y="1"/>
+      <vector name="head" x="-14" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="247" height="205">
+      <vector name="origin" x="148" y="199"/>
+      <vector name="lt" x="-137" y="-185"/>
+      <vector name="rb" x="86" y="0"/>
+      <vector name="head" x="-13" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-373" y="-128"/>
+        <vector name="rb" x="338" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="66" height="79">
+          <vector name="origin" x="31" y="63"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="79" height="73">
+          <vector name="origin" x="35" y="70"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="70" height="79">
+          <vector name="origin" x="31" y="63"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="79" height="73">
+          <vector name="origin" x="35" y="70"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="66" height="80">
+          <vector name="origin" x="25" y="83"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="79" height="73">
+          <vector name="origin" x="34" y="90"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="1080"/>
+        </canvas>
+        <canvas name="1" width="670" height="161">
+          <vector name="origin" x="379" y="158"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="668" height="200">
+          <vector name="origin" x="370" y="197"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="706" height="191">
+          <vector name="origin" x="362" y="188"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="729" height="178">
+          <vector name="origin" x="379" y="175"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="709" height="173">
+          <vector name="origin" x="370" y="170"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="706" height="167">
+          <vector name="origin" x="362" y="164"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="729" height="178">
+          <vector name="origin" x="379" y="175"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="8" width="709" height="173">
+          <vector name="origin" x="370" y="170"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="15"/>
+      <int name="attackAfter" value="1080"/>
+      <int name="effectAfter" value="0"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="253" height="201">
+      <vector name="origin" x="151" y="194"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="253" height="201">
+      <vector name="origin" x="148" y="197"/>
+      <vector name="lt" x="-144" y="-192"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-15" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="244" height="201">
+      <vector name="origin" x="123" y="195"/>
+      <vector name="lt" x="-113" y="-189"/>
+      <vector name="rb" x="97" y="0"/>
+      <vector name="head" x="-14" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="186" height="206">
+      <vector name="origin" x="90" y="196"/>
+      <vector name="lt" x="-64" y="-179"/>
+      <vector name="rb" x="80" y="2"/>
+      <vector name="head" x="-13" y="-138"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="162" height="204">
+      <vector name="origin" x="81" y="190"/>
+      <vector name="lt" x="-64" y="-179"/>
+      <vector name="rb" x="80" y="2"/>
+      <vector name="head" x="-13" y="-138"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="210" height="214">
+      <vector name="origin" x="108" y="350"/>
+      <vector name="lt" x="-98" y="-335"/>
+      <vector name="rb" x="86" y="-145"/>
+      <vector name="head" x="-11" y="-291"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="208" height="204">
+      <vector name="origin" x="107" y="375"/>
+      <vector name="lt" x="-98" y="-365"/>
+      <vector name="rb" x="92" y="-178"/>
+      <vector name="head" x="-13" y="-319"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="208" height="207">
+      <vector name="origin" x="107" y="380"/>
+      <vector name="lt" x="-97" y="-364"/>
+      <vector name="rb" x="90" y="-179"/>
+      <vector name="head" x="-13" y="-321"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="559" height="377">
+      <vector name="origin" x="292" y="380"/>
+      <vector name="lt" x="-113" y="-351"/>
+      <vector name="rb" x="162" y="-179"/>
+      <vector name="head" x="-13" y="-316"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="544" height="381">
+      <vector name="origin" x="277" y="384"/>
+      <vector name="lt" x="-130" y="-365"/>
+      <vector name="rb" x="148" y="-186"/>
+      <vector name="head" x="-11" y="-320"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="559" height="379">
+      <vector name="origin" x="292" y="382"/>
+      <vector name="lt" x="-130" y="-357"/>
+      <vector name="rb" x="129" y="-179"/>
+      <vector name="head" x="-13" y="-315"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="544" height="383">
+      <vector name="origin" x="277" y="386"/>
+      <vector name="lt" x="-66" y="-357"/>
+      <vector name="rb" x="69" y="-175"/>
+      <vector name="head" x="-12" y="-319"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="559" height="375">
+      <vector name="origin" x="292" y="378"/>
+      <vector name="lt" x="-73" y="-355"/>
+      <vector name="rb" x="80" y="-173"/>
+      <vector name="head" x="-14" y="-316"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="544" height="377">
+      <vector name="origin" x="277" y="380"/>
+      <vector name="lt" x="-98" y="-356"/>
+      <vector name="rb" x="91" y="-180"/>
+      <vector name="head" x="-14" y="-321"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="559" height="372">
+      <vector name="origin" x="292" y="375"/>
+      <vector name="lt" x="-84" y="-351"/>
+      <vector name="rb" x="79" y="-182"/>
+      <vector name="head" x="-16" y="-316"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="544" height="379">
+      <vector name="origin" x="277" y="382"/>
+      <vector name="lt" x="-98" y="-356"/>
+      <vector name="rb" x="91" y="-180"/>
+      <vector name="head" x="-14" y="-319"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="208" height="208">
+      <vector name="origin" x="107" y="380"/>
+      <vector name="lt" x="-97" y="-363"/>
+      <vector name="rb" x="87" y="-182"/>
+      <vector name="head" x="-13" y="-321"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="208" height="212">
+      <vector name="origin" x="111" y="396"/>
+      <vector name="lt" x="-100" y="-380"/>
+      <vector name="rb" x="85" y="-193"/>
+      <vector name="head" x="-18" y="-339"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="188" height="243">
+      <vector name="origin" x="91" y="295"/>
+      <vector name="lt" x="-77" y="-249"/>
+      <vector name="rb" x="81" y="-62"/>
+      <vector name="head" x="-12" y="-199"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="244" height="219">
+      <vector name="origin" x="123" y="216"/>
+      <vector name="lt" x="-101" y="-192"/>
+      <vector name="rb" x="99" y="-13"/>
+      <vector name="head" x="-15" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="259" height="201">
+      <vector name="origin" x="151" y="190"/>
+      <vector name="lt" x="-140" y="-174"/>
+      <vector name="rb" x="88" y="0"/>
+      <vector name="head" x="-14" y="-136"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="260" height="199">
+      <vector name="origin" x="151" y="186"/>
+      <vector name="lt" x="-139" y="-174"/>
+      <vector name="rb" x="91" y="0"/>
+      <vector name="head" x="-14" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="259" height="199">
+      <vector name="origin" x="151" y="190"/>
+      <vector name="lt" x="-139" y="-180"/>
+      <vector name="rb" x="90" y="-1"/>
+      <vector name="head" x="-13" y="-140"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-48" y="-100"/>
+        <vector name="rb" x="47" y="0"/>
+        <int name="start" value="-5"/>
+        <int name="areaCount" value="11"/>
+        <int name="attackCount" value="3"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="0" y="0"/>
+          <int name="delay" value="360"/>
+          <int name="z" value="0"/>
+        </canvas>
+        <canvas name="1" width="36" height="11">
+          <vector name="origin" x="21" y="9"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="40" height="18">
+          <vector name="origin" x="23" y="17"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="56" height="24">
+          <vector name="origin" x="31" y="24"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="85" height="45">
+          <vector name="origin" x="38" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="96" height="97">
+          <vector name="origin" x="43" y="97"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="97" height="110">
+          <vector name="origin" x="45" y="98"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="99" height="111">
+          <vector name="origin" x="46" y="98"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="95" height="112">
+          <vector name="origin" x="43" y="99"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="97" height="110">
+          <vector name="origin" x="45" y="98"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="99" height="112">
+          <vector name="origin" x="46" y="99"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="11" width="95" height="111">
+          <vector name="origin" x="43" y="98"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="12" width="97" height="111">
+          <vector name="origin" x="45" y="99"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="13" width="99" height="111">
+          <vector name="origin" x="46" y="98"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="14" width="153" height="132">
+          <vector name="origin" x="67" y="122"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="15" width="164" height="166">
+          <vector name="origin" x="56" y="158"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="16" width="215" height="186">
+          <vector name="origin" x="64" y="174"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="17" width="223" height="195">
+          <vector name="origin" x="68" y="185"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="18" width="287" height="197">
+          <vector name="origin" x="99" y="189"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="19" width="198" height="155">
+          <vector name="origin" x="59" y="203"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="20" width="156" height="103">
+          <vector name="origin" x="80" y="103"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="124" height="109">
+          <vector name="origin" x="61" y="60"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="96" height="98">
+          <vector name="origin" x="46" y="53"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="94" height="92">
+          <vector name="origin" x="47" y="49"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="99" height="83">
+          <vector name="origin" x="57" y="43"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="106" height="89">
+          <vector name="origin" x="59" y="47"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="attackAfter" value="1800"/>
+      <int name="conMP" value="10"/>
+      <int name="deadlyAttack" value="1"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="253" height="202">
+      <vector name="origin" x="151" y="194"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-142" y="-185"/>
+      <vector name="rb" x="87" y="0"/>
+      <vector name="head" x="-14" y="-141"/>
+    </canvas>
+    <canvas name="1" width="254" height="203">
+      <vector name="origin" x="157" y="198"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-145" y="-185"/>
+      <vector name="rb" x="84" y="0"/>
+      <vector name="head" x="-14" y="-144"/>
+    </canvas>
+    <canvas name="2" width="160" height="203">
+      <vector name="origin" x="78" y="232"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-68" y="-219"/>
+      <vector name="rb" x="72" y="-35"/>
+      <vector name="head" x="-14" y="-178"/>
+    </canvas>
+    <canvas name="3" width="163" height="204">
+      <vector name="origin" x="81" y="244"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-71" y="-230"/>
+      <vector name="rb" x="69" y="-48"/>
+      <vector name="head" x="-12" y="-189"/>
+    </canvas>
+    <canvas name="4" width="216" height="203">
+      <vector name="origin" x="107" y="248"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-77" y="-235"/>
+      <vector name="rb" x="70" y="-55"/>
+      <vector name="head" x="-13" y="-194"/>
+    </canvas>
+    <canvas name="5" width="212" height="201">
+      <vector name="origin" x="107" y="248"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-96" y="-236"/>
+      <vector name="rb" x="71" y="-57"/>
+      <vector name="head" x="-14" y="-196"/>
+    </canvas>
+    <canvas name="6" width="212" height="201">
+      <vector name="origin" x="112" y="250"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-96" y="-236"/>
+      <vector name="rb" x="71" y="-57"/>
+      <vector name="head" x="-14" y="-196"/>
+    </canvas>
+    <canvas name="7" width="202" height="202">
+      <vector name="origin" x="112" y="252"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-100" y="-239"/>
+      <vector name="rb" x="70" y="-58"/>
+      <vector name="head" x="-13" y="-199"/>
+    </canvas>
+    <canvas name="8" width="193" height="201">
+      <vector name="origin" x="111" y="250"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-99" y="-239"/>
+      <vector name="rb" x="71" y="-57"/>
+      <vector name="head" x="-13" y="-198"/>
+    </canvas>
+    <canvas name="9" width="195" height="201">
+      <vector name="origin" x="112" y="251"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-100" y="-239"/>
+      <vector name="rb" x="73" y="-58"/>
+      <vector name="head" x="-13" y="-199"/>
+    </canvas>
+    <canvas name="10" width="223" height="204">
+      <vector name="origin" x="113" y="250"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-100" y="-239"/>
+      <vector name="rb" x="73" y="-58"/>
+      <vector name="head" x="-13" y="-199"/>
+    </canvas>
+    <canvas name="11" width="217" height="203">
+      <vector name="origin" x="112" y="251"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-100" y="-239"/>
+      <vector name="rb" x="73" y="-58"/>
+      <vector name="head" x="-13" y="-199"/>
+    </canvas>
+    <canvas name="12" width="211" height="203">
+      <vector name="origin" x="111" y="250"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-100" y="-239"/>
+      <vector name="rb" x="73" y="-58"/>
+      <vector name="head" x="-13" y="-199"/>
+    </canvas>
+    <canvas name="13" width="201" height="203">
+      <vector name="origin" x="112" y="251"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-100" y="-239"/>
+      <vector name="rb" x="73" y="-58"/>
+      <vector name="head" x="-13" y="-199"/>
+    </canvas>
+    <canvas name="14" width="194" height="201">
+      <vector name="origin" x="111" y="250"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-100" y="-239"/>
+      <vector name="rb" x="73" y="-58"/>
+      <vector name="head" x="-13" y="-199"/>
+    </canvas>
+    <canvas name="15" width="196" height="201">
+      <vector name="origin" x="112" y="251"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-100" y="-239"/>
+      <vector name="rb" x="73" y="-58"/>
+      <vector name="head" x="-13" y="-199"/>
+    </canvas>
+    <canvas name="16" width="268" height="229">
+      <vector name="origin" x="125" y="297"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-96" y="-285"/>
+      <vector name="rb" x="114" y="-87"/>
+      <vector name="head" x="-11" y="-221"/>
+    </canvas>
+    <canvas name="17" width="238" height="240">
+      <vector name="origin" x="110" y="296"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-96" y="-285"/>
+      <vector name="rb" x="114" y="-87"/>
+      <vector name="head" x="-11" y="-221"/>
+    </canvas>
+    <canvas name="18" width="238" height="247">
+      <vector name="origin" x="110" y="297"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-96" y="-285"/>
+      <vector name="rb" x="114" y="-87"/>
+      <vector name="head" x="-11" y="-221"/>
+    </canvas>
+    <canvas name="19" width="256" height="252">
+      <vector name="origin" x="125" y="254"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-112" y="-245"/>
+      <vector name="rb" x="117" y="-31"/>
+      <vector name="head" x="-11" y="-178"/>
+    </canvas>
+    <canvas name="20" width="253" height="228">
+      <vector name="origin" x="149" y="220"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-137" y="-191"/>
+      <vector name="rb" x="91" y="-2"/>
+      <vector name="head" x="-13" y="-150"/>
+    </canvas>
+    <canvas name="21" width="253" height="212">
+      <vector name="origin" x="149" y="207"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-138" y="-184"/>
+      <vector name="rb" x="91" y="0"/>
+      <vector name="head" x="-14" y="-146"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="253" height="204">
+      <vector name="origin" x="151" y="195"/>
+      <vector name="lt" x="-140" y="-182"/>
+      <vector name="rb" x="89" y="0"/>
+      <vector name="head" x="-13" y="-141"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="157" height="206">
+      <vector name="origin" x="69" y="203"/>
+      <vector name="lt" x="-55" y="-187"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="-5" y="-146"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="172" height="206">
+      <vector name="origin" x="66" y="207"/>
+      <vector name="lt" x="-52" y="-198"/>
+      <vector name="rb" x="95" y="-6"/>
+      <vector name="head" x="-1" y="-151"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="175" height="206">
+      <vector name="origin" x="66" y="212"/>
+      <vector name="lt" x="-49" y="-202"/>
+      <vector name="rb" x="80" y="-9"/>
+      <vector name="head" x="2" y="-154"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="177" height="206">
+      <vector name="origin" x="66" y="212"/>
+      <vector name="lt" x="-48" y="-198"/>
+      <vector name="rb" x="101" y="-17"/>
+      <vector name="head" x="5" y="-157"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="176" height="205">
+      <vector name="origin" x="64" y="212"/>
+      <vector name="lt" x="-48" y="-198"/>
+      <vector name="rb" x="101" y="-17"/>
+      <vector name="head" x="5" y="-157"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="173" height="205">
+      <vector name="origin" x="61" y="212"/>
+      <vector name="lt" x="-48" y="-198"/>
+      <vector name="rb" x="101" y="-17"/>
+      <vector name="head" x="5" y="-157"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="173" height="205">
+      <vector name="origin" x="61" y="212"/>
+      <vector name="lt" x="-48" y="-198"/>
+      <vector name="rb" x="101" y="-17"/>
+      <vector name="head" x="5" y="-157"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="244" height="205">
+      <vector name="origin" x="196" y="181"/>
+      <vector name="lt" x="-184" y="-177"/>
+      <vector name="rb" x="38" y="15"/>
+      <vector name="head" x="-64" y="-118"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="287" height="278">
+      <vector name="origin" x="201" y="250"/>
+      <vector name="lt" x="-188" y="-157"/>
+      <vector name="rb" x="32" y="16"/>
+      <vector name="head" x="-71" y="-113"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="487" height="354">
+      <vector name="origin" x="269" y="323"/>
+      <vector name="lt" x="-190" y="-151"/>
+      <vector name="rb" x="29" y="16"/>
+      <vector name="head" x="-73" y="-111"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="444" height="225">
+      <vector name="origin" x="262" y="192"/>
+      <vector name="lt" x="-193" y="-151"/>
+      <vector name="rb" x="27" y="19"/>
+      <vector name="head" x="-76" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="281" height="281">
+      <vector name="origin" x="207" y="247"/>
+      <vector name="lt" x="-193" y="-151"/>
+      <vector name="rb" x="27" y="19"/>
+      <vector name="head" x="-76" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="399" height="357">
+      <vector name="origin" x="269" y="323"/>
+      <vector name="lt" x="-193" y="-151"/>
+      <vector name="rb" x="27" y="19"/>
+      <vector name="head" x="-76" y="-108"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="378" height="216">
+      <vector name="origin" x="196" y="189"/>
+      <vector name="lt" x="-182" y="-157"/>
+      <vector name="rb" x="39" y="16"/>
+      <vector name="head" x="-66" y="-114"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="244" height="192">
+      <vector name="origin" x="165" y="178"/>
+      <vector name="lt" x="-152" y="-166"/>
+      <vector name="rb" x="68" y="2"/>
+      <vector name="head" x="-35" y="-128"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="244" height="192">
+      <vector name="origin" x="160" y="182"/>
+      <vector name="lt" x="-148" y="-176"/>
+      <vector name="rb" x="73" y="2"/>
+      <vector name="head" x="-28" y="-137"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我忠诚的部下们，消灭入侵者！"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="253" height="203">
+      <vector name="origin" x="151" y="194"/>
+      <vector name="lt" x="-139" y="-181"/>
+      <vector name="rb" x="87" y="0"/>
+      <vector name="head" x="-14" y="-141"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="209" height="203">
+      <vector name="origin" x="109" y="194"/>
+      <vector name="lt" x="-96" y="-180"/>
+      <vector name="rb" x="87" y="0"/>
+      <vector name="head" x="-13" y="-139"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="221" height="201">
+      <vector name="origin" x="124" y="191"/>
+      <vector name="lt" x="-113" y="-179"/>
+      <vector name="rb" x="83" y="0"/>
+      <vector name="head" x="-13" y="-139"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="220" height="200">
+      <vector name="origin" x="103" y="189"/>
+      <vector name="lt" x="-65" y="-178"/>
+      <vector name="rb" x="82" y="0"/>
+      <vector name="head" x="-14" y="-137"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="253" height="200">
+      <vector name="origin" x="122" y="210"/>
+      <vector name="lt" x="-112" y="-198"/>
+      <vector name="rb" x="119" y="-16"/>
+      <vector name="head" x="-12" y="-158"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="257" height="230">
+      <vector name="origin" x="124" y="252"/>
+      <vector name="lt" x="-112" y="-210"/>
+      <vector name="rb" x="117" y="-30"/>
+      <vector name="head" x="-12" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="255" height="226">
+      <vector name="origin" x="123" y="252"/>
+      <vector name="lt" x="-112" y="-214"/>
+      <vector name="rb" x="118" y="-33"/>
+      <vector name="head" x="-12" y="-174"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="254" height="224">
+      <vector name="origin" x="123" y="252"/>
+      <vector name="lt" x="-112" y="-217"/>
+      <vector name="rb" x="117" y="-36"/>
+      <vector name="head" x="-12" y="-176"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="251" height="223">
+      <vector name="origin" x="123" y="252"/>
+      <vector name="lt" x="-112" y="-219"/>
+      <vector name="rb" x="115" y="-37"/>
+      <vector name="head" x="-12" y="-177"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="248" height="222">
+      <vector name="origin" x="123" y="252"/>
+      <vector name="lt" x="-103" y="-219"/>
+      <vector name="rb" x="112" y="-39"/>
+      <vector name="head" x="-12" y="-178"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="256" height="229">
+      <vector name="origin" x="124" y="255"/>
+      <vector name="lt" x="-112" y="-215"/>
+      <vector name="rb" x="115" y="-34"/>
+      <vector name="head" x="-13" y="-174"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="253" height="240">
+      <vector name="origin" x="122" y="262"/>
+      <vector name="lt" x="-112" y="-211"/>
+      <vector name="rb" x="115" y="-34"/>
+      <vector name="head" x="-13" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="249" height="251">
+      <vector name="origin" x="120" y="293"/>
+      <vector name="lt" x="-105" y="-233"/>
+      <vector name="rb" x="117" y="-48"/>
+      <vector name="head" x="-12" y="-191"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="202" height="277">
+      <vector name="origin" x="105" y="323"/>
+      <vector name="lt" x="-83" y="-259"/>
+      <vector name="rb" x="64" y="-63"/>
+      <vector name="head" x="-5" y="-241"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="170" height="276">
+      <vector name="origin" x="90" y="323"/>
+      <vector name="lt" x="-83" y="-259"/>
+      <vector name="rb" x="64" y="-63"/>
+      <vector name="head" x="-9" y="-194"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="176" height="281">
+      <vector name="origin" x="93" y="323"/>
+      <vector name="lt" x="-74" y="-259"/>
+      <vector name="rb" x="66" y="-51"/>
+      <vector name="head" x="-11" y="-189"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="255" height="291">
+      <vector name="origin" x="123" y="323"/>
+      <vector name="lt" x="-109" y="-224"/>
+      <vector name="rb" x="117" y="-43"/>
+      <vector name="head" x="-11" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="221" height="316">
+      <vector name="origin" x="119" y="321"/>
+      <vector name="lt" x="-112" y="-191"/>
+      <vector name="rb" x="90" y="-14"/>
+      <vector name="head" x="-14" y="-153"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="253" height="320">
+      <vector name="origin" x="151" y="315"/>
+      <vector name="lt" x="-141" y="-184"/>
+      <vector name="rb" x="89" y="-1"/>
+      <vector name="head" x="-14" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="50"/>
+      <string name="0" value="为了海军的名誉！！"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9870021.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9870021.img.xml
@@ -1,0 +1,243 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9870021.img">
+  <imgdir name="die1">
+    <canvas name="1" width="166" height="158">
+      <vector name="origin" x="47" y="164"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="b26777da6c3034c9942e547982413ab692840a464cdd87ad7d7edbd0ebef7137"/>
+    </canvas>
+    <canvas name="2" width="171" height="155">
+      <vector name="origin" x="50" y="159"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="b8965faf42dd7b2265ebc66aa9653d20c1954380a0f46cbaf4dc1db6ff189d9f"/>
+    </canvas>
+    <canvas name="3" width="144" height="156">
+      <vector name="origin" x="22" y="154"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="1502de3498911657ca624ebb31873328547accf2096709fcd972f8c049c581e0"/>
+    </canvas>
+    <canvas name="4" width="144" height="149">
+      <vector name="origin" x="20" y="147"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="2b6f88b0cb03c60280d3d06de4e247ff42fef30829482d780566c85cd9347d37"/>
+    </canvas>
+    <canvas name="5" width="144" height="147">
+      <vector name="origin" x="19" y="143"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="b59c3fd08bc9f91743acefb1006d89663d75d394b5de89223ac4d549cf60d94b"/>
+    </canvas>
+    <canvas name="6" width="146" height="147">
+      <vector name="origin" x="20" y="141"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="549e94cafe4e7117d27e54b22a636cc819f214e3719b274a6aeac8a188f0c539"/>
+    </canvas>
+    <canvas name="7" width="146" height="147">
+      <vector name="origin" x="19" y="140"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="5a9ae39c7eceb5f1d8237c9be6c4b508130c535d79d8ee395db61e9e04dbe336"/>
+    </canvas>
+    <canvas name="8" width="143" height="26">
+      <vector name="origin" x="21" y="34"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="654c14afdcbac94c5057376d590416bfae55ccb08fd0afa1f473052550e90331"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="我又要回到过去了吗……"/>
+      <int name="delay" value="150"/>
+    </imgdir>
+    <canvas name="0" width="166" height="169">
+      <vector name="origin" x="72" y="173"/>
+      <vector name="lt" x="-67" y="-165"/>
+      <vector name="rb" x="86" y="-8"/>
+      <vector name="head" x="4" y="-157"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="27a3ca5e517757897fd06982f851139a189109dc0d30cc4bf4c13c99e93810a3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="166" height="169">
+      <vector name="origin" x="72" y="173"/>
+      <vector name="lt" x="-67" y="-165"/>
+      <vector name="rb" x="86" y="-8"/>
+      <vector name="head" x="4" y="-157"/>
+      <int name="delay" value="300"/>
+      <string name="_hash" value="27a3ca5e517757897fd06982f851139a189109dc0d30cc4bf4c13c99e93810a3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="146" height="146">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7a884eb3f27f8be4f1ec9c2e374dac979db11a885f6f713ae319d9eaa69355c2"/>
+    </canvas>
+    <canvas name="1" width="144" height="147">
+      <vector name="origin" x="69" y="149"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-6"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="24f9c88990290a82f0f24b0178db8b8fddbe0714b8c03904507a9cf8d81b3a2a"/>
+    </canvas>
+    <canvas name="2" width="144" height="145">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="-5" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bfffdf22371253aac17d4191f4c7e354573b239120a3f6971995be20bfc1fe79"/>
+    </canvas>
+    <canvas name="3" width="144" height="145">
+      <vector name="origin" x="69" y="151"/>
+      <vector name="lt" x="-71" y="-152"/>
+      <vector name="rb" x="75" y="-7"/>
+      <vector name="head" x="-4" y="-151"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ae5e37c17237542c9063a8e314f506e999e5f2babff963ac449f0d428111575b"/>
+    </canvas>
+    <canvas name="4" width="144" height="146">
+      <vector name="origin" x="68" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="76" y="-4"/>
+      <vector name="head" x="-3" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6fdbb127966dd276d5c9bda2f88f77d84247db4e209cb815d84839bb5e8f4475"/>
+    </canvas>
+    <canvas name="5" width="146" height="147">
+      <vector name="origin" x="69" y="149"/>
+      <vector name="lt" x="-70" y="-150"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="-2" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4653e6c866b2b9963981aaa8598307bf90a0366ee6f6885038b22e6102f22f9b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="146" height="145">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="183b2363968d901509b6096e827bbe753e17f7084cb1dea644ac4274faa7fb96"/>
+    </canvas>
+    <canvas name="1" width="145" height="144">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-6"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b665edc222a07c0e984555d1aad9c50d8d1110ed9837fd9dbcbdeb91f8f0b064"/>
+    </canvas>
+    <canvas name="2" width="144" height="143">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="-4" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="da18fdbfa1972cb4b243f964dd9723f4b0f6b9fb128c3efea899f7eb15318a5e"/>
+    </canvas>
+    <canvas name="3" width="145" height="145">
+      <vector name="origin" x="70" y="151"/>
+      <vector name="lt" x="-71" y="-152"/>
+      <vector name="rb" x="75" y="-7"/>
+      <vector name="head" x="-4" y="-151"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e0f3a13bc0a0ab0b84bf934868c5e2859a5ecb4e0e1d47f87af7daa5c850cc57"/>
+    </canvas>
+    <canvas name="4" width="146" height="146">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="76" y="-4"/>
+      <vector name="head" x="-4" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="56e11d8d8eb97a38e8a48b33f826276e85884c76d4d05bff7ba433101cf9e1a5"/>
+    </canvas>
+    <canvas name="5" width="147" height="147">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-70" y="-150"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="-2" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="66de9c6269e1f78ac7d7b7c9a6cecb38ede6b53090b85d92bf3b1af318dde187"/>
+    </canvas>
+    <canvas name="6" width="146" height="145">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="233587ff2cd16883a78e4f19a4fa23b7145ba280ddf949efa7f5973279bf026b"/>
+    </canvas>
+    <canvas name="7" width="145" height="144">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="75" y="-5"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_inlink" value="stand/1"/>
+    </canvas>
+    <canvas name="8" width="144" height="143">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-70" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="-4" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4da2e35cfe01442d1a155582211fe0d041604f62ee283f0ad0877c8c730be144"/>
+    </canvas>
+    <canvas name="9" width="145" height="145">
+      <vector name="origin" x="70" y="151"/>
+      <vector name="lt" x="-70" y="-152"/>
+      <vector name="rb" x="75" y="-6"/>
+      <vector name="head" x="-5" y="-152"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c00dbb6944442e8294c17c0f6fcf4b9abcfcfdff88de229273416064d6707885"/>
+    </canvas>
+    <canvas name="10" width="146" height="146">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="-3" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cd33cfe80f0124b2bfdd9971e7f97287857ed76fa4f2fd6f08540e674c14b81c"/>
+    </canvas>
+    <canvas name="11" width="147" height="147">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-70" y="-151"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="-3" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4c951eb97ca6259343a056f5f02495cf6cbee1a452818f1a84bd8913c1fd5fe2"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="41"/>
+    <int name="maxHP" value="20500"/>
+    <int name="maxMP" value="50"/>
+    <int name="speed" value="-15"/>
+    <int name="PADamage" value="125"/>
+    <int name="PDDamage" value="130"/>
+    <int name="MADamage" value="142"/>
+    <int name="MDDamage" value="160"/>
+    <int name="acc" value="145"/>
+    <int name="eva" value="22"/>
+    <int name="exp" value="2050"/>
+    <int name="undead" value="1"/>
+    <int name="pushed" value="0"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="mobType" value="5"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9870040.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9870040.img.xml
@@ -1,0 +1,213 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9870040.img">
+  <imgdir name="stand">
+    <canvas name="0" width="235" height="189">
+      <vector name="origin" x="100" y="193"/>
+      <vector name="lt" x="-101" y="-179"/>
+      <vector name="rb" x="70" y="-5"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8a107e73ec7e11fcb01c001460a09f460cca4a0acd35f308e8eafdaeff9c5f04"/>
+    </canvas>
+    <canvas name="1" width="236" height="189">
+      <vector name="origin" x="100" y="194"/>
+      <vector name="lt" x="-100" y="-179"/>
+      <vector name="rb" x="68" y="-5"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3423cee0d86daf8c9afae4733a912d1f93f3022b902852e4e7f4683b234bae9f"/>
+    </canvas>
+    <canvas name="2" width="238" height="190">
+      <vector name="origin" x="100" y="196"/>
+      <vector name="lt" x="-99" y="-181"/>
+      <vector name="rb" x="63" y="-7"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3be8480d68cd8d0ed62d6e6340b60bd7c3fbc93bea017447e1f10aafce9e8b0f"/>
+    </canvas>
+    <canvas name="3" width="236" height="188">
+      <vector name="origin" x="100" y="195"/>
+      <vector name="lt" x="-99" y="-182"/>
+      <vector name="rb" x="61" y="-7"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ad71d26de1e76ce0ec97641bee9cd92fbd9d57278b859822115361039d8bce63"/>
+    </canvas>
+    <canvas name="4" width="243" height="189">
+      <vector name="origin" x="100" y="197"/>
+      <vector name="lt" x="-100" y="-183"/>
+      <vector name="rb" x="54" y="-8"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bc56e97fae2d7e35af7429aece3affe3d772961208e56c136c0f96b7acb9d133"/>
+    </canvas>
+    <canvas name="5" width="238" height="189">
+      <vector name="origin" x="100" y="196"/>
+      <vector name="lt" x="-91" y="-162"/>
+      <vector name="rb" x="53" y="-7"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d6f4d38639881847fe802db199c1e618f1daf40f863843d4d78668199298d85e"/>
+    </canvas>
+    <canvas name="6" width="235" height="190">
+      <vector name="origin" x="100" y="196"/>
+      <vector name="lt" x="-91" y="-162"/>
+      <vector name="rb" x="57" y="-6"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2acd20d4194bf5d25aac4e5b95b32ceb3abf1e3bf0b73f01872189f1b88fd1eb"/>
+    </canvas>
+    <canvas name="7" width="234" height="190">
+      <vector name="origin" x="100" y="194"/>
+      <vector name="lt" x="-91" y="-162"/>
+      <vector name="rb" x="65" y="-4"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6b9942d14743f4151ec792754445ddbfe988b5376601c5fd987570d4de9f155f"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="234" height="189">
+      <vector name="origin" x="100" y="181"/>
+      <vector name="lt" x="-99" y="-162"/>
+      <vector name="rb" x="67" y="7"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c06e861c807754ad708b6b55640b1fd123dd77cb6c398b082957e6d128576b1c"/>
+    </canvas>
+    <canvas name="1" width="238" height="189">
+      <vector name="origin" x="100" y="182"/>
+      <vector name="lt" x="-100" y="-162"/>
+      <vector name="rb" x="47" y="4"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9da781721d887b8d1092bc71b52b3e08b2cafa97f873939488f5f52e16ddadae"/>
+    </canvas>
+    <canvas name="2" width="233" height="188">
+      <vector name="origin" x="100" y="187"/>
+      <vector name="lt" x="-100" y="-169"/>
+      <vector name="rb" x="45" y="-2"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1731a4f2972a30cc82a0665d1056841c17776c97d8e5c90b12f3d0851d3490c3"/>
+    </canvas>
+    <canvas name="3" width="228" height="184">
+      <vector name="origin" x="100" y="189"/>
+      <vector name="lt" x="-99" y="-174"/>
+      <vector name="rb" x="39" y="-5"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="39430d42783c17ba05f488f45484894d714f433cf82ee5e01365d3ca1af8eaf4"/>
+    </canvas>
+    <canvas name="4" width="223" height="187">
+      <vector name="origin" x="100" y="189"/>
+      <vector name="lt" x="-100" y="-171"/>
+      <vector name="rb" x="49" y="-2"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fb8abe436d88ef793a421762ff6f01e59bddabf33d3e68e70c713637b51e73ab"/>
+    </canvas>
+    <canvas name="5" width="239" height="186">
+      <vector name="origin" x="100" y="185"/>
+      <vector name="lt" x="-100" y="-173"/>
+      <vector name="rb" x="48" y="-2"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7f777db15697811e167f816b5cdc81ebb7245785237d5889dbebde8daa2f8cc5"/>
+    </canvas>
+    <canvas name="6" width="238" height="190">
+      <vector name="origin" x="100" y="184"/>
+      <vector name="lt" x="-99" y="-170"/>
+      <vector name="rb" x="69" y="4"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7192773e89b450babd09450714fc4c2e48189c706354ae0d3327c74b1df3afa1"/>
+    </canvas>
+    <canvas name="7" width="239" height="182">
+      <vector name="origin" x="100" y="181"/>
+      <vector name="lt" x="-100" y="-168"/>
+      <vector name="rb" x="68" y="-1"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="77852d6b842889fb39e56fccf10bf905ac42795b9f54e700a2c683d035c33e98"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="264" height="184">
+      <vector name="origin" x="96" y="219"/>
+      <vector name="lt" x="-75" y="-175"/>
+      <vector name="rb" x="56" y="-32"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="300"/>
+      <string name="_hash" value="1e4cb8ea951f5f8ae7f8202bd20f876ed07607d6d75199c54ba2198c305472f5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="236" height="189">
+      <vector name="origin" x="100" y="185"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="f4fac2d31da7cb4e6ff236287e2210ab66df6e55e6979b937a97ebaeb65ab235"/>
+    </canvas>
+    <canvas name="1" width="264" height="184">
+      <vector name="origin" x="96" y="219"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="3ab7d8de5e9b87c3bcc4452a4cb65eece0bc208cb8e18f5a8aa236e2c5206578"/>
+    </canvas>
+    <canvas name="2" width="275" height="176">
+      <vector name="origin" x="89" y="214"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="5a27660c793791ec25f15128e1000ae51c427ab808a4cd5acb0c59286f1bfbd6"/>
+    </canvas>
+    <canvas name="3" width="281" height="162">
+      <vector name="origin" x="90" y="195"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="6849a8194c104c9dda266283676a28a293be262e49dee220b7f5abb268172d32"/>
+    </canvas>
+    <canvas name="4" width="264" height="162">
+      <vector name="origin" x="63" y="190"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="e6d2398db6a033bfc8248f3838aecaecaab5d7eadf7088007e39b3aa6ebd3463"/>
+    </canvas>
+    <canvas name="5" width="264" height="162">
+      <vector name="origin" x="54" y="169"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="83c27b29335bfe7dd095d4304ba0ae917a6c82e8d309723db36a57385cb25f6a"/>
+    </canvas>
+    <canvas name="6" width="267" height="162">
+      <vector name="origin" x="53" y="145"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="c2bac7d58283aa4693fa809b60774462100967b14e568686757e5c60546c5878"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="呜呜，又要挨骂了……"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="97"/>
+    <int name="maxHP" value="490000"/>
+    <int name="maxMP" value="210"/>
+    <int name="speed" value="-70"/>
+    <int name="PADamage" value="445"/>
+    <int name="PDDamage" value="830"/>
+    <int name="MADamage" value="500"/>
+    <int name="MDDamage" value="550"/>
+    <int name="acc" value="203"/>
+    <int name="eva" value="37"/>
+    <int name="exp" value="49000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="4300"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <string name="elemAttr" value="F2L2"/>
+    <int name="mobType" value="3"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9900000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9900000.img.xml
@@ -1,0 +1,2808 @@
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9900000.img">
+  <imgdir name="stand">
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="161" height="113">
+      <vector name="origin" x="85" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-85" y="-148"/>
+      <vector name="rb" x="76" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="161" height="114">
+      <vector name="origin" x="85" y="147"/>
+      <vector name="head" x="1" y="-151"/>
+      <vector name="lt" x="-85" y="-147"/>
+      <vector name="rb" x="76" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="161" height="115">
+      <vector name="origin" x="85" y="146"/>
+      <vector name="head" x="1" y="-150"/>
+      <vector name="lt" x="-85" y="-146"/>
+      <vector name="rb" x="76" y="-31"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="160" height="116">
+      <vector name="origin" x="85" y="145"/>
+      <vector name="head" x="1" y="-149"/>
+      <vector name="lt" x="-85" y="-145"/>
+      <vector name="rb" x="75" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="160" height="115">
+      <vector name="origin" x="85" y="146"/>
+      <vector name="head" x="1" y="-150"/>
+      <vector name="lt" x="-85" y="-146"/>
+      <vector name="rb" x="75" y="-31"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="160" height="114">
+      <vector name="origin" x="85" y="147"/>
+      <vector name="head" x="1" y="-151"/>
+      <vector name="lt" x="-85" y="-147"/>
+      <vector name="rb" x="75" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="160" height="114">
+      <vector name="origin" x="85" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-85" y="-148"/>
+      <vector name="rb" x="75" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="158" height="112">
+      <vector name="origin" x="81" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-81" y="-149"/>
+      <vector name="rb" x="77" y="-37"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="158" height="113">
+      <vector name="origin" x="81" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-81" y="-148"/>
+      <vector name="rb" x="77" y="-35"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="158" height="114">
+      <vector name="origin" x="81" y="147"/>
+      <vector name="head" x="1" y="-151"/>
+      <vector name="lt" x="-81" y="-147"/>
+      <vector name="rb" x="77" y="-33"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="158" height="115">
+      <vector name="origin" x="81" y="146"/>
+      <vector name="head" x="1" y="-150"/>
+      <vector name="lt" x="-81" y="-146"/>
+      <vector name="rb" x="77" y="-31"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="157" height="116">
+      <vector name="origin" x="81" y="145"/>
+      <vector name="head" x="1" y="-149"/>
+      <vector name="lt" x="-81" y="-145"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="157" height="115">
+      <vector name="origin" x="81" y="146"/>
+      <vector name="head" x="1" y="-150"/>
+      <vector name="lt" x="-81" y="-146"/>
+      <vector name="rb" x="76" y="-31"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="157" height="114">
+      <vector name="origin" x="81" y="147"/>
+      <vector name="head" x="1" y="-151"/>
+      <vector name="lt" x="-81" y="-147"/>
+      <vector name="rb" x="76" y="-33"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="157" height="114">
+      <vector name="origin" x="81" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-81" y="-148"/>
+      <vector name="rb" x="76" y="-34"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-404" y="-205"/>
+        <vector name="rb" x="50" y="46"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="139" height="154">
+          <vector name="origin" x="66" y="70"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="149" height="140">
+          <vector name="origin" x="72" y="74"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="162" height="154">
+          <vector name="origin" x="82" y="84"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="159" height="132">
+          <vector name="origin" x="76" y="69"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="155" height="132">
+          <vector name="origin" x="70" y="74"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="154" height="132">
+          <vector name="origin" x="71" y="73"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="900"/>
+      <int name="delay" value="90"/>
+    </imgdir>
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="178" height="113">
+      <vector name="origin" x="90" y="151"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-90" y="-151"/>
+      <vector name="rb" x="88" y="-38"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="158" height="154">
+      <vector name="origin" x="61" y="197"/>
+      <vector name="head" x="12" y="-161"/>
+      <vector name="lt" x="-61" y="-197"/>
+      <vector name="rb" x="97" y="-43"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="166" height="155">
+      <vector name="origin" x="70" y="199"/>
+      <vector name="head" x="15" y="-163"/>
+      <vector name="lt" x="-70" y="-199"/>
+      <vector name="rb" x="96" y="-44"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="166" height="156">
+      <vector name="origin" x="70" y="202"/>
+      <vector name="head" x="18" y="-166"/>
+      <vector name="lt" x="-32" y="-175"/>
+      <vector name="rb" x="96" y="-46"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="161" height="155">
+      <vector name="origin" x="62" y="203"/>
+      <vector name="head" x="19" y="-167"/>
+      <vector name="lt" x="-62" y="-203"/>
+      <vector name="rb" x="99" y="-48"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="155" height="154">
+      <vector name="origin" x="57" y="204"/>
+      <vector name="head" x="20" y="-168"/>
+      <vector name="lt" x="-57" y="-204"/>
+      <vector name="rb" x="98" y="-50"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="154" height="154">
+      <vector name="origin" x="56" y="204"/>
+      <vector name="head" x="20" y="-168"/>
+      <vector name="lt" x="-56" y="-204"/>
+      <vector name="rb" x="98" y="-50"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="220" height="180">
+      <vector name="origin" x="158" y="186"/>
+      <vector name="head" x="-45" y="-126"/>
+      <vector name="lt" x="-158" y="-186"/>
+      <vector name="rb" x="62" y="-6"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="9" width="311" height="205">
+      <vector name="origin" x="263" y="176"/>
+      <vector name="head" x="-49" y="-124"/>
+      <vector name="lt" x="-158" y="-186"/>
+      <vector name="rb" x="62" y="-6"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="10" width="396" height="177">
+      <vector name="origin" x="349" y="143"/>
+      <vector name="head" x="-51" y="-123"/>
+      <vector name="lt" x="-144" y="-143"/>
+      <vector name="rb" x="47" y="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="11" width="451" height="171">
+      <vector name="origin" x="404" y="145"/>
+      <vector name="head" x="-51" y="-123"/>
+      <vector name="lt" x="-132" y="-145"/>
+      <vector name="rb" x="47" y="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="449" height="160">
+      <vector name="origin" x="403" y="144"/>
+      <vector name="head" x="-49" y="-125"/>
+      <vector name="lt" x="-137" y="-144"/>
+      <vector name="rb" x="47" y="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="13" width="466" height="146">
+      <vector name="origin" x="404" y="141"/>
+      <vector name="head" x="-38" y="-131"/>
+      <vector name="lt" x="-125" y="-141"/>
+      <vector name="rb" x="61" y="2"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="14" width="468" height="130">
+      <vector name="origin" x="393" y="142"/>
+      <vector name="head" x="-12" y="-146"/>
+      <vector name="lt" x="-97" y="-142"/>
+      <vector name="rb" x="75" y="-32"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="15" width="162" height="114">
+      <vector name="origin" x="86" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-86" y="-148"/>
+      <vector name="rb" x="76" y="-34"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="16" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="17" width="160" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-192" y="-199"/>
+        <vector name="rb" x="137" y="22"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="143" height="192">
+          <vector name="origin" x="67" y="95"/>
+          <string name="source" value="Mob/8850011.img/attack1/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="147" height="192">
+          <vector name="origin" x="71" y="95"/>
+          <string name="source" value="Mob/8850011.img/attack1/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="136" height="135">
+          <vector name="origin" x="71" y="66"/>
+          <string name="source" value="Mob/8850011.img/attack1/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="135" height="133">
+          <vector name="origin" x="70" y="65"/>
+          <string name="source" value="Mob/8850011.img/attack1/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="140" height="140">
+          <vector name="origin" x="72" y="67"/>
+          <string name="source" value="Mob/8850011.img/attack1/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="149" height="152">
+          <vector name="origin" x="80" y="75"/>
+          <string name="source" value="Mob/8620009.img/attack2/info/hit/4"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="attackAfter" value="900"/>
+      <int name="delay" value="120"/>
+      <imgdir name="hit2">
+        <canvas name="0" width="112" height="150">
+          <vector name="origin" x="350" y="108"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-350" y="-108"/>
+          <vector name="rb" x="-238" y="42"/>
+        </canvas>
+        <canvas name="1" width="115" height="150">
+          <vector name="origin" x="353" y="108"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-353" y="-108"/>
+          <vector name="rb" x="-238" y="42"/>
+        </canvas>
+        <canvas name="2" width="107" height="104">
+          <vector name="origin" x="353" y="85"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-353" y="-85"/>
+          <vector name="rb" x="-246" y="19"/>
+        </canvas>
+        <canvas name="3" width="106" height="104">
+          <vector name="origin" x="352" y="85"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-352" y="-85"/>
+          <vector name="rb" x="-246" y="19"/>
+        </canvas>
+        <canvas name="4" width="110" height="111">
+          <vector name="origin" x="354" y="87"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-354" y="-87"/>
+          <vector name="rb" x="-244" y="24"/>
+        </canvas>
+        <canvas name="5" width="113" height="119">
+          <vector name="origin" x="360" y="93"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-360" y="-93"/>
+          <vector name="rb" x="-247" y="26"/>
+        </canvas>
+      </imgdir>
+    </imgdir>
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="165" height="114">
+      <vector name="origin" x="89" y="178"/>
+      <vector name="head" x="2" y="-181"/>
+      <vector name="lt" x="-89" y="-178"/>
+      <vector name="rb" x="76" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="189" height="228">
+      <vector name="origin" x="113" y="297"/>
+      <vector name="head" x="2" y="-191"/>
+      <vector name="lt" x="-74" y="-219"/>
+      <vector name="rb" x="76" y="-72"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="187" height="224">
+      <vector name="origin" x="111" y="294"/>
+      <vector name="head" x="2" y="-194"/>
+      <vector name="lt" x="-64" y="-192"/>
+      <vector name="rb" x="76" y="-70"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="179" height="217">
+      <vector name="origin" x="104" y="287"/>
+      <vector name="head" x="2" y="-196"/>
+      <vector name="lt" x="-65" y="-231"/>
+      <vector name="rb" x="75" y="-71"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="167" height="207">
+      <vector name="origin" x="92" y="278"/>
+      <vector name="head" x="2" y="-197"/>
+      <vector name="lt" x="-68" y="-240"/>
+      <vector name="rb" x="75" y="-71"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="152" height="199">
+      <vector name="origin" x="77" y="272"/>
+      <vector name="head" x="2" y="-198"/>
+      <vector name="lt" x="-77" y="-224"/>
+      <vector name="rb" x="75" y="-73"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="152" height="201">
+      <vector name="origin" x="77" y="275"/>
+      <vector name="head" x="2" y="-199"/>
+      <vector name="lt" x="-77" y="-250"/>
+      <vector name="rb" x="75" y="-74"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="344" height="283">
+      <vector name="origin" x="205" y="254"/>
+      <vector name="head" x="2" y="-126"/>
+      <vector name="lt" x="-98" y="-128"/>
+      <vector name="rb" x="98" y="-2"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="483" height="210">
+      <vector name="origin" x="271" y="182"/>
+      <vector name="head" x="2" y="-117"/>
+      <vector name="lt" x="-100" y="-129"/>
+      <vector name="rb" x="110" y="-5"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="561" height="211">
+      <vector name="origin" x="310" y="184"/>
+      <vector name="head" x="2" y="-113"/>
+      <vector name="lt" x="-114" y="-127"/>
+      <vector name="rb" x="113" y="-1"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="603" height="227">
+      <vector name="origin" x="331" y="202"/>
+      <vector name="head" x="2" y="-111"/>
+      <vector name="lt" x="-97" y="-112"/>
+      <vector name="rb" x="81" y="1"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="601" height="219">
+      <vector name="origin" x="330" y="200"/>
+      <vector name="head" x="2" y="-110"/>
+      <vector name="lt" x="-80" y="-113"/>
+      <vector name="rb" x="62" y="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="591" height="206">
+      <vector name="origin" x="325" y="194"/>
+      <vector name="head" x="2" y="-111"/>
+      <vector name="lt" x="-79" y="-112"/>
+      <vector name="rb" x="64" y="11"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="492" height="145">
+      <vector name="origin" x="281" y="143"/>
+      <vector name="head" x="2" y="-126"/>
+      <vector name="lt" x="-65" y="-142"/>
+      <vector name="rb" x="62" y="1"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-65" y="-125"/>
+        <vector name="rb" x="65" y="0"/>
+        <int name="start" value="-4"/>
+        <int name="areaCount" value="9"/>
+        <int name="attackCount" value="4"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="124" height="130">
+          <vector name="origin" x="57" y="117"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/0"/>
+        </canvas>
+        <canvas name="1" width="128" height="127">
+          <vector name="origin" x="59" y="114"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/1"/>
+        </canvas>
+        <canvas name="2" width="132" height="124">
+          <vector name="origin" x="62" y="111"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/2"/>
+        </canvas>
+        <canvas name="3" width="127" height="115">
+          <vector name="origin" x="65" y="102"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/3"/>
+        </canvas>
+        <canvas name="4" width="132" height="138">
+          <vector name="origin" x="69" y="109"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/4"/>
+        </canvas>
+        <canvas name="5" width="132" height="145">
+          <vector name="origin" x="69" y="119"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/5"/>
+        </canvas>
+        <canvas name="6" width="131" height="139">
+          <vector name="origin" x="65" y="126"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/6"/>
+        </canvas>
+        <canvas name="7" width="128" height="137">
+          <vector name="origin" x="61" y="124"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/7"/>
+        </canvas>
+        <canvas name="8" width="130" height="134">
+          <vector name="origin" x="60" y="121"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/8"/>
+        </canvas>
+        <canvas name="9" width="127" height="99">
+          <vector name="origin" x="65" y="86"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/9"/>
+        </canvas>
+        <canvas name="10" width="141" height="118">
+          <vector name="origin" x="69" y="100"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/10"/>
+        </canvas>
+        <canvas name="11" width="163" height="294">
+          <vector name="origin" x="79" y="277"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/11"/>
+        </canvas>
+        <canvas name="12" width="168" height="302">
+          <vector name="origin" x="85" y="286"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/12"/>
+        </canvas>
+        <canvas name="13" width="198" height="303">
+          <vector name="origin" x="100" y="285"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/13"/>
+        </canvas>
+        <canvas name="14" width="218" height="287">
+          <vector name="origin" x="110" y="267"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/14"/>
+        </canvas>
+        <canvas name="15" width="231" height="262">
+          <vector name="origin" x="116" y="241"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/15"/>
+        </canvas>
+        <canvas name="16" width="237" height="61">
+          <vector name="origin" x="119" y="41"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/16"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="128" height="167">
+          <vector name="origin" x="58" y="89"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="176" height="164">
+          <vector name="origin" x="96" y="85"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="177" height="162">
+          <vector name="origin" x="97" y="83"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="176" height="157">
+          <vector name="origin" x="97" y="81"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="172" height="146">
+          <vector name="origin" x="93" y="80"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="88" height="71">
+          <vector name="origin" x="41" y="54"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/5"/>
+        </canvas>
+        <canvas name="6" width="13" height="16">
+          <vector name="origin" x="7" y="4"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/6"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1620"/>
+    </imgdir>
+    <canvas name="0" width="160" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="160" height="113">
+      <vector name="origin" x="85" y="148"/>
+      <vector name="head" x="2" y="-152"/>
+      <vector name="lt" x="-85" y="-148"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="168" height="114">
+      <vector name="origin" x="92" y="147"/>
+      <vector name="head" x="2" y="-151"/>
+      <vector name="lt" x="-92" y="-147"/>
+      <vector name="rb" x="76" y="-33"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="146" height="146">
+      <vector name="origin" x="70" y="175"/>
+      <vector name="head" x="2" y="-150"/>
+      <vector name="lt" x="-70" y="-175"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="147" height="183">
+      <vector name="origin" x="71" y="207"/>
+      <vector name="head" x="2" y="-149"/>
+      <vector name="lt" x="-71" y="-207"/>
+      <vector name="rb" x="76" y="-24"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="149" height="189">
+      <vector name="origin" x="73" y="214"/>
+      <vector name="head" x="2" y="-150"/>
+      <vector name="lt" x="-64" y="-176"/>
+      <vector name="rb" x="76" y="-25"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="148" height="189">
+      <vector name="origin" x="73" y="215"/>
+      <vector name="head" x="2" y="-151"/>
+      <vector name="lt" x="-73" y="-185"/>
+      <vector name="rb" x="75" y="-26"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="148" height="189">
+      <vector name="origin" x="73" y="216"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-73" y="-216"/>
+      <vector name="rb" x="75" y="-27"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="150" height="189">
+      <vector name="origin" x="75" y="219"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-75" y="-219"/>
+      <vector name="rb" x="75" y="-30"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="151" height="191">
+      <vector name="origin" x="76" y="219"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-76" y="-219"/>
+      <vector name="rb" x="75" y="-28"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="152" height="193">
+      <vector name="origin" x="77" y="219"/>
+      <vector name="head" x="1" y="-151"/>
+      <vector name="lt" x="-77" y="-219"/>
+      <vector name="rb" x="75" y="-26"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="171" height="220">
+      <vector name="origin" x="96" y="243"/>
+      <vector name="head" x="1" y="-149"/>
+      <vector name="lt" x="-95" y="-210"/>
+      <vector name="rb" x="75" y="-23"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="175" height="225">
+      <vector name="origin" x="99" y="243"/>
+      <vector name="head" x="1" y="-145"/>
+      <vector name="lt" x="-80" y="-191"/>
+      <vector name="rb" x="76" y="-18"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="175" height="226">
+      <vector name="origin" x="100" y="243"/>
+      <vector name="head" x="1" y="-143"/>
+      <vector name="lt" x="-96" y="-200"/>
+      <vector name="rb" x="75" y="-17"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="174" height="227">
+      <vector name="origin" x="99" y="263"/>
+      <vector name="head" x="1" y="-159"/>
+      <vector name="lt" x="-95" y="-208"/>
+      <vector name="rb" x="75" y="-36"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="174" height="231">
+      <vector name="origin" x="99" y="279"/>
+      <vector name="head" x="1" y="-172"/>
+      <vector name="lt" x="-95" y="-225"/>
+      <vector name="rb" x="75" y="-48"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="174" height="235">
+      <vector name="origin" x="99" y="285"/>
+      <vector name="head" x="1" y="-175"/>
+      <vector name="lt" x="-99" y="-245"/>
+      <vector name="rb" x="75" y="-50"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="174" height="232">
+      <vector name="origin" x="99" y="283"/>
+      <vector name="head" x="1" y="-177"/>
+      <vector name="lt" x="-99" y="-283"/>
+      <vector name="rb" x="75" y="-51"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="173" height="240">
+      <vector name="origin" x="98" y="289"/>
+      <vector name="head" x="1" y="-176"/>
+      <vector name="lt" x="-82" y="-225"/>
+      <vector name="rb" x="75" y="-49"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="165" height="238">
+      <vector name="origin" x="90" y="288"/>
+      <vector name="head" x="2" y="-172"/>
+      <vector name="lt" x="-91" y="-194"/>
+      <vector name="rb" x="75" y="-50"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="165" height="230">
+      <vector name="origin" x="90" y="267"/>
+      <vector name="head" x="2" y="-160"/>
+      <vector name="lt" x="-80" y="-161"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="162" height="120">
+      <vector name="origin" x="87" y="152"/>
+      <vector name="head" x="2" y="-152"/>
+      <vector name="lt" x="-87" y="-152"/>
+      <vector name="rb" x="75" y="-32"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="预告攻击"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-480" y="-617"/>
+        <vector name="rb" x="434" y="10"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="303" height="735">
+          <vector name="origin" x="148" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="284" height="735">
+          <vector name="origin" x="139" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="270" height="735">
+          <vector name="origin" x="131" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="266" height="735">
+          <vector name="origin" x="132" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="261" height="735">
+          <vector name="origin" x="120" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="188" height="735">
+          <vector name="origin" x="95" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/5"/>
+        </canvas>
+        <canvas name="6" width="22" height="721">
+          <vector name="origin" x="8" y="717"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/6"/>
+        </canvas>
+        <int name="pos" value="3"/>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="attackAfter" value="1680"/>
+    </imgdir>
+    <canvas name="1" width="161" height="113">
+      <vector name="origin" x="85" y="150"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-85" y="-150"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="205" height="190">
+      <vector name="origin" x="104" y="238"/>
+      <vector name="head" x="2" y="-166"/>
+      <vector name="lt" x="-104" y="-176"/>
+      <vector name="rb" x="101" y="-48"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="311" height="243">
+      <vector name="origin" x="154" y="297"/>
+      <vector name="head" x="2" y="-212"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="346" height="264">
+      <vector name="origin" x="167" y="302"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="367" height="265">
+      <vector name="origin" x="178" y="304"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="372" height="227">
+      <vector name="origin" x="181" y="311"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="371" height="211">
+      <vector name="origin" x="182" y="308"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="368" height="244">
+      <vector name="origin" x="181" y="308"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="365" height="220">
+      <vector name="origin" x="179" y="305"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="359" height="212">
+      <vector name="origin" x="174" y="306"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="357" height="214">
+      <vector name="origin" x="173" y="306"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="355" height="217">
+      <vector name="origin" x="173" y="307"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="352" height="614">
+      <vector name="origin" x="171" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="350" height="607">
+      <vector name="origin" x="168" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="359" height="607">
+      <vector name="origin" x="173" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="365" height="608">
+      <vector name="origin" x="176" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="367" height="609">
+      <vector name="origin" x="178" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="358" height="633">
+      <vector name="origin" x="176" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="333" height="678">
+      <vector name="origin" x="170" y="726"/>
+      <vector name="head" x="4" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="158" height="763">
+      <vector name="origin" x="84" y="725"/>
+      <vector name="head" x="2" y="-200"/>
+      <vector name="lt" x="-84" y="-199"/>
+      <vector name="rb" x="74" y="-57"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack5">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-185" y="-150"/>
+        <vector name="rb" x="185" y="0"/>
+        <int name="start" value="-1"/>
+        <int name="areaCount" value="3"/>
+        <int name="attackCount" value="1"/>
+        <int name="reverse" value="1"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="56" height="167">
+          <vector name="origin" x="25" y="141"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/0"/>
+        </canvas>
+        <canvas name="1" width="57" height="164">
+          <vector name="origin" x="26" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/1"/>
+        </canvas>
+        <canvas name="2" width="82" height="157">
+          <vector name="origin" x="40" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/2"/>
+        </canvas>
+        <canvas name="3" width="82" height="141">
+          <vector name="origin" x="40" y="117"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/3"/>
+        </canvas>
+        <canvas name="4" width="83" height="92">
+          <vector name="origin" x="41" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/4"/>
+        </canvas>
+        <canvas name="5" width="83" height="92">
+          <vector name="origin" x="41" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/4"/>
+        </canvas>
+        <canvas name="6" width="83" height="92">
+          <vector name="origin" x="41" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/6"/>
+        </canvas>
+        <canvas name="7" width="95" height="97">
+          <vector name="origin" x="46" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/7"/>
+        </canvas>
+        <canvas name="8" width="201" height="102">
+          <vector name="origin" x="99" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/8"/>
+        </canvas>
+        <canvas name="9" width="269" height="105">
+          <vector name="origin" x="133" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/9"/>
+        </canvas>
+        <canvas name="10" width="345" height="176">
+          <vector name="origin" x="171" y="158"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/10"/>
+        </canvas>
+        <canvas name="11" width="369" height="185">
+          <vector name="origin" x="183" y="166"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/11"/>
+        </canvas>
+        <canvas name="12" width="371" height="187">
+          <vector name="origin" x="184" y="168"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/12"/>
+        </canvas>
+        <canvas name="13" width="373" height="189">
+          <vector name="origin" x="185" y="170"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/13"/>
+        </canvas>
+        <canvas name="14" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/14"/>
+        </canvas>
+        <canvas name="15" width="382" height="188">
+          <vector name="origin" x="190" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/15"/>
+        </canvas>
+        <canvas name="16" width="373" height="188">
+          <vector name="origin" x="185" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/16"/>
+        </canvas>
+        <canvas name="17" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/17"/>
+        </canvas>
+        <canvas name="18" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/18"/>
+        </canvas>
+        <canvas name="19" width="382" height="188">
+          <vector name="origin" x="190" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/19"/>
+        </canvas>
+        <canvas name="20" width="373" height="188">
+          <vector name="origin" x="185" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/20"/>
+        </canvas>
+        <canvas name="21" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/21"/>
+        </canvas>
+        <canvas name="22" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/22"/>
+        </canvas>
+        <canvas name="23" width="382" height="188">
+          <vector name="origin" x="190" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/23"/>
+        </canvas>
+        <canvas name="24" width="373" height="188">
+          <vector name="origin" x="185" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/24"/>
+        </canvas>
+        <canvas name="25" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/25"/>
+        </canvas>
+        <canvas name="26" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/26"/>
+        </canvas>
+        <canvas name="27" width="382" height="188">
+          <vector name="origin" x="190" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/15"/>
+        </canvas>
+        <canvas name="28" width="373" height="188">
+          <vector name="origin" x="185" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/40"/>
+        </canvas>
+        <canvas name="29" width="371" height="189">
+          <vector name="origin" x="184" y="170"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/41"/>
+        </canvas>
+        <canvas name="30" width="369" height="186">
+          <vector name="origin" x="183" y="167"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/42"/>
+        </canvas>
+        <canvas name="31" width="345" height="176">
+          <vector name="origin" x="171" y="158"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/43"/>
+        </canvas>
+        <canvas name="32" width="269" height="152">
+          <vector name="origin" x="133" y="122"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/44"/>
+        </canvas>
+        <canvas name="33" width="95" height="162">
+          <vector name="origin" x="46" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/45"/>
+        </canvas>
+        <canvas name="34" width="56" height="167">
+          <vector name="origin" x="25" y="141"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/0"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="136" height="123">
+          <vector name="origin" x="80" y="63"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="168" height="127">
+          <vector name="origin" x="96" y="68"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="169" height="134">
+          <vector name="origin" x="94" y="72"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="176" height="140">
+          <vector name="origin" x="100" y="74"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="168" height="139">
+          <vector name="origin" x="97" y="76"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="110" height="105">
+          <vector name="origin" x="48" y="85"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8600005.img/attack2/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="2400"/>
+    </imgdir>
+    <canvas name="1" width="296" height="168">
+      <vector name="origin" x="113" y="163"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="313" height="214">
+      <vector name="origin" x="167" y="211"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="240" height="250">
+      <vector name="origin" x="142" y="242"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="208" height="300">
+      <vector name="origin" x="119" y="235"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="338" height="262">
+      <vector name="origin" x="94" y="223"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="272" height="343">
+      <vector name="origin" x="85" y="325"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="226" height="271">
+      <vector name="origin" x="85" y="266"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="194" height="215">
+      <vector name="origin" x="85" y="219"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="175" height="172">
+      <vector name="origin" x="86" y="185"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="153" height="135">
+      <vector name="origin" x="83" y="172"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="126" height="186">
+      <vector name="origin" x="66" y="223"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="119" height="247">
+      <vector name="origin" x="54" y="284"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="121" height="264">
+      <vector name="origin" x="55" y="303"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="111" height="264">
+      <vector name="origin" x="51" y="305"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="159" height="294">
+      <vector name="origin" x="78" y="336"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="182" height="304">
+      <vector name="origin" x="89" y="347"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="788" height="641">
+      <vector name="origin" x="387" y="584"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="819" height="652">
+      <vector name="origin" x="402" y="590"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="839" height="660">
+      <vector name="origin" x="427" y="594"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="862" height="711">
+      <vector name="origin" x="442" y="649"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="897" height="754">
+      <vector name="origin" x="454" y="690"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="931" height="801">
+      <vector name="origin" x="474" y="710"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="950" height="813">
+      <vector name="origin" x="480" y="712"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="968" height="826">
+      <vector name="origin" x="478" y="711"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="922" height="795">
+      <vector name="origin" x="426" y="680"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="26" width="822" height="691">
+      <vector name="origin" x="363" y="581"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="27" width="850" height="681">
+      <vector name="origin" x="371" y="589"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="28" width="858" height="633">
+      <vector name="origin" x="373" y="591"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="29" width="749" height="594">
+      <vector name="origin" x="367" y="561"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="30" width="165" height="298">
+      <vector name="origin" x="85" y="336"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="31" width="135" height="263">
+      <vector name="origin" x="85" y="303"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="32" width="145" height="183">
+      <vector name="origin" x="85" y="223"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="33" width="161" height="114">
+      <vector name="origin" x="85" y="152"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="危险！快躲到魔法阵里面！！！"/>
+      <int name="floatNotice" value="73"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="160" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="165" height="113">
+      <vector name="origin" x="90" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-90" y="-148"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="181" height="114">
+      <vector name="origin" x="105" y="147"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-105" y="-147"/>
+      <vector name="rb" x="76" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="191" height="200">
+      <vector name="origin" x="115" y="231"/>
+      <vector name="head" x="1" y="-150"/>
+      <vector name="lt" x="-115" y="-231"/>
+      <vector name="rb" x="76" y="-31"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="207" height="210">
+      <vector name="origin" x="131" y="239"/>
+      <vector name="head" x="2" y="-149"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="211" height="210">
+      <vector name="origin" x="135" y="241"/>
+      <vector name="head" x="2" y="-150"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="213" height="223">
+      <vector name="origin" x="138" y="257"/>
+      <vector name="head" x="2" y="-152"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="217" height="224">
+      <vector name="origin" x="142" y="262"/>
+      <vector name="head" x="2" y="-156"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="224" height="229">
+      <vector name="origin" x="149" y="277"/>
+      <vector name="head" x="2" y="-164"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="222" height="222">
+      <vector name="origin" x="145" y="284"/>
+      <vector name="head" x="2" y="-179"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="10" width="218" height="223">
+      <vector name="origin" x="142" y="287"/>
+      <vector name="head" x="2" y="-182"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="216" height="221">
+      <vector name="origin" x="139" y="286"/>
+      <vector name="head" x="2" y="-184"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="216" height="222">
+      <vector name="origin" x="139" y="287"/>
+      <vector name="head" x="2" y="-185"/>
+      <vector name="lt" x="-99" y="-193"/>
+      <vector name="rb" x="77" y="-65"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="213" height="220">
+      <vector name="origin" x="137" y="285"/>
+      <vector name="head" x="2" y="-184"/>
+      <vector name="lt" x="-110" y="-223"/>
+      <vector name="rb" x="76" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="212" height="222">
+      <vector name="origin" x="136" y="283"/>
+      <vector name="head" x="2" y="-182"/>
+      <vector name="lt" x="-100" y="-208"/>
+      <vector name="rb" x="76" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="209" height="229">
+      <vector name="origin" x="134" y="282"/>
+      <vector name="head" x="2" y="-171"/>
+      <vector name="lt" x="-64" y="-176"/>
+      <vector name="rb" x="75" y="-53"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="206" height="229">
+      <vector name="origin" x="131" y="264"/>
+      <vector name="head" x="2" y="-151"/>
+      <vector name="lt" x="-97" y="-160"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="188" height="228">
+      <vector name="origin" x="113" y="263"/>
+      <vector name="head" x="2" y="-152"/>
+      <vector name="lt" x="-112" y="-160"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="158" height="114">
+      <vector name="origin" x="83" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-83" y="-149"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="158" height="115">
+      <vector name="origin" x="75" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-75" y="-149"/>
+      <vector name="rb" x="83" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="265" height="126">
+      <vector name="origin" x="106" y="159"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-106" y="-159"/>
+      <vector name="rb" x="159" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="268" height="118">
+      <vector name="origin" x="108" y="151"/>
+      <vector name="head" x="3" y="-154"/>
+      <vector name="lt" x="-64" y="-151"/>
+      <vector name="rb" x="80" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="272" height="132">
+      <vector name="origin" x="110" y="166"/>
+      <vector name="head" x="4" y="-155"/>
+      <vector name="lt" x="-60" y="-160"/>
+      <vector name="rb" x="96" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="272" height="158">
+      <vector name="origin" x="110" y="192"/>
+      <vector name="head" x="6" y="-157"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="95" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="272" height="192">
+      <vector name="origin" x="110" y="215"/>
+      <vector name="head" x="13" y="-163"/>
+      <vector name="lt" x="-65" y="-192"/>
+      <vector name="rb" x="128" y="-32"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="264" height="200">
+      <vector name="origin" x="106" y="224"/>
+      <vector name="head" x="23" y="-172"/>
+      <vector name="lt" x="-106" y="-224"/>
+      <vector name="rb" x="158" y="-24"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="264" height="210">
+      <vector name="origin" x="105" y="227"/>
+      <vector name="head" x="27" y="-176"/>
+      <vector name="lt" x="-105" y="-227"/>
+      <vector name="rb" x="159" y="-17"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="266" height="211">
+      <vector name="origin" x="106" y="227"/>
+      <vector name="head" x="28" y="-177"/>
+      <vector name="lt" x="-106" y="-227"/>
+      <vector name="rb" x="160" y="-16"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="266" height="210">
+      <vector name="origin" x="106" y="226"/>
+      <vector name="head" x="29" y="-178"/>
+      <vector name="lt" x="-106" y="-226"/>
+      <vector name="rb" x="160" y="-16"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="266" height="209">
+      <vector name="origin" x="106" y="226"/>
+      <vector name="head" x="30" y="-179"/>
+      <vector name="lt" x="-106" y="-226"/>
+      <vector name="rb" x="160" y="-17"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="264" height="210">
+      <vector name="origin" x="105" y="228"/>
+      <vector name="head" x="31" y="-180"/>
+      <vector name="lt" x="-105" y="-228"/>
+      <vector name="rb" x="159" y="-18"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="260" height="206">
+      <vector name="origin" x="103" y="225"/>
+      <vector name="head" x="30" y="-179"/>
+      <vector name="lt" x="-103" y="-225"/>
+      <vector name="rb" x="157" y="-19"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="254" height="194">
+      <vector name="origin" x="103" y="218"/>
+      <vector name="head" x="27" y="-176"/>
+      <vector name="lt" x="-49" y="-208"/>
+      <vector name="rb" x="79" y="-48"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="170" height="125">
+      <vector name="origin" x="77" y="169"/>
+      <vector name="head" x="17" y="-167"/>
+      <vector name="lt" x="-77" y="-169"/>
+      <vector name="rb" x="93" y="-44"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="158" height="115">
+      <vector name="origin" x="78" y="156"/>
+      <vector name="head" x="9" y="-160"/>
+      <vector name="lt" x="-78" y="-156"/>
+      <vector name="rb" x="80" y="-42"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="攻击反射"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill3">
+    <canvas name="0" width="162" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="77" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="230" height="113">
+      <vector name="origin" x="143" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="87" y="-36"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="245" height="114">
+      <vector name="origin" x="153" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-89" y="-149"/>
+      <vector name="rb" x="92" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="254" height="115">
+      <vector name="origin" x="158" y="149"/>
+      <vector name="head" x="3" y="-153"/>
+      <vector name="lt" x="-89" y="-149"/>
+      <vector name="rb" x="96" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="258" height="116">
+      <vector name="origin" x="160" y="149"/>
+      <vector name="head" x="4" y="-153"/>
+      <vector name="lt" x="-89" y="-149"/>
+      <vector name="rb" x="98" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="261" height="115">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-89" y="-149"/>
+      <vector name="rb" x="100" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="262" height="125">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="6" y="-153"/>
+      <vector name="lt" x="-91" y="-149"/>
+      <vector name="rb" x="101" y="-24"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="262" height="129">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="7" y="-153"/>
+      <vector name="lt" x="-91" y="-149"/>
+      <vector name="rb" x="101" y="-20"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="198" height="152">
+      <vector name="origin" x="141" y="165"/>
+      <vector name="head" x="-2" y="-153"/>
+      <vector name="lt" x="-90" y="-165"/>
+      <vector name="rb" x="57" y="-13"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="196" height="153">
+      <vector name="origin" x="143" y="166"/>
+      <vector name="head" x="-4" y="-153"/>
+      <vector name="lt" x="-111" y="-166"/>
+      <vector name="rb" x="53" y="-13"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="196" height="151">
+      <vector name="origin" x="144" y="167"/>
+      <vector name="head" x="-5" y="-153"/>
+      <vector name="lt" x="-96" y="-167"/>
+      <vector name="rb" x="52" y="-16"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="210" height="144">
+      <vector name="origin" x="144" y="166"/>
+      <vector name="head" x="-2" y="-153"/>
+      <vector name="lt" x="-97" y="-166"/>
+      <vector name="rb" x="66" y="-22"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="210" height="135">
+      <vector name="origin" x="138" y="163"/>
+      <vector name="head" x="0" y="-153"/>
+      <vector name="lt" x="-87" y="-163"/>
+      <vector name="rb" x="72" y="-28"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="207" height="115">
+      <vector name="origin" x="133" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-80" y="-149"/>
+      <vector name="rb" x="74" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="177" height="114">
+      <vector name="origin" x="102" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-80" y="-149"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="173" height="114">
+      <vector name="origin" x="97" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-80" y="-149"/>
+      <vector name="rb" x="76" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="潜能无效化"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill4">
+    <canvas name="0" width="162" height="112">
+      <vector name="origin" x="84" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="77" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="190" height="113">
+      <vector name="origin" x="81" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="108" y="-36"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="182" height="114">
+      <vector name="origin" x="79" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="102" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="178" height="121">
+      <vector name="origin" x="78" y="151"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-78" y="-151"/>
+      <vector name="rb" x="100" y="-30"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="179" height="120">
+      <vector name="origin" x="77" y="153"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-77" y="-153"/>
+      <vector name="rb" x="102" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="180" height="115">
+      <vector name="origin" x="76" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-76" y="-149"/>
+      <vector name="rb" x="104" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="180" height="114">
+      <vector name="origin" x="75" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-75" y="-149"/>
+      <vector name="rb" x="105" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="180" height="114">
+      <vector name="origin" x="75" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-75" y="-149"/>
+      <vector name="rb" x="105" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="289" height="144">
+      <vector name="origin" x="238" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-238" y="-149"/>
+      <vector name="rb" x="51" y="-5"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="346" height="141">
+      <vector name="origin" x="303" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-303" y="-149"/>
+      <vector name="rb" x="43" y="-8"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="382" height="142">
+      <vector name="origin" x="343" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-343" y="-149"/>
+      <vector name="rb" x="39" y="-7"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="442" height="142">
+      <vector name="origin" x="375" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-375" y="-149"/>
+      <vector name="rb" x="67" y="-7"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="456" height="143">
+      <vector name="origin" x="383" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-383" y="-149"/>
+      <vector name="rb" x="73" y="-6"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="460" height="143">
+      <vector name="origin" x="385" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-385" y="-149"/>
+      <vector name="rb" x="75" y="-6"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="404" height="143">
+      <vector name="origin" x="328" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-328" y="-149"/>
+      <vector name="rb" x="76" y="-6"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="406" height="142">
+      <vector name="origin" x="329" y="149"/>
+      <vector name="head" x="1" y="-161"/>
+      <vector name="lt" x="-329" y="-149"/>
+      <vector name="rb" x="77" y="-7"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill5">
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="186" height="125">
+      <vector name="origin" x="93" y="160"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-93" y="-160"/>
+      <vector name="rb" x="93" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="192" height="156">
+      <vector name="origin" x="96" y="189"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-96" y="-189"/>
+      <vector name="rb" x="96" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="194" height="169">
+      <vector name="origin" x="97" y="200"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-200"/>
+      <vector name="rb" x="97" y="-31"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="194" height="172">
+      <vector name="origin" x="97" y="201"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-201"/>
+      <vector name="rb" x="97" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="194" height="173">
+      <vector name="origin" x="97" y="202"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-202"/>
+      <vector name="rb" x="97" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="192" height="173">
+      <vector name="origin" x="96" y="203"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-96" y="-203"/>
+      <vector name="rb" x="96" y="-30"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="192" height="173">
+      <vector name="origin" x="96" y="203"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-96" y="-203"/>
+      <vector name="rb" x="96" y="-30"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="194" height="163">
+      <vector name="origin" x="97" y="182"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-182"/>
+      <vector name="rb" x="97" y="-19"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="194" height="184">
+      <vector name="origin" x="97" y="189"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-189"/>
+      <vector name="rb" x="97" y="-5"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="194" height="198">
+      <vector name="origin" x="97" y="198"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-198"/>
+      <vector name="rb" x="97" y="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="192" height="196">
+      <vector name="origin" x="95" y="198"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-95" y="-198"/>
+      <vector name="rb" x="97" y="-2"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="186" height="193">
+      <vector name="origin" x="93" y="198"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-93" y="-198"/>
+      <vector name="rb" x="93" y="-5"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="160" height="132">
+      <vector name="origin" x="85" y="171"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-171"/>
+      <vector name="rb" x="75" y="-39"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="160" height="114">
+      <vector name="origin" x="85" y="150"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-150"/>
+      <vector name="rb" x="75" y="-36"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="160" height="114">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill6">
+    <canvas name="0" width="162" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="77" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="230" height="113">
+      <vector name="origin" x="143" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-143" y="-149"/>
+      <vector name="rb" x="87" y="-36"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="245" height="114">
+      <vector name="origin" x="153" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-153" y="-149"/>
+      <vector name="rb" x="92" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="254" height="115">
+      <vector name="origin" x="158" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-158" y="-149"/>
+      <vector name="rb" x="96" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="258" height="116">
+      <vector name="origin" x="160" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-160" y="-149"/>
+      <vector name="rb" x="98" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="261" height="115">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-161" y="-149"/>
+      <vector name="rb" x="100" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="262" height="125">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-161" y="-149"/>
+      <vector name="rb" x="101" y="-24"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="262" height="129">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-161" y="-149"/>
+      <vector name="rb" x="101" y="-20"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="198" height="152">
+      <vector name="origin" x="141" y="165"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-141" y="-165"/>
+      <vector name="rb" x="57" y="-13"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="196" height="153">
+      <vector name="origin" x="143" y="166"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-143" y="-166"/>
+      <vector name="rb" x="53" y="-13"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="196" height="151">
+      <vector name="origin" x="144" y="167"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-144" y="-167"/>
+      <vector name="rb" x="52" y="-16"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="210" height="144">
+      <vector name="origin" x="144" y="166"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-144" y="-166"/>
+      <vector name="rb" x="66" y="-22"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="210" height="135">
+      <vector name="origin" x="138" y="163"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-138" y="-163"/>
+      <vector name="rb" x="72" y="-28"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="207" height="115">
+      <vector name="origin" x="133" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-133" y="-149"/>
+      <vector name="rb" x="74" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="177" height="114">
+      <vector name="origin" x="102" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-102" y="-149"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="173" height="114">
+      <vector name="origin" x="97" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-149"/>
+      <vector name="rb" x="76" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="增益解除"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill7">
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="163" height="113">
+      <vector name="origin" x="79" y="148"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-79" y="-148"/>
+      <vector name="rb" x="84" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="166" height="139">
+      <vector name="origin" x="84" y="172"/>
+      <vector name="head" x="2" y="-151"/>
+      <vector name="lt" x="-84" y="-172"/>
+      <vector name="rb" x="82" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="189" height="180">
+      <vector name="origin" x="114" y="211"/>
+      <vector name="head" x="1" y="-161"/>
+      <vector name="lt" x="-114" y="-211"/>
+      <vector name="rb" x="75" y="-31"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="182" height="184">
+      <vector name="origin" x="119" y="233"/>
+      <vector name="head" x="2" y="-169"/>
+      <vector name="lt" x="-119" y="-233"/>
+      <vector name="rb" x="63" y="-49"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="168" height="195">
+      <vector name="origin" x="124" y="251"/>
+      <vector name="head" x="2" y="-176"/>
+      <vector name="lt" x="-124" y="-251"/>
+      <vector name="rb" x="44" y="-56"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="179" height="212">
+      <vector name="origin" x="135" y="272"/>
+      <vector name="head" x="2" y="-179"/>
+      <vector name="lt" x="-135" y="-272"/>
+      <vector name="rb" x="44" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="202" height="215">
+      <vector name="origin" x="158" y="276"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-158" y="-276"/>
+      <vector name="rb" x="44" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="212" height="231">
+      <vector name="origin" x="168" y="294"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-168" y="-294"/>
+      <vector name="rb" x="44" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="202" height="232">
+      <vector name="origin" x="158" y="294"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-158" y="-294"/>
+      <vector name="rb" x="44" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="184" height="223">
+      <vector name="origin" x="140" y="284"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-140" y="-284"/>
+      <vector name="rb" x="44" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="180" height="214">
+      <vector name="origin" x="136" y="274"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-136" y="-274"/>
+      <vector name="rb" x="44" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="167" height="201">
+      <vector name="origin" x="123" y="260"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-123" y="-260"/>
+      <vector name="rb" x="44" y="-59"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="167" height="198">
+      <vector name="origin" x="123" y="258"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-123" y="-258"/>
+      <vector name="rb" x="44" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="167" height="198">
+      <vector name="origin" x="123" y="259"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-123" y="-259"/>
+      <vector name="rb" x="44" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="167" height="199">
+      <vector name="origin" x="123" y="258"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-123" y="-258"/>
+      <vector name="rb" x="44" y="-59"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="133" height="144">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-89" y="-202"/>
+      <vector name="rb" x="44" y="-58"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="133" height="149">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-89" y="-202"/>
+      <vector name="rb" x="44" y="-53"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="157" height="157">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-89" y="-202"/>
+      <vector name="rb" x="68" y="-45"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="160" height="112">
+      <vector name="origin" x="85" y="152"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-85" y="-152"/>
+      <vector name="rb" x="75" y="-40"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill8">
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-154"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+      <string name="source" value="Mob/8870200.img/attack2/0"/>
+    </canvas>
+    <canvas name="1" width="165" height="114">
+      <vector name="origin" x="89" y="178"/>
+      <vector name="head" x="2" y="-181"/>
+      <vector name="lt" x="-89" y="-178"/>
+      <vector name="rb" x="76" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="189" height="228">
+      <vector name="origin" x="113" y="297"/>
+      <vector name="head" x="2" y="-192"/>
+      <vector name="lt" x="-113" y="-297"/>
+      <vector name="rb" x="76" y="-69"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="187" height="224">
+      <vector name="origin" x="111" y="294"/>
+      <vector name="head" x="2" y="-194"/>
+      <vector name="lt" x="-111" y="-294"/>
+      <vector name="rb" x="76" y="-70"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="179" height="217">
+      <vector name="origin" x="104" y="287"/>
+      <vector name="head" x="2" y="-196"/>
+      <vector name="lt" x="-104" y="-287"/>
+      <vector name="rb" x="75" y="-70"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="167" height="207">
+      <vector name="origin" x="92" y="278"/>
+      <vector name="head" x="2" y="-198"/>
+      <vector name="lt" x="-92" y="-278"/>
+      <vector name="rb" x="75" y="-71"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="160" height="201">
+      <vector name="origin" x="85" y="274"/>
+      <vector name="head" x="-1" y="-152"/>
+      <vector name="lt" x="-85" y="-274"/>
+      <vector name="rb" x="75" y="-73"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="161" height="203">
+      <vector name="origin" x="86" y="277"/>
+      <vector name="head" x="2" y="-200"/>
+      <vector name="lt" x="-86" y="-277"/>
+      <vector name="rb" x="75" y="-74"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="234" height="280">
+      <vector name="origin" x="147" y="266"/>
+      <vector name="head" x="-1" y="-152"/>
+      <vector name="lt" x="-147" y="-266"/>
+      <vector name="rb" x="87" y="14"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="274" height="225">
+      <vector name="origin" x="167" y="210"/>
+      <vector name="head" x="-1" y="-152"/>
+      <vector name="lt" x="-167" y="-210"/>
+      <vector name="rb" x="107" y="15"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="296" height="184">
+      <vector name="origin" x="178" y="167"/>
+      <vector name="head" x="-1" y="-152"/>
+      <vector name="lt" x="-178" y="-167"/>
+      <vector name="rb" x="118" y="17"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="294" height="169">
+      <vector name="origin" x="177" y="151"/>
+      <vector name="head" x="0" y="-118"/>
+      <vector name="lt" x="-177" y="-151"/>
+      <vector name="rb" x="117" y="18"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="292" height="149">
+      <vector name="origin" x="176" y="132"/>
+      <vector name="head" x="2" y="-110"/>
+      <vector name="lt" x="-176" y="-132"/>
+      <vector name="rb" x="116" y="17"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="259" height="125">
+      <vector name="origin" x="151" y="113"/>
+      <vector name="head" x="2" y="-111"/>
+      <vector name="lt" x="-151" y="-113"/>
+      <vector name="rb" x="108" y="12"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="145" height="132">
+      <vector name="origin" x="70" y="140"/>
+      <vector name="head" x="2" y="-126"/>
+      <vector name="lt" x="-70" y="-140"/>
+      <vector name="rb" x="75" y="-8"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill9">
+    <canvas name="0" width="160" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="160" height="113">
+      <vector name="origin" x="85" y="148"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-148"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="245" height="142">
+      <vector name="origin" x="170" y="147"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-170" y="-147"/>
+      <vector name="rb" x="75" y="-5"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="335" height="175">
+      <vector name="origin" x="171" y="146"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-146"/>
+      <vector name="rb" x="164" y="29"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="336" height="163">
+      <vector name="origin" x="171" y="145"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-145"/>
+      <vector name="rb" x="165" y="18"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="337" height="152">
+      <vector name="origin" x="171" y="146"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-146"/>
+      <vector name="rb" x="166" y="6"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="337" height="153">
+      <vector name="origin" x="171" y="157"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-157"/>
+      <vector name="rb" x="166" y="-4"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="337" height="146">
+      <vector name="origin" x="171" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-149"/>
+      <vector name="rb" x="166" y="-3"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="337" height="232">
+      <vector name="origin" x="171" y="237"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-237"/>
+      <vector name="rb" x="166" y="-5"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="371" height="234">
+      <vector name="origin" x="205" y="238"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-205" y="-238"/>
+      <vector name="rb" x="166" y="-4"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="404" height="267">
+      <vector name="origin" x="207" y="245"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-207" y="-245"/>
+      <vector name="rb" x="197" y="22"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="404" height="264">
+      <vector name="origin" x="207" y="242"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-207" y="-242"/>
+      <vector name="rb" x="197" y="22"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="403" height="262">
+      <vector name="origin" x="206" y="239"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-206" y="-239"/>
+      <vector name="rb" x="197" y="23"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="373" height="247">
+      <vector name="origin" x="175" y="224"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-175" y="-224"/>
+      <vector name="rb" x="198" y="23"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="14" width="347" height="179">
+      <vector name="origin" x="153" y="160"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-153" y="-160"/>
+      <vector name="rb" x="194" y="19"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="15" width="285" height="158">
+      <vector name="origin" x="132" y="152"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-132" y="-152"/>
+      <vector name="rb" x="153" y="6"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="16" width="198" height="145">
+      <vector name="origin" x="85" y="150"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-150"/>
+      <vector name="rb" x="113" y="-5"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="17" width="160" height="114">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="152" height="124">
+      <vector name="origin" x="27" y="161"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-27" y="-161"/>
+      <vector name="rb" x="125" y="-37"/>
+      <int name="delay" value="300"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="1" width="152" height="115">
+      <vector name="origin" x="22" y="152"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="151" height="112">
+      <vector name="origin" x="20" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="161" height="112">
+      <vector name="origin" x="29" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="195" height="118">
+      <vector name="origin" x="47" y="154"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="205" height="163">
+      <vector name="origin" x="47" y="161"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="204" height="176">
+      <vector name="origin" x="51" y="174"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="226" height="167">
+      <vector name="origin" x="67" y="165"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="220" height="168">
+      <vector name="origin" x="51" y="166"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="9" width="228" height="166">
+      <vector name="origin" x="52" y="164"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="10" width="226" height="168">
+      <vector name="origin" x="67" y="166"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="11" width="220" height="163">
+      <vector name="origin" x="51" y="161"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="228" height="169">
+      <vector name="origin" x="52" y="167"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="13" width="228" height="171">
+      <vector name="origin" x="67" y="166"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="14" width="229" height="353">
+      <vector name="origin" x="55" y="345"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="15" width="240" height="357">
+      <vector name="origin" x="58" y="348"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="16" width="236" height="355">
+      <vector name="origin" x="71" y="346"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="17" width="231" height="362">
+      <vector name="origin" x="56" y="353"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="18" width="240" height="360">
+      <vector name="origin" x="58" y="351"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="19" width="181" height="348">
+      <vector name="origin" x="36" y="339"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="20" width="153" height="354">
+      <vector name="origin" x="34" y="346"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="21" width="95" height="353">
+      <vector name="origin" x="-12" y="345"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="22" width="76" height="313">
+      <vector name="origin" x="-23" y="310"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="sleep">
+    <canvas name="0" width="337" height="153">
+      <vector name="origin" x="171" y="183"/>
+      <int name="delay" value="300"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+    <canvas name="1" width="337" height="153">
+      <vector name="origin" x="171" y="184"/>
+      <int name="delay" value="300"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+    <canvas name="2" width="337" height="153">
+      <vector name="origin" x="171" y="185"/>
+      <int name="delay" value="300"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+    <canvas name="3" width="337" height="153">
+      <vector name="origin" x="171" y="184"/>
+      <int name="delay" value="300"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="wakeup">
+    <canvas name="0" width="337" height="153">
+      <vector name="origin" x="171" y="184"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+    <canvas name="1" width="337" height="153">
+      <vector name="origin" x="171" y="157"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-157"/>
+      <vector name="rb" x="166" y="-4"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+    <canvas name="2" width="337" height="146">
+      <vector name="origin" x="171" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-149"/>
+      <vector name="rb" x="166" y="-3"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/6"/>
+    </canvas>
+    <canvas name="3" width="337" height="152">
+      <vector name="origin" x="171" y="146"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-146"/>
+      <vector name="rb" x="166" y="6"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/5"/>
+    </canvas>
+    <canvas name="4" width="336" height="163">
+      <vector name="origin" x="171" y="145"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-145"/>
+      <vector name="rb" x="165" y="18"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/4"/>
+    </canvas>
+    <canvas name="5" width="335" height="175">
+      <vector name="origin" x="171" y="146"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-146"/>
+      <vector name="rb" x="164" y="29"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/3"/>
+    </canvas>
+    <canvas name="6" width="245" height="142">
+      <vector name="origin" x="170" y="147"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-170" y="-147"/>
+      <vector name="rb" x="75" y="-5"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/2"/>
+    </canvas>
+    <canvas name="7" width="160" height="113">
+      <vector name="origin" x="85" y="148"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-148"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/1"/>
+    </canvas>
+    <canvas name="8" width="160" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/0"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="180"/>
+    <int name="maxHP" value="2100000000"/>
+    <int name="maxMP" value="50000"/>
+    <int name="speed" value="-50"/>
+    <int name="PADamage" value="2100"/>
+    <int name="PDDamage" value="1930"/>
+    <int name="MADamage" value="2100"/>
+    <int name="MDDamage" value="1930"/>
+    <int name="acc" value="270"/>
+    <int name="eva" value="55"/>
+    <int name="exp" value="300000000"/>
+    <int name="hpRecovery" value="100000"/>
+    <int name="mpRecovery" value="1000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="140000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="12"/>
+    <int name="firstAttack" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="publicReward" value="1"/>
+    <int name="explosiveReward" value="1"/>
+    <string name="buff" value="2022449"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <string name="elemAttr" value="P2H2F2I2"/>
+    <int name="mobType" value="1"/>
+    <int name="rareItemDropLevel" value="3"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="101"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="145"/>
+        <int name="action" value="2"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="133"/>
+        <int name="action" value="3"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8300006.img.xml
+++ b/gms-server/wz/Mob.wz/8300006.img.xml
@@ -1,1 +1,1300 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8300006.img"><imgdir name="info"><int name="bodyAttack" value="1"/><int name="level" value="70"/><int name="maxHP" value="570000"/><int name="maxMP" value="15000"/><int name="speed" value="30"/><int name="PADamage" value="380"/><int name="MADamage" value="380"/><int name="acc" value="210"/><int name="eva" value="12"/><int name="pushed" value="50000"/><float name="fs" value="10.0"/><int name="summonType" value="1"/><int name="undead" value="0"/><int name="boss" value="1"/><int name="exp" value="5000"/><int name="ignoreFieldOut" value="1"/><int name="category" value="4"/><int name="firstAttack" value="1"/><imgdir name="skill"><imgdir name="0"><int name="skill" value="145"/><int name="action" value="1"/><string name="level" value="6"/><int name="effectAfter" value="0"/><int name="skillAfter" value="1920"/></imgdir><imgdir name="1"><int name="skill" value="110"/><int name="action" value="2"/><string name="level" value="10"/><int name="effectAfter" value="0"/><int name="skillAfter" value="1920"/></imgdir><imgdir name="2"><int name="skill" value="200"/><int name="action" value="3"/><string name="level" value="177"/><int name="effectAfter" value="0"/></imgdir><imgdir name="3"><int name="skill" value="128"/><int name="action" value="4"/><string name="level" value="15"/><int name="effectAfter" value="0"/><int name="skillAfter" value="1920"/></imgdir></imgdir></imgdir><imgdir name="stand"><canvas name="0" width="352" height="265"><vector name="origin" x="192" y="298"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="1" width="343" height="293"><vector name="origin" x="192" y="327"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="2" width="341" height="267"><vector name="origin" x="192" y="302"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="3" width="356" height="260"><vector name="origin" x="192" y="294"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="4" width="359" height="265"><vector name="origin" x="192" y="295"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="5" width="354" height="285"><vector name="origin" x="192" y="297"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas></imgdir><imgdir name="fly"><canvas name="0" width="352" height="265"><vector name="origin" x="192" y="298"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="1" width="343" height="293"><vector name="origin" x="192" y="327"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="2" width="341" height="267"><vector name="origin" x="192" y="302"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="3" width="356" height="260"><vector name="origin" x="192" y="294"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="4" width="359" height="265"><vector name="origin" x="192" y="295"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="5" width="354" height="285"><vector name="origin" x="192" y="297"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-176" y="-288"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-41" y="-263"/></canvas></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="sp" x="-227" y="-79"/><int name="r" value="400"/></imgdir><imgdir name="hit"><canvas name="0" width="124" height="109"><vector name="origin" x="62" y="97"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="1" width="96" height="98"><vector name="origin" x="47" y="90"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="2" width="94" height="92"><vector name="origin" x="48" y="86"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="3" width="99" height="83"><vector name="origin" x="58" y="80"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="4" width="106" height="89"><vector name="origin" x="60" y="84"/><int name="z" value="0"/><int name="delay" value="90"/></canvas></imgdir><imgdir name="ball"><canvas name="0" width="211" height="91"><vector name="origin" x="49" y="45"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="189" height="90"><vector name="origin" x="47" y="45"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="2" width="160" height="83"><vector name="origin" x="44" y="45"/><int name="z" value="0"/><int name="delay" value="120"/></canvas></imgdir><int name="bulletNumber" value="5"/><int name="bulletSpeed" value="-200"/><int name="type" value="2"/><int name="attackAfter" value="600"/><int name="magic" value="1"/><int name="conMP" value="5"/></imgdir><canvas name="0" width="359" height="293"><vector name="origin" x="197" y="337"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-167" y="-295"/><vector name="rb" x="144" y="-49"/><vector name="head" x="-30" y="-274"/></canvas><canvas name="1" width="346" height="260"><vector name="origin" x="184" y="310"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-167" y="-295"/><vector name="rb" x="144" y="-64"/><vector name="head" x="-28" y="-280"/></canvas><canvas name="2" width="356" height="265"><vector name="origin" x="177" y="313"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-167" y="-295"/><vector name="rb" x="144" y="-64"/><vector name="head" x="-25" y="-282"/></canvas><canvas name="3" width="362" height="285"><vector name="origin" x="178" y="315"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-160" y="-305"/><vector name="rb" x="160" y="-63"/><vector name="head" x="-24" y="-282"/></canvas><canvas name="4" width="404" height="267"><vector name="origin" x="304" y="264"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-241" y="-246"/><vector name="rb" x="79" y="-16"/><vector name="head" x="-102" y="-228"/></canvas><canvas name="5" width="404" height="277"><vector name="origin" x="311" y="265"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-256" y="-240"/><vector name="rb" x="79" y="-7"/><vector name="head" x="-110" y="-217"/></canvas><canvas name="6" width="401" height="267"><vector name="origin" x="309" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-256" y="-240"/><vector name="rb" x="79" y="0"/><vector name="head" x="-115" y="-212"/></canvas><canvas name="7" width="372" height="277"><vector name="origin" x="291" y="260"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-256" y="-240"/><vector name="rb" x="79" y="0"/><vector name="head" x="-116" y="-212"/></canvas><canvas name="8" width="355" height="285"><vector name="origin" x="225" y="275"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-209" y="-264"/><vector name="rb" x="112" y="-16"/><vector name="head" x="-73" y="-243"/></canvas><canvas name="9" width="354" height="285"><vector name="origin" x="194" y="297"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-182" y="-288"/><vector name="rb" x="144" y="-34"/><vector name="head" x="-45" y="-265"/></canvas></imgdir><imgdir name="attack2"><imgdir name="info"><imgdir name="hit"><canvas name="0" width="121" height="136"><vector name="origin" x="55" y="108"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="1" width="121" height="127"><vector name="origin" x="55" y="104"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="2" width="120" height="134"><vector name="origin" x="57" y="109"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="3" width="115" height="133"><vector name="origin" x="59" y="110"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="4" width="107" height="132"><vector name="origin" x="58" y="111"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="5" width="108" height="127"><vector name="origin" x="59" y="110"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="6" width="93" height="124"><vector name="origin" x="57" y="111"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="7" width="43" height="66"><vector name="origin" x="50" y="106"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="8" width="59" height="62"><vector name="origin" x="28" y="76"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="9" width="67" height="70"><vector name="origin" x="32" y="77"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="10" width="75" height="72"><vector name="origin" x="37" y="80"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="11" width="77" height="70"><vector name="origin" x="38" y="81"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="12" width="66" height="69"><vector name="origin" x="39" y="80"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="13" width="61" height="43"><vector name="origin" x="36" y="54"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><canvas name="14" width="12" height="18"><vector name="origin" x="-12" y="31"/><int name="z" value="0"/><int name="delay" value="90"/></canvas><int name="attach" value="1"/></imgdir><imgdir name="range"><vector name="lt" x="-988" y="-177"/><vector name="rb" x="-256" y="45"/></imgdir><int name="type" value="0"/><int name="conMP" value="10"/><int name="attackAfter" value="1200"/><int name="magic" value="1"/></imgdir><canvas name="0" width="343" height="383"><vector name="origin" x="176" y="430"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-161" y="-304"/><vector name="rb" x="161" y="-49"/><vector name="head" x="-26" y="-280"/></canvas><canvas name="1" width="341" height="378"><vector name="origin" x="169" y="429"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-161" y="-304"/><vector name="rb" x="161" y="-49"/><vector name="head" x="-18" y="-283"/></canvas><canvas name="2" width="356" height="375"><vector name="origin" x="166" y="429"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-161" y="-305"/><vector name="rb" x="160" y="-65"/><vector name="head" x="-16" y="-285"/></canvas><canvas name="3" width="359" height="375"><vector name="origin" x="164" y="428"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-145" y="-312"/><vector name="rb" x="175" y="-65"/><vector name="head" x="-14" y="-287"/></canvas><canvas name="4" width="354" height="378"><vector name="origin" x="163" y="414"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-144" y="-304"/><vector name="rb" x="176" y="-50"/><vector name="head" x="-13" y="-288"/></canvas><canvas name="5" width="352" height="365"><vector name="origin" x="162" y="423"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-145" y="-305"/><vector name="rb" x="175" y="-64"/><vector name="head" x="-12" y="-289"/></canvas><canvas name="6" width="343" height="339"><vector name="origin" x="161" y="398"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-145" y="-308"/><vector name="rb" x="159" y="-66"/><vector name="head" x="-11" y="-291"/></canvas><canvas name="7" width="341" height="293"><vector name="origin" x="161" y="352"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-145" y="-309"/><vector name="rb" x="159" y="-65"/><vector name="head" x="-11" y="-291"/></canvas><canvas name="8" width="1135" height="343"><vector name="origin" x="995" y="307"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-234" y="-245"/><vector name="rb" x="95" y="-3"/><vector name="head" x="-88" y="-230"/></canvas><canvas name="9" width="1109" height="332"><vector name="origin" x="1000" y="286"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-241" y="-240"/><vector name="rb" x="79" y="0"/><vector name="head" x="-95" y="-226"/></canvas><canvas name="10" width="1094" height="336"><vector name="origin" x="1006" y="285"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-250" y="-241"/><vector name="rb" x="63" y="-1"/><vector name="head" x="-102" y="-223"/></canvas><canvas name="11" width="1107" height="326"><vector name="origin" x="1009" y="283"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-250" y="-241"/><vector name="rb" x="79" y="0"/><vector name="head" x="-108" y="-225"/></canvas><canvas name="12" width="1108" height="333"><vector name="origin" x="1010" y="283"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-250" y="-241"/><vector name="rb" x="79" y="0"/><vector name="head" x="-111" y="-224"/></canvas><canvas name="13" width="1107" height="334"><vector name="origin" x="1016" y="281"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-250" y="-241"/><vector name="rb" x="79" y="0"/><vector name="head" x="-113" y="-222"/></canvas><canvas name="14" width="1105" height="327"><vector name="origin" x="1018" y="281"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-250" y="-241"/><vector name="rb" x="79" y="0"/><vector name="head" x="-116" y="-221"/></canvas><canvas name="15" width="1089" height="321"><vector name="origin" x="1012" y="279"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="lt" x="-250" y="-241"/><vector name="rb" x="79" y="0"/><vector name="head" x="-115" y="-219"/></canvas><canvas name="16" width="866" height="308"><vector name="origin" x="791" y="280"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="lt" x="-250" y="-241"/><vector name="rb" x="79" y="0"/><vector name="head" x="-116" y="-220"/></canvas><canvas name="17" width="600" height="264"><vector name="origin" x="502" y="257"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="lt" x="-241" y="-241"/><vector name="rb" x="81" y="1"/><vector name="head" x="-107" y="-226"/></canvas><canvas name="18" width="428" height="267"><vector name="origin" x="315" y="266"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="lt" x="-234" y="-256"/><vector name="rb" x="96" y="-1"/><vector name="head" x="-96" y="-236"/></canvas><canvas name="19" width="354" height="286"><vector name="origin" x="227" y="280"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="lt" x="-221" y="-266"/><vector name="rb" x="112" y="-5"/><vector name="head" x="-77" y="-249"/></canvas></imgdir><imgdir name="skill1"><canvas name="0" width="371" height="293"><vector name="origin" x="221" y="348"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-304"/><vector name="rb" x="143" y="-65"/><vector name="head" x="-42" y="-286"/></canvas><canvas name="1" width="366" height="276"><vector name="origin" x="220" y="343"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-65"/><vector name="head" x="-43" y="-296"/></canvas><canvas name="2" width="378" height="273"><vector name="origin" x="217" y="342"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-43" y="-305"/></canvas><canvas name="3" width="376" height="285"><vector name="origin" x="211" y="340"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-42" y="-309"/></canvas><canvas name="4" width="362" height="265"><vector name="origin" x="203" y="343"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-43" y="-312"/></canvas><canvas name="5" width="351" height="293"><vector name="origin" x="201" y="375"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-44" y="-314"/></canvas><canvas name="6" width="348" height="268"><vector name="origin" x="202" y="353"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-44" y="-314"/></canvas><canvas name="7" width="383" height="279"><vector name="origin" x="222" y="360"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-44" y="-315"/></canvas><canvas name="8" width="392" height="324"><vector name="origin" x="227" y="386"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-43" y="-314"/></canvas><canvas name="9" width="364" height="368"><vector name="origin" x="228" y="386"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-66" y="-247"/></canvas><canvas name="10" width="365" height="368"><vector name="origin" x="227" y="385"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-68" y="-245"/></canvas><canvas name="11" width="361" height="368"><vector name="origin" x="227" y="384"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-68" y="-246"/></canvas><canvas name="12" width="355" height="336"><vector name="origin" x="227" y="350"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-70" y="-244"/></canvas><canvas name="13" width="357" height="350"><vector name="origin" x="227" y="346"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-65" y="-249"/></canvas><canvas name="14" width="378" height="337"><vector name="origin" x="224" y="344"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-192" y="-279"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-55" y="-260"/></canvas><canvas name="15" width="354" height="316"><vector name="origin" x="195" y="328"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-192" y="-290"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-46" y="-265"/></canvas><canvas name="16" width="352" height="298"><vector name="origin" x="194" y="331"/><int name="z" value="0"/><int name="delay" value="200"/><vector name="head" x="-44" y="-267"/><vector name="lt" x="-192" y="-290"/><vector name="rb" x="110" y="-33"/></canvas><canvas name="17" width="343" height="296"><vector name="origin" x="194" y="330"/><int name="z" value="0"/><int name="delay" value="200"/><vector name="head" x="-44" y="-267"/><vector name="lt" x="-192" y="-290"/><vector name="rb" x="110" y="-33"/></canvas><canvas name="18" width="341" height="294"><vector name="origin" x="194" y="329"/><int name="z" value="0"/><int name="delay" value="200"/><vector name="head" x="-43" y="-265"/><vector name="lt" x="-192" y="-290"/><vector name="rb" x="110" y="-33"/></canvas><canvas name="19" width="356" height="294"><vector name="origin" x="194" y="328"/><int name="z" value="0"/><int name="delay" value="200"/><vector name="head" x="-43" y="-264"/><vector name="lt" x="-192" y="-290"/><vector name="rb" x="110" y="-33"/></canvas><canvas name="20" width="359" height="299"><vector name="origin" x="194" y="329"/><int name="z" value="0"/><int name="delay" value="200"/><vector name="head" x="-43" y="-264"/><vector name="lt" x="-192" y="-290"/><vector name="rb" x="110" y="-33"/></canvas><canvas name="21" width="354" height="318"><vector name="origin" x="194" y="330"/><int name="z" value="0"/><int name="delay" value="200"/><vector name="head" x="-43" y="-265"/><vector name="lt" x="-192" y="-290"/><vector name="rb" x="110" y="-33"/></canvas><uol name="22" value="16"/><uol name="23" value="17"/><uol name="24" value="18"/><uol name="25" value="19"/><uol name="26" value="20"/><uol name="27" value="21"/><uol name="28" value="16"/><uol name="29" value="17"/><uol name="30" value="18"/><uol name="31" value="19"/><uol name="32" value="20"/><uol name="33" value="21"/><uol name="34" value="16"/><uol name="35" value="17"/><uol name="36" value="18"/><uol name="37" value="19"/><uol name="38" value="20"/><uol name="39" value="21"/><uol name="40" value="16"/><uol name="41" value="17"/><uol name="42" value="18"/><uol name="43" value="19"/><uol name="44" value="20"/><uol name="45" value="21"/></imgdir><imgdir name="skill2"><canvas name="0" width="371" height="293"><vector name="origin" x="220" y="362"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-304"/><vector name="rb" x="143" y="-65"/><vector name="head" x="-42" y="-300"/></canvas><canvas name="1" width="366" height="276"><vector name="origin" x="219" y="357"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-65"/><vector name="head" x="-41" y="-308"/></canvas><canvas name="2" width="378" height="273"><vector name="origin" x="216" y="356"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-42" y="-316"/></canvas><canvas name="3" width="376" height="285"><vector name="origin" x="210" y="354"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-41" y="-321"/></canvas><canvas name="4" width="362" height="265"><vector name="origin" x="202" y="357"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-42" y="-323"/></canvas><canvas name="5" width="351" height="293"><vector name="origin" x="200" y="389"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-42" y="-325"/></canvas><canvas name="6" width="348" height="268"><vector name="origin" x="201" y="367"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-41" y="-327"/></canvas><canvas name="7" width="383" height="279"><vector name="origin" x="221" y="374"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-42" y="-327"/></canvas><canvas name="8" width="392" height="324"><vector name="origin" x="226" y="400"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-41" y="-328"/></canvas><canvas name="9" width="364" height="368"><vector name="origin" x="227" y="400"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-65" y="-261"/></canvas><canvas name="10" width="365" height="368"><vector name="origin" x="226" y="399"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-66" y="-259"/></canvas><canvas name="11" width="361" height="368"><vector name="origin" x="226" y="398"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-66" y="-258"/></canvas><canvas name="12" width="355" height="336"><vector name="origin" x="226" y="364"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-69" y="-257"/></canvas><canvas name="13" width="357" height="350"><vector name="origin" x="226" y="360"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-64" y="-261"/></canvas><canvas name="14" width="378" height="337"><vector name="origin" x="223" y="358"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-192" y="-279"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-50" y="-270"/></canvas><canvas name="15" width="354" height="316"><vector name="origin" x="194" y="342"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-192" y="-290"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-44" y="-277"/></canvas></imgdir><imgdir name="skill3"><canvas name="0" width="371" height="293"><vector name="origin" x="221" y="348"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-304"/><vector name="rb" x="143" y="-65"/><vector name="head" x="-42" y="-284"/></canvas><canvas name="1" width="366" height="276"><vector name="origin" x="220" y="343"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-65"/><vector name="head" x="-42" y="-293"/></canvas><canvas name="2" width="378" height="273"><vector name="origin" x="217" y="342"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-41" y="-300"/></canvas><canvas name="3" width="376" height="285"><vector name="origin" x="211" y="340"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-41" y="-306"/></canvas><canvas name="4" width="362" height="265"><vector name="origin" x="203" y="343"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-41" y="-309"/></canvas><canvas name="5" width="351" height="293"><vector name="origin" x="201" y="375"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-43" y="-310"/></canvas><canvas name="6" width="348" height="268"><vector name="origin" x="202" y="353"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-42" y="-311"/></canvas><canvas name="7" width="383" height="279"><vector name="origin" x="222" y="360"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-43" y="-314"/></canvas><canvas name="8" width="392" height="324"><vector name="origin" x="227" y="386"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-42" y="-314"/></canvas><canvas name="9" width="364" height="368"><vector name="origin" x="228" y="386"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-64" y="-246"/></canvas><canvas name="10" width="365" height="368"><vector name="origin" x="227" y="385"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-65" y="-245"/></canvas><canvas name="11" width="361" height="368"><vector name="origin" x="227" y="384"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-67" y="-243"/></canvas><canvas name="12" width="355" height="336"><vector name="origin" x="227" y="350"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-69" y="-240"/></canvas><canvas name="13" width="357" height="350"><vector name="origin" x="227" y="346"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-64" y="-247"/></canvas><canvas name="14" width="378" height="337"><vector name="origin" x="224" y="344"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-192" y="-279"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-53" y="-257"/></canvas><canvas name="15" width="354" height="316"><vector name="origin" x="195" y="328"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-192" y="-290"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-44" y="-263"/></canvas></imgdir><imgdir name="skill4"><canvas name="0" width="371" height="293"><vector name="origin" x="220" y="362"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-304"/><vector name="rb" x="143" y="-65"/><vector name="head" x="-42" y="-300"/></canvas><canvas name="1" width="366" height="276"><vector name="origin" x="219" y="357"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-65"/><vector name="head" x="-41" y="-308"/></canvas><canvas name="2" width="378" height="273"><vector name="origin" x="216" y="356"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-42" y="-316"/></canvas><canvas name="3" width="376" height="285"><vector name="origin" x="210" y="354"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-41" y="-321"/></canvas><canvas name="4" width="362" height="265"><vector name="origin" x="202" y="357"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-321"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-42" y="-323"/></canvas><canvas name="5" width="351" height="293"><vector name="origin" x="200" y="389"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="143" y="-80"/><vector name="head" x="-42" y="-325"/></canvas><canvas name="6" width="348" height="268"><vector name="origin" x="201" y="367"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-41" y="-327"/></canvas><canvas name="7" width="383" height="279"><vector name="origin" x="221" y="374"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-42" y="-327"/></canvas><canvas name="8" width="392" height="324"><vector name="origin" x="226" y="400"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-178" y="-335"/><vector name="rb" x="144" y="-96"/><vector name="head" x="-41" y="-328"/></canvas><canvas name="9" width="364" height="368"><vector name="origin" x="227" y="400"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-65" y="-261"/></canvas><canvas name="10" width="365" height="368"><vector name="origin" x="226" y="399"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-66" y="-259"/></canvas><canvas name="11" width="361" height="368"><vector name="origin" x="226" y="398"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-66" y="-258"/></canvas><canvas name="12" width="355" height="336"><vector name="origin" x="226" y="364"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-69" y="-257"/></canvas><canvas name="13" width="357" height="350"><vector name="origin" x="226" y="360"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-208" y="-273"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-64" y="-261"/></canvas><canvas name="14" width="378" height="337"><vector name="origin" x="223" y="358"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-192" y="-279"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-50" y="-270"/></canvas><canvas name="15" width="354" height="316"><vector name="origin" x="194" y="342"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-192" y="-290"/><vector name="rb" x="110" y="-33"/><vector name="head" x="-44" y="-277"/></canvas></imgdir><imgdir name="hit"><canvas name="0" width="343" height="294"><vector name="origin" x="178" y="337"/><int name="z" value="0"/><int name="delay" value="500"/><vector name="lt" x="-164" y="-295"/><vector name="rb" x="143" y="-59"/><vector name="head" x="-48" y="-271"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="343" height="294"><vector name="origin" x="193" y="327"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-64" y="-263"/></canvas><canvas name="1" width="339" height="269"><vector name="origin" x="183" y="307"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-51" y="-267"/></canvas><canvas name="2" width="352" height="259"><vector name="origin" x="177" y="298"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-45" y="-266"/></canvas><canvas name="3" width="350" height="259"><vector name="origin" x="170" y="295"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-41" y="-266"/></canvas><canvas name="4" width="336" height="270"><vector name="origin" x="160" y="289"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-41" y="-264"/></canvas><canvas name="5" width="331" height="262"><vector name="origin" x="151" y="291"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="6" width="322" height="294"><vector name="origin" x="142" y="293"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-40" y="-262"/></canvas><canvas name="7" width="318" height="349"><vector name="origin" x="131" y="294"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-40" y="-262"/></canvas><canvas name="8" width="112" height="163"><vector name="origin" x="71" y="294"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-40" y="-262"/></canvas><canvas name="9" width="113" height="164"><vector name="origin" x="71" y="295"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-40" y="-262"/></canvas><canvas name="10" width="111" height="162"><vector name="origin" x="71" y="296"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="11" width="112" height="163"><vector name="origin" x="71" y="295"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="12" width="113" height="164"><vector name="origin" x="71" y="294"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-41" y="-262"/></canvas><canvas name="13" width="112" height="163"><vector name="origin" x="71" y="294"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-40" y="-262"/></canvas><canvas name="14" width="113" height="164"><vector name="origin" x="71" y="295"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-40" y="-262"/></canvas><canvas name="15" width="111" height="162"><vector name="origin" x="71" y="296"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="16" width="112" height="163"><vector name="origin" x="71" y="295"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-41" y="-263"/></canvas><canvas name="17" width="113" height="164"><vector name="origin" x="71" y="294"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-41" y="-262"/></canvas><canvas name="18" width="111" height="162"><vector name="origin" x="71" y="293"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-41" y="-261"/></canvas><canvas name="19" width="93" height="250"><vector name="origin" x="64" y="302"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-24" y="-240"/></canvas><canvas name="20" width="63" height="260"><vector name="origin" x="56" y="268"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-21" y="-201"/></canvas><canvas name="21" width="56" height="297"><vector name="origin" x="55" y="248"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-21" y="-201"/></canvas><canvas name="22" width="49" height="91"><vector name="origin" x="55" y="235"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-21" y="-201"/></canvas><canvas name="23" width="49" height="105"><vector name="origin" x="55" y="214"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-21" y="-201"/></canvas><canvas name="24" width="51" height="79"><vector name="origin" x="47" y="185"/><int name="z" value="0"/><int name="delay" value="600"/><int name="a0" value="255"/><int name="a1" value="0"/><vector name="head" x="-21" y="-201"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="건방진 인간 녀석들.... 이걸로 끝이라고 생각하면 오산이다."/></imgdir></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8300006.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="70"/>
+    <int name="maxHP" value="570000"/>
+    <int name="maxMP" value="15000"/>
+    <int name="speed" value="30"/>
+    <int name="PADamage" value="380"/>
+    <int name="MADamage" value="380"/>
+    <int name="acc" value="210"/>
+    <int name="eva" value="12"/>
+    <int name="pushed" value="50000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="undead" value="0"/>
+    <int name="boss" value="1"/>
+    <int name="exp" value="5000"/>
+    <int name="ignoreFieldOut" value="1"/>
+    <int name="category" value="4"/>
+    <int name="firstAttack" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="145"/>
+        <int name="action" value="1"/>
+        <string name="level" value="6"/>
+        <int name="effectAfter" value="0"/>
+        <int name="skillAfter" value="1920"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="110"/>
+        <int name="action" value="2"/>
+        <string name="level" value="10"/>
+        <int name="effectAfter" value="0"/>
+        <int name="skillAfter" value="1920"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="200"/>
+        <int name="action" value="3"/>
+        <string name="level" value="177"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="128"/>
+        <int name="action" value="4"/>
+        <string name="level" value="15"/>
+        <int name="effectAfter" value="0"/>
+        <int name="skillAfter" value="1920"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="352" height="265">
+      <vector name="origin" x="192" y="298"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="1" width="343" height="293">
+      <vector name="origin" x="192" y="327"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="2" width="341" height="267">
+      <vector name="origin" x="192" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="3" width="356" height="260">
+      <vector name="origin" x="192" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="4" width="359" height="265">
+      <vector name="origin" x="192" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="5" width="354" height="285">
+      <vector name="origin" x="192" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="fly">
+    <canvas name="0" width="352" height="265">
+      <vector name="origin" x="192" y="298"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="1" width="343" height="293">
+      <vector name="origin" x="192" y="327"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="2" width="341" height="267">
+      <vector name="origin" x="192" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="3" width="356" height="260">
+      <vector name="origin" x="192" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="4" width="359" height="265">
+      <vector name="origin" x="192" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="5" width="354" height="285">
+      <vector name="origin" x="192" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-176" y="-288"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-227" y="-79"/>
+        <int name="r" value="400"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="124" height="109">
+          <vector name="origin" x="62" y="97"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="96" height="98">
+          <vector name="origin" x="47" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="94" height="92">
+          <vector name="origin" x="48" y="86"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="99" height="83">
+          <vector name="origin" x="58" y="80"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="106" height="89">
+          <vector name="origin" x="60" y="84"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="211" height="91">
+          <vector name="origin" x="49" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="189" height="90">
+          <vector name="origin" x="47" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="160" height="83">
+          <vector name="origin" x="44" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <int name="bulletNumber" value="5"/>
+      <int name="bulletSpeed" value="-200"/>
+      <int name="type" value="2"/>
+      <int name="attackAfter" value="600"/>
+      <int name="magic" value="1"/>
+      <int name="conMP" value="5"/>
+    </imgdir>
+    <canvas name="0" width="359" height="293">
+      <vector name="origin" x="197" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-167" y="-295"/>
+      <vector name="rb" x="144" y="-49"/>
+      <vector name="head" x="-30" y="-274"/>
+    </canvas>
+    <canvas name="1" width="346" height="260">
+      <vector name="origin" x="184" y="310"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-167" y="-295"/>
+      <vector name="rb" x="144" y="-64"/>
+      <vector name="head" x="-28" y="-280"/>
+    </canvas>
+    <canvas name="2" width="356" height="265">
+      <vector name="origin" x="177" y="313"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-167" y="-295"/>
+      <vector name="rb" x="144" y="-64"/>
+      <vector name="head" x="-25" y="-282"/>
+    </canvas>
+    <canvas name="3" width="362" height="285">
+      <vector name="origin" x="178" y="315"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-160" y="-305"/>
+      <vector name="rb" x="160" y="-63"/>
+      <vector name="head" x="-24" y="-282"/>
+    </canvas>
+    <canvas name="4" width="404" height="267">
+      <vector name="origin" x="304" y="264"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-241" y="-246"/>
+      <vector name="rb" x="79" y="-16"/>
+      <vector name="head" x="-102" y="-228"/>
+    </canvas>
+    <canvas name="5" width="404" height="277">
+      <vector name="origin" x="311" y="265"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-256" y="-240"/>
+      <vector name="rb" x="79" y="-7"/>
+      <vector name="head" x="-110" y="-217"/>
+    </canvas>
+    <canvas name="6" width="401" height="267">
+      <vector name="origin" x="309" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-256" y="-240"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-115" y="-212"/>
+    </canvas>
+    <canvas name="7" width="372" height="277">
+      <vector name="origin" x="291" y="260"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-256" y="-240"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-116" y="-212"/>
+    </canvas>
+    <canvas name="8" width="355" height="285">
+      <vector name="origin" x="225" y="275"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-209" y="-264"/>
+      <vector name="rb" x="112" y="-16"/>
+      <vector name="head" x="-73" y="-243"/>
+    </canvas>
+    <canvas name="9" width="354" height="285">
+      <vector name="origin" x="194" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-182" y="-288"/>
+      <vector name="rb" x="144" y="-34"/>
+      <vector name="head" x="-45" y="-265"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="hit">
+        <canvas name="0" width="121" height="136">
+          <vector name="origin" x="55" y="108"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="121" height="127">
+          <vector name="origin" x="55" y="104"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="120" height="134">
+          <vector name="origin" x="57" y="109"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="115" height="133">
+          <vector name="origin" x="59" y="110"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="107" height="132">
+          <vector name="origin" x="58" y="111"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="108" height="127">
+          <vector name="origin" x="59" y="110"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="93" height="124">
+          <vector name="origin" x="57" y="111"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="7" width="43" height="66">
+          <vector name="origin" x="50" y="106"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="8" width="59" height="62">
+          <vector name="origin" x="28" y="76"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="9" width="67" height="70">
+          <vector name="origin" x="32" y="77"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="10" width="75" height="72">
+          <vector name="origin" x="37" y="80"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="11" width="77" height="70">
+          <vector name="origin" x="38" y="81"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="12" width="66" height="69">
+          <vector name="origin" x="39" y="80"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="13" width="61" height="43">
+          <vector name="origin" x="36" y="54"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="14" width="12" height="18">
+          <vector name="origin" x="-12" y="31"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <imgdir name="range">
+        <vector name="lt" x="-988" y="-177"/>
+        <vector name="rb" x="-256" y="45"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="10"/>
+      <int name="attackAfter" value="1200"/>
+      <int name="magic" value="1"/>
+    </imgdir>
+    <canvas name="0" width="343" height="383">
+      <vector name="origin" x="176" y="430"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-161" y="-304"/>
+      <vector name="rb" x="161" y="-49"/>
+      <vector name="head" x="-26" y="-280"/>
+    </canvas>
+    <canvas name="1" width="341" height="378">
+      <vector name="origin" x="169" y="429"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-161" y="-304"/>
+      <vector name="rb" x="161" y="-49"/>
+      <vector name="head" x="-18" y="-283"/>
+    </canvas>
+    <canvas name="2" width="356" height="375">
+      <vector name="origin" x="166" y="429"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-161" y="-305"/>
+      <vector name="rb" x="160" y="-65"/>
+      <vector name="head" x="-16" y="-285"/>
+    </canvas>
+    <canvas name="3" width="359" height="375">
+      <vector name="origin" x="164" y="428"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-145" y="-312"/>
+      <vector name="rb" x="175" y="-65"/>
+      <vector name="head" x="-14" y="-287"/>
+    </canvas>
+    <canvas name="4" width="354" height="378">
+      <vector name="origin" x="163" y="414"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-144" y="-304"/>
+      <vector name="rb" x="176" y="-50"/>
+      <vector name="head" x="-13" y="-288"/>
+    </canvas>
+    <canvas name="5" width="352" height="365">
+      <vector name="origin" x="162" y="423"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-145" y="-305"/>
+      <vector name="rb" x="175" y="-64"/>
+      <vector name="head" x="-12" y="-289"/>
+    </canvas>
+    <canvas name="6" width="343" height="339">
+      <vector name="origin" x="161" y="398"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-145" y="-308"/>
+      <vector name="rb" x="159" y="-66"/>
+      <vector name="head" x="-11" y="-291"/>
+    </canvas>
+    <canvas name="7" width="341" height="293">
+      <vector name="origin" x="161" y="352"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-145" y="-309"/>
+      <vector name="rb" x="159" y="-65"/>
+      <vector name="head" x="-11" y="-291"/>
+    </canvas>
+    <canvas name="8" width="1135" height="343">
+      <vector name="origin" x="995" y="307"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-234" y="-245"/>
+      <vector name="rb" x="95" y="-3"/>
+      <vector name="head" x="-88" y="-230"/>
+    </canvas>
+    <canvas name="9" width="1109" height="332">
+      <vector name="origin" x="1000" y="286"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-241" y="-240"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-95" y="-226"/>
+    </canvas>
+    <canvas name="10" width="1094" height="336">
+      <vector name="origin" x="1006" y="285"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="63" y="-1"/>
+      <vector name="head" x="-102" y="-223"/>
+    </canvas>
+    <canvas name="11" width="1107" height="326">
+      <vector name="origin" x="1009" y="283"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-108" y="-225"/>
+    </canvas>
+    <canvas name="12" width="1108" height="333">
+      <vector name="origin" x="1010" y="283"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-111" y="-224"/>
+    </canvas>
+    <canvas name="13" width="1107" height="334">
+      <vector name="origin" x="1016" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-113" y="-222"/>
+    </canvas>
+    <canvas name="14" width="1105" height="327">
+      <vector name="origin" x="1018" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-116" y="-221"/>
+    </canvas>
+    <canvas name="15" width="1089" height="321">
+      <vector name="origin" x="1012" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-115" y="-219"/>
+    </canvas>
+    <canvas name="16" width="866" height="308">
+      <vector name="origin" x="791" y="280"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-250" y="-241"/>
+      <vector name="rb" x="79" y="0"/>
+      <vector name="head" x="-116" y="-220"/>
+    </canvas>
+    <canvas name="17" width="600" height="264">
+      <vector name="origin" x="502" y="257"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-241" y="-241"/>
+      <vector name="rb" x="81" y="1"/>
+      <vector name="head" x="-107" y="-226"/>
+    </canvas>
+    <canvas name="18" width="428" height="267">
+      <vector name="origin" x="315" y="266"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-234" y="-256"/>
+      <vector name="rb" x="96" y="-1"/>
+      <vector name="head" x="-96" y="-236"/>
+    </canvas>
+    <canvas name="19" width="354" height="286">
+      <vector name="origin" x="227" y="280"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="lt" x="-221" y="-266"/>
+      <vector name="rb" x="112" y="-5"/>
+      <vector name="head" x="-77" y="-249"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="371" height="293">
+      <vector name="origin" x="221" y="348"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-304"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-42" y="-286"/>
+    </canvas>
+    <canvas name="1" width="366" height="276">
+      <vector name="origin" x="220" y="343"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-43" y="-296"/>
+    </canvas>
+    <canvas name="2" width="378" height="273">
+      <vector name="origin" x="217" y="342"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-43" y="-305"/>
+    </canvas>
+    <canvas name="3" width="376" height="285">
+      <vector name="origin" x="211" y="340"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-309"/>
+    </canvas>
+    <canvas name="4" width="362" height="265">
+      <vector name="origin" x="203" y="343"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-43" y="-312"/>
+    </canvas>
+    <canvas name="5" width="351" height="293">
+      <vector name="origin" x="201" y="375"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-44" y="-314"/>
+    </canvas>
+    <canvas name="6" width="348" height="268">
+      <vector name="origin" x="202" y="353"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-44" y="-314"/>
+    </canvas>
+    <canvas name="7" width="383" height="279">
+      <vector name="origin" x="222" y="360"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-44" y="-315"/>
+    </canvas>
+    <canvas name="8" width="392" height="324">
+      <vector name="origin" x="227" y="386"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-43" y="-314"/>
+    </canvas>
+    <canvas name="9" width="364" height="368">
+      <vector name="origin" x="228" y="386"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-66" y="-247"/>
+    </canvas>
+    <canvas name="10" width="365" height="368">
+      <vector name="origin" x="227" y="385"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-68" y="-245"/>
+    </canvas>
+    <canvas name="11" width="361" height="368">
+      <vector name="origin" x="227" y="384"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-68" y="-246"/>
+    </canvas>
+    <canvas name="12" width="355" height="336">
+      <vector name="origin" x="227" y="350"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-70" y="-244"/>
+    </canvas>
+    <canvas name="13" width="357" height="350">
+      <vector name="origin" x="227" y="346"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-65" y="-249"/>
+    </canvas>
+    <canvas name="14" width="378" height="337">
+      <vector name="origin" x="224" y="344"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-279"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-55" y="-260"/>
+    </canvas>
+    <canvas name="15" width="354" height="316">
+      <vector name="origin" x="195" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-46" y="-265"/>
+    </canvas>
+    <canvas name="16" width="352" height="298">
+      <vector name="origin" x="194" y="331"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-44" y="-267"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <canvas name="17" width="343" height="296">
+      <vector name="origin" x="194" y="330"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-44" y="-267"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <canvas name="18" width="341" height="294">
+      <vector name="origin" x="194" y="329"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-43" y="-265"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <canvas name="19" width="356" height="294">
+      <vector name="origin" x="194" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-43" y="-264"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <canvas name="20" width="359" height="299">
+      <vector name="origin" x="194" y="329"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-43" y="-264"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <canvas name="21" width="354" height="318">
+      <vector name="origin" x="194" y="330"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="200"/>
+      <vector name="head" x="-43" y="-265"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+    </canvas>
+    <uol name="22" value="16"/>
+    <uol name="23" value="17"/>
+    <uol name="24" value="18"/>
+    <uol name="25" value="19"/>
+    <uol name="26" value="20"/>
+    <uol name="27" value="21"/>
+    <uol name="28" value="16"/>
+    <uol name="29" value="17"/>
+    <uol name="30" value="18"/>
+    <uol name="31" value="19"/>
+    <uol name="32" value="20"/>
+    <uol name="33" value="21"/>
+    <uol name="34" value="16"/>
+    <uol name="35" value="17"/>
+    <uol name="36" value="18"/>
+    <uol name="37" value="19"/>
+    <uol name="38" value="20"/>
+    <uol name="39" value="21"/>
+    <uol name="40" value="16"/>
+    <uol name="41" value="17"/>
+    <uol name="42" value="18"/>
+    <uol name="43" value="19"/>
+    <uol name="44" value="20"/>
+    <uol name="45" value="21"/>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="371" height="293">
+      <vector name="origin" x="220" y="362"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-304"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-42" y="-300"/>
+    </canvas>
+    <canvas name="1" width="366" height="276">
+      <vector name="origin" x="219" y="357"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-41" y="-308"/>
+    </canvas>
+    <canvas name="2" width="378" height="273">
+      <vector name="origin" x="216" y="356"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-316"/>
+    </canvas>
+    <canvas name="3" width="376" height="285">
+      <vector name="origin" x="210" y="354"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-41" y="-321"/>
+    </canvas>
+    <canvas name="4" width="362" height="265">
+      <vector name="origin" x="202" y="357"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-323"/>
+    </canvas>
+    <canvas name="5" width="351" height="293">
+      <vector name="origin" x="200" y="389"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-325"/>
+    </canvas>
+    <canvas name="6" width="348" height="268">
+      <vector name="origin" x="201" y="367"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-41" y="-327"/>
+    </canvas>
+    <canvas name="7" width="383" height="279">
+      <vector name="origin" x="221" y="374"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-42" y="-327"/>
+    </canvas>
+    <canvas name="8" width="392" height="324">
+      <vector name="origin" x="226" y="400"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-41" y="-328"/>
+    </canvas>
+    <canvas name="9" width="364" height="368">
+      <vector name="origin" x="227" y="400"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-65" y="-261"/>
+    </canvas>
+    <canvas name="10" width="365" height="368">
+      <vector name="origin" x="226" y="399"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-66" y="-259"/>
+    </canvas>
+    <canvas name="11" width="361" height="368">
+      <vector name="origin" x="226" y="398"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-66" y="-258"/>
+    </canvas>
+    <canvas name="12" width="355" height="336">
+      <vector name="origin" x="226" y="364"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-69" y="-257"/>
+    </canvas>
+    <canvas name="13" width="357" height="350">
+      <vector name="origin" x="226" y="360"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-64" y="-261"/>
+    </canvas>
+    <canvas name="14" width="378" height="337">
+      <vector name="origin" x="223" y="358"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-279"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-50" y="-270"/>
+    </canvas>
+    <canvas name="15" width="354" height="316">
+      <vector name="origin" x="194" y="342"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-44" y="-277"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill3">
+    <canvas name="0" width="371" height="293">
+      <vector name="origin" x="221" y="348"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-304"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-42" y="-284"/>
+    </canvas>
+    <canvas name="1" width="366" height="276">
+      <vector name="origin" x="220" y="343"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-42" y="-293"/>
+    </canvas>
+    <canvas name="2" width="378" height="273">
+      <vector name="origin" x="217" y="342"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-41" y="-300"/>
+    </canvas>
+    <canvas name="3" width="376" height="285">
+      <vector name="origin" x="211" y="340"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-41" y="-306"/>
+    </canvas>
+    <canvas name="4" width="362" height="265">
+      <vector name="origin" x="203" y="343"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-41" y="-309"/>
+    </canvas>
+    <canvas name="5" width="351" height="293">
+      <vector name="origin" x="201" y="375"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-43" y="-310"/>
+    </canvas>
+    <canvas name="6" width="348" height="268">
+      <vector name="origin" x="202" y="353"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-42" y="-311"/>
+    </canvas>
+    <canvas name="7" width="383" height="279">
+      <vector name="origin" x="222" y="360"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-43" y="-314"/>
+    </canvas>
+    <canvas name="8" width="392" height="324">
+      <vector name="origin" x="227" y="386"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-42" y="-314"/>
+    </canvas>
+    <canvas name="9" width="364" height="368">
+      <vector name="origin" x="228" y="386"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-64" y="-246"/>
+    </canvas>
+    <canvas name="10" width="365" height="368">
+      <vector name="origin" x="227" y="385"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-65" y="-245"/>
+    </canvas>
+    <canvas name="11" width="361" height="368">
+      <vector name="origin" x="227" y="384"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-67" y="-243"/>
+    </canvas>
+    <canvas name="12" width="355" height="336">
+      <vector name="origin" x="227" y="350"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-69" y="-240"/>
+    </canvas>
+    <canvas name="13" width="357" height="350">
+      <vector name="origin" x="227" y="346"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-64" y="-247"/>
+    </canvas>
+    <canvas name="14" width="378" height="337">
+      <vector name="origin" x="224" y="344"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-279"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-53" y="-257"/>
+    </canvas>
+    <canvas name="15" width="354" height="316">
+      <vector name="origin" x="195" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-44" y="-263"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill4">
+    <canvas name="0" width="371" height="293">
+      <vector name="origin" x="220" y="362"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-304"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-42" y="-300"/>
+    </canvas>
+    <canvas name="1" width="366" height="276">
+      <vector name="origin" x="219" y="357"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-65"/>
+      <vector name="head" x="-41" y="-308"/>
+    </canvas>
+    <canvas name="2" width="378" height="273">
+      <vector name="origin" x="216" y="356"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-316"/>
+    </canvas>
+    <canvas name="3" width="376" height="285">
+      <vector name="origin" x="210" y="354"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-41" y="-321"/>
+    </canvas>
+    <canvas name="4" width="362" height="265">
+      <vector name="origin" x="202" y="357"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-321"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-323"/>
+    </canvas>
+    <canvas name="5" width="351" height="293">
+      <vector name="origin" x="200" y="389"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="143" y="-80"/>
+      <vector name="head" x="-42" y="-325"/>
+    </canvas>
+    <canvas name="6" width="348" height="268">
+      <vector name="origin" x="201" y="367"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-41" y="-327"/>
+    </canvas>
+    <canvas name="7" width="383" height="279">
+      <vector name="origin" x="221" y="374"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-42" y="-327"/>
+    </canvas>
+    <canvas name="8" width="392" height="324">
+      <vector name="origin" x="226" y="400"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-178" y="-335"/>
+      <vector name="rb" x="144" y="-96"/>
+      <vector name="head" x="-41" y="-328"/>
+    </canvas>
+    <canvas name="9" width="364" height="368">
+      <vector name="origin" x="227" y="400"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-65" y="-261"/>
+    </canvas>
+    <canvas name="10" width="365" height="368">
+      <vector name="origin" x="226" y="399"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-66" y="-259"/>
+    </canvas>
+    <canvas name="11" width="361" height="368">
+      <vector name="origin" x="226" y="398"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-66" y="-258"/>
+    </canvas>
+    <canvas name="12" width="355" height="336">
+      <vector name="origin" x="226" y="364"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-69" y="-257"/>
+    </canvas>
+    <canvas name="13" width="357" height="350">
+      <vector name="origin" x="226" y="360"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-208" y="-273"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-64" y="-261"/>
+    </canvas>
+    <canvas name="14" width="378" height="337">
+      <vector name="origin" x="223" y="358"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-279"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-50" y="-270"/>
+    </canvas>
+    <canvas name="15" width="354" height="316">
+      <vector name="origin" x="194" y="342"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-192" y="-290"/>
+      <vector name="rb" x="110" y="-33"/>
+      <vector name="head" x="-44" y="-277"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit">
+    <canvas name="0" width="343" height="294">
+      <vector name="origin" x="178" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="500"/>
+      <vector name="lt" x="-164" y="-295"/>
+      <vector name="rb" x="143" y="-59"/>
+      <vector name="head" x="-48" y="-271"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="343" height="294">
+      <vector name="origin" x="193" y="327"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-64" y="-263"/>
+    </canvas>
+    <canvas name="1" width="339" height="269">
+      <vector name="origin" x="183" y="307"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-51" y="-267"/>
+    </canvas>
+    <canvas name="2" width="352" height="259">
+      <vector name="origin" x="177" y="298"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-45" y="-266"/>
+    </canvas>
+    <canvas name="3" width="350" height="259">
+      <vector name="origin" x="170" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-266"/>
+    </canvas>
+    <canvas name="4" width="336" height="270">
+      <vector name="origin" x="160" y="289"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-264"/>
+    </canvas>
+    <canvas name="5" width="331" height="262">
+      <vector name="origin" x="151" y="291"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="6" width="322" height="294">
+      <vector name="origin" x="142" y="293"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="7" width="318" height="349">
+      <vector name="origin" x="131" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="8" width="112" height="163">
+      <vector name="origin" x="71" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="9" width="113" height="164">
+      <vector name="origin" x="71" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="10" width="111" height="162">
+      <vector name="origin" x="71" y="296"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="11" width="112" height="163">
+      <vector name="origin" x="71" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="12" width="113" height="164">
+      <vector name="origin" x="71" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-262"/>
+    </canvas>
+    <canvas name="13" width="112" height="163">
+      <vector name="origin" x="71" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="14" width="113" height="164">
+      <vector name="origin" x="71" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-40" y="-262"/>
+    </canvas>
+    <canvas name="15" width="111" height="162">
+      <vector name="origin" x="71" y="296"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="16" width="112" height="163">
+      <vector name="origin" x="71" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-263"/>
+    </canvas>
+    <canvas name="17" width="113" height="164">
+      <vector name="origin" x="71" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-262"/>
+    </canvas>
+    <canvas name="18" width="111" height="162">
+      <vector name="origin" x="71" y="293"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-41" y="-261"/>
+    </canvas>
+    <canvas name="19" width="93" height="250">
+      <vector name="origin" x="64" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-24" y="-240"/>
+    </canvas>
+    <canvas name="20" width="63" height="260">
+      <vector name="origin" x="56" y="268"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-21" y="-201"/>
+    </canvas>
+    <canvas name="21" width="56" height="297">
+      <vector name="origin" x="55" y="248"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-21" y="-201"/>
+    </canvas>
+    <canvas name="22" width="49" height="91">
+      <vector name="origin" x="55" y="235"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-21" y="-201"/>
+    </canvas>
+    <canvas name="23" width="49" height="105">
+      <vector name="origin" x="55" y="214"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-21" y="-201"/>
+    </canvas>
+    <canvas name="24" width="51" height="79">
+      <vector name="origin" x="47" y="185"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="600"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+      <vector name="head" x="-21" y="-201"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Arrogant humans... If you think this is over, you are gravely mistaken."/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787125.img.xml
+++ b/gms-server/wz/Mob.wz/8787125.img.xml
@@ -1,1 +1,1025 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787125.img"><imgdir name="info"><int name="level" value="120"/><int name="maxHP" value="999999999"/><int name="maxMP" value="999999999"/><int name="PADamage" value="1500"/><int name="MADamage" value="1500"/><int name="PDRate" value="25"/><int name="MDRate" value="25"/><int name="acc" value="300"/><string name="elemAttr" value="P2"/><int name="eva" value="80"/><int name="pushed" value="100000"/><float name="fs" value="10.0"/><int name="exp" value="500000"/><int name="summonType" value="1"/><int name="category" value="8"/><int name="firstAttack" value="1"/><string name="mobType" value="1N"/><int name="boss" value="1"/><imgdir name="attack"><imgdir name="0"><int name="action" value="1"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="2"/><int name="magic" value="1"/><int name="attackCount" value="3"/><int name="disease" value="123"/><int name="level" value="9"/></imgdir></imgdir><int name="ignoreMoveImpact" value="1"/><int name="bodyAttack" value="1"/><int name="speed" value="-10"/><int name="PDDamage" value="3000"/><int name="MDDamage" value="3000"/><int name="nonLevelCheckACC" value="1"/><int name="nonLevelCheckEVA" value="1"/><int name="notConsiderFieldSet" value="1"/><imgdir name="speak"><int name="chatBalloon" value="0"/><imgdir name="0"><string name="0" value="讓你後悔！"/></imgdir></imgdir><imgdir name="skill"><imgdir name="1"><int name="skill" value="145"/><int name="action" value="2"/><int name="level" value="2"/><int name="effectAfter" value="0"/></imgdir><imgdir name="0"><int name="skill" value="114"/><int name="action" value="1"/><int name="level" value="23"/><int name="effectAfter" value="0"/></imgdir></imgdir><int name="hpTagBgcolor" value="3"/><int name="hpTagColor" value="1"/></imgdir><imgdir name="stand"><canvas name="0" width="255" height="246"><vector name="origin" x="130" y="243"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-125" y="-224"/><vector name="rb" x="116" y="-10"/><string name="_hash" value="8c24f04892a98e251afd139a9659c6a46e56a49d047d62a6a4ff07a56af93b86"/></canvas><canvas name="1" width="254" height="246"><vector name="origin" x="130" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-125" y="-224"/><vector name="rb" x="116" y="-10"/><string name="_hash" value="a397d88b29437b34ac2b77bb24fe2b68d903c2da425462fef0cc388ae929c7e0"/></canvas><canvas name="2" width="255" height="233"><vector name="origin" x="130" y="230"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-125" y="-224"/><vector name="rb" x="116" y="-10"/><string name="_hash" value="710572e4e40f4f2b30fc62c9c554d45da34a76d6cd9ff997fe40db1dc1ce3032"/></canvas><canvas name="3" width="255" height="239"><vector name="origin" x="130" y="238"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-125" y="-224"/><vector name="rb" x="116" y="-10"/><string name="_hash" value="a45ab7142d5b3ad7dcb1a0d55a4bb790176325d5c5ed410bdd51e79d793d4071"/></canvas><canvas name="4" width="255" height="227"><vector name="origin" x="130" y="227"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-125" y="-224"/><vector name="rb" x="116" y="-10"/><string name="_hash" value="e337c8706c5e4a87d0805439de9d0935e22abc260a77f4bb3b8e7e63c180c734"/></canvas><canvas name="5" width="255" height="242"><vector name="origin" x="130" y="243"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-125" y="-224"/><vector name="rb" x="116" y="-10"/><string name="_hash" value="4dc0d7c2f3b4fe8f7d76c63e99456a733f826b69e833b17d5e0f495f89ba05b6"/></canvas><canvas name="6" width="255" height="252"><vector name="origin" x="130" y="252"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-125" y="-224"/><vector name="rb" x="116" y="-10"/><string name="_hash" value="670b4acbafde2bba6d49683e6565cf7f3133519952e7427cea8ad4f04679818f"/></canvas><canvas name="7" width="255" height="252"><vector name="origin" x="130" y="251"/><int name="z" value="0"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-125" y="-224"/><vector name="rb" x="116" y="-10"/><int name="delay" value="120"/><string name="_hash" value="303012421928dcc70131d9fde69c7b42e7d05d7b96e8abc4a757449718c2c52b"/></canvas></imgdir><imgdir name="move"><canvas name="0" width="259" height="246"><vector name="origin" x="134" y="243"/><int name="z" value="0"/><vector name="head" x="-8" y="-157"/><vector name="lt" x="-132" y="-207"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="5826510ec24f7f5711bbd599b04e25c1d038529e4f48c1c0164f9f2eec15f3eb"/></canvas><canvas name="1" width="257" height="246"><vector name="origin" x="133" y="241"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-8" y="-157"/><vector name="lt" x="-132" y="-207"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="f7949e6e67f2a84373187993f8398a393d6e0a4227a4b13db7350c11c5be3f9f"/></canvas><canvas name="2" width="259" height="233"><vector name="origin" x="134" y="230"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-8" y="-157"/><vector name="lt" x="-132" y="-207"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="fddf24f6497bed7bc59e9a3e8b32461863b0f952f24562d659caf1ab40cbec2a"/></canvas><canvas name="3" width="260" height="227"><vector name="origin" x="135" y="227"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-8" y="-157"/><vector name="lt" x="-132" y="-207"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="4d4c78629c12f2e16687d7c0719a3fae207d85ce1319f00a6048cc4e4d6619f1"/></canvas><canvas name="4" width="261" height="242"><vector name="origin" x="136" y="244"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-8" y="-157"/><vector name="lt" x="-132" y="-207"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="eb129d61b881bd05455bec562ef3268ff1091cd67ce1afbd454916778c93f458"/></canvas><canvas name="5" width="260" height="252"><vector name="origin" x="135" y="252"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-8" y="-157"/><vector name="lt" x="-132" y="-207"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="e32e1e7f0910d6cf1c30ddf552656d4f1bfafed075f2868bed45c8f2e69ebf1e"/></canvas></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-333" y="-325"/><vector name="rb" x="240" y="100"/></imgdir><imgdir name="hit"><canvas name="0" width="159" height="112"><vector name="origin" x="79" y="56"/><int name="z" value="0"/><int name="delay" value="60"/><string name="_hash" value="c409463e4d926877460ade99a68718c8c0259929f05e5629eb2359c665713339"/></canvas><canvas name="1" width="192" height="187"><vector name="origin" x="96" y="93"/><int name="z" value="0"/><int name="delay" value="60"/><string name="_hash" value="6fcf49cabd214dcc850c833773b3b7e0bc6eecae359f0f71ea05ee67163d1d89"/></canvas><canvas name="2" width="197" height="179"><vector name="origin" x="98" y="89"/><int name="z" value="0"/><int name="delay" value="60"/><string name="_hash" value="dc5d7cbbaaaafca1fd82537438ed90720ba33e559d14a16ff4d84ed96ce9aab3"/></canvas><canvas name="3" width="205" height="223"><vector name="origin" x="102" y="111"/><int name="z" value="0"/><int name="delay" value="60"/><string name="_hash" value="8bda67deca143c036410d4c046da32879e76aec265704d3ccd78fafb3400d06b"/></canvas><canvas name="4" width="198" height="210"><vector name="origin" x="99" y="105"/><int name="z" value="0"/><int name="delay" value="60"/><string name="_hash" value="7be1a18ecf779ddc85ab401d7f4398e9cae0c26e002b03155265090d6f71bf69"/></canvas><canvas name="5" width="184" height="185"><vector name="origin" x="92" y="92"/><int name="z" value="0"/><int name="delay" value="60"/><string name="_hash" value="d973660d13a7ad1817e94e277de76d63a71234b304bfb61d419eb5b2afe1cfb3"/></canvas><canvas name="6" width="201" height="164"><vector name="origin" x="100" y="82"/><int name="z" value="0"/><int name="delay" value="60"/><string name="_hash" value="ac9dd6027cd927bc759a99e8963fe48db2e0f6cda8fbad317cbee045b98df27a"/></canvas><canvas name="7" width="198" height="145"><vector name="origin" x="99" y="72"/><int name="z" value="0"/><int name="delay" value="60"/><string name="_hash" value="24d29499e6620c9a445cc38e7934dca1eb2850ea1112860eef91ed339823f4b3"/></canvas><canvas name="8" width="206" height="148"><vector name="origin" x="103" y="74"/><int name="z" value="0"/><int name="delay" value="60"/><string name="_hash" value="347ac42104d245b7e017d7faa51a5b0c55d9086af6869c43c1ced777b12fc0d4"/></canvas><canvas name="9" width="207" height="161"><vector name="origin" x="103" y="80"/><int name="z" value="0"/><int name="delay" value="60"/><string name="_hash" value="ac995c23eb2a2dcb95fd39106164618da3ac975aa88c3b0de06fdd94241ce773"/></canvas></imgdir><int name="attackAfter" value="720"/></imgdir><canvas name="0" width="255" height="246"><vector name="origin" x="130" y="243"/><vector name="head" x="3" y="-161"/><vector name="lt" x="-128" y="-205"/><vector name="rb" x="113" y="-11"/><int name="delay" value="100"/></canvas><canvas name="1" width="310" height="243"><vector name="origin" x="65" y="242"/><int name="delay" value="100"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-64" y="-210"/><vector name="rb" x="132" y="-11"/></canvas><canvas name="2" width="315" height="241"><vector name="origin" x="65" y="240"/><int name="delay" value="90"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-64" y="-210"/><vector name="rb" x="224" y="-7"/></canvas><canvas name="3" width="317" height="230"><vector name="origin" x="65" y="229"/><int name="delay" value="90"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-64" y="-210"/><vector name="rb" x="229" y="-9"/></canvas><canvas name="4" width="318" height="227"><vector name="origin" x="65" y="226"/><int name="delay" value="90"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-64" y="-210"/><vector name="rb" x="229" y="-9"/></canvas><canvas name="5" width="317" height="244"><vector name="origin" x="65" y="243"/><int name="delay" value="90"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-64" y="-210"/><vector name="rb" x="229" y="-9"/></canvas><canvas name="6" width="317" height="252"><vector name="origin" x="65" y="251"/><int name="delay" value="90"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-64" y="-210"/><vector name="rb" x="229" y="-9"/></canvas><canvas name="7" width="323" height="259"><vector name="origin" x="65" y="242"/><int name="delay" value="90"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-64" y="-210"/><vector name="rb" x="236" y="-1"/></canvas><canvas name="8" width="386" height="314"><vector name="origin" x="280" y="275"/><int name="delay" value="60"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-102" y="-219"/><vector name="rb" x="101" y="-11"/></canvas><canvas name="9" width="383" height="348"><vector name="origin" x="279" y="322"/><int name="delay" value="60"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-102" y="-219"/><vector name="rb" x="101" y="-11"/></canvas><canvas name="10" width="381" height="343"><vector name="origin" x="277" y="329"/><int name="delay" value="80"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-102" y="-219"/><vector name="rb" x="101" y="-11"/></canvas><canvas name="11" width="352" height="372"><vector name="origin" x="244" y="272"/><int name="delay" value="80"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-102" y="-219"/><vector name="rb" x="101" y="-11"/></canvas><canvas name="12" width="452" height="347"><vector name="origin" x="211" y="253"/><int name="delay" value="60"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-102" y="-219"/><vector name="rb" x="101" y="-11"/></canvas><canvas name="13" width="404" height="301"><vector name="origin" x="273" y="275"/><int name="delay" value="60"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-102" y="-219"/><vector name="rb" x="101" y="-11"/></canvas><canvas name="14" width="408" height="314"><vector name="origin" x="249" y="267"/><int name="delay" value="60"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-61" y="-215"/><vector name="rb" x="120" y="-9"/></canvas><canvas name="15" width="442" height="262"><vector name="origin" x="337" y="229"/><int name="delay" value="60"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-102" y="-219"/><vector name="rb" x="101" y="-11"/></canvas><canvas name="16" width="418" height="234"><vector name="origin" x="334" y="226"/><int name="delay" value="60"/><vector name="head" x="-21" y="-161"/><vector name="lt" x="-102" y="-219"/><vector name="rb" x="80" y="-11"/></canvas><canvas name="17" width="409" height="244"><vector name="origin" x="327" y="243"/><int name="delay" value="60"/></canvas><uol name="18" value="0"/><uol name="19" value="../stand/5"/><uol name="20" value="../stand/6"/><uol name="21" value="../stand/7"/></imgdir><imgdir name="hit1"><canvas name="0" width="268" height="243"><vector name="origin" x="110" y="242"/><vector name="head" x="32" y="-163"/><vector name="lt" x="-112" y="-212"/><vector name="rb" x="150" y="-14"/><int name="delay" value="300"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="255" height="246"><vector name="origin" x="130" y="243"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="150"/></canvas><canvas name="1" width="268" height="243"><vector name="origin" x="110" y="242"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="1" y="-161"/><string name="_hash" value="07a292263d1b5a85d258620faa49c8801fc492bf893e50bb1959c9ee64a02c15"/></canvas><canvas name="2" width="266" height="231"><vector name="origin" x="106" y="230"/><int name="z" value="0"/><int name="delay" value="180"/><vector name="head" x="1" y="-161"/><string name="_hash" value="b2aa446463aab979bb3705328e803e873e537c11aae966223464bb1ca59e541c"/></canvas><canvas name="3" width="267" height="237"><vector name="origin" x="104" y="236"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="1" y="-161"/><string name="_hash" value="ca00fb56f32a27c8ed080df5e41488b8ff1dcc44f9f6b7a1373e4de4fdfdb1d4"/></canvas><canvas name="4" width="268" height="240"><vector name="origin" x="103" y="239"/><int name="z" value="0"/><int name="delay" value="240"/><vector name="head" x="1" y="-161"/><string name="_hash" value="7f5c70c478ff9abe59ef19612a9d105335bc33408dd266338a9347cc0e3d38ef"/></canvas><canvas name="5" width="268" height="241"><vector name="origin" x="102" y="240"/><int name="z" value="0"/><int name="delay" value="240"/><vector name="head" x="1" y="-161"/><string name="_hash" value="0be9b5d853296243b08f8ca4cae318ed6c1ea36945bf90ad0c23581ddd6964fc"/></canvas><canvas name="6" width="268" height="237"><vector name="origin" x="101" y="236"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="1" y="-161"/><string name="_hash" value="6b4cc11f89c69f27152d88a289fb6ce7de6fcb7326d50a44b91485221e641a97"/></canvas><canvas name="7" width="268" height="203"><vector name="origin" x="100" y="202"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="1" y="-161"/><string name="_hash" value="e6820ac1ed49971bb7b2e99dfa2004fab67333e78d71707504659824fa04577d"/></canvas><canvas name="8" width="268" height="203"><vector name="origin" x="99" y="202"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="1" y="-161"/><string name="_hash" value="12eed69ebfa36119e3e50bd1b04272696576d9f500dc830ab462aa97adbdd537"/></canvas><canvas name="9" width="263" height="200"><vector name="origin" x="95" y="200"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="1" y="-161"/><string name="_hash" value="236bdc6fe24b5a3ebf7137117275370b757e442454b53508d886151a29976e25"/></canvas><canvas name="10" width="250" height="182"><vector name="origin" x="83" y="182"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="1" y="-161"/><string name="_hash" value="bb0c9b23cb9834fbfdea70a0110daed2d4b37f6cc48c3c35f0e7630c0cd00d36"/></canvas><canvas name="11" width="243" height="174"><vector name="origin" x="78" y="176"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="1" y="-161"/><string name="_hash" value="a7809463bf4fcc04577e3c7e0150e50ea7f604127e9c97b64481742ae73b84df"/></canvas><canvas name="12" width="231" height="150"><vector name="origin" x="72" y="155"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="1" y="-161"/><string name="_hash" value="5fa1a1b7acb82ec4dd86d1a9e436ece425dc44ad3b0e47c8834cea8c1f409d55"/></canvas><canvas name="13" width="213" height="141"><vector name="origin" x="56" y="150"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="1" y="-161"/><string name="_hash" value="5dcc758b5453db87846032bf5062f8c94c82d7057652b5a8170628d77882dee4"/></canvas><canvas name="14" width="96" height="98"><vector name="origin" x="-53" y="110"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="1" y="-161"/><string name="_hash" value="f21ff6a85910bbdb81054a1309205751b3ed97fd75b95b8ceab04bbe137c7a7d"/></canvas><canvas name="15" width="35" height="86"><vector name="origin" x="-59" y="106"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="1" y="-161"/><string name="_hash" value="47712c61a7a39ad84e21b7f1919725512c6e7c8391a807a133beab5aad271b95"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="佩服............."/></imgdir></imgdir><imgdir name="regen"><canvas name="0" width="163" height="121"><vector name="origin" x="-108" y="104"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="2d5b4ce04af61635ec2842256342be576b5fc9d09e32d089603db1775e2d6e08"/></canvas><canvas name="1" width="183" height="159"><vector name="origin" x="-106" y="143"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="08f18fb519dfabc13811fe5695be97446af01aa2f5a63e6169c86427900847da"/></canvas><canvas name="2" width="562" height="486"><vector name="origin" x="132" y="469"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d1607ffdd39ac479c56f08212818c58b4b2770867ce6974b681a918e4b1af62d"/></canvas><canvas name="3" width="857" height="510"><vector name="origin" x="429" y="467"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="74611b04713129a952214114ad5f3a67e17de98025136a5bf70c02a37a4b997a"/></canvas><canvas name="4" width="845" height="498"><vector name="origin" x="422" y="469"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="fb1bb021cee9da8db55c8c5c8f1172a0f043cece335c05a1d9789dd99fea6efd"/></canvas><canvas name="5" width="836" height="483"><vector name="origin" x="421" y="467"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="2b95b0d905f9724d1aa2056a8eee544fa28f1f70a7e2fdfa94d2284aa74400d4"/></canvas><canvas name="6" width="793" height="482"><vector name="origin" x="416" y="466"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="6a4333723be51fd634f9ab4f76f896b8ea30982a27382fd6be4f807a04cefa1a"/></canvas><canvas name="7" width="726" height="463"><vector name="origin" x="357" y="452"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="558ade5df104f10e6ed67f675aabccaf2f75c176787e5773916588a909169e08"/></canvas><canvas name="8" width="533" height="444"><vector name="origin" x="343" y="433"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7c8e52a0204be493c3ffe5252083c58840c290b8d61387790514b68fe5faf3cf"/></canvas><canvas name="9" width="371" height="425"><vector name="origin" x="176" y="422"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1c0eb9d184e2dbced20b2eb83e8309b97b2b91f55a4d2d4978cedd3454adffab"/></canvas><canvas name="10" width="424" height="397"><vector name="origin" x="248" y="338"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="16437ffb463403813a9e27257c8f5c082b8c68516e424d33b73c0fb62e4a78b1"/></canvas><canvas name="11" width="385" height="301"><vector name="origin" x="198" y="292"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="de14046a00143be908f436e605e8dfe9c7d843f7fc150b902c7fe3417fcdfbca"/></canvas><canvas name="12" width="435" height="346"><vector name="origin" x="171" y="337"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d217b903e9c3a334d57465863b8b45d0f878127409d006cc4ded285d34fa4622"/></canvas><canvas name="13" width="468" height="432"><vector name="origin" x="257" y="274"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9d6cdb634de2ef06a774f033c000c40f2212c44eb9c33a8879bb5af81a3975eb"/></canvas><canvas name="14" width="418" height="240"><vector name="origin" x="242" y="237"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9c2f93d25e7efb67d9d4db7e3cb27723cf673dbf3fb2a702f76f13b10ec808dd"/></canvas><canvas name="15" width="374" height="375"><vector name="origin" x="187" y="234"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f16caff1f49e670f85b0f547367480237c2b6f650ddc9af4f1f7b96b28960a0c"/></canvas><canvas name="16" width="457" height="398"><vector name="origin" x="146" y="230"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="eb168fae0855a88be358632e5efab06864084c789f062199d7dd29d879ed9f24"/></canvas><canvas name="17" width="423" height="463"><vector name="origin" x="228" y="317"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="25d8dbc5b1beef9695158c7dcdebf7d320124f865851554e3a7bdd218e5403d7"/></canvas><canvas name="18" width="386" height="400"><vector name="origin" x="210" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8dc822b25525620eae6286f9182b0282a35ad1c8bbc099332b90c348fd3f360e"/></canvas><canvas name="19" width="458" height="430"><vector name="origin" x="143" y="278"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9b99e5dbae7486f643c20ca1b8a195714f7d7220cfd5c24d62d06d7cfdaa552c"/></canvas><canvas name="20" width="549" height="530"><vector name="origin" x="260" y="390"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bbbf94179d8b8de33deec454905df9212420d786aea06e6f273da8914efc6003"/></canvas><canvas name="21" width="440" height="308"><vector name="origin" x="245" y="222"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="819b547a07bed2178b0cd455eef186d9e58325fd178dc9e0d5f94dfd5bc136b4"/></canvas><canvas name="22" width="350" height="334"><vector name="origin" x="162" y="282"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="20dada7a61f6c5acbd6656669dcb8dae0cad77f9535a411b279f811d06bce934"/></canvas><canvas name="23" width="396" height="360"><vector name="origin" x="182" y="294"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d96817664341ec31615119c3317afbf8880e068e4a419138bdcec93f798ef245"/></canvas><canvas name="24" width="396" height="376"><vector name="origin" x="180" y="302"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b477aa9892b05065b53d32944572f8ef9961091856c3824d38e2b4057924f1e6"/></canvas><canvas name="25" width="383" height="382"><vector name="origin" x="175" y="305"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="648519edf45df8cdd8fad397642263f24e6588d0ce13f9245c81facd50df75b4"/></canvas><canvas name="26" width="382" height="382"><vector name="origin" x="174" y="305"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="3d7f0258801842983faf3bf462aa409d698b50ad544062bbeaf54b5ac8c4ae5c"/></canvas><canvas name="27" width="378" height="378"><vector name="origin" x="172" y="303"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c40b980575aa2ba43279d47360b01fd65b19248ef865c329badfa6dd741c2ec6"/></canvas><canvas name="28" width="331" height="348"><vector name="origin" x="172" y="289"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="5c4328408b58d5d5514b3ecd6db47a086ec840925686dbb066f87e43cad0154e"/></canvas><canvas name="29" width="330" height="350"><vector name="origin" x="173" y="291"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="eacd10b2ce0d59556d84827a3203808f8fa794e0ca1c2a2468508fa846d7cfa4"/></canvas><canvas name="30" width="320" height="320"><vector name="origin" x="166" y="278"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="52a1aa3c869999c01c57dcc287b33e0bf3d36e7a6c33fa42d8de8e733792fdda"/></canvas><canvas name="31" width="315" height="315"><vector name="origin" x="168" y="280"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d5f9010cc7551da209e8350e452458be2cc6a21b838c3db9f6e6c33f7464dce2"/></canvas><canvas name="32" width="258" height="252"><vector name="origin" x="130" y="250"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b5c1514bc0d9509834b975f692178e6d9c6290fae67fef647c03a560699e7a11"/></canvas><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="偉大なお方のために！"/></imgdir></imgdir><imgdir name="skill1"><canvas name="0" width="256" height="248"><vector name="origin" x="130" y="243"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="901f9a18a5774272e940f79aef08e21b822a59ada9b58099f5657c0d68239f0e"/></canvas><canvas name="1" width="380" height="328"><vector name="origin" x="178" y="277"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="64226e1352f93ccfd53500ce559a456e2d1e0d407198ae2580ca611898806311"/></canvas><canvas name="2" width="376" height="324"><vector name="origin" x="176" y="275"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="ccbe7757472f8329d059c5392da84b920e37338abf59d9a2e01cda535b300c03"/></canvas><canvas name="3" width="368" height="372"><vector name="origin" x="172" y="300"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="117a182fd3e404959d642da2e6c348bd31f04b3bce5968b99b62945b3fdd3ab8"/></canvas><canvas name="4" width="332" height="384"><vector name="origin" x="153" y="306"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="982c0e745ab202102d1cf496436ad798b830d05475341f8db99cbbbdc1e50175"/></canvas><canvas name="5" width="328" height="380"><vector name="origin" x="151" y="304"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="33d005df1b1c233c81f36aea8db08d7b6ebf26dc290a19a227445773a3f7e520"/></canvas><canvas name="6" width="372" height="376"><vector name="origin" x="174" y="301"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="e4705e1ccf799791860b81c6ae50f84f5e47a8dfb109f060b223afc042eda796"/></canvas><canvas name="7" width="384" height="368"><vector name="origin" x="180" y="297"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="3ffbaa78e566b4ab5f29938435588be76e529ce0560569f13b82219951a0fd87"/></canvas><canvas name="8" width="320" height="420"><vector name="origin" x="151" y="419"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="a5aa40bd1965c1a7de17b55bdaf3915e76a5029a6e913f3d9e821e8b3ba8da3e"/></canvas><canvas name="9" width="288" height="408"><vector name="origin" x="139" y="404"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="3b9b8982c46c37e2f4ae57c4d401830ba50ee04479ebdd5b2f5270cda9553982"/></canvas><canvas name="10" width="284" height="408"><vector name="origin" x="135" y="405"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="3b4427253e23567cc876ac29ec814621d4c1746ae92dc9ed51b79a3db84cce4a"/></canvas><canvas name="11" width="288" height="408"><vector name="origin" x="136" y="407"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="0cc610047d56064385ab70e1b9f9a88af8aed8897de1545140d3279a8a3e4a03"/></canvas><canvas name="12" width="288" height="404"><vector name="origin" x="136" y="407"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="ba3c0c83652d48fb231eab1144a342840d6986eb32c5f0ae7c7e96e5f5ebf6b9"/></canvas><canvas name="13" width="284" height="372"><vector name="origin" x="134" y="405"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="b42ef4f024df8e6aa9e9022404c02a0865acba6378c6c14ccbf979eef31a476f"/></canvas><canvas name="14" width="256" height="356"><vector name="origin" x="130" y="379"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="79f3cc244f4682245a6a3e792995c78d1070336c89de9c1d6ce17769851e0804"/></canvas><canvas name="15" width="256" height="372"><vector name="origin" x="130" y="376"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="b7b6a04e3861269039b384cb41f321be60cf46d99466f3392516fb0ec215984e"/></canvas><uol name="16" value="../stand/5"/><uol name="17" value="../stand/6"/><uol name="18" value="../stand/7"/><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="別再耍些小把戲了.."/></imgdir></imgdir><imgdir name="skill2"><canvas name="0" width="256" height="248"><vector name="origin" x="130" y="243"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="901f9a18a5774272e940f79aef08e21b822a59ada9b58099f5657c0d68239f0e"/></canvas><canvas name="1" width="380" height="328"><vector name="origin" x="178" y="277"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="64226e1352f93ccfd53500ce559a456e2d1e0d407198ae2580ca611898806311"/></canvas><canvas name="2" width="376" height="324"><vector name="origin" x="176" y="275"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="ccbe7757472f8329d059c5392da84b920e37338abf59d9a2e01cda535b300c03"/></canvas><canvas name="3" width="368" height="372"><vector name="origin" x="172" y="300"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="117a182fd3e404959d642da2e6c348bd31f04b3bce5968b99b62945b3fdd3ab8"/></canvas><canvas name="4" width="332" height="384"><vector name="origin" x="153" y="306"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="982c0e745ab202102d1cf496436ad798b830d05475341f8db99cbbbdc1e50175"/></canvas><canvas name="5" width="328" height="380"><vector name="origin" x="151" y="304"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="33d005df1b1c233c81f36aea8db08d7b6ebf26dc290a19a227445773a3f7e520"/></canvas><canvas name="6" width="372" height="376"><vector name="origin" x="174" y="301"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="e4705e1ccf799791860b81c6ae50f84f5e47a8dfb109f060b223afc042eda796"/></canvas><canvas name="7" width="384" height="368"><vector name="origin" x="180" y="297"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="3ffbaa78e566b4ab5f29938435588be76e529ce0560569f13b82219951a0fd87"/></canvas><canvas name="8" width="320" height="420"><vector name="origin" x="151" y="419"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="a5aa40bd1965c1a7de17b55bdaf3915e76a5029a6e913f3d9e821e8b3ba8da3e"/></canvas><canvas name="9" width="288" height="408"><vector name="origin" x="139" y="404"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="3b9b8982c46c37e2f4ae57c4d401830ba50ee04479ebdd5b2f5270cda9553982"/></canvas><canvas name="10" width="284" height="408"><vector name="origin" x="135" y="405"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="3b4427253e23567cc876ac29ec814621d4c1746ae92dc9ed51b79a3db84cce4a"/></canvas><canvas name="11" width="288" height="408"><vector name="origin" x="136" y="407"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="0cc610047d56064385ab70e1b9f9a88af8aed8897de1545140d3279a8a3e4a03"/></canvas><canvas name="12" width="288" height="404"><vector name="origin" x="136" y="407"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="ba3c0c83652d48fb231eab1144a342840d6986eb32c5f0ae7c7e96e5f5ebf6b9"/></canvas><canvas name="13" width="284" height="372"><vector name="origin" x="134" y="405"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="b42ef4f024df8e6aa9e9022404c02a0865acba6378c6c14ccbf979eef31a476f"/></canvas><canvas name="14" width="256" height="356"><vector name="origin" x="130" y="379"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="79f3cc244f4682245a6a3e792995c78d1070336c89de9c1d6ce17769851e0804"/></canvas><canvas name="15" width="256" height="372"><vector name="origin" x="130" y="376"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="3" y="-160"/><vector name="lt" x="-130" y="-216"/><vector name="rb" x="123" y="-9"/><string name="_hash" value="b7b6a04e3861269039b384cb41f321be60cf46d99466f3392516fb0ec215984e"/></canvas><uol name="16" value="../stand/5"/><uol name="17" value="../stand/6"/><uol name="18" value="../stand/7"/></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787125.img">
+  <imgdir name="info">
+    <int name="level" value="120"/>
+    <int name="maxHP" value="999999999"/>
+    <int name="maxMP" value="999999999"/>
+    <int name="PADamage" value="1500"/>
+    <int name="MADamage" value="1500"/>
+    <int name="PDRate" value="25"/>
+    <int name="MDRate" value="25"/>
+    <int name="acc" value="300"/>
+    <string name="elemAttr" value="P2"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="500000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="magic" value="1"/>
+        <int name="attackCount" value="3"/>
+        <int name="disease" value="123"/>
+        <int name="level" value="9"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="speed" value="-10"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <int name="nonLevelCheckACC" value="1"/>
+    <int name="nonLevelCheckEVA" value="1"/>
+    <int name="notConsiderFieldSet" value="1"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="I will make you regret this!"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="skill">
+      <imgdir name="1">
+        <int name="skill" value="145"/>
+        <int name="action" value="2"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="0">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="23"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <int name="hpTagBgcolor" value="3"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="255" height="246">
+      <vector name="origin" x="130" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="8c24f04892a98e251afd139a9659c6a46e56a49d047d62a6a4ff07a56af93b86"/>
+    </canvas>
+    <canvas name="1" width="254" height="246">
+      <vector name="origin" x="130" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="a397d88b29437b34ac2b77bb24fe2b68d903c2da425462fef0cc388ae929c7e0"/>
+    </canvas>
+    <canvas name="2" width="255" height="233">
+      <vector name="origin" x="130" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="710572e4e40f4f2b30fc62c9c554d45da34a76d6cd9ff997fe40db1dc1ce3032"/>
+    </canvas>
+    <canvas name="3" width="255" height="239">
+      <vector name="origin" x="130" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="a45ab7142d5b3ad7dcb1a0d55a4bb790176325d5c5ed410bdd51e79d793d4071"/>
+    </canvas>
+    <canvas name="4" width="255" height="227">
+      <vector name="origin" x="130" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="e337c8706c5e4a87d0805439de9d0935e22abc260a77f4bb3b8e7e63c180c734"/>
+    </canvas>
+    <canvas name="5" width="255" height="242">
+      <vector name="origin" x="130" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="4dc0d7c2f3b4fe8f7d76c63e99456a733f826b69e833b17d5e0f495f89ba05b6"/>
+    </canvas>
+    <canvas name="6" width="255" height="252">
+      <vector name="origin" x="130" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <string name="_hash" value="670b4acbafde2bba6d49683e6565cf7f3133519952e7427cea8ad4f04679818f"/>
+    </canvas>
+    <canvas name="7" width="255" height="252">
+      <vector name="origin" x="130" y="251"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-125" y="-224"/>
+      <vector name="rb" x="116" y="-10"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="303012421928dcc70131d9fde69c7b42e7d05d7b96e8abc4a757449718c2c52b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="259" height="246">
+      <vector name="origin" x="134" y="243"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5826510ec24f7f5711bbd599b04e25c1d038529e4f48c1c0164f9f2eec15f3eb"/>
+    </canvas>
+    <canvas name="1" width="257" height="246">
+      <vector name="origin" x="133" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="f7949e6e67f2a84373187993f8398a393d6e0a4227a4b13db7350c11c5be3f9f"/>
+    </canvas>
+    <canvas name="2" width="259" height="233">
+      <vector name="origin" x="134" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="fddf24f6497bed7bc59e9a3e8b32461863b0f952f24562d659caf1ab40cbec2a"/>
+    </canvas>
+    <canvas name="3" width="260" height="227">
+      <vector name="origin" x="135" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="4d4c78629c12f2e16687d7c0719a3fae207d85ce1319f00a6048cc4e4d6619f1"/>
+    </canvas>
+    <canvas name="4" width="261" height="242">
+      <vector name="origin" x="136" y="244"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="eb129d61b881bd05455bec562ef3268ff1091cd67ce1afbd454916778c93f458"/>
+    </canvas>
+    <canvas name="5" width="260" height="252">
+      <vector name="origin" x="135" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-8" y="-157"/>
+      <vector name="lt" x="-132" y="-207"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="e32e1e7f0910d6cf1c30ddf552656d4f1bfafed075f2868bed45c8f2e69ebf1e"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-333" y="-325"/>
+        <vector name="rb" x="240" y="100"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="159" height="112">
+          <vector name="origin" x="79" y="56"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="c409463e4d926877460ade99a68718c8c0259929f05e5629eb2359c665713339"/>
+        </canvas>
+        <canvas name="1" width="192" height="187">
+          <vector name="origin" x="96" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="6fcf49cabd214dcc850c833773b3b7e0bc6eecae359f0f71ea05ee67163d1d89"/>
+        </canvas>
+        <canvas name="2" width="197" height="179">
+          <vector name="origin" x="98" y="89"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="dc5d7cbbaaaafca1fd82537438ed90720ba33e559d14a16ff4d84ed96ce9aab3"/>
+        </canvas>
+        <canvas name="3" width="205" height="223">
+          <vector name="origin" x="102" y="111"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="8bda67deca143c036410d4c046da32879e76aec265704d3ccd78fafb3400d06b"/>
+        </canvas>
+        <canvas name="4" width="198" height="210">
+          <vector name="origin" x="99" y="105"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="7be1a18ecf779ddc85ab401d7f4398e9cae0c26e002b03155265090d6f71bf69"/>
+        </canvas>
+        <canvas name="5" width="184" height="185">
+          <vector name="origin" x="92" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="d973660d13a7ad1817e94e277de76d63a71234b304bfb61d419eb5b2afe1cfb3"/>
+        </canvas>
+        <canvas name="6" width="201" height="164">
+          <vector name="origin" x="100" y="82"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="ac9dd6027cd927bc759a99e8963fe48db2e0f6cda8fbad317cbee045b98df27a"/>
+        </canvas>
+        <canvas name="7" width="198" height="145">
+          <vector name="origin" x="99" y="72"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="24d29499e6620c9a445cc38e7934dca1eb2850ea1112860eef91ed339823f4b3"/>
+        </canvas>
+        <canvas name="8" width="206" height="148">
+          <vector name="origin" x="103" y="74"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="347ac42104d245b7e017d7faa51a5b0c55d9086af6869c43c1ced777b12fc0d4"/>
+        </canvas>
+        <canvas name="9" width="207" height="161">
+          <vector name="origin" x="103" y="80"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="ac995c23eb2a2dcb95fd39106164618da3ac975aa88c3b0de06fdd94241ce773"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="720"/>
+    </imgdir>
+    <canvas name="0" width="255" height="246">
+      <vector name="origin" x="130" y="243"/>
+      <vector name="head" x="3" y="-161"/>
+      <vector name="lt" x="-128" y="-205"/>
+      <vector name="rb" x="113" y="-11"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="1" width="310" height="243">
+      <vector name="origin" x="65" y="242"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="132" y="-11"/>
+    </canvas>
+    <canvas name="2" width="315" height="241">
+      <vector name="origin" x="65" y="240"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="224" y="-7"/>
+    </canvas>
+    <canvas name="3" width="317" height="230">
+      <vector name="origin" x="65" y="229"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="229" y="-9"/>
+    </canvas>
+    <canvas name="4" width="318" height="227">
+      <vector name="origin" x="65" y="226"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="229" y="-9"/>
+    </canvas>
+    <canvas name="5" width="317" height="244">
+      <vector name="origin" x="65" y="243"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="229" y="-9"/>
+    </canvas>
+    <canvas name="6" width="317" height="252">
+      <vector name="origin" x="65" y="251"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="229" y="-9"/>
+    </canvas>
+    <canvas name="7" width="323" height="259">
+      <vector name="origin" x="65" y="242"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-64" y="-210"/>
+      <vector name="rb" x="236" y="-1"/>
+    </canvas>
+    <canvas name="8" width="386" height="314">
+      <vector name="origin" x="280" y="275"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="9" width="383" height="348">
+      <vector name="origin" x="279" y="322"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="10" width="381" height="343">
+      <vector name="origin" x="277" y="329"/>
+      <int name="delay" value="80"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="11" width="352" height="372">
+      <vector name="origin" x="244" y="272"/>
+      <int name="delay" value="80"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="12" width="452" height="347">
+      <vector name="origin" x="211" y="253"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="13" width="404" height="301">
+      <vector name="origin" x="273" y="275"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="14" width="408" height="314">
+      <vector name="origin" x="249" y="267"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-61" y="-215"/>
+      <vector name="rb" x="120" y="-9"/>
+    </canvas>
+    <canvas name="15" width="442" height="262">
+      <vector name="origin" x="337" y="229"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="101" y="-11"/>
+    </canvas>
+    <canvas name="16" width="418" height="234">
+      <vector name="origin" x="334" y="226"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="-21" y="-161"/>
+      <vector name="lt" x="-102" y="-219"/>
+      <vector name="rb" x="80" y="-11"/>
+    </canvas>
+    <canvas name="17" width="409" height="244">
+      <vector name="origin" x="327" y="243"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <uol name="18" value="0"/>
+    <uol name="19" value="../stand/5"/>
+    <uol name="20" value="../stand/6"/>
+    <uol name="21" value="../stand/7"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="268" height="243">
+      <vector name="origin" x="110" y="242"/>
+      <vector name="head" x="32" y="-163"/>
+      <vector name="lt" x="-112" y="-212"/>
+      <vector name="rb" x="150" y="-14"/>
+      <int name="delay" value="300"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="255" height="246">
+      <vector name="origin" x="130" y="243"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="268" height="243">
+      <vector name="origin" x="110" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="07a292263d1b5a85d258620faa49c8801fc492bf893e50bb1959c9ee64a02c15"/>
+    </canvas>
+    <canvas name="2" width="266" height="231">
+      <vector name="origin" x="106" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="b2aa446463aab979bb3705328e803e873e537c11aae966223464bb1ca59e541c"/>
+    </canvas>
+    <canvas name="3" width="267" height="237">
+      <vector name="origin" x="104" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="ca00fb56f32a27c8ed080df5e41488b8ff1dcc44f9f6b7a1373e4de4fdfdb1d4"/>
+    </canvas>
+    <canvas name="4" width="268" height="240">
+      <vector name="origin" x="103" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="7f5c70c478ff9abe59ef19612a9d105335bc33408dd266338a9347cc0e3d38ef"/>
+    </canvas>
+    <canvas name="5" width="268" height="241">
+      <vector name="origin" x="102" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="0be9b5d853296243b08f8ca4cae318ed6c1ea36945bf90ad0c23581ddd6964fc"/>
+    </canvas>
+    <canvas name="6" width="268" height="237">
+      <vector name="origin" x="101" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="6b4cc11f89c69f27152d88a289fb6ce7de6fcb7326d50a44b91485221e641a97"/>
+    </canvas>
+    <canvas name="7" width="268" height="203">
+      <vector name="origin" x="100" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="e6820ac1ed49971bb7b2e99dfa2004fab67333e78d71707504659824fa04577d"/>
+    </canvas>
+    <canvas name="8" width="268" height="203">
+      <vector name="origin" x="99" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="12eed69ebfa36119e3e50bd1b04272696576d9f500dc830ab462aa97adbdd537"/>
+    </canvas>
+    <canvas name="9" width="263" height="200">
+      <vector name="origin" x="95" y="200"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="236bdc6fe24b5a3ebf7137117275370b757e442454b53508d886151a29976e25"/>
+    </canvas>
+    <canvas name="10" width="250" height="182">
+      <vector name="origin" x="83" y="182"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="bb0c9b23cb9834fbfdea70a0110daed2d4b37f6cc48c3c35f0e7630c0cd00d36"/>
+    </canvas>
+    <canvas name="11" width="243" height="174">
+      <vector name="origin" x="78" y="176"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="a7809463bf4fcc04577e3c7e0150e50ea7f604127e9c97b64481742ae73b84df"/>
+    </canvas>
+    <canvas name="12" width="231" height="150">
+      <vector name="origin" x="72" y="155"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="5fa1a1b7acb82ec4dd86d1a9e436ece425dc44ad3b0e47c8834cea8c1f409d55"/>
+    </canvas>
+    <canvas name="13" width="213" height="141">
+      <vector name="origin" x="56" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="5dcc758b5453db87846032bf5062f8c94c82d7057652b5a8170628d77882dee4"/>
+    </canvas>
+    <canvas name="14" width="96" height="98">
+      <vector name="origin" x="-53" y="110"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="f21ff6a85910bbdb81054a1309205751b3ed97fd75b95b8ceab04bbe137c7a7d"/>
+    </canvas>
+    <canvas name="15" width="35" height="86">
+      <vector name="origin" x="-59" y="106"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="1" y="-161"/>
+      <string name="_hash" value="47712c61a7a39ad84e21b7f1919725512c6e7c8391a807a133beab5aad271b95"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Impressive............."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="regen">
+    <canvas name="0" width="163" height="121">
+      <vector name="origin" x="-108" y="104"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2d5b4ce04af61635ec2842256342be576b5fc9d09e32d089603db1775e2d6e08"/>
+    </canvas>
+    <canvas name="1" width="183" height="159">
+      <vector name="origin" x="-106" y="143"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="08f18fb519dfabc13811fe5695be97446af01aa2f5a63e6169c86427900847da"/>
+    </canvas>
+    <canvas name="2" width="562" height="486">
+      <vector name="origin" x="132" y="469"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d1607ffdd39ac479c56f08212818c58b4b2770867ce6974b681a918e4b1af62d"/>
+    </canvas>
+    <canvas name="3" width="857" height="510">
+      <vector name="origin" x="429" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74611b04713129a952214114ad5f3a67e17de98025136a5bf70c02a37a4b997a"/>
+    </canvas>
+    <canvas name="4" width="845" height="498">
+      <vector name="origin" x="422" y="469"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fb1bb021cee9da8db55c8c5c8f1172a0f043cece335c05a1d9789dd99fea6efd"/>
+    </canvas>
+    <canvas name="5" width="836" height="483">
+      <vector name="origin" x="421" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2b95b0d905f9724d1aa2056a8eee544fa28f1f70a7e2fdfa94d2284aa74400d4"/>
+    </canvas>
+    <canvas name="6" width="793" height="482">
+      <vector name="origin" x="416" y="466"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a4333723be51fd634f9ab4f76f896b8ea30982a27382fd6be4f807a04cefa1a"/>
+    </canvas>
+    <canvas name="7" width="726" height="463">
+      <vector name="origin" x="357" y="452"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="558ade5df104f10e6ed67f675aabccaf2f75c176787e5773916588a909169e08"/>
+    </canvas>
+    <canvas name="8" width="533" height="444">
+      <vector name="origin" x="343" y="433"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7c8e52a0204be493c3ffe5252083c58840c290b8d61387790514b68fe5faf3cf"/>
+    </canvas>
+    <canvas name="9" width="371" height="425">
+      <vector name="origin" x="176" y="422"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1c0eb9d184e2dbced20b2eb83e8309b97b2b91f55a4d2d4978cedd3454adffab"/>
+    </canvas>
+    <canvas name="10" width="424" height="397">
+      <vector name="origin" x="248" y="338"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="16437ffb463403813a9e27257c8f5c082b8c68516e424d33b73c0fb62e4a78b1"/>
+    </canvas>
+    <canvas name="11" width="385" height="301">
+      <vector name="origin" x="198" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="de14046a00143be908f436e605e8dfe9c7d843f7fc150b902c7fe3417fcdfbca"/>
+    </canvas>
+    <canvas name="12" width="435" height="346">
+      <vector name="origin" x="171" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d217b903e9c3a334d57465863b8b45d0f878127409d006cc4ded285d34fa4622"/>
+    </canvas>
+    <canvas name="13" width="468" height="432">
+      <vector name="origin" x="257" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9d6cdb634de2ef06a774f033c000c40f2212c44eb9c33a8879bb5af81a3975eb"/>
+    </canvas>
+    <canvas name="14" width="418" height="240">
+      <vector name="origin" x="242" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9c2f93d25e7efb67d9d4db7e3cb27723cf673dbf3fb2a702f76f13b10ec808dd"/>
+    </canvas>
+    <canvas name="15" width="374" height="375">
+      <vector name="origin" x="187" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f16caff1f49e670f85b0f547367480237c2b6f650ddc9af4f1f7b96b28960a0c"/>
+    </canvas>
+    <canvas name="16" width="457" height="398">
+      <vector name="origin" x="146" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="eb168fae0855a88be358632e5efab06864084c789f062199d7dd29d879ed9f24"/>
+    </canvas>
+    <canvas name="17" width="423" height="463">
+      <vector name="origin" x="228" y="317"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="25d8dbc5b1beef9695158c7dcdebf7d320124f865851554e3a7bdd218e5403d7"/>
+    </canvas>
+    <canvas name="18" width="386" height="400">
+      <vector name="origin" x="210" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8dc822b25525620eae6286f9182b0282a35ad1c8bbc099332b90c348fd3f360e"/>
+    </canvas>
+    <canvas name="19" width="458" height="430">
+      <vector name="origin" x="143" y="278"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9b99e5dbae7486f643c20ca1b8a195714f7d7220cfd5c24d62d06d7cfdaa552c"/>
+    </canvas>
+    <canvas name="20" width="549" height="530">
+      <vector name="origin" x="260" y="390"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bbbf94179d8b8de33deec454905df9212420d786aea06e6f273da8914efc6003"/>
+    </canvas>
+    <canvas name="21" width="440" height="308">
+      <vector name="origin" x="245" y="222"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="819b547a07bed2178b0cd455eef186d9e58325fd178dc9e0d5f94dfd5bc136b4"/>
+    </canvas>
+    <canvas name="22" width="350" height="334">
+      <vector name="origin" x="162" y="282"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="20dada7a61f6c5acbd6656669dcb8dae0cad77f9535a411b279f811d06bce934"/>
+    </canvas>
+    <canvas name="23" width="396" height="360">
+      <vector name="origin" x="182" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d96817664341ec31615119c3317afbf8880e068e4a419138bdcec93f798ef245"/>
+    </canvas>
+    <canvas name="24" width="396" height="376">
+      <vector name="origin" x="180" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b477aa9892b05065b53d32944572f8ef9961091856c3824d38e2b4057924f1e6"/>
+    </canvas>
+    <canvas name="25" width="383" height="382">
+      <vector name="origin" x="175" y="305"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="648519edf45df8cdd8fad397642263f24e6588d0ce13f9245c81facd50df75b4"/>
+    </canvas>
+    <canvas name="26" width="382" height="382">
+      <vector name="origin" x="174" y="305"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3d7f0258801842983faf3bf462aa409d698b50ad544062bbeaf54b5ac8c4ae5c"/>
+    </canvas>
+    <canvas name="27" width="378" height="378">
+      <vector name="origin" x="172" y="303"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c40b980575aa2ba43279d47360b01fd65b19248ef865c329badfa6dd741c2ec6"/>
+    </canvas>
+    <canvas name="28" width="331" height="348">
+      <vector name="origin" x="172" y="289"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5c4328408b58d5d5514b3ecd6db47a086ec840925686dbb066f87e43cad0154e"/>
+    </canvas>
+    <canvas name="29" width="330" height="350">
+      <vector name="origin" x="173" y="291"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="eacd10b2ce0d59556d84827a3203808f8fa794e0ca1c2a2468508fa846d7cfa4"/>
+    </canvas>
+    <canvas name="30" width="320" height="320">
+      <vector name="origin" x="166" y="278"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="52a1aa3c869999c01c57dcc287b33e0bf3d36e7a6c33fa42d8de8e733792fdda"/>
+    </canvas>
+    <canvas name="31" width="315" height="315">
+      <vector name="origin" x="168" y="280"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d5f9010cc7551da209e8350e452458be2cc6a21b838c3db9f6e6c33f7464dce2"/>
+    </canvas>
+    <canvas name="32" width="258" height="252">
+      <vector name="origin" x="130" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b5c1514bc0d9509834b975f692178e6d9c6290fae67fef647c03a560699e7a11"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="For the great master!"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="130" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="901f9a18a5774272e940f79aef08e21b822a59ada9b58099f5657c0d68239f0e"/>
+    </canvas>
+    <canvas name="1" width="380" height="328">
+      <vector name="origin" x="178" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="64226e1352f93ccfd53500ce559a456e2d1e0d407198ae2580ca611898806311"/>
+    </canvas>
+    <canvas name="2" width="376" height="324">
+      <vector name="origin" x="176" y="275"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="ccbe7757472f8329d059c5392da84b920e37338abf59d9a2e01cda535b300c03"/>
+    </canvas>
+    <canvas name="3" width="368" height="372">
+      <vector name="origin" x="172" y="300"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="117a182fd3e404959d642da2e6c348bd31f04b3bce5968b99b62945b3fdd3ab8"/>
+    </canvas>
+    <canvas name="4" width="332" height="384">
+      <vector name="origin" x="153" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="982c0e745ab202102d1cf496436ad798b830d05475341f8db99cbbbdc1e50175"/>
+    </canvas>
+    <canvas name="5" width="328" height="380">
+      <vector name="origin" x="151" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="33d005df1b1c233c81f36aea8db08d7b6ebf26dc290a19a227445773a3f7e520"/>
+    </canvas>
+    <canvas name="6" width="372" height="376">
+      <vector name="origin" x="174" y="301"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="e4705e1ccf799791860b81c6ae50f84f5e47a8dfb109f060b223afc042eda796"/>
+    </canvas>
+    <canvas name="7" width="384" height="368">
+      <vector name="origin" x="180" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3ffbaa78e566b4ab5f29938435588be76e529ce0560569f13b82219951a0fd87"/>
+    </canvas>
+    <canvas name="8" width="320" height="420">
+      <vector name="origin" x="151" y="419"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="a5aa40bd1965c1a7de17b55bdaf3915e76a5029a6e913f3d9e821e8b3ba8da3e"/>
+    </canvas>
+    <canvas name="9" width="288" height="408">
+      <vector name="origin" x="139" y="404"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3b9b8982c46c37e2f4ae57c4d401830ba50ee04479ebdd5b2f5270cda9553982"/>
+    </canvas>
+    <canvas name="10" width="284" height="408">
+      <vector name="origin" x="135" y="405"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3b4427253e23567cc876ac29ec814621d4c1746ae92dc9ed51b79a3db84cce4a"/>
+    </canvas>
+    <canvas name="11" width="288" height="408">
+      <vector name="origin" x="136" y="407"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="0cc610047d56064385ab70e1b9f9a88af8aed8897de1545140d3279a8a3e4a03"/>
+    </canvas>
+    <canvas name="12" width="288" height="404">
+      <vector name="origin" x="136" y="407"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="ba3c0c83652d48fb231eab1144a342840d6986eb32c5f0ae7c7e96e5f5ebf6b9"/>
+    </canvas>
+    <canvas name="13" width="284" height="372">
+      <vector name="origin" x="134" y="405"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="b42ef4f024df8e6aa9e9022404c02a0865acba6378c6c14ccbf979eef31a476f"/>
+    </canvas>
+    <canvas name="14" width="256" height="356">
+      <vector name="origin" x="130" y="379"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="79f3cc244f4682245a6a3e792995c78d1070336c89de9c1d6ce17769851e0804"/>
+    </canvas>
+    <canvas name="15" width="256" height="372">
+      <vector name="origin" x="130" y="376"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="b7b6a04e3861269039b384cb41f321be60cf46d99466f3392516fb0ec215984e"/>
+    </canvas>
+    <uol name="16" value="../stand/5"/>
+    <uol name="17" value="../stand/6"/>
+    <uol name="18" value="../stand/7"/>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Stop playing your petty tricks."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="130" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="901f9a18a5774272e940f79aef08e21b822a59ada9b58099f5657c0d68239f0e"/>
+    </canvas>
+    <canvas name="1" width="380" height="328">
+      <vector name="origin" x="178" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="64226e1352f93ccfd53500ce559a456e2d1e0d407198ae2580ca611898806311"/>
+    </canvas>
+    <canvas name="2" width="376" height="324">
+      <vector name="origin" x="176" y="275"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="ccbe7757472f8329d059c5392da84b920e37338abf59d9a2e01cda535b300c03"/>
+    </canvas>
+    <canvas name="3" width="368" height="372">
+      <vector name="origin" x="172" y="300"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="117a182fd3e404959d642da2e6c348bd31f04b3bce5968b99b62945b3fdd3ab8"/>
+    </canvas>
+    <canvas name="4" width="332" height="384">
+      <vector name="origin" x="153" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="982c0e745ab202102d1cf496436ad798b830d05475341f8db99cbbbdc1e50175"/>
+    </canvas>
+    <canvas name="5" width="328" height="380">
+      <vector name="origin" x="151" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="33d005df1b1c233c81f36aea8db08d7b6ebf26dc290a19a227445773a3f7e520"/>
+    </canvas>
+    <canvas name="6" width="372" height="376">
+      <vector name="origin" x="174" y="301"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="e4705e1ccf799791860b81c6ae50f84f5e47a8dfb109f060b223afc042eda796"/>
+    </canvas>
+    <canvas name="7" width="384" height="368">
+      <vector name="origin" x="180" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3ffbaa78e566b4ab5f29938435588be76e529ce0560569f13b82219951a0fd87"/>
+    </canvas>
+    <canvas name="8" width="320" height="420">
+      <vector name="origin" x="151" y="419"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="a5aa40bd1965c1a7de17b55bdaf3915e76a5029a6e913f3d9e821e8b3ba8da3e"/>
+    </canvas>
+    <canvas name="9" width="288" height="408">
+      <vector name="origin" x="139" y="404"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3b9b8982c46c37e2f4ae57c4d401830ba50ee04479ebdd5b2f5270cda9553982"/>
+    </canvas>
+    <canvas name="10" width="284" height="408">
+      <vector name="origin" x="135" y="405"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="3b4427253e23567cc876ac29ec814621d4c1746ae92dc9ed51b79a3db84cce4a"/>
+    </canvas>
+    <canvas name="11" width="288" height="408">
+      <vector name="origin" x="136" y="407"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="0cc610047d56064385ab70e1b9f9a88af8aed8897de1545140d3279a8a3e4a03"/>
+    </canvas>
+    <canvas name="12" width="288" height="404">
+      <vector name="origin" x="136" y="407"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="ba3c0c83652d48fb231eab1144a342840d6986eb32c5f0ae7c7e96e5f5ebf6b9"/>
+    </canvas>
+    <canvas name="13" width="284" height="372">
+      <vector name="origin" x="134" y="405"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="b42ef4f024df8e6aa9e9022404c02a0865acba6378c6c14ccbf979eef31a476f"/>
+    </canvas>
+    <canvas name="14" width="256" height="356">
+      <vector name="origin" x="130" y="379"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="79f3cc244f4682245a6a3e792995c78d1070336c89de9c1d6ce17769851e0804"/>
+    </canvas>
+    <canvas name="15" width="256" height="372">
+      <vector name="origin" x="130" y="376"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="3" y="-160"/>
+      <vector name="lt" x="-130" y="-216"/>
+      <vector name="rb" x="123" y="-9"/>
+      <string name="_hash" value="b7b6a04e3861269039b384cb41f321be60cf46d99466f3392516fb0ec215984e"/>
+    </canvas>
+    <uol name="16" value="../stand/5"/>
+    <uol name="17" value="../stand/6"/>
+    <uol name="18" value="../stand/7"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787126.img.xml
+++ b/gms-server/wz/Mob.wz/8787126.img.xml
@@ -1,1 +1,551 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787126.img"><imgdir name="info"><int name="level" value="10"/><int name="maxHP" value="500"/><int name="maxMP" value="0"/><int name="PADamage" value="10"/><int name="PDDamage" value="10"/><int name="PDRate" value="1"/><int name="MADamage" value="10"/><int name="MDDamage" value="10"/><int name="MDRate" value="1"/><int name="acc" value="0"/><int name="eva" value="0"/><int name="pushed" value="1"/><float name="fs" value="10.0"/><int name="exp" value="0"/><int name="summonType" value="1"/><string name="mobType" value="1N"/><int name="bodyAttack" value="0"/><int name="fixedDamage" value="1"/><int name="individualReward" value="1"/><int name="firstAttack" value="1"/><int name="ignoreFieldOut" value="1"/><int name="explosiveReward" value="1"/><int name="removeAfter" value="360000"/><int name="boss" value="1"/><int name="speed" value="-40"/><imgdir name="speak"><imgdir name="0"><int name="hp" value="1649"/><string name="0" value="わたしを元の姿に戻してくだされ！勇者殿！"/></imgdir><int name="chatBalloon" value="0"/></imgdir><int name="onlyNormalAttack" value="1"/></imgdir><imgdir name="move"><canvas name="0" width="252" height="335"><vector name="origin" x="138" y="334"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="21700974f8bf0eb26a811b3316c06f2d29cf13bbd8a184eb5711f3eced135db6"/></canvas><canvas name="1" width="260" height="339"><vector name="origin" x="150" y="338"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="74c80dbbb1005cb9d35edcb22bf6968f6f01f1b7b89fd0597ec3b1ec1bc3b407"/></canvas><canvas name="2" width="268" height="335"><vector name="origin" x="158" y="334"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="5c0e4a18515b275c20f9c6def0bcd92ffd7019d22e1aaaa54a7e1cbe1a283b26"/></canvas><canvas name="3" width="236" height="319"><vector name="origin" x="118" y="318"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="23c512a46ff5e3a6512aa7aab5678e7f952b85d8ed2a3d49b59220780a565c50"/></canvas><canvas name="4" width="176" height="315"><vector name="origin" x="94" y="314"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="389acc18a2346512ba51add8fb1db094b0cc5b8e3a56cb74d42d221d54eae97c"/></canvas><canvas name="5" width="204" height="319"><vector name="origin" x="130" y="318"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="14339c0eb86ced079bf71ff0f9b520b1273a467d7c6fb93004495b06bd701215"/></canvas><canvas name="6" width="228" height="319"><vector name="origin" x="146" y="318"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="7354379894103d4fe0274be2c6b58545270f01250d17abf03cceabab7cc9ed35"/></canvas><canvas name="7" width="236" height="319"><vector name="origin" x="98" y="318"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="61ea2ba32231a09f84eac4386adf39dcf97213bd8e942811393de9b2b78193c6"/></canvas><canvas name="8" width="236" height="323"><vector name="origin" x="82" y="322"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="da667621d11b0a055a3ba5a1f625d3da88d6de1285747d26c916d13753350790"/></canvas><canvas name="9" width="176" height="315"><vector name="origin" x="18" y="314"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="10" width="204" height="319"><vector name="origin" x="98" y="318"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="11" width="228" height="319"><vector name="origin" x="138" y="318"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><imgdir name="speak"><int name="prob" value="15"/><string name="0" value="わたしを元の姿に戻してくだされ！勇者殿！"/><string name="1" value="おーい！助けてくだされ～!!"/></imgdir></imgdir><imgdir name="stand"><canvas name="0" width="232" height="324"><vector name="origin" x="115" y="324"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="5cafe798c74ff494e9ccb944b25eeb5bc06da6ee587ce1f005e20dd00dcdd653"/></canvas><canvas name="1" width="216" height="320"><vector name="origin" x="99" y="320"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="4c9392ce466ed568da8db90854e405f1b4e74af72a3e98b33344d698a0ba4191"/></canvas><canvas name="2" width="216" height="324"><vector name="origin" x="99" y="324"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="f2e5532d31c36fe61b187c1315f2f7b6d328488d46551f020c77e1c877ab12b9"/></canvas><canvas name="3" width="236" height="328"><vector name="origin" x="123" y="328"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="04c9026b7a55b46a51adc75e7226c49dbe77fd0f509d5502e710975fcdcc053b"/></canvas><canvas name="4" width="240" height="316"><vector name="origin" x="143" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="7ef69a04c4d380fb8311cd5de9300aa06b41b1d1eb007e92b7bfad5fb01bcc53"/></canvas><canvas name="5" width="236" height="324"><vector name="origin" x="111" y="324"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="38c57922577283ca970c12ea9a8d40a4f7bf348bc508ab3bd5967cbc415c020c"/></canvas><canvas name="6" width="236" height="324"><vector name="origin" x="83" y="324"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="0cdfc4f70b115f0e9a2950fcfc8893b761df4bbf5214b72788894b97041102dd"/></canvas><canvas name="7" width="236" height="316"><vector name="origin" x="107" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="4846e83d60f76965d31a4ae2ddcb83ac7def91e90afac5dc9ab4ccfbc395809e"/></canvas><canvas name="8" width="176" height="312"><vector name="origin" x="27" y="312"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="1044cf513ae40f68fbe78c1745d1e96291c20b7c4569ba7a4468075c48bf8a60"/></canvas><canvas name="9" width="204" height="316"><vector name="origin" x="63" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="2cb962ecc822cab6da8abc793533944c2e9d459cf09dcd287013f6f8abc53f94"/></canvas><canvas name="10" width="228" height="312"><vector name="origin" x="107" y="312"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="4706f6db66073862fbf4668e0676d79dca3e50898590d52da03dd4ed7bf0d769"/></canvas><canvas name="11" width="228" height="308"><vector name="origin" x="107" y="308"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="cce9f7fcc716382db69ecd31ed1826db7829e30b86cf04e4bf23a03e288405b6"/></canvas><canvas name="12" width="216" height="320"><vector name="origin" x="103" y="320"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="13" width="236" height="328"><vector name="origin" x="127" y="328"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="14" width="240" height="316"><vector name="origin" x="147" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="15" width="236" height="316"><vector name="origin" x="111" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="43bdee24bb984baf66e9d3d506ad6aa5920ff542bf47231fdb0beecff40fa8fd"/></canvas><canvas name="16" width="248" height="312"><vector name="origin" x="119" y="312"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="97b15a5968f863da21abb39d4e7eba32a9b4f0dceb2f79a34779f029c25e5850"/></canvas><canvas name="17" width="244" height="312"><vector name="origin" x="119" y="312"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="8d03ffe71b87ba470d6cdde49a37a01847ff3d6fb6c23a21d9fe019f3a713201"/></canvas><canvas name="18" width="232" height="300"><vector name="origin" x="103" y="300"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="6f5b1e22a7a08e342440116b5143cfdbc2b6850184ffa03f41241f3e60fcc604"/></canvas><canvas name="19" width="264" height="312"><vector name="origin" x="99" y="312"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="d75063ce484782086f8bfd1e7a1ee66b18427e96304358c1b65890dde517a481"/></canvas><canvas name="20" width="252" height="308"><vector name="origin" x="123" y="308"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="aeaf519ea14bcd1ecb1154604fbe6f30f40fad0664dde82cc031b44b91f0c130"/></canvas><canvas name="21" width="264" height="316"><vector name="origin" x="127" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="d1dc836e5085c7c1b94d786f16c149e65f7f3e97aa1d5f1698d3e585be5ae03c"/></canvas><canvas name="22" width="240" height="308"><vector name="origin" x="131" y="308"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="f845179e24cab4241f2d172e63ad19306342f64f75e17e5776f887a9c98c393a"/></canvas><canvas name="23" width="264" height="316"><vector name="origin" x="127" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="24" width="216" height="320"><vector name="origin" x="95" y="320"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="8368e04ad97252d7896704bb947009438dd4b69d4dd6014c7dee049bc018215b"/></canvas><canvas name="25" width="216" height="324"><vector name="origin" x="95" y="324"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="5fb0e8e81e5ae5323a9d4a63da18415bdc5d4174bceb63e05b021113993c6012"/></canvas><canvas name="26" width="216" height="320"><vector name="origin" x="95" y="320"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="27" width="236" height="316"><vector name="origin" x="71" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="28" width="264" height="316"><vector name="origin" x="127" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="29" width="252" height="308"><vector name="origin" x="119" y="308"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="30" width="240" height="316"><vector name="origin" x="171" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="31" width="260" height="316"><vector name="origin" x="135" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="46207cd9d0afdf4dc6b3d85a4e283d4b0c3a99b7f55316246b191e98d8ef69dd"/></canvas><canvas name="32" width="236" height="308"><vector name="origin" x="103" y="308"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><string name="_hash" value="9d0b54d373ce2e8249c1a3d2b1fa36010dd1e25dc783bceb65956deaf7460056"/></canvas><canvas name="33" width="236" height="316"><vector name="origin" x="123" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="34" width="252" height="308"><vector name="origin" x="111" y="308"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="35" width="240" height="308"><vector name="origin" x="123" y="308"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="36" width="264" height="316"><vector name="origin" x="119" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="37" width="248" height="312"><vector name="origin" x="123" y="312"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas><canvas name="38" width="236" height="328"><vector name="origin" x="131" y="328"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="248" height="312"><vector name="origin" x="118" y="327"/><vector name="lt" x="-123" y="-333"/><vector name="rb" x="95" y="0"/><vector name="head" x="-39" y="-286"/><int name="delay" value="120"/><int name="z" value="0"/><string name="_hash" value="5235befd95593a19a2f2e5eed85cbfdee952b6fe99b8cb88490a819ef2d3a665"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="296" height="344"><vector name="origin" x="138" y="344"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d250972e1702238d617c6f6773cf393afd40817a9b2505ae50d03d6fb7077959"/></canvas><canvas name="1" width="288" height="364"><vector name="origin" x="94" y="380"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c8c06db5287fec1610ce7424aab73dc86748c19ea691334d84ef81d580b1154e"/></canvas><canvas name="2" width="316" height="356"><vector name="origin" x="70" y="394"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="840be8ddf174224f7eea6c83b7304e7acc750d15fc3516aed608dde62601f820"/></canvas><canvas name="3" width="296" height="344"><vector name="origin" x="30" y="394"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="330ec8cbbad2ab0893646c88801fb1cb855a07e88a83e3f4eb5ad6a278704047"/></canvas><canvas name="4" width="288" height="364"><vector name="origin" x="-6" y="392"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="da7b7690971a3811e1e4833a2a0e3e8d369eac84f7d40fb2e1a0e23f21f328c0"/></canvas><canvas name="5" width="316" height="356"><vector name="origin" x="-22" y="392"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="6cdad95124b95cd562180c364cfd83aa4b171a801fee8445d001e82167accc81"/></canvas><canvas name="6" width="296" height="344"><vector name="origin" x="-70" y="380"/><int name="z" value="0"/><string name="_hash" value="0e63844a7470823087ad723dd08671b26aae2b936afbe0f84b9e339e56c62fbb"/></canvas><canvas name="7" width="288" height="364"><vector name="origin" x="-82" y="368"/><int name="z" value="0"/><string name="_hash" value="bc4d79a27b30eba1b45fe7f0174f2566428cda96bd1dfd97effee102c03929fc"/></canvas><canvas name="8" width="1" height="1"><vector name="origin" x="-91" y="368"/><int name="z" value="0"/></canvas></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787126.img">
+  <imgdir name="info">
+    <int name="level" value="10"/>
+    <int name="maxHP" value="500"/>
+    <int name="maxMP" value="0"/>
+    <int name="PADamage" value="10"/>
+    <int name="PDDamage" value="10"/>
+    <int name="PDRate" value="1"/>
+    <int name="MADamage" value="10"/>
+    <int name="MDDamage" value="10"/>
+    <int name="MDRate" value="1"/>
+    <int name="acc" value="0"/>
+    <int name="eva" value="0"/>
+    <int name="pushed" value="1"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="0"/>
+    <int name="summonType" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="bodyAttack" value="0"/>
+    <int name="fixedDamage" value="1"/>
+    <int name="individualReward" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="ignoreFieldOut" value="1"/>
+    <int name="explosiveReward" value="1"/>
+    <int name="removeAfter" value="360000"/>
+    <int name="boss" value="1"/>
+    <int name="speed" value="-40"/>
+    <imgdir name="speak">
+      <imgdir name="0">
+        <int name="hp" value="1649"/>
+        <string name="0" value="Please restore me to my true form, brave hero!"/>
+      </imgdir>
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+    <int name="onlyNormalAttack" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="252" height="335">
+      <vector name="origin" x="138" y="334"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="21700974f8bf0eb26a811b3316c06f2d29cf13bbd8a184eb5711f3eced135db6"/>
+    </canvas>
+    <canvas name="1" width="260" height="339">
+      <vector name="origin" x="150" y="338"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="74c80dbbb1005cb9d35edcb22bf6968f6f01f1b7b89fd0597ec3b1ec1bc3b407"/>
+    </canvas>
+    <canvas name="2" width="268" height="335">
+      <vector name="origin" x="158" y="334"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="5c0e4a18515b275c20f9c6def0bcd92ffd7019d22e1aaaa54a7e1cbe1a283b26"/>
+    </canvas>
+    <canvas name="3" width="236" height="319">
+      <vector name="origin" x="118" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="23c512a46ff5e3a6512aa7aab5678e7f952b85d8ed2a3d49b59220780a565c50"/>
+    </canvas>
+    <canvas name="4" width="176" height="315">
+      <vector name="origin" x="94" y="314"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="389acc18a2346512ba51add8fb1db094b0cc5b8e3a56cb74d42d221d54eae97c"/>
+    </canvas>
+    <canvas name="5" width="204" height="319">
+      <vector name="origin" x="130" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="14339c0eb86ced079bf71ff0f9b520b1273a467d7c6fb93004495b06bd701215"/>
+    </canvas>
+    <canvas name="6" width="228" height="319">
+      <vector name="origin" x="146" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="7354379894103d4fe0274be2c6b58545270f01250d17abf03cceabab7cc9ed35"/>
+    </canvas>
+    <canvas name="7" width="236" height="319">
+      <vector name="origin" x="98" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="61ea2ba32231a09f84eac4386adf39dcf97213bd8e942811393de9b2b78193c6"/>
+    </canvas>
+    <canvas name="8" width="236" height="323">
+      <vector name="origin" x="82" y="322"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="da667621d11b0a055a3ba5a1f625d3da88d6de1285747d26c916d13753350790"/>
+    </canvas>
+    <canvas name="9" width="176" height="315">
+      <vector name="origin" x="18" y="314"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="10" width="204" height="319">
+      <vector name="origin" x="98" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="11" width="228" height="319">
+      <vector name="origin" x="138" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="15"/>
+      <string name="0" value="Please restore me to my true form, brave hero!"/>
+      <string name="1" value="Hey! Please help me!"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="232" height="324">
+      <vector name="origin" x="115" y="324"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="5cafe798c74ff494e9ccb944b25eeb5bc06da6ee587ce1f005e20dd00dcdd653"/>
+    </canvas>
+    <canvas name="1" width="216" height="320">
+      <vector name="origin" x="99" y="320"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="4c9392ce466ed568da8db90854e405f1b4e74af72a3e98b33344d698a0ba4191"/>
+    </canvas>
+    <canvas name="2" width="216" height="324">
+      <vector name="origin" x="99" y="324"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="f2e5532d31c36fe61b187c1315f2f7b6d328488d46551f020c77e1c877ab12b9"/>
+    </canvas>
+    <canvas name="3" width="236" height="328">
+      <vector name="origin" x="123" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="04c9026b7a55b46a51adc75e7226c49dbe77fd0f509d5502e710975fcdcc053b"/>
+    </canvas>
+    <canvas name="4" width="240" height="316">
+      <vector name="origin" x="143" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="7ef69a04c4d380fb8311cd5de9300aa06b41b1d1eb007e92b7bfad5fb01bcc53"/>
+    </canvas>
+    <canvas name="5" width="236" height="324">
+      <vector name="origin" x="111" y="324"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="38c57922577283ca970c12ea9a8d40a4f7bf348bc508ab3bd5967cbc415c020c"/>
+    </canvas>
+    <canvas name="6" width="236" height="324">
+      <vector name="origin" x="83" y="324"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="0cdfc4f70b115f0e9a2950fcfc8893b761df4bbf5214b72788894b97041102dd"/>
+    </canvas>
+    <canvas name="7" width="236" height="316">
+      <vector name="origin" x="107" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="4846e83d60f76965d31a4ae2ddcb83ac7def91e90afac5dc9ab4ccfbc395809e"/>
+    </canvas>
+    <canvas name="8" width="176" height="312">
+      <vector name="origin" x="27" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="1044cf513ae40f68fbe78c1745d1e96291c20b7c4569ba7a4468075c48bf8a60"/>
+    </canvas>
+    <canvas name="9" width="204" height="316">
+      <vector name="origin" x="63" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="2cb962ecc822cab6da8abc793533944c2e9d459cf09dcd287013f6f8abc53f94"/>
+    </canvas>
+    <canvas name="10" width="228" height="312">
+      <vector name="origin" x="107" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="4706f6db66073862fbf4668e0676d79dca3e50898590d52da03dd4ed7bf0d769"/>
+    </canvas>
+    <canvas name="11" width="228" height="308">
+      <vector name="origin" x="107" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="cce9f7fcc716382db69ecd31ed1826db7829e30b86cf04e4bf23a03e288405b6"/>
+    </canvas>
+    <canvas name="12" width="216" height="320">
+      <vector name="origin" x="103" y="320"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="13" width="236" height="328">
+      <vector name="origin" x="127" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="14" width="240" height="316">
+      <vector name="origin" x="147" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="15" width="236" height="316">
+      <vector name="origin" x="111" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="43bdee24bb984baf66e9d3d506ad6aa5920ff542bf47231fdb0beecff40fa8fd"/>
+    </canvas>
+    <canvas name="16" width="248" height="312">
+      <vector name="origin" x="119" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="97b15a5968f863da21abb39d4e7eba32a9b4f0dceb2f79a34779f029c25e5850"/>
+    </canvas>
+    <canvas name="17" width="244" height="312">
+      <vector name="origin" x="119" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="8d03ffe71b87ba470d6cdde49a37a01847ff3d6fb6c23a21d9fe019f3a713201"/>
+    </canvas>
+    <canvas name="18" width="232" height="300">
+      <vector name="origin" x="103" y="300"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="6f5b1e22a7a08e342440116b5143cfdbc2b6850184ffa03f41241f3e60fcc604"/>
+    </canvas>
+    <canvas name="19" width="264" height="312">
+      <vector name="origin" x="99" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="d75063ce484782086f8bfd1e7a1ee66b18427e96304358c1b65890dde517a481"/>
+    </canvas>
+    <canvas name="20" width="252" height="308">
+      <vector name="origin" x="123" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="aeaf519ea14bcd1ecb1154604fbe6f30f40fad0664dde82cc031b44b91f0c130"/>
+    </canvas>
+    <canvas name="21" width="264" height="316">
+      <vector name="origin" x="127" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="d1dc836e5085c7c1b94d786f16c149e65f7f3e97aa1d5f1698d3e585be5ae03c"/>
+    </canvas>
+    <canvas name="22" width="240" height="308">
+      <vector name="origin" x="131" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="f845179e24cab4241f2d172e63ad19306342f64f75e17e5776f887a9c98c393a"/>
+    </canvas>
+    <canvas name="23" width="264" height="316">
+      <vector name="origin" x="127" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="24" width="216" height="320">
+      <vector name="origin" x="95" y="320"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="8368e04ad97252d7896704bb947009438dd4b69d4dd6014c7dee049bc018215b"/>
+    </canvas>
+    <canvas name="25" width="216" height="324">
+      <vector name="origin" x="95" y="324"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="5fb0e8e81e5ae5323a9d4a63da18415bdc5d4174bceb63e05b021113993c6012"/>
+    </canvas>
+    <canvas name="26" width="216" height="320">
+      <vector name="origin" x="95" y="320"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="27" width="236" height="316">
+      <vector name="origin" x="71" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="28" width="264" height="316">
+      <vector name="origin" x="127" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="29" width="252" height="308">
+      <vector name="origin" x="119" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="30" width="240" height="316">
+      <vector name="origin" x="171" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="31" width="260" height="316">
+      <vector name="origin" x="135" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="46207cd9d0afdf4dc6b3d85a4e283d4b0c3a99b7f55316246b191e98d8ef69dd"/>
+    </canvas>
+    <canvas name="32" width="236" height="308">
+      <vector name="origin" x="103" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <string name="_hash" value="9d0b54d373ce2e8249c1a3d2b1fa36010dd1e25dc783bceb65956deaf7460056"/>
+    </canvas>
+    <canvas name="33" width="236" height="316">
+      <vector name="origin" x="123" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="34" width="252" height="308">
+      <vector name="origin" x="111" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="35" width="240" height="308">
+      <vector name="origin" x="123" y="308"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="36" width="264" height="316">
+      <vector name="origin" x="119" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="37" width="248" height="312">
+      <vector name="origin" x="123" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+    <canvas name="38" width="236" height="328">
+      <vector name="origin" x="131" y="328"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="248" height="312">
+      <vector name="origin" x="118" y="327"/>
+      <vector name="lt" x="-123" y="-333"/>
+      <vector name="rb" x="95" y="0"/>
+      <vector name="head" x="-39" y="-286"/>
+      <int name="delay" value="120"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="5235befd95593a19a2f2e5eed85cbfdee952b6fe99b8cb88490a819ef2d3a665"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="296" height="344">
+      <vector name="origin" x="138" y="344"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d250972e1702238d617c6f6773cf393afd40817a9b2505ae50d03d6fb7077959"/>
+    </canvas>
+    <canvas name="1" width="288" height="364">
+      <vector name="origin" x="94" y="380"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c8c06db5287fec1610ce7424aab73dc86748c19ea691334d84ef81d580b1154e"/>
+    </canvas>
+    <canvas name="2" width="316" height="356">
+      <vector name="origin" x="70" y="394"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="840be8ddf174224f7eea6c83b7304e7acc750d15fc3516aed608dde62601f820"/>
+    </canvas>
+    <canvas name="3" width="296" height="344">
+      <vector name="origin" x="30" y="394"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="330ec8cbbad2ab0893646c88801fb1cb855a07e88a83e3f4eb5ad6a278704047"/>
+    </canvas>
+    <canvas name="4" width="288" height="364">
+      <vector name="origin" x="-6" y="392"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="da7b7690971a3811e1e4833a2a0e3e8d369eac84f7d40fb2e1a0e23f21f328c0"/>
+    </canvas>
+    <canvas name="5" width="316" height="356">
+      <vector name="origin" x="-22" y="392"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6cdad95124b95cd562180c364cfd83aa4b171a801fee8445d001e82167accc81"/>
+    </canvas>
+    <canvas name="6" width="296" height="344">
+      <vector name="origin" x="-70" y="380"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="0e63844a7470823087ad723dd08671b26aae2b936afbe0f84b9e339e56c62fbb"/>
+    </canvas>
+    <canvas name="7" width="288" height="364">
+      <vector name="origin" x="-82" y="368"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="bc4d79a27b30eba1b45fe7f0174f2566428cda96bd1dfd97effee102c03929fc"/>
+    </canvas>
+    <canvas name="8" width="1" height="1">
+      <vector name="origin" x="-91" y="368"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787127.img.xml
+++ b/gms-server/wz/Mob.wz/8787127.img.xml
@@ -1,1 +1,1598 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787127.img"><imgdir name="info"><int name="level" value="100"/><int name="maxHP" value="999999999"/><int name="maxMP" value="50000"/><int name="speed" value="5"/><int name="PADamage" value="1500"/><int name="MADamage" value="1500"/><int name="PDRate" value="25"/><int name="MDRate" value="25"/><int name="acc" value="600"/><string name="elemAttr" value="P2"/><int name="eva" value="80"/><int name="pushed" value="100000"/><float name="fs" value="10.0"/><int name="exp" value="500000"/><int name="summonType" value="1"/><int name="category" value="8"/><int name="firstAttack" value="1"/><string name="mobType" value="1N"/><int name="boss" value="1"/><imgdir name="attack"><imgdir name="0"><int name="action" value="1"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="2"/><int name="magic" value="1"/><int name="disease" value="0"/><int name="level" value="0"/><int name="attackCount" value="3"/><int name="cooltime" value="2500"/></imgdir></imgdir><int name="ignoreMoveImpact" value="1"/><int name="bodyAttack" value="1"/><int name="PDDamage" value="3000"/><int name="MDDamage" value="3000"/><int name="nonLevelCheckACC" value="1"/><int name="nonLevelCheckEVA" value="1"/><int name="notConsiderFieldSet" value="1"/><imgdir name="skill"><imgdir name="0"><int name="skill" value="100"/><int name="action" value="1"/><int name="level" value="2"/><int name="effectAfter" value="0"/></imgdir><imgdir name="1"><int name="skill" value="128"/><int name="action" value="1"/><int name="level" value="7"/><int name="effectAfter" value="0"/></imgdir><imgdir name="2"><int name="skill" value="114"/><int name="action" value="1"/><int name="level" value="9"/><int name="effectAfter" value="0"/></imgdir></imgdir><imgdir name="speak"><int name="chatBalloon" value="0"/><imgdir name="0"><string name="0" value="讓你後悔！"/></imgdir></imgdir><int name="hpTagBgcolor" value="3"/><int name="hpTagColor" value="1"/></imgdir><imgdir name="stand"><canvas name="0" width="256" height="248"><vector name="origin" x="161" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="bd427aaaea1847c666479be67792b05b06beb82bb32632a7126ded955f2afb71"/></canvas><canvas name="1" width="256" height="248"><vector name="origin" x="161" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="951a0963998c1de1183445b160e0fb78b804f77e6859b5f8a97c7d9fe248b179"/></canvas><canvas name="2" width="256" height="236"><vector name="origin" x="161" y="230"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="0606df1357becbb92ed8164123bc4f0c50a453d8bb2f2d862054175d3d7c2215"/></canvas><canvas name="3" width="256" height="244"><vector name="origin" x="161" y="239"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="d9b9deb1cfdc029c3cbda2a2e5f276a46e7cdbbb368a849a4ae7e20b570b4124"/></canvas><canvas name="4" width="256" height="232"><vector name="origin" x="161" y="228"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="b5946b5908a1bebf8155ee04ef507f02822b574efc8adaf0ba87c2b359af4f00"/></canvas><canvas name="5" width="256" height="244"><vector name="origin" x="161" y="243"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="76172f894f9bb377f75cb5dbd73523dc8ad5ac286d9ae09c43ac9a989d4115d6"/></canvas><canvas name="6" width="256" height="256"><vector name="origin" x="161" y="253"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="0a004e609478e64d284d0e81e28ffe7973a48b60160b8dff11459d97dcee615e"/></canvas><canvas name="7" width="256" height="256"><vector name="origin" x="161" y="252"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="893a803240bb06adb568714125dbd3f44c7760592f9f95af1bd8acddb6f9f057"/></canvas></imgdir><imgdir name="move"><imgdir name="speak"><int name="prob" value="30"/><string name="0" value="私を相手に逃げられると思うか？何を根拠にそんなことを考えられるんだ？愚かな！下等生物が…私を誰だと思って…"/></imgdir><canvas name="0" width="260" height="248"><vector name="origin" x="165" y="242"/><int name="z" value="0"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><int name="delay" value="120"/><string name="_hash" value="255c88d1e614078a57f14fe65da5a8c0363b43fab7f9065a68c7de09e49ca76d"/></canvas><canvas name="1" width="260" height="248"><vector name="origin" x="164" y="241"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="b144c1da77dd8c1aef8a512d17ba7fa541241b2ea00ccd3eea2b19fd87c0b5b7"/></canvas><canvas name="2" width="260" height="236"><vector name="origin" x="165" y="230"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="e9d065cdda0860d58faf577d05fbe5dc5630f82172f5042a373728095c6dee32"/></canvas><canvas name="3" width="260" height="232"><vector name="origin" x="166" y="228"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="47cec7d12cdaeb8b24206a4af4ef5c9d6d40e2d6777def038deed603affd6e98"/></canvas><canvas name="4" width="264" height="244"><vector name="origin" x="167" y="244"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="ed4e7b0f0b05665e4acc22dd8cac3067641f03ee9cb249c1f1ab705a76939107"/></canvas><canvas name="5" width="260" height="256"><vector name="origin" x="166" y="253"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="0318b92874568c35819660d8c424265d2759e872ec94ddedc0e635b899629aef"/></canvas></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-627" y="-597"/><vector name="rb" x="582" y="246"/></imgdir><int name="attackAfter" value="2520"/><int name="effectAfter" value="900"/><imgdir name="hit"><canvas name="0" width="1" height="1"><vector name="origin" x="49" y="63"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f22fe7714033f8f8e781056f7d0a203d0efd708c2d7f218c66e5f45f9db1578c"/><string name="_outlink" value="Mob/8220024.img/attack1/info/hit/0"/></canvas><canvas name="1" width="1" height="1"><vector name="origin" x="49" y="62"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9f9bc70c590a7bdcc02e62d83c1efb977987ce36e0a0093eee4ce234347cf93f"/><string name="_outlink" value="Mob/8220024.img/attack1/info/hit/1"/></canvas><canvas name="2" width="1" height="1"><vector name="origin" x="48" y="52"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="4e868d8208e74fac1e6077a048e57546cde70ca76bb5096f2ee69951155d91f8"/><string name="_outlink" value="Mob/8220024.img/attack1/info/hit/2"/></canvas><canvas name="3" width="1" height="1"><vector name="origin" x="50" y="45"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1fcc1e04e096ffd8b07dde8ab85432d434e24ccd9221fef3a50595ab13b14809"/><string name="_outlink" value="Mob/8220024.img/attack1/info/hit/3"/></canvas><canvas name="4" width="1" height="1"><vector name="origin" x="50" y="45"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f72900dbb32c47a09453725348ddf4122a2bef2260d3e52d6e6aafba0563564c"/><string name="_outlink" value="Mob/8220024.img/attack1/info/hit/4"/></canvas><canvas name="5" width="1" height="1"><vector name="origin" x="49" y="44"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e20c38698a34cc81e858072970fbc265563bc47aa08b567546b3c895638d5246"/><string name="_outlink" value="Mob/8220024.img/attack1/info/hit/5"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="23" height="45"><vector name="origin" x="16" y="181"/><int name="delay" value="100"/></canvas><canvas name="1" width="24" height="48"><vector name="origin" x="16" y="184"/><int name="delay" value="100"/></canvas><canvas name="2" width="25" height="49"><vector name="origin" x="16" y="185"/><int name="delay" value="100"/></canvas><canvas name="3" width="114" height="138"><vector name="origin" x="56" y="147"/><int name="delay" value="100"/></canvas><canvas name="4" width="117" height="139"><vector name="origin" x="59" y="147"/><int name="delay" value="100"/></canvas><canvas name="5" width="133" height="133"><vector name="origin" x="65" y="134"/><int name="delay" value="100"/></canvas><canvas name="6" width="136" height="134"><vector name="origin" x="67" y="134"/><int name="delay" value="100"/></canvas><canvas name="7" width="136" height="134"><vector name="origin" x="67" y="135"/><int name="delay" value="100"/></canvas><canvas name="8" width="134" height="133"><vector name="origin" x="66" y="135"/><int name="delay" value="100"/></canvas><canvas name="9" width="128" height="130"><vector name="origin" x="60" y="135"/><int name="delay" value="180"/></canvas><canvas name="10" width="252" height="258"><vector name="origin" x="128" y="192"/><int name="delay" value="130"/></canvas><canvas name="11" width="246" height="250"><vector name="origin" x="125" y="188"/><int name="delay" value="140"/></canvas><canvas name="12" width="246" height="250"><vector name="origin" x="125" y="188"/><int name="delay" value="150"/></canvas></imgdir></imgdir><uol name="18" value="../stand/0"/><uol name="19" value="../stand/1"/><uol name="20" value="../stand/2"/><uol name="21" value="../stand/3"/><uol name="22" value="../stand/4"/><uol name="23" value="../stand/5"/><uol name="24" value="../stand/6"/><uol name="25" value="../stand/7"/><imgdir name="speak"><int name="prob" value="30"/><string name="0" value="この偉大なる力で燃えてしまえ！この世界と共に！キャキャキャキャキャ！"/><string name="1" value="灰になれ！キャハハハハハハ！"/></imgdir><canvas name="0" width="256" height="248"><vector name="origin" x="161" y="243"/><int name="z" value="0"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><int name="delay" value="90"/><string name="_hash" value="443f7e9b9f6c3ed07c35e9b6dbcc8ba2808e2f92a4abd68351396b1f33dd9c83"/></canvas><canvas name="1" width="268" height="248"><vector name="origin" x="175" y="246"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="fb24c914f53bcca82b22d44eb9c7c4449acff5ea6ac4536d8f8ec5ae8fe4efb3"/></canvas><canvas name="2" width="240" height="252"><vector name="origin" x="146" y="250"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="375d944f4a6074552542141e61b03b96eb33ea2713b37fa24561834659e99437"/></canvas><canvas name="3" width="256" height="256"><vector name="origin" x="160" y="258"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="ecaa56224c4334cd21deb97029b49c4abf19cea8d8ed74697be03e052aadd710"/></canvas><canvas name="4" width="260" height="288"><vector name="origin" x="164" y="290"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="4ac0b9bbe1404a7141819b9347f1573462612dc140a0f186d200e1c6a6f4f09b"/></canvas><canvas name="5" width="252" height="296"><vector name="origin" x="155" y="296"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="cf5342c67bf6bfea01e09acea31824bbe9beefc48ded3334a1eb54a66c3f11c6"/></canvas><canvas name="6" width="256" height="292"><vector name="origin" x="160" y="295"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="32aa4a59c0e86a68433fc8d157ef9efb46e57a76d595fa7541fb8261495186a5"/></canvas><canvas name="7" width="244" height="296"><vector name="origin" x="149" y="295"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="cd2dfd0e0985e56ad9574a48c44216b74f3238a62509c8a64004a23f64b8c253"/></canvas><canvas name="8" width="244" height="296"><vector name="origin" x="149" y="295"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="cd7398cd61559adbd4bcd60fb739cc1014813c00745005ead3dec75fde4406c2"/></canvas><canvas name="9" width="244" height="292"><vector name="origin" x="149" y="292"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="9ac969c4db107878ae55dfa6157d5c7bb0c8cc23112e028b2f7ac4f41ed78526"/></canvas><canvas name="10" width="320" height="356"><vector name="origin" x="188" y="348"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="c94d2ad080d4a962d4915be307d3f170e1f8fee4fcaa85b28d742f1484d711d6"/></canvas><canvas name="11" width="304" height="348"><vector name="origin" x="170" y="339"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="7656f96fb9fa88e362bb47c74b469ce6da6c4c1c326db674a8cff8f8dbe1db76"/></canvas><canvas name="12" width="304" height="348"><vector name="origin" x="170" y="342"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="5a5c8fa93f2d10c6467fa890ff4a76dace10923e3c1da9b475dc4baa36da5a42"/></canvas><canvas name="13" width="304" height="348"><vector name="origin" x="170" y="343"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="2ba0304fa47453642386edbb3656da20c1847b375faa4a796e90a0324b9b2c82"/></canvas><canvas name="14" width="304" height="348"><vector name="origin" x="169" y="344"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="500268ad257514073d05b3f37337e62c4c8ed21e3a1ec7d41e293641b597c269"/></canvas><canvas name="15" width="300" height="348"><vector name="origin" x="167" y="345"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="97eac791e961e878107ffd9cd256b1423cd5a56d7463be1408b3ce6c9a85b8eb"/></canvas><canvas name="16" width="244" height="328"><vector name="origin" x="147" y="345"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="8eae3d8f3f91654aacca2bf5d512e45799836e98f2458a865c8d6ebaa5d07836"/></canvas><canvas name="17" width="272" height="316"><vector name="origin" x="175" y="336"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="3d044a6be5326d21125c5373e6b796e0d8cc36f4da8834ff32d717c5db003924"/></canvas></imgdir><imgdir name="hit1"><imgdir name="speak"><int name="prob" value="30"/><string name="0" value="嘘だ！嘘だ！"/></imgdir><canvas name="0" width="268" height="244"><vector name="origin" x="110" y="242"/><int name="z" value="0"/><vector name="head" x="32" y="-163"/><vector name="lt" x="-112" y="-212"/><vector name="rb" x="150" y="-14"/><int name="delay" value="300"/><string name="_hash" value="474f053c65a85581388b238f9c0291503544fc394ea2e5fef687488163d7d55a"/></canvas></imgdir><imgdir name="die1"><imgdir name="speak"><int name="prob" value="30"/><string name="0" value="你竟敢! 你! 你! 你! 不可能! 我怎麼會輸! 不可能!"/></imgdir><canvas name="0" width="256" height="248"><vector name="origin" x="130" y="242"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="150"/><string name="_hash" value="61b6f4efb51896b9f57a98fe28f3f35363dbb3a4d0728c83f134683dbef216dc"/></canvas><canvas name="1" width="268" height="244"><vector name="origin" x="110" y="242"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="150"/><string name="_inlink" value="hit1/0"/></canvas><canvas name="2" width="268" height="232"><vector name="origin" x="106" y="230"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="180"/><string name="_hash" value="a1b6b0c38bd998aa4648fa41a2d3290676ca319e263c37e313f6f25e4064469c"/></canvas><canvas name="3" width="268" height="240"><vector name="origin" x="104" y="236"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="fbf90f79c1e015a2f3daf253bb292bed85ce37c9b3a64c67573c1a543e45f3ab"/></canvas><canvas name="4" width="268" height="244"><vector name="origin" x="103" y="239"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="240"/><string name="_hash" value="765e749105e33ea28ba053deb5c024d0143291e7c20950a83e7c930b8aa525e2"/></canvas><canvas name="5" width="268" height="244"><vector name="origin" x="102" y="240"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="240"/><string name="_hash" value="8efbfe202d95b3874454dd633999efce8ed1bb241ab30548729d8291f6886d3b"/></canvas><canvas name="6" width="268" height="240"><vector name="origin" x="101" y="236"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="ba5ce48495fa17cf045cca8a0f313d80b66e7244bc94bc974750953f4466b60c"/></canvas><canvas name="7" width="268" height="204"><vector name="origin" x="100" y="202"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="1c0dc1f2de266f43a38e6421e15e439d64d5d2d62f275e00537db74ef3170bfb"/></canvas><canvas name="8" width="268" height="208"><vector name="origin" x="97" y="202"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="85962e12ccbcf0adba8d48b3133a0fadb22bd508f2e755ae42f115a310c192a1"/></canvas><canvas name="9" width="252" height="200"><vector name="origin" x="81" y="200"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="f7a5ac42c0be621139c078f763ec0266751d04584d8d7ccd01549eb7a0260f35"/></canvas><canvas name="10" width="232" height="184"><vector name="origin" x="64" y="182"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="a99eb2ff64f2e3b15f1b356ecf9e399514fbd34a311b74ff5b85dce6e383837a"/></canvas><canvas name="11" width="220" height="176"><vector name="origin" x="52" y="176"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="41defa07fc4dc50f571e274447d9c3b18bf22a76f75f698ba322ddaf3c440496"/></canvas><canvas name="12" width="172" height="152"><vector name="origin" x="10" y="155"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="769558f583c365edcd68f00e604e851d93c12340bcf492d653f1f2e66d6ce1fa"/></canvas><canvas name="13" width="160" height="144"><vector name="origin" x="3" y="150"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="e8054507a9e49558dc89a400d25a636f835650de107b68a82fa190ee1753d0ec"/></canvas><canvas name="14" width="96" height="100"><vector name="origin" x="-53" y="110"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="099d21c3aa7e6dee09618c11a597cd9ea17041306a68e2a26057f9e86c855f2c"/></canvas><canvas name="15" width="36" height="88"><vector name="origin" x="-59" y="106"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="150"/><string name="_hash" value="03f6f6f4ee0aba23be5fac43d0cbd1f26f70281d0fd4640431c34a3ca5bdf0c9"/></canvas></imgdir><imgdir name="regen"><imgdir name="speak"><int name="prob" value="30"/><string name="0" value="また怖いもの知らずどもが現れたようだな。私の力を見せてやろう。この偉大なる力の前で屈服するがいい！"/></imgdir><canvas name="0" width="164" height="124"><vector name="origin" x="-97" y="104"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="383006fadb41017b717bfdbb3df14b22dbf09873bb2d7257279340cc43f89731"/></canvas><canvas name="1" width="184" height="160"><vector name="origin" x="-95" y="143"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="6a9c43056e2849d974d54bff5025d8e4156bf559f74735889f1ebf7fe2b3e85d"/></canvas><canvas name="2" width="564" height="488"><vector name="origin" x="143" y="469"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c23bac0ad00bfbce57b25fe6e214fed99751d2273970bfbf853303a9e40aae38"/></canvas><canvas name="3" width="860" height="512"><vector name="origin" x="440" y="467"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="3692c45cb927feaece7e9464eee47c777c442fe724b8330cca9635abf67d96bd"/></canvas><canvas name="4" width="848" height="500"><vector name="origin" x="433" y="469"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="10fe4b2574c04d0fe40e877f10086bf6cec53982abc34d751ec03ea31237ba36"/></canvas><canvas name="5" width="836" height="484"><vector name="origin" x="432" y="467"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="a4b66cc52c70d612c84928ad0f12c17d70581e0e814a025f5ea033bc353e301f"/></canvas><canvas name="6" width="796" height="484"><vector name="origin" x="427" y="466"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="355dba27120226e8005ba1987e3779f9429d572ab2476a6a6c4f7451be7ac131"/></canvas><canvas name="7" width="728" height="464"><vector name="origin" x="368" y="452"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="a6efbbb2e26dba3125476dff15fc9a4882855d5988719112a45d55de638964b4"/></canvas><canvas name="8" width="536" height="444"><vector name="origin" x="354" y="433"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bca5f386756cd000cd09f717a820de4c508f0fe5b8c72b2fc090bfede87cd4a4"/></canvas><canvas name="9" width="372" height="428"><vector name="origin" x="187" y="422"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="dbd5718714d9918b6f0afb1e8f7e1ea8bbcdd8dfa3b9a1e3676fbbf9074baf62"/></canvas><canvas name="10" width="424" height="400"><vector name="origin" x="259" y="338"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="638552a138ab2073144ecd62f0bdf02364c408e2560764ae59e796bf57c5a06d"/></canvas><canvas name="11" width="388" height="304"><vector name="origin" x="209" y="292"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bff550983c2f3359481fc4f0a85ec8c6b2bd7e11b731f087a1fe1556a6a1d10e"/></canvas><canvas name="12" width="436" height="348"><vector name="origin" x="182" y="337"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="ea20ffa0329d7e33ebd9598d08bab9225fec7159737e659050fb48d0f3639acf"/></canvas><canvas name="13" width="468" height="432"><vector name="origin" x="268" y="274"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="853dcd7913494e31f66aff413dd159426338d78a211b2fb8dce9851321fbb366"/></canvas><canvas name="14" width="420" height="240"><vector name="origin" x="253" y="237"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c14307c39a05cb48072d524ae381a2663f5ca5c863ba1f1888dc2a4feaf056a8"/></canvas><canvas name="15" width="376" height="376"><vector name="origin" x="198" y="234"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="fa075d29d4a81444fd67a51f2f29a562a6e8b09c8dcc78e73d62934f02eec42b"/></canvas><canvas name="16" width="460" height="400"><vector name="origin" x="157" y="230"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d0dbc7361eae8cdf8f1bde04e77c68d207a84fec95632596013b6fc5a79e9cac"/></canvas><canvas name="17" width="424" height="464"><vector name="origin" x="239" y="317"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="520d6f97cb7d618000772ed2162c362779f223f6795fd53730eee954a8bf8e0f"/></canvas><canvas name="18" width="388" height="400"><vector name="origin" x="221" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="45fb2f1330ab604313a7cea5bc42cb9f7e2e83cfbc90b2b19059f70df8a87273"/></canvas><canvas name="19" width="460" height="432"><vector name="origin" x="154" y="278"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0454cde7197ece210169fbcac3ebb1ea744b8e1eb53e704ded9da47d6aca9237"/></canvas><canvas name="20" width="552" height="532"><vector name="origin" x="271" y="390"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="cac5f25b8fb7821a34341e64abec071609752bcd3993afbdf7b76d95f6e5f99c"/></canvas><canvas name="21" width="440" height="308"><vector name="origin" x="256" y="222"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bbbda1b3256cf1cd7f6d0b559370af092201c4bb620bf8f4683cbd532f819cdd"/></canvas><canvas name="22" width="352" height="336"><vector name="origin" x="173" y="282"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="a37748adbb655dc8f3e8f1e76ce9a670bad12d0cd58489e47c1debcd6b2b2e71"/></canvas><canvas name="23" width="396" height="360"><vector name="origin" x="193" y="294"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7595dc6eb03d4b684a39f403306f80cb9941deafc5ed566710db40d55a697a6b"/></canvas><canvas name="24" width="396" height="376"><vector name="origin" x="191" y="302"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b55f08ba541ff2d2b48b1d78e683f587a825c7d33d2261e98ac1986748e002b3"/></canvas><canvas name="25" width="384" height="384"><vector name="origin" x="186" y="305"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bd1a894b26c17c38d62c2d3c8e421c68caf00f1773dc4771760d9cc740e34191"/></canvas><canvas name="26" width="384" height="384"><vector name="origin" x="185" y="305"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e1634ea15dc79210137c22479ba9aa77f7a7298672af8476da60a22e4090dc2b"/></canvas><canvas name="27" width="380" height="380"><vector name="origin" x="183" y="303"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c3fa7b2710c328f3a0a5152177725f97fbb4de004ab0b4b9578aa353c8c59951"/></canvas><canvas name="28" width="332" height="348"><vector name="origin" x="183" y="289"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="81015d10a202430bfc86fa524726b4710a52f5d2d84825f7fb425c07f6689ef3"/></canvas><canvas name="29" width="332" height="352"><vector name="origin" x="184" y="291"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8dcb22e042dc12ed16fd01af950da50e1d7290b25b4c5f35f200040bee56ef7c"/></canvas><canvas name="30" width="320" height="320"><vector name="origin" x="177" y="278"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="ecf51634b6c189de16798cecdb0f4ba6d421bff4d8192aa086380275c6b38920"/></canvas><canvas name="31" width="316" height="316"><vector name="origin" x="179" y="280"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1152a8f37d7fb58712f803b4a1f721b6ecbb561cd027ace0ac2862b267265622"/></canvas><canvas name="32" width="260" height="256"><vector name="origin" x="131" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="00e3fdacedc92990e3d4dd771684d8bbb70b2467f4cf43c2015316f84ef160ed"/></canvas></imgdir><imgdir name="attack2"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-570" y="-645"/><vector name="rb" x="603" y="171"/></imgdir><imgdir name="hit"><canvas name="0" width="100" height="128"><vector name="origin" x="49" y="63"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="965aebbf037df2db2238fd06c80659dcccd2aaa3217afda4039a32b3beabe400"/></canvas><canvas name="1" width="100" height="124"><vector name="origin" x="49" y="62"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="15982111885848b17a5328515e925d50886c1a549cb1fd7d6556f9fd5e059112"/></canvas><canvas name="2" width="104" height="108"><vector name="origin" x="50" y="52"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="5fbc2ac381a9e65736876dbaa03e333a5cbbfba0217046dc75e37f7e154fd131"/></canvas><canvas name="3" width="104" height="92"><vector name="origin" x="51" y="45"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="70056b82e35774211e06cc98209213efe560ea9bcc564a9ceef5f197e175f883"/></canvas><canvas name="4" width="104" height="92"><vector name="origin" x="50" y="45"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="36c394d69b6d8b4856dfada0fb9133dbfc62ff3e7863edbd72da5fa1dd1b8e74"/></canvas><canvas name="5" width="100" height="88"><vector name="origin" x="49" y="44"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="92360631ff8eb213b6add343b43e27969831853ae5a655c387b78596408e154c"/></canvas></imgdir><int name="attackAfter" value="2610"/><int name="effectAfter" value="990"/><imgdir name="effect"><canvas name="0" width="110" height="140"><vector name="origin" x="53" y="140"/><int name="delay" value="95"/></canvas><canvas name="1" width="124" height="140"><vector name="origin" x="61" y="140"/><int name="delay" value="95"/></canvas><canvas name="2" width="132" height="142"><vector name="origin" x="64" y="142"/><int name="delay" value="95"/></canvas><canvas name="3" width="132" height="142"><vector name="origin" x="64" y="142"/><int name="delay" value="95"/></canvas><canvas name="4" width="132" height="140"><vector name="origin" x="64" y="142"/><int name="delay" value="95"/></canvas><canvas name="5" width="132" height="138"><vector name="origin" x="64" y="142"/><int name="delay" value="95"/></canvas><canvas name="6" width="134" height="139"><vector name="origin" x="65" y="143"/><int name="delay" value="95"/></canvas><canvas name="7" width="132" height="136"><vector name="origin" x="64" y="142"/><int name="delay" value="95"/></canvas><canvas name="8" width="114" height="125"><vector name="origin" x="52" y="131"/><int name="delay" value="95"/></canvas><canvas name="9" width="21" height="113"><vector name="origin" x="9" y="122"/><int name="delay" value="95"/></canvas><canvas name="10" width="3" height="53"><vector name="origin" x="0" y="103"/><int name="delay" value="95"/></canvas></imgdir></imgdir><canvas name="0" width="256" height="248"><vector name="origin" x="161" y="241"/><int name="z" value="0"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><int name="delay" value="90"/><string name="_hash" value="78fe704193ae1d25bad9e69f8ffb6cca0950316631b4de7fed38112aee032bb9"/></canvas><canvas name="1" width="268" height="264"><vector name="origin" x="168" y="242"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="cc8cf2eb9a12ff8cfcaf39524dc68173d44369e8fca7ebad03c257c03e6c9235"/></canvas><canvas name="2" width="232" height="252"><vector name="origin" x="128" y="229"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="5a60fd42c640b8c62b114675225c2784741d0f8545016a7a7a10f23793c007c0"/></canvas><canvas name="3" width="232" height="264"><vector name="origin" x="128" y="239"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="9bf363e074210560447ba375c4353da981e1817e6657ce6d91a223ee8041f3f9"/></canvas><canvas name="4" width="232" height="256"><vector name="origin" x="129" y="227"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="5d92981afe7d59260603170335ecc31accf76fd2a72634f02117288986e1553a"/></canvas><canvas name="5" width="236" height="272"><vector name="origin" x="130" y="242"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="b7a67ff5808ded2a6fb9b89becd8dfe804ce714a88c4a63f761a8bfbafedcd9a"/></canvas><canvas name="6" width="232" height="284"><vector name="origin" x="129" y="252"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="f46fe352bbfb1771e23ecf539d8bcb649f6a988f2fb2623d25c915594df06d48"/></canvas><canvas name="7" width="232" height="280"><vector name="origin" x="127" y="251"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="e41f48b769c8d7ff54ef10d1c3db1700188dd421adc62386b61fe3302567db11"/></canvas><canvas name="8" width="228" height="272"><vector name="origin" x="125" y="241"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="559aa2a9f70cd4e22b81dbdaee021a46b62b62b7e848cdb2a3c1e9e2836ee3f4"/></canvas><canvas name="9" width="224" height="272"><vector name="origin" x="124" y="242"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="cf8332d9c9d1db0295748ae23d383f0ec3540ae16e5b978c90c9c1d8eed1beac"/></canvas><canvas name="10" width="228" height="256"><vector name="origin" x="124" y="229"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="8d2de386936a84a9d6f9f075ffa6cce0ab5d287030732e55925848f09028fb3c"/></canvas><canvas name="11" width="308" height="328"><vector name="origin" x="168" y="297"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="54f0b3eaea571388a06e6cc1e5991f618e5aa97da5229bc3b1351226119b8677"/></canvas><canvas name="12" width="304" height="348"><vector name="origin" x="168" y="317"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="18c5721ff3c7e74df40d5a13a1b1bf5f1781024d7a14f3c6385b6494e0b72b4a"/></canvas><canvas name="13" width="304" height="352"><vector name="origin" x="168" y="322"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="a1f99e048ead3997e6ee2c4d96d7777fc565c775294afbe2deed91ba2b209e89"/></canvas><canvas name="14" width="304" height="356"><vector name="origin" x="168" y="325"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="e8474758a497d3d8ed56d24db516a199e57f3bc057c38582b12e014d03d53add"/></canvas><canvas name="15" width="304" height="352"><vector name="origin" x="167" y="326"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="c358b2e93c047f1395b5b90c4f1ddfed2ceea5907f2505fdb1cb510cc9837c31"/></canvas><canvas name="16" width="300" height="348"><vector name="origin" x="165" y="327"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="029987b54b21eb920698b111d13f47bbec5e59fdd85c61cf00356859ebd4050b"/></canvas><canvas name="17" width="224" height="308"><vector name="origin" x="121" y="292"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="38168422525371e01ac0503e07a743e71002bcb80cf273a1df8affb8de3d0b85"/></canvas><canvas name="18" width="272" height="280"><vector name="origin" x="168" y="271"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="8c801cfecdcc1d282f00de6ed00a99301d843941c5bec884961a0fca53ebb8bf"/></canvas><uol name="19" value="../stand/0"/><uol name="20" value="../stand/1"/><uol name="21" value="../stand/2"/><uol name="22" value="../stand/3"/><uol name="23" value="../stand/4"/><uol name="24" value="../stand/5"/><uol name="25" value="../stand/6"/><uol name="26" value="../stand/7"/><imgdir name="speak"><int name="prob" value="30"/><string name="0" value="凍結吧! 這可笑的世界!"/><string name="1" value="啊哈哈哈哈哈哈哈哈哈哈哈哈!"/></imgdir></imgdir><imgdir name="attack3"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-584" y="-900"/><vector name="rb" x="592" y="48"/></imgdir><imgdir name="hit"><canvas name="0" width="156" height="204"><vector name="origin" x="78" y="101"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="df0c08c9cb4cd67ce2fd5ac6b8871e86afcaab3d2be771bc331682ea9ce2831b"/></canvas><canvas name="1" width="168" height="168"><vector name="origin" x="84" y="84"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e8cbe781ec7017c52de7c613964eea9ebff0db72e69f8f2e65a8418f98542843"/></canvas><canvas name="2" width="176" height="176"><vector name="origin" x="86" y="87"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c99bf4b6a89d58c848bba5a6f0e6c8270c4882b502f6898e274d4a736456476a"/></canvas><canvas name="3" width="172" height="172"><vector name="origin" x="86" y="86"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="4e571f43378a791b61e02dde80c1476f958f6aa28b96d150c4efbf309af2e65d"/></canvas><canvas name="4" width="172" height="172"><vector name="origin" x="86" y="86"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="2d2b130ca964fcb48d51ab67b7a244b4998bc36c9d29113edfca4fa46965be62"/></canvas><canvas name="5" width="172" height="172"><vector name="origin" x="86" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="63d19520e356bf3a42ccab1b1acb46d360374f283bc4bb7ca4d5b84579f6aa23"/></canvas><canvas name="6" width="144" height="144"><vector name="origin" x="71" y="71"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8d4d606ffb78257cd85cc863d6926e397750d3c112b6662b0c297cb5ff65f675"/></canvas><canvas name="7" width="140" height="136"><vector name="origin" x="68" y="68"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="72f874ed8dc1224abf628797e028b94f5a494020cc5aff624f578253c8ff3585"/></canvas></imgdir><int name="attackAfter" value="1890"/><int name="effectAfter" value="990"/><imgdir name="effect"><canvas name="0" width="162" height="142"><vector name="origin" x="82" y="120"/><int name="delay" value="120"/></canvas><canvas name="1" width="165" height="153"><vector name="origin" x="85" y="131"/><int name="delay" value="120"/></canvas><canvas name="2" width="166" height="159"><vector name="origin" x="78" y="140"/><int name="delay" value="120"/></canvas><canvas name="3" width="180" height="181"><vector name="origin" x="78" y="162"/><int name="delay" value="120"/></canvas><canvas name="4" width="162" height="205"><vector name="origin" x="69" y="186"/><int name="delay" value="120"/></canvas><canvas name="5" width="159" height="216"><vector name="origin" x="70" y="197"/><int name="delay" value="120"/></canvas><canvas name="6" width="142" height="202"><vector name="origin" x="65" y="188"/><int name="delay" value="120"/></canvas><canvas name="7" width="162" height="210"><vector name="origin" x="73" y="194"/><int name="delay" value="120"/></canvas><canvas name="8" width="176" height="193"><vector name="origin" x="73" y="193"/><int name="delay" value="120"/></canvas><canvas name="9" width="165" height="145"><vector name="origin" x="73" y="198"/><int name="delay" value="120"/></canvas><canvas name="10" width="171" height="173"><vector name="origin" x="72" y="202"/><int name="delay" value="120"/></canvas></imgdir></imgdir><canvas name="0" width="256" height="248"><vector name="origin" x="161" y="241"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/></canvas><canvas name="1" width="268" height="244"><vector name="origin" x="175" y="241"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="209c7e1f6af03aabd74ce3c84eb77884cc72518db1d5ab2d12a16785209a62a6"/></canvas><canvas name="2" width="224" height="236"><vector name="origin" x="127" y="233"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="5d3bcb103f556ca9dc794de52ad2557f4c898ffd3e46ee9cd0d3c1210ddaf726"/></canvas><canvas name="3" width="208" height="240"><vector name="origin" x="114" y="238"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="640193e4bd9675242acb323a190fa912b1384a2c14e9e55d9d728aa847588977"/></canvas><canvas name="4" width="224" height="280"><vector name="origin" x="128" y="277"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="b558d1dc825752bcb7db6d75113f54bec95d8d2148011e88ed0a39a7d56dd9d0"/></canvas><canvas name="5" width="248" height="284"><vector name="origin" x="141" y="282"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="faaaa97213e0e766202dd28e9247f9b28fdaae230f3c79448187847b8e9d7fdf"/></canvas><canvas name="6" width="264" height="284"><vector name="origin" x="151" y="282"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="0304b0a998faf19a2fa1f81af3c8fa291a7cc191421b715d4edfc0be637fdd5d"/></canvas><canvas name="7" width="320" height="312"><vector name="origin" x="184" y="309"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="982084f06f695832aced6edadd9dc079fe18c7f8a6d612577050be5afc029703"/></canvas><canvas name="8" width="324" height="316"><vector name="origin" x="187" y="312"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="08381d07d9b2a094ebb35bf2b2ac5dfd708ec1d521d34d20c0df58243ccf1735"/></canvas><canvas name="9" width="324" height="316"><vector name="origin" x="187" y="312"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="5cdc90aa4ce335cb7c58fa5953006047c6508154e141ef2fdf4f513f4ff16dc7"/></canvas><canvas name="10" width="336" height="324"><vector name="origin" x="195" y="317"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="44fc135f382de5a7a56bbb1578fdffb6ae9421497bc64693840159d682d3e079"/></canvas><canvas name="11" width="388" height="364"><vector name="origin" x="242" y="344"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="bac336f5696480eba768cb5094d1c1862c468873dbfa4b7cffb91fae981d7e8a"/></canvas><canvas name="12" width="404" height="416"><vector name="origin" x="242" y="402"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="8dc737e354632c7d7018081a091c426f1c46eaf10b9befc23cfea72ff599bce4"/></canvas><canvas name="13" width="456" height="416"><vector name="origin" x="253" y="408"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="6d6419d5084f1e6ce845f1e98647b8552ec1b44629d29420a4ba80cd0217d913"/></canvas><canvas name="14" width="472" height="420"><vector name="origin" x="262" y="411"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="9e661b433683c05fdf8243c6b38820e06a08b14ff6a1e75ebc8cf1da0dcea83d"/></canvas><canvas name="15" width="480" height="416"><vector name="origin" x="266" y="412"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="7b58786140c032741f1a8672f2298b29bf5067d4ffecf966aaf004ba2ef4e6f8"/></canvas><canvas name="16" width="480" height="420"><vector name="origin" x="266" y="413"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="fc8f88b656f9776f021aed16842fa79979998814354325661ac39b602b3104bb"/></canvas><canvas name="17" width="476" height="340"><vector name="origin" x="263" y="337"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="944560ebc78370f63eded4db3ccd384cedc4c54c9b64d341e34758ee7201743f"/></canvas><canvas name="18" width="464" height="276"><vector name="origin" x="258" y="274"/><int name="z" value="0"/><int name="delay" value="100"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="0b19357b61333b6b24fac8820c21ba50a8a5c10af9b81c3f24e413ee6ffe90f0"/></canvas><uol name="19" value="../stand/0"/><uol name="20" value="../stand/1"/><uol name="21" value="../stand/2"/><uol name="22" value="../stand/3"/><uol name="23" value="../stand/4"/><uol name="24" value="../stand/5"/><uol name="25" value="../stand/6"/><uol name="26" value="../stand/7"/><imgdir name="speak"><int name="prob" value="30"/><string name="0" value="我將掌控這世上所有的魔法! 在光芒之前消失吧! "/><string name="1" value="啊哈哈哈哈哈哈哈哈哈哈哈哈!"/></imgdir></imgdir><imgdir name="skill1"><imgdir name="speak"><int name="prob" value="30"/><string name="0" value="這樣如何, 哈哈哈哈!"/><string name="1" value="吃我這招!"/></imgdir><canvas name="0" width="256" height="248"><vector name="origin" x="161" y="242"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_outlink" value="Mob/9303131.img/attack1/0"/></canvas><canvas name="1" width="268" height="244"><vector name="origin" x="175" y="242"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="44525d70458ba03c2c201835f66dcc143181bb2e78d8f47c8f777644329aef81"/></canvas><canvas name="2" width="224" height="232"><vector name="origin" x="130" y="230"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="44d11bb6ce4a65db7488184ed2b22c9206477782377bbaf14013e8f987e30c66"/></canvas><canvas name="3" width="216" height="228"><vector name="origin" x="122" y="228"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="478250de271aaa3439754d708b7e56a9a68db309a2fa8193513a5d8ba1b7c2e0"/></canvas><canvas name="4" width="216" height="240"><vector name="origin" x="122" y="243"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="8fe9b0fabb8f05bcaf5076e46d6aaca165b3088f6f44f4e324b6c8b1bb78b4d0"/></canvas><canvas name="5" width="216" height="252"><vector name="origin" x="121" y="253"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="3f427e1ce586bb831f36fa092fbc4cb5b4ca2150c39eeed4d348d8d19e308a46"/></canvas><canvas name="6" width="216" height="252"><vector name="origin" x="120" y="252"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="ff3699b8174c90a37d0060f4a523a25cb131ca3ba83dd6d1628f0e9bdf3be7b1"/></canvas><canvas name="7" width="216" height="244"><vector name="origin" x="119" y="242"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="2644cec5c879cfecad9f66432357ab823b277679009e3b22b6d8ea941c48ca41"/></canvas><canvas name="8" width="212" height="244"><vector name="origin" x="118" y="242"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="ffe396a90e084625e0ddfee061016d3346bda89ff277ced45596cd3194e5e5d5"/></canvas><canvas name="9" width="212" height="232"><vector name="origin" x="117" y="230"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="f343f83d4836bdde634eb9e80f0ba29d45215f013da1c8a1b5dd232ba0e361ee"/></canvas><canvas name="10" width="212" height="240"><vector name="origin" x="116" y="239"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="a629d2e11bfa3de386e1c5a60e285289c046a51a143124cc2ea332e3a36d933c"/></canvas><canvas name="11" width="212" height="228"><vector name="origin" x="115" y="228"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="7ffe1c9b041c33afdaf867f446f1ac5b7018c1d56cfef566289785cee81d0935"/></canvas><canvas name="12" width="208" height="252"><vector name="origin" x="114" y="253"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="6fb33064b45871e6767f0e637b32ec29ae1dade0c07e6d9330ed7fc3c98798eb"/></canvas><canvas name="13" width="248" height="288"><vector name="origin" x="154" y="274"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="156206cf35e0f3a4ef4ec52f5cb96b4c1925524092391480e0bfe4db6e33fbe8"/></canvas><canvas name="14" width="256" height="268"><vector name="origin" x="161" y="256"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="676a115da7a0734ca0c8091c7229017351e465f121a8591abee83310d675f0fa"/></canvas><canvas name="15" width="256" height="268"><vector name="origin" x="160" y="259"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="e7ccfb17de2f025bc77b886abc6276c4adb2ce76ab374e7ed254e349e6bec4a9"/></canvas><canvas name="16" width="244" height="264"><vector name="origin" x="150" y="261"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="e8d8d62c2513597d339a5b38727264da299421f8e32f8d46e341bc8fb7e02c24"/></canvas><canvas name="17" width="248" height="268"><vector name="origin" x="151" y="263"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="3f1bca2bd12ab666539c3e9704d86cf1051bb857dfba5c5f248d117ab6687a4c"/></canvas><canvas name="18" width="244" height="260"><vector name="origin" x="150" y="263"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="7fe96770e5851dc16dd60a44be4175edd516c461a7ad046d1a71b5c97cad192c"/></canvas><canvas name="19" width="244" height="260"><vector name="origin" x="149" y="263"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="a1c46c708c26d240b8179dcb5b477acf06fe9722b6245fdf92f82125372523a9"/></canvas><canvas name="20" width="240" height="260"><vector name="origin" x="146" y="260"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="7317f100cd6b3158db0fc40b73e9f56278efd26ee8dcb575cb25a0ba984ea8bd"/></canvas><canvas name="21" width="272" height="252"><vector name="origin" x="175" y="252"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="-25" y="-157"/><vector name="lt" x="-160" y="-226"/><vector name="rb" x="92" y="-12"/><string name="_hash" value="987ef4288e5f79b6009ef3de2cf32be2e0ac98cca312ad11803f8f1eb54df67c"/></canvas></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787127.img">
+  <imgdir name="info">
+    <int name="level" value="100"/>
+    <int name="maxHP" value="999999999"/>
+    <int name="maxMP" value="50000"/>
+    <int name="speed" value="5"/>
+    <int name="PADamage" value="1500"/>
+    <int name="MADamage" value="1500"/>
+    <int name="PDRate" value="25"/>
+    <int name="MDRate" value="25"/>
+    <int name="acc" value="600"/>
+    <string name="elemAttr" value="P2"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="500000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="magic" value="1"/>
+        <int name="disease" value="0"/>
+        <int name="level" value="0"/>
+        <int name="attackCount" value="3"/>
+        <int name="cooltime" value="2500"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <int name="nonLevelCheckACC" value="1"/>
+    <int name="nonLevelCheckEVA" value="1"/>
+    <int name="notConsiderFieldSet" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="100"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="128"/>
+        <int name="action" value="1"/>
+        <int name="level" value="7"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="9"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="I will make you regret this!"/>
+      </imgdir>
+    </imgdir>
+    <int name="hpTagBgcolor" value="3"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="161" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="bd427aaaea1847c666479be67792b05b06beb82bb32632a7126ded955f2afb71"/>
+    </canvas>
+    <canvas name="1" width="256" height="248">
+      <vector name="origin" x="161" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="951a0963998c1de1183445b160e0fb78b804f77e6859b5f8a97c7d9fe248b179"/>
+    </canvas>
+    <canvas name="2" width="256" height="236">
+      <vector name="origin" x="161" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="0606df1357becbb92ed8164123bc4f0c50a453d8bb2f2d862054175d3d7c2215"/>
+    </canvas>
+    <canvas name="3" width="256" height="244">
+      <vector name="origin" x="161" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="d9b9deb1cfdc029c3cbda2a2e5f276a46e7cdbbb368a849a4ae7e20b570b4124"/>
+    </canvas>
+    <canvas name="4" width="256" height="232">
+      <vector name="origin" x="161" y="228"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="b5946b5908a1bebf8155ee04ef507f02822b574efc8adaf0ba87c2b359af4f00"/>
+    </canvas>
+    <canvas name="5" width="256" height="244">
+      <vector name="origin" x="161" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="76172f894f9bb377f75cb5dbd73523dc8ad5ac286d9ae09c43ac9a989d4115d6"/>
+    </canvas>
+    <canvas name="6" width="256" height="256">
+      <vector name="origin" x="161" y="253"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="0a004e609478e64d284d0e81e28ffe7973a48b60160b8dff11459d97dcee615e"/>
+    </canvas>
+    <canvas name="7" width="256" height="256">
+      <vector name="origin" x="161" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="893a803240bb06adb568714125dbd3f44c7760592f9f95af1bd8acddb6f9f057"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="Do you think you can escape from me? What makes you think that? Foolish lower life-form... Who do you think I am?"/>
+    </imgdir>
+    <canvas name="0" width="260" height="248">
+      <vector name="origin" x="165" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="255c88d1e614078a57f14fe65da5a8c0363b43fab7f9065a68c7de09e49ca76d"/>
+    </canvas>
+    <canvas name="1" width="260" height="248">
+      <vector name="origin" x="164" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="b144c1da77dd8c1aef8a512d17ba7fa541241b2ea00ccd3eea2b19fd87c0b5b7"/>
+    </canvas>
+    <canvas name="2" width="260" height="236">
+      <vector name="origin" x="165" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="e9d065cdda0860d58faf577d05fbe5dc5630f82172f5042a373728095c6dee32"/>
+    </canvas>
+    <canvas name="3" width="260" height="232">
+      <vector name="origin" x="166" y="228"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="47cec7d12cdaeb8b24206a4af4ef5c9d6d40e2d6777def038deed603affd6e98"/>
+    </canvas>
+    <canvas name="4" width="264" height="244">
+      <vector name="origin" x="167" y="244"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="ed4e7b0f0b05665e4acc22dd8cac3067641f03ee9cb249c1f1ab705a76939107"/>
+    </canvas>
+    <canvas name="5" width="260" height="256">
+      <vector name="origin" x="166" y="253"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="0318b92874568c35819660d8c424265d2759e872ec94ddedc0e635b899629aef"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-627" y="-597"/>
+        <vector name="rb" x="582" y="246"/>
+      </imgdir>
+      <int name="attackAfter" value="2520"/>
+      <int name="effectAfter" value="900"/>
+      <imgdir name="hit">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="49" y="63"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f22fe7714033f8f8e781056f7d0a203d0efd708c2d7f218c66e5f45f9db1578c"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="1" height="1">
+          <vector name="origin" x="49" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9f9bc70c590a7bdcc02e62d83c1efb977987ce36e0a0093eee4ce234347cf93f"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="1" height="1">
+          <vector name="origin" x="48" y="52"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4e868d8208e74fac1e6077a048e57546cde70ca76bb5096f2ee69951155d91f8"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="1" height="1">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1fcc1e04e096ffd8b07dde8ab85432d434e24ccd9221fef3a50595ab13b14809"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="1" height="1">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f72900dbb32c47a09453725348ddf4122a2bef2260d3e52d6e6aafba0563564c"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="49" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e20c38698a34cc81e858072970fbc265563bc47aa08b567546b3c895638d5246"/>
+          <string name="_outlink" value="Mob/8220024.img/attack1/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="23" height="45">
+          <vector name="origin" x="16" y="181"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="1" width="24" height="48">
+          <vector name="origin" x="16" y="184"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="2" width="25" height="49">
+          <vector name="origin" x="16" y="185"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="3" width="114" height="138">
+          <vector name="origin" x="56" y="147"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="4" width="117" height="139">
+          <vector name="origin" x="59" y="147"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="5" width="133" height="133">
+          <vector name="origin" x="65" y="134"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="6" width="136" height="134">
+          <vector name="origin" x="67" y="134"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="7" width="136" height="134">
+          <vector name="origin" x="67" y="135"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="8" width="134" height="133">
+          <vector name="origin" x="66" y="135"/>
+          <int name="delay" value="100"/>
+        </canvas>
+        <canvas name="9" width="128" height="130">
+          <vector name="origin" x="60" y="135"/>
+          <int name="delay" value="180"/>
+        </canvas>
+        <canvas name="10" width="252" height="258">
+          <vector name="origin" x="128" y="192"/>
+          <int name="delay" value="130"/>
+        </canvas>
+        <canvas name="11" width="246" height="250">
+          <vector name="origin" x="125" y="188"/>
+          <int name="delay" value="140"/>
+        </canvas>
+        <canvas name="12" width="246" height="250">
+          <vector name="origin" x="125" y="188"/>
+          <int name="delay" value="150"/>
+        </canvas>
+      </imgdir>
+    </imgdir>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+    <uol name="24" value="../stand/6"/>
+    <uol name="25" value="../stand/7"/>
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="Burn before this great power, along with this world! Hahahahaha!"/>
+      <string name="1" value="Turn to ash! Hahahahaha!"/>
+    </imgdir>
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="161" y="243"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="443f7e9b9f6c3ed07c35e9b6dbcc8ba2808e2f92a4abd68351396b1f33dd9c83"/>
+    </canvas>
+    <canvas name="1" width="268" height="248">
+      <vector name="origin" x="175" y="246"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="fb24c914f53bcca82b22d44eb9c7c4449acff5ea6ac4536d8f8ec5ae8fe4efb3"/>
+    </canvas>
+    <canvas name="2" width="240" height="252">
+      <vector name="origin" x="146" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="375d944f4a6074552542141e61b03b96eb33ea2713b37fa24561834659e99437"/>
+    </canvas>
+    <canvas name="3" width="256" height="256">
+      <vector name="origin" x="160" y="258"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="ecaa56224c4334cd21deb97029b49c4abf19cea8d8ed74697be03e052aadd710"/>
+    </canvas>
+    <canvas name="4" width="260" height="288">
+      <vector name="origin" x="164" y="290"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="4ac0b9bbe1404a7141819b9347f1573462612dc140a0f186d200e1c6a6f4f09b"/>
+    </canvas>
+    <canvas name="5" width="252" height="296">
+      <vector name="origin" x="155" y="296"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="cf5342c67bf6bfea01e09acea31824bbe9beefc48ded3334a1eb54a66c3f11c6"/>
+    </canvas>
+    <canvas name="6" width="256" height="292">
+      <vector name="origin" x="160" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="32aa4a59c0e86a68433fc8d157ef9efb46e57a76d595fa7541fb8261495186a5"/>
+    </canvas>
+    <canvas name="7" width="244" height="296">
+      <vector name="origin" x="149" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="cd2dfd0e0985e56ad9574a48c44216b74f3238a62509c8a64004a23f64b8c253"/>
+    </canvas>
+    <canvas name="8" width="244" height="296">
+      <vector name="origin" x="149" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="cd7398cd61559adbd4bcd60fb739cc1014813c00745005ead3dec75fde4406c2"/>
+    </canvas>
+    <canvas name="9" width="244" height="292">
+      <vector name="origin" x="149" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="9ac969c4db107878ae55dfa6157d5c7bb0c8cc23112e028b2f7ac4f41ed78526"/>
+    </canvas>
+    <canvas name="10" width="320" height="356">
+      <vector name="origin" x="188" y="348"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="c94d2ad080d4a962d4915be307d3f170e1f8fee4fcaa85b28d742f1484d711d6"/>
+    </canvas>
+    <canvas name="11" width="304" height="348">
+      <vector name="origin" x="170" y="339"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="7656f96fb9fa88e362bb47c74b469ce6da6c4c1c326db674a8cff8f8dbe1db76"/>
+    </canvas>
+    <canvas name="12" width="304" height="348">
+      <vector name="origin" x="170" y="342"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="5a5c8fa93f2d10c6467fa890ff4a76dace10923e3c1da9b475dc4baa36da5a42"/>
+    </canvas>
+    <canvas name="13" width="304" height="348">
+      <vector name="origin" x="170" y="343"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="2ba0304fa47453642386edbb3656da20c1847b375faa4a796e90a0324b9b2c82"/>
+    </canvas>
+    <canvas name="14" width="304" height="348">
+      <vector name="origin" x="169" y="344"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="500268ad257514073d05b3f37337e62c4c8ed21e3a1ec7d41e293641b597c269"/>
+    </canvas>
+    <canvas name="15" width="300" height="348">
+      <vector name="origin" x="167" y="345"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="97eac791e961e878107ffd9cd256b1423cd5a56d7463be1408b3ce6c9a85b8eb"/>
+    </canvas>
+    <canvas name="16" width="244" height="328">
+      <vector name="origin" x="147" y="345"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="8eae3d8f3f91654aacca2bf5d512e45799836e98f2458a865c8d6ebaa5d07836"/>
+    </canvas>
+    <canvas name="17" width="272" height="316">
+      <vector name="origin" x="175" y="336"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="3d044a6be5326d21125c5373e6b796e0d8cc36f4da8834ff32d717c5db003924"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="Impossible! Impossible!"/>
+    </imgdir>
+    <canvas name="0" width="268" height="244">
+      <vector name="origin" x="110" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="32" y="-163"/>
+      <vector name="lt" x="-112" y="-212"/>
+      <vector name="rb" x="150" y="-14"/>
+      <int name="delay" value="300"/>
+      <string name="_hash" value="474f053c65a85581388b238f9c0291503544fc394ea2e5fef687488163d7d55a"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="How dare you! You! You! You! Impossible! How could I lose? Impossible!"/>
+    </imgdir>
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="130" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="61b6f4efb51896b9f57a98fe28f3f35363dbb3a4d0728c83f134683dbef216dc"/>
+    </canvas>
+    <canvas name="1" width="268" height="244">
+      <vector name="origin" x="110" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+      <string name="_inlink" value="hit1/0"/>
+    </canvas>
+    <canvas name="2" width="268" height="232">
+      <vector name="origin" x="106" y="230"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="a1b6b0c38bd998aa4648fa41a2d3290676ca319e263c37e313f6f25e4064469c"/>
+    </canvas>
+    <canvas name="3" width="268" height="240">
+      <vector name="origin" x="104" y="236"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="fbf90f79c1e015a2f3daf253bb292bed85ce37c9b3a64c67573c1a543e45f3ab"/>
+    </canvas>
+    <canvas name="4" width="268" height="244">
+      <vector name="origin" x="103" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="765e749105e33ea28ba053deb5c024d0143291e7c20950a83e7c930b8aa525e2"/>
+    </canvas>
+    <canvas name="5" width="268" height="244">
+      <vector name="origin" x="102" y="240"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="8efbfe202d95b3874454dd633999efce8ed1bb241ab30548729d8291f6886d3b"/>
+    </canvas>
+    <canvas name="6" width="268" height="240">
+      <vector name="origin" x="101" y="236"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="ba5ce48495fa17cf045cca8a0f313d80b66e7244bc94bc974750953f4466b60c"/>
+    </canvas>
+    <canvas name="7" width="268" height="204">
+      <vector name="origin" x="100" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="1c0dc1f2de266f43a38e6421e15e439d64d5d2d62f275e00537db74ef3170bfb"/>
+    </canvas>
+    <canvas name="8" width="268" height="208">
+      <vector name="origin" x="97" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="85962e12ccbcf0adba8d48b3133a0fadb22bd508f2e755ae42f115a310c192a1"/>
+    </canvas>
+    <canvas name="9" width="252" height="200">
+      <vector name="origin" x="81" y="200"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="f7a5ac42c0be621139c078f763ec0266751d04584d8d7ccd01549eb7a0260f35"/>
+    </canvas>
+    <canvas name="10" width="232" height="184">
+      <vector name="origin" x="64" y="182"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="a99eb2ff64f2e3b15f1b356ecf9e399514fbd34a311b74ff5b85dce6e383837a"/>
+    </canvas>
+    <canvas name="11" width="220" height="176">
+      <vector name="origin" x="52" y="176"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="41defa07fc4dc50f571e274447d9c3b18bf22a76f75f698ba322ddaf3c440496"/>
+    </canvas>
+    <canvas name="12" width="172" height="152">
+      <vector name="origin" x="10" y="155"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="769558f583c365edcd68f00e604e851d93c12340bcf492d653f1f2e66d6ce1fa"/>
+    </canvas>
+    <canvas name="13" width="160" height="144">
+      <vector name="origin" x="3" y="150"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="e8054507a9e49558dc89a400d25a636f835650de107b68a82fa190ee1753d0ec"/>
+    </canvas>
+    <canvas name="14" width="96" height="100">
+      <vector name="origin" x="-53" y="110"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="099d21c3aa7e6dee09618c11a597cd9ea17041306a68e2a26057f9e86c855f2c"/>
+    </canvas>
+    <canvas name="15" width="36" height="88">
+      <vector name="origin" x="-59" y="106"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="03f6f6f4ee0aba23be5fac43d0cbd1f26f70281d0fd4640431c34a3ca5bdf0c9"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="regen">
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="More fearless fools have appeared. I will show you my power. Kneel before this great might!"/>
+    </imgdir>
+    <canvas name="0" width="164" height="124">
+      <vector name="origin" x="-97" y="104"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="383006fadb41017b717bfdbb3df14b22dbf09873bb2d7257279340cc43f89731"/>
+    </canvas>
+    <canvas name="1" width="184" height="160">
+      <vector name="origin" x="-95" y="143"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a9c43056e2849d974d54bff5025d8e4156bf559f74735889f1ebf7fe2b3e85d"/>
+    </canvas>
+    <canvas name="2" width="564" height="488">
+      <vector name="origin" x="143" y="469"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c23bac0ad00bfbce57b25fe6e214fed99751d2273970bfbf853303a9e40aae38"/>
+    </canvas>
+    <canvas name="3" width="860" height="512">
+      <vector name="origin" x="440" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3692c45cb927feaece7e9464eee47c777c442fe724b8330cca9635abf67d96bd"/>
+    </canvas>
+    <canvas name="4" width="848" height="500">
+      <vector name="origin" x="433" y="469"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="10fe4b2574c04d0fe40e877f10086bf6cec53982abc34d751ec03ea31237ba36"/>
+    </canvas>
+    <canvas name="5" width="836" height="484">
+      <vector name="origin" x="432" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a4b66cc52c70d612c84928ad0f12c17d70581e0e814a025f5ea033bc353e301f"/>
+    </canvas>
+    <canvas name="6" width="796" height="484">
+      <vector name="origin" x="427" y="466"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="355dba27120226e8005ba1987e3779f9429d572ab2476a6a6c4f7451be7ac131"/>
+    </canvas>
+    <canvas name="7" width="728" height="464">
+      <vector name="origin" x="368" y="452"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a6efbbb2e26dba3125476dff15fc9a4882855d5988719112a45d55de638964b4"/>
+    </canvas>
+    <canvas name="8" width="536" height="444">
+      <vector name="origin" x="354" y="433"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bca5f386756cd000cd09f717a820de4c508f0fe5b8c72b2fc090bfede87cd4a4"/>
+    </canvas>
+    <canvas name="9" width="372" height="428">
+      <vector name="origin" x="187" y="422"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dbd5718714d9918b6f0afb1e8f7e1ea8bbcdd8dfa3b9a1e3676fbbf9074baf62"/>
+    </canvas>
+    <canvas name="10" width="424" height="400">
+      <vector name="origin" x="259" y="338"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="638552a138ab2073144ecd62f0bdf02364c408e2560764ae59e796bf57c5a06d"/>
+    </canvas>
+    <canvas name="11" width="388" height="304">
+      <vector name="origin" x="209" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bff550983c2f3359481fc4f0a85ec8c6b2bd7e11b731f087a1fe1556a6a1d10e"/>
+    </canvas>
+    <canvas name="12" width="436" height="348">
+      <vector name="origin" x="182" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ea20ffa0329d7e33ebd9598d08bab9225fec7159737e659050fb48d0f3639acf"/>
+    </canvas>
+    <canvas name="13" width="468" height="432">
+      <vector name="origin" x="268" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="853dcd7913494e31f66aff413dd159426338d78a211b2fb8dce9851321fbb366"/>
+    </canvas>
+    <canvas name="14" width="420" height="240">
+      <vector name="origin" x="253" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c14307c39a05cb48072d524ae381a2663f5ca5c863ba1f1888dc2a4feaf056a8"/>
+    </canvas>
+    <canvas name="15" width="376" height="376">
+      <vector name="origin" x="198" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fa075d29d4a81444fd67a51f2f29a562a6e8b09c8dcc78e73d62934f02eec42b"/>
+    </canvas>
+    <canvas name="16" width="460" height="400">
+      <vector name="origin" x="157" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d0dbc7361eae8cdf8f1bde04e77c68d207a84fec95632596013b6fc5a79e9cac"/>
+    </canvas>
+    <canvas name="17" width="424" height="464">
+      <vector name="origin" x="239" y="317"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="520d6f97cb7d618000772ed2162c362779f223f6795fd53730eee954a8bf8e0f"/>
+    </canvas>
+    <canvas name="18" width="388" height="400">
+      <vector name="origin" x="221" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45fb2f1330ab604313a7cea5bc42cb9f7e2e83cfbc90b2b19059f70df8a87273"/>
+    </canvas>
+    <canvas name="19" width="460" height="432">
+      <vector name="origin" x="154" y="278"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0454cde7197ece210169fbcac3ebb1ea744b8e1eb53e704ded9da47d6aca9237"/>
+    </canvas>
+    <canvas name="20" width="552" height="532">
+      <vector name="origin" x="271" y="390"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cac5f25b8fb7821a34341e64abec071609752bcd3993afbdf7b76d95f6e5f99c"/>
+    </canvas>
+    <canvas name="21" width="440" height="308">
+      <vector name="origin" x="256" y="222"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bbbda1b3256cf1cd7f6d0b559370af092201c4bb620bf8f4683cbd532f819cdd"/>
+    </canvas>
+    <canvas name="22" width="352" height="336">
+      <vector name="origin" x="173" y="282"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a37748adbb655dc8f3e8f1e76ce9a670bad12d0cd58489e47c1debcd6b2b2e71"/>
+    </canvas>
+    <canvas name="23" width="396" height="360">
+      <vector name="origin" x="193" y="294"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7595dc6eb03d4b684a39f403306f80cb9941deafc5ed566710db40d55a697a6b"/>
+    </canvas>
+    <canvas name="24" width="396" height="376">
+      <vector name="origin" x="191" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b55f08ba541ff2d2b48b1d78e683f587a825c7d33d2261e98ac1986748e002b3"/>
+    </canvas>
+    <canvas name="25" width="384" height="384">
+      <vector name="origin" x="186" y="305"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bd1a894b26c17c38d62c2d3c8e421c68caf00f1773dc4771760d9cc740e34191"/>
+    </canvas>
+    <canvas name="26" width="384" height="384">
+      <vector name="origin" x="185" y="305"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e1634ea15dc79210137c22479ba9aa77f7a7298672af8476da60a22e4090dc2b"/>
+    </canvas>
+    <canvas name="27" width="380" height="380">
+      <vector name="origin" x="183" y="303"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c3fa7b2710c328f3a0a5152177725f97fbb4de004ab0b4b9578aa353c8c59951"/>
+    </canvas>
+    <canvas name="28" width="332" height="348">
+      <vector name="origin" x="183" y="289"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="81015d10a202430bfc86fa524726b4710a52f5d2d84825f7fb425c07f6689ef3"/>
+    </canvas>
+    <canvas name="29" width="332" height="352">
+      <vector name="origin" x="184" y="291"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8dcb22e042dc12ed16fd01af950da50e1d7290b25b4c5f35f200040bee56ef7c"/>
+    </canvas>
+    <canvas name="30" width="320" height="320">
+      <vector name="origin" x="177" y="278"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ecf51634b6c189de16798cecdb0f4ba6d421bff4d8192aa086380275c6b38920"/>
+    </canvas>
+    <canvas name="31" width="316" height="316">
+      <vector name="origin" x="179" y="280"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1152a8f37d7fb58712f803b4a1f721b6ecbb561cd027ace0ac2862b267265622"/>
+    </canvas>
+    <canvas name="32" width="260" height="256">
+      <vector name="origin" x="131" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="00e3fdacedc92990e3d4dd771684d8bbb70b2467f4cf43c2015316f84ef160ed"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-570" y="-645"/>
+        <vector name="rb" x="603" y="171"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="100" height="128">
+          <vector name="origin" x="49" y="63"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="965aebbf037df2db2238fd06c80659dcccd2aaa3217afda4039a32b3beabe400"/>
+        </canvas>
+        <canvas name="1" width="100" height="124">
+          <vector name="origin" x="49" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="15982111885848b17a5328515e925d50886c1a549cb1fd7d6556f9fd5e059112"/>
+        </canvas>
+        <canvas name="2" width="104" height="108">
+          <vector name="origin" x="50" y="52"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5fbc2ac381a9e65736876dbaa03e333a5cbbfba0217046dc75e37f7e154fd131"/>
+        </canvas>
+        <canvas name="3" width="104" height="92">
+          <vector name="origin" x="51" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="70056b82e35774211e06cc98209213efe560ea9bcc564a9ceef5f197e175f883"/>
+        </canvas>
+        <canvas name="4" width="104" height="92">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="36c394d69b6d8b4856dfada0fb9133dbfc62ff3e7863edbd72da5fa1dd1b8e74"/>
+        </canvas>
+        <canvas name="5" width="100" height="88">
+          <vector name="origin" x="49" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="92360631ff8eb213b6add343b43e27969831853ae5a655c387b78596408e154c"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="2610"/>
+      <int name="effectAfter" value="990"/>
+      <imgdir name="effect">
+        <canvas name="0" width="110" height="140">
+          <vector name="origin" x="53" y="140"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="1" width="124" height="140">
+          <vector name="origin" x="61" y="140"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="2" width="132" height="142">
+          <vector name="origin" x="64" y="142"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="3" width="132" height="142">
+          <vector name="origin" x="64" y="142"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="4" width="132" height="140">
+          <vector name="origin" x="64" y="142"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="5" width="132" height="138">
+          <vector name="origin" x="64" y="142"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="6" width="134" height="139">
+          <vector name="origin" x="65" y="143"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="7" width="132" height="136">
+          <vector name="origin" x="64" y="142"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="8" width="114" height="125">
+          <vector name="origin" x="52" y="131"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="9" width="21" height="113">
+          <vector name="origin" x="9" y="122"/>
+          <int name="delay" value="95"/>
+        </canvas>
+        <canvas name="10" width="3" height="53">
+          <vector name="origin" x="0" y="103"/>
+          <int name="delay" value="95"/>
+        </canvas>
+      </imgdir>
+    </imgdir>
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="161" y="241"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="78fe704193ae1d25bad9e69f8ffb6cca0950316631b4de7fed38112aee032bb9"/>
+    </canvas>
+    <canvas name="1" width="268" height="264">
+      <vector name="origin" x="168" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="cc8cf2eb9a12ff8cfcaf39524dc68173d44369e8fca7ebad03c257c03e6c9235"/>
+    </canvas>
+    <canvas name="2" width="232" height="252">
+      <vector name="origin" x="128" y="229"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="5a60fd42c640b8c62b114675225c2784741d0f8545016a7a7a10f23793c007c0"/>
+    </canvas>
+    <canvas name="3" width="232" height="264">
+      <vector name="origin" x="128" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="9bf363e074210560447ba375c4353da981e1817e6657ce6d91a223ee8041f3f9"/>
+    </canvas>
+    <canvas name="4" width="232" height="256">
+      <vector name="origin" x="129" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="5d92981afe7d59260603170335ecc31accf76fd2a72634f02117288986e1553a"/>
+    </canvas>
+    <canvas name="5" width="236" height="272">
+      <vector name="origin" x="130" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="b7a67ff5808ded2a6fb9b89becd8dfe804ce714a88c4a63f761a8bfbafedcd9a"/>
+    </canvas>
+    <canvas name="6" width="232" height="284">
+      <vector name="origin" x="129" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="f46fe352bbfb1771e23ecf539d8bcb649f6a988f2fb2623d25c915594df06d48"/>
+    </canvas>
+    <canvas name="7" width="232" height="280">
+      <vector name="origin" x="127" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="e41f48b769c8d7ff54ef10d1c3db1700188dd421adc62386b61fe3302567db11"/>
+    </canvas>
+    <canvas name="8" width="228" height="272">
+      <vector name="origin" x="125" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="559aa2a9f70cd4e22b81dbdaee021a46b62b62b7e848cdb2a3c1e9e2836ee3f4"/>
+    </canvas>
+    <canvas name="9" width="224" height="272">
+      <vector name="origin" x="124" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="cf8332d9c9d1db0295748ae23d383f0ec3540ae16e5b978c90c9c1d8eed1beac"/>
+    </canvas>
+    <canvas name="10" width="228" height="256">
+      <vector name="origin" x="124" y="229"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="8d2de386936a84a9d6f9f075ffa6cce0ab5d287030732e55925848f09028fb3c"/>
+    </canvas>
+    <canvas name="11" width="308" height="328">
+      <vector name="origin" x="168" y="297"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="54f0b3eaea571388a06e6cc1e5991f618e5aa97da5229bc3b1351226119b8677"/>
+    </canvas>
+    <canvas name="12" width="304" height="348">
+      <vector name="origin" x="168" y="317"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="18c5721ff3c7e74df40d5a13a1b1bf5f1781024d7a14f3c6385b6494e0b72b4a"/>
+    </canvas>
+    <canvas name="13" width="304" height="352">
+      <vector name="origin" x="168" y="322"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="a1f99e048ead3997e6ee2c4d96d7777fc565c775294afbe2deed91ba2b209e89"/>
+    </canvas>
+    <canvas name="14" width="304" height="356">
+      <vector name="origin" x="168" y="325"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="e8474758a497d3d8ed56d24db516a199e57f3bc057c38582b12e014d03d53add"/>
+    </canvas>
+    <canvas name="15" width="304" height="352">
+      <vector name="origin" x="167" y="326"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="c358b2e93c047f1395b5b90c4f1ddfed2ceea5907f2505fdb1cb510cc9837c31"/>
+    </canvas>
+    <canvas name="16" width="300" height="348">
+      <vector name="origin" x="165" y="327"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="029987b54b21eb920698b111d13f47bbec5e59fdd85c61cf00356859ebd4050b"/>
+    </canvas>
+    <canvas name="17" width="224" height="308">
+      <vector name="origin" x="121" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="38168422525371e01ac0503e07a743e71002bcb80cf273a1df8affb8de3d0b85"/>
+    </canvas>
+    <canvas name="18" width="272" height="280">
+      <vector name="origin" x="168" y="271"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="8c801cfecdcc1d282f00de6ed00a99301d843941c5bec884961a0fca53ebb8bf"/>
+    </canvas>
+    <uol name="19" value="../stand/0"/>
+    <uol name="20" value="../stand/1"/>
+    <uol name="21" value="../stand/2"/>
+    <uol name="22" value="../stand/3"/>
+    <uol name="23" value="../stand/4"/>
+    <uol name="24" value="../stand/5"/>
+    <uol name="25" value="../stand/6"/>
+    <uol name="26" value="../stand/7"/>
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="Freeze, you ridiculous world!"/>
+      <string name="1" value="Ahahahahahahahahaha!"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-584" y="-900"/>
+        <vector name="rb" x="592" y="48"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="156" height="204">
+          <vector name="origin" x="78" y="101"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="df0c08c9cb4cd67ce2fd5ac6b8871e86afcaab3d2be771bc331682ea9ce2831b"/>
+        </canvas>
+        <canvas name="1" width="168" height="168">
+          <vector name="origin" x="84" y="84"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e8cbe781ec7017c52de7c613964eea9ebff0db72e69f8f2e65a8418f98542843"/>
+        </canvas>
+        <canvas name="2" width="176" height="176">
+          <vector name="origin" x="86" y="87"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="c99bf4b6a89d58c848bba5a6f0e6c8270c4882b502f6898e274d4a736456476a"/>
+        </canvas>
+        <canvas name="3" width="172" height="172">
+          <vector name="origin" x="86" y="86"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4e571f43378a791b61e02dde80c1476f958f6aa28b96d150c4efbf309af2e65d"/>
+        </canvas>
+        <canvas name="4" width="172" height="172">
+          <vector name="origin" x="86" y="86"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="2d2b130ca964fcb48d51ab67b7a244b4998bc36c9d29113edfca4fa46965be62"/>
+        </canvas>
+        <canvas name="5" width="172" height="172">
+          <vector name="origin" x="86" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="63d19520e356bf3a42ccab1b1acb46d360374f283bc4bb7ca4d5b84579f6aa23"/>
+        </canvas>
+        <canvas name="6" width="144" height="144">
+          <vector name="origin" x="71" y="71"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8d4d606ffb78257cd85cc863d6926e397750d3c112b6662b0c297cb5ff65f675"/>
+        </canvas>
+        <canvas name="7" width="140" height="136">
+          <vector name="origin" x="68" y="68"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="72f874ed8dc1224abf628797e028b94f5a494020cc5aff624f578253c8ff3585"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1890"/>
+      <int name="effectAfter" value="990"/>
+      <imgdir name="effect">
+        <canvas name="0" width="162" height="142">
+          <vector name="origin" x="82" y="120"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="165" height="153">
+          <vector name="origin" x="85" y="131"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="166" height="159">
+          <vector name="origin" x="78" y="140"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="180" height="181">
+          <vector name="origin" x="78" y="162"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="162" height="205">
+          <vector name="origin" x="69" y="186"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="159" height="216">
+          <vector name="origin" x="70" y="197"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="142" height="202">
+          <vector name="origin" x="65" y="188"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="162" height="210">
+          <vector name="origin" x="73" y="194"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="176" height="193">
+          <vector name="origin" x="73" y="193"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="165" height="145">
+          <vector name="origin" x="73" y="198"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="171" height="173">
+          <vector name="origin" x="72" y="202"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+    </imgdir>
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="161" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+    </canvas>
+    <canvas name="1" width="268" height="244">
+      <vector name="origin" x="175" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="209c7e1f6af03aabd74ce3c84eb77884cc72518db1d5ab2d12a16785209a62a6"/>
+    </canvas>
+    <canvas name="2" width="224" height="236">
+      <vector name="origin" x="127" y="233"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="5d3bcb103f556ca9dc794de52ad2557f4c898ffd3e46ee9cd0d3c1210ddaf726"/>
+    </canvas>
+    <canvas name="3" width="208" height="240">
+      <vector name="origin" x="114" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="640193e4bd9675242acb323a190fa912b1384a2c14e9e55d9d728aa847588977"/>
+    </canvas>
+    <canvas name="4" width="224" height="280">
+      <vector name="origin" x="128" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="b558d1dc825752bcb7db6d75113f54bec95d8d2148011e88ed0a39a7d56dd9d0"/>
+    </canvas>
+    <canvas name="5" width="248" height="284">
+      <vector name="origin" x="141" y="282"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="faaaa97213e0e766202dd28e9247f9b28fdaae230f3c79448187847b8e9d7fdf"/>
+    </canvas>
+    <canvas name="6" width="264" height="284">
+      <vector name="origin" x="151" y="282"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="0304b0a998faf19a2fa1f81af3c8fa291a7cc191421b715d4edfc0be637fdd5d"/>
+    </canvas>
+    <canvas name="7" width="320" height="312">
+      <vector name="origin" x="184" y="309"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="982084f06f695832aced6edadd9dc079fe18c7f8a6d612577050be5afc029703"/>
+    </canvas>
+    <canvas name="8" width="324" height="316">
+      <vector name="origin" x="187" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="08381d07d9b2a094ebb35bf2b2ac5dfd708ec1d521d34d20c0df58243ccf1735"/>
+    </canvas>
+    <canvas name="9" width="324" height="316">
+      <vector name="origin" x="187" y="312"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="5cdc90aa4ce335cb7c58fa5953006047c6508154e141ef2fdf4f513f4ff16dc7"/>
+    </canvas>
+    <canvas name="10" width="336" height="324">
+      <vector name="origin" x="195" y="317"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="44fc135f382de5a7a56bbb1578fdffb6ae9421497bc64693840159d682d3e079"/>
+    </canvas>
+    <canvas name="11" width="388" height="364">
+      <vector name="origin" x="242" y="344"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="bac336f5696480eba768cb5094d1c1862c468873dbfa4b7cffb91fae981d7e8a"/>
+    </canvas>
+    <canvas name="12" width="404" height="416">
+      <vector name="origin" x="242" y="402"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="8dc737e354632c7d7018081a091c426f1c46eaf10b9befc23cfea72ff599bce4"/>
+    </canvas>
+    <canvas name="13" width="456" height="416">
+      <vector name="origin" x="253" y="408"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="6d6419d5084f1e6ce845f1e98647b8552ec1b44629d29420a4ba80cd0217d913"/>
+    </canvas>
+    <canvas name="14" width="472" height="420">
+      <vector name="origin" x="262" y="411"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="9e661b433683c05fdf8243c6b38820e06a08b14ff6a1e75ebc8cf1da0dcea83d"/>
+    </canvas>
+    <canvas name="15" width="480" height="416">
+      <vector name="origin" x="266" y="412"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="7b58786140c032741f1a8672f2298b29bf5067d4ffecf966aaf004ba2ef4e6f8"/>
+    </canvas>
+    <canvas name="16" width="480" height="420">
+      <vector name="origin" x="266" y="413"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="fc8f88b656f9776f021aed16842fa79979998814354325661ac39b602b3104bb"/>
+    </canvas>
+    <canvas name="17" width="476" height="340">
+      <vector name="origin" x="263" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="944560ebc78370f63eded4db3ccd384cedc4c54c9b64d341e34758ee7201743f"/>
+    </canvas>
+    <canvas name="18" width="464" height="276">
+      <vector name="origin" x="258" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="0b19357b61333b6b24fac8820c21ba50a8a5c10af9b81c3f24e413ee6ffe90f0"/>
+    </canvas>
+    <uol name="19" value="../stand/0"/>
+    <uol name="20" value="../stand/1"/>
+    <uol name="21" value="../stand/2"/>
+    <uol name="22" value="../stand/3"/>
+    <uol name="23" value="../stand/4"/>
+    <uol name="24" value="../stand/5"/>
+    <uol name="25" value="../stand/6"/>
+    <uol name="26" value="../stand/7"/>
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="I will control all magic in this world! Vanish before the light!"/>
+      <string name="1" value="Ahahahahahahahahaha!"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="How about this? Hahahaha!"/>
+      <string name="1" value="Take this!"/>
+    </imgdir>
+    <canvas name="0" width="256" height="248">
+      <vector name="origin" x="161" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_outlink" value="Mob/9303131.img/attack1/0"/>
+    </canvas>
+    <canvas name="1" width="268" height="244">
+      <vector name="origin" x="175" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="44525d70458ba03c2c201835f66dcc143181bb2e78d8f47c8f777644329aef81"/>
+    </canvas>
+    <canvas name="2" width="224" height="232">
+      <vector name="origin" x="130" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="44d11bb6ce4a65db7488184ed2b22c9206477782377bbaf14013e8f987e30c66"/>
+    </canvas>
+    <canvas name="3" width="216" height="228">
+      <vector name="origin" x="122" y="228"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="478250de271aaa3439754d708b7e56a9a68db309a2fa8193513a5d8ba1b7c2e0"/>
+    </canvas>
+    <canvas name="4" width="216" height="240">
+      <vector name="origin" x="122" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="8fe9b0fabb8f05bcaf5076e46d6aaca165b3088f6f44f4e324b6c8b1bb78b4d0"/>
+    </canvas>
+    <canvas name="5" width="216" height="252">
+      <vector name="origin" x="121" y="253"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="3f427e1ce586bb831f36fa092fbc4cb5b4ca2150c39eeed4d348d8d19e308a46"/>
+    </canvas>
+    <canvas name="6" width="216" height="252">
+      <vector name="origin" x="120" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="ff3699b8174c90a37d0060f4a523a25cb131ca3ba83dd6d1628f0e9bdf3be7b1"/>
+    </canvas>
+    <canvas name="7" width="216" height="244">
+      <vector name="origin" x="119" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="2644cec5c879cfecad9f66432357ab823b277679009e3b22b6d8ea941c48ca41"/>
+    </canvas>
+    <canvas name="8" width="212" height="244">
+      <vector name="origin" x="118" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="ffe396a90e084625e0ddfee061016d3346bda89ff277ced45596cd3194e5e5d5"/>
+    </canvas>
+    <canvas name="9" width="212" height="232">
+      <vector name="origin" x="117" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="f343f83d4836bdde634eb9e80f0ba29d45215f013da1c8a1b5dd232ba0e361ee"/>
+    </canvas>
+    <canvas name="10" width="212" height="240">
+      <vector name="origin" x="116" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="a629d2e11bfa3de386e1c5a60e285289c046a51a143124cc2ea332e3a36d933c"/>
+    </canvas>
+    <canvas name="11" width="212" height="228">
+      <vector name="origin" x="115" y="228"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="7ffe1c9b041c33afdaf867f446f1ac5b7018c1d56cfef566289785cee81d0935"/>
+    </canvas>
+    <canvas name="12" width="208" height="252">
+      <vector name="origin" x="114" y="253"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="6fb33064b45871e6767f0e637b32ec29ae1dade0c07e6d9330ed7fc3c98798eb"/>
+    </canvas>
+    <canvas name="13" width="248" height="288">
+      <vector name="origin" x="154" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="156206cf35e0f3a4ef4ec52f5cb96b4c1925524092391480e0bfe4db6e33fbe8"/>
+    </canvas>
+    <canvas name="14" width="256" height="268">
+      <vector name="origin" x="161" y="256"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="676a115da7a0734ca0c8091c7229017351e465f121a8591abee83310d675f0fa"/>
+    </canvas>
+    <canvas name="15" width="256" height="268">
+      <vector name="origin" x="160" y="259"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="e7ccfb17de2f025bc77b886abc6276c4adb2ce76ab374e7ed254e349e6bec4a9"/>
+    </canvas>
+    <canvas name="16" width="244" height="264">
+      <vector name="origin" x="150" y="261"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="e8d8d62c2513597d339a5b38727264da299421f8e32f8d46e341bc8fb7e02c24"/>
+    </canvas>
+    <canvas name="17" width="248" height="268">
+      <vector name="origin" x="151" y="263"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="3f1bca2bd12ab666539c3e9704d86cf1051bb857dfba5c5f248d117ab6687a4c"/>
+    </canvas>
+    <canvas name="18" width="244" height="260">
+      <vector name="origin" x="150" y="263"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="7fe96770e5851dc16dd60a44be4175edd516c461a7ad046d1a71b5c97cad192c"/>
+    </canvas>
+    <canvas name="19" width="244" height="260">
+      <vector name="origin" x="149" y="263"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="a1c46c708c26d240b8179dcb5b477acf06fe9722b6245fdf92f82125372523a9"/>
+    </canvas>
+    <canvas name="20" width="240" height="260">
+      <vector name="origin" x="146" y="260"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="7317f100cd6b3158db0fc40b73e9f56278efd26ee8dcb575cb25a0ba984ea8bd"/>
+    </canvas>
+    <canvas name="21" width="272" height="252">
+      <vector name="origin" x="175" y="252"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="-25" y="-157"/>
+      <vector name="lt" x="-160" y="-226"/>
+      <vector name="rb" x="92" y="-12"/>
+      <string name="_hash" value="987ef4288e5f79b6009ef3de2cf32be2e0ac98cca312ad11803f8f1eb54df67c"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787128.img.xml
+++ b/gms-server/wz/Mob.wz/8787128.img.xml
@@ -1,1 +1,999 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787128.img"><imgdir name="info"><int name="level" value="100"/><int name="maxHP" value="999999999"/><int name="maxMP" value="50000"/><int name="speed" value="5"/><int name="PADamage" value="1500"/><int name="MADamage" value="1500"/><int name="PDRate" value="25"/><int name="MDRate" value="25"/><int name="acc" value="600"/><string name="elemAttr" value="P2"/><int name="eva" value="80"/><int name="pushed" value="100000"/><float name="fs" value="10.0"/><int name="exp" value="500000"/><int name="summonType" value="1"/><int name="category" value="8"/><int name="firstAttack" value="1"/><string name="mobType" value="1N"/><int name="boss" value="1"/><imgdir name="attack"><imgdir name="0"><int name="action" value="1"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="2"/><int name="magic" value="1"/><int name="rush" value="1"/><int name="knockback" value="1"/><int name="ignoreStance" value="100"/></imgdir></imgdir><int name="ignoreMoveImpact" value="1"/><int name="bodyAttack" value="1"/><int name="PDDamage" value="3000"/><int name="MDDamage" value="3000"/><int name="nonLevelCheckACC" value="1"/><int name="nonLevelCheckEVA" value="1"/><int name="notConsiderFieldSet" value="1"/><imgdir name="speak"><int name="chatBalloon" value="0"/><imgdir name="0"><string name="0" value="讓你後悔！"/></imgdir></imgdir><int name="hpTagBgcolor" value="3"/><int name="hpTagColor" value="1"/></imgdir><imgdir name="stand"><canvas name="0" width="202" height="242"><vector name="origin" x="77" y="242"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="9af6f81a1ab95b0e0c4f55c0a53f8f2f635bcfd706301d4aa995e5d4a9c4eb0d"/></canvas><canvas name="1" width="201" height="243"><vector name="origin" x="77" y="242"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="d707327d6bee4545ec95ccd3f4fcf6c1161d673f7efe94cf565c66bc1768c124"/></canvas><canvas name="2" width="202" height="230"><vector name="origin" x="77" y="230"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="7c83ff901cb3faea57d33cb638db973498aa1a1f5dbcce932d5cb9575a2b3d26"/></canvas><canvas name="3" width="202" height="237"><vector name="origin" x="77" y="239"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="e07750e90046d1a1960344001286c5ec26199031caed0b7459d7d54ab248df3f"/></canvas><canvas name="4" width="202" height="225"><vector name="origin" x="77" y="228"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="0954b0fa686369d05d9a4f11861be60a4d8f32a99a877d9b255771130b576b99"/></canvas><canvas name="5" width="202" height="239"><vector name="origin" x="77" y="243"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="d920cb060a062489fe62e53f4a31d791a706134036615cbf43cc3865b51fdd76"/></canvas><canvas name="6" width="202" height="250"><vector name="origin" x="77" y="253"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="f9a152963ba5d59af7a05ce5cd81c504df234d1466f8162465f897f0d325e64c"/></canvas><canvas name="7" width="202" height="250"><vector name="origin" x="77" y="252"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="8cba5c517a90c09bb5b0b450d4af4f962e97f64b025b53c19687eb24ce9137e9"/></canvas></imgdir><imgdir name="move"><canvas name="0" width="206" height="242"><vector name="origin" x="81" y="242"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="b979d6cde026396b625c94835b84c71850af63340493b43ad85c3834827557e3"/></canvas><canvas name="1" width="204" height="243"><vector name="origin" x="80" y="241"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="c0ac3dac95654d89e3cefe605bc60e7fb30e1366fa057b68f3e816809f197f56"/></canvas><canvas name="2" width="206" height="230"><vector name="origin" x="81" y="230"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="dd3bb5d40ed54f37310bb2e142075fc3d883308a7144ee760926e37cdac1c02d"/></canvas><canvas name="3" width="207" height="225"><vector name="origin" x="82" y="228"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="3d98aa4231cf6b5a9b8b2774ba8979cabed08ecfd557233ee2730a775fffdac6"/></canvas><canvas name="4" width="208" height="239"><vector name="origin" x="83" y="244"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="aadc7791cdb288a3fab6437f1a6d3f3b83844b1abbeef5524958102ed3ad557a"/></canvas><canvas name="5" width="207" height="250"><vector name="origin" x="82" y="253"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="64cc5e674d8c4e791e9555ae406b23efa6dd03267cbc0b951942a57aac11c474"/></canvas><imgdir name="speak"><int name="prob" value="30"/><string name="0" value="追撃開始"/></imgdir></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-571" y="-192"/><vector name="rb" x="0" y="0"/></imgdir><imgdir name="hit"><canvas name="0" width="98" height="126"><vector name="origin" x="49" y="63"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0be27986f4af3a6f70bf4ea8c24f71ea70101ce9e65a5817f8feb627bd01bec6"/></canvas><canvas name="1" width="99" height="124"><vector name="origin" x="49" y="62"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b2115db9d9cc4575ccc141471d8ff61b0a214fe3c40aa3d9e2910f02c2b74644"/></canvas><canvas name="2" width="97" height="104"><vector name="origin" x="48" y="52"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="dc2b872017c48e5b213e13ce656b69ba546923e5cb27bb77d84481412e8eea62"/></canvas><canvas name="3" width="100" height="91"><vector name="origin" x="50" y="45"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b01695807d8d166acafb60143a1f19ebd757f62d1e2f54007a77bbaee82fc8f2"/></canvas><canvas name="4" width="101" height="91"><vector name="origin" x="50" y="45"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0636f3fbc9203b254f2d701993cc222a8583baf61e965a0d02a9bbd344e46eb7"/></canvas><canvas name="5" width="99" height="88"><vector name="origin" x="49" y="44"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="718af6e4a522fe73161025ec5fbe5a46f69597acc859e037bd0378a573e8c4b8"/></canvas><int name="attach" value="1"/></imgdir><int name="attackAfter" value="780"/></imgdir><canvas name="0" width="202" height="242"><vector name="origin" x="77" y="242"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="e6476f77cb542b59cacfa41762e1e7290317fa3e8b3fb648bd7bfe0ad95ffb73"/></canvas><canvas name="1" width="255" height="240"><vector name="origin" x="148" y="238"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="bf7b09da821e6ed8bf5d43339982965be49e6ac315c62b78dfa3f9217e93bd4a"/></canvas><canvas name="2" width="258" height="240"><vector name="origin" x="149" y="237"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="78c202668b3421033468c3a2f3943cecd502114c559b71f64937445ca3eb5b71"/></canvas><canvas name="3" width="261" height="228"><vector name="origin" x="150" y="226"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="54734a5c538e8df9f1a3d2e826d0f711788ff24a87ffe4e888fea580845c76df"/></canvas><canvas name="4" width="263" height="237"><vector name="origin" x="151" y="236"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="0b7cfd9a9f7eaebe6e7ab8bd382be3f2b748d6c349c1e00c2520c5202e55de86"/></canvas><canvas name="5" width="263" height="226"><vector name="origin" x="151" y="226"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="b306af63eab31a6a5f1f58ea3fd0883b43a4fa3bc118ce45ace549356a44e105"/></canvas><canvas name="6" width="261" height="241"><vector name="origin" x="149" y="242"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="1973af609752a4a3116cfce81a35d1ddc67762b909dd582dfc8d87f7adda6b8b"/></canvas><canvas name="7" width="263" height="251"><vector name="origin" x="151" y="251"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="cffadff5aa2484f24f578de5cd222e26a970692a15eff5503c1e207b22956c1f"/></canvas><canvas name="8" width="263" height="270"><vector name="origin" x="151" y="249"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="13c9a2cbd1ef43aa38754b7173c261c46fc31d8d581d3d9a9cc28c70cc9874c6"/></canvas><canvas name="9" width="263" height="258"><vector name="origin" x="151" y="238"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="5360aacafb9719c59698760e3a0946126e0e9fb4c78e27ba4dec653bb1ac7b67"/></canvas><canvas name="10" width="261" height="254"><vector name="origin" x="150" y="237"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="65ae2616de6dea6566c569297628af03bc24ec0284902ec86a858328712aa952"/></canvas><canvas name="11" width="260" height="240"><vector name="origin" x="149" y="226"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="a9f25ea830ead9c9979097cda2843c230ee92a8b0ddcb7dd9784b4033f4e9da5"/></canvas><canvas name="12" width="255" height="243"><vector name="origin" x="148" y="236"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-77" y="-225"/><vector name="rb" x="122" y="-12"/><string name="_hash" value="80aeaf08de5aaba6a0ae139e427161da4ba1f53b704ae773edb2d0341cc95893"/></canvas><canvas name="13" width="593" height="176"><vector name="origin" x="193" y="155"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="82" y="-116"/><vector name="lt" x="-194" y="-157"/><vector name="rb" x="398" y="19"/><string name="_hash" value="ade621a108c79ecbbc322ab70193822eea48140caeee928d5cd4eb6217711546"/></canvas><canvas name="14" width="595" height="222"><vector name="origin" x="198" y="211"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-194" y="-157"/><vector name="rb" x="398" y="19"/><string name="_hash" value="3ca45c00decc1cfc64834dcc0ab9ebe68530174c61f8040529ddec2ba54e9a9b"/></canvas><canvas name="15" width="339" height="222"><vector name="origin" x="209" y="211"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-206" y="-157"/><vector name="rb" x="128" y="1"/><string name="_hash" value="492b7a29819a026a5620819b4ad86f18d8db8e1c33454d8178b8147442c8fe11"/></canvas><canvas name="16" width="343" height="210"><vector name="origin" x="211" y="199"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-207" y="-157"/><vector name="rb" x="128" y="1"/><string name="_hash" value="da979da6dddacdb7155c6b23856e41e31d713883ee55f527d8104961d08d4a35"/></canvas><canvas name="17" width="335" height="219"><vector name="origin" x="207" y="208"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-207" y="-157"/><vector name="rb" x="128" y="1"/><string name="_hash" value="70d5c1f37acd19ba89787389e80cac7ff71360f34ab39dffcc844eb8ff190992"/></canvas><canvas name="18" width="336" height="208"><vector name="origin" x="208" y="197"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-207" y="-157"/><vector name="rb" x="128" y="1"/><string name="_hash" value="3b81d891c78a9c48aef0122e4f08e8e79372dc74492214a69f8584782cca1117"/></canvas><canvas name="19" width="334" height="223"><vector name="origin" x="209" y="212"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-207" y="-157"/><vector name="rb" x="128" y="1"/><string name="_hash" value="9455a3b0c431291399ce787cc4a916ed0f1e1bb9be9794ed8707e300e299a195"/></canvas><canvas name="20" width="335" height="233"><vector name="origin" x="209" y="222"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-207" y="-157"/><vector name="rb" x="128" y="1"/><string name="_hash" value="214f7371a02a3c93a5f5eac40e26e638a54000445e1efdcb74f345c0cd857faf"/></canvas><canvas name="21" width="335" height="232"><vector name="origin" x="209" y="221"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-207" y="-157"/><vector name="rb" x="128" y="1"/><string name="_hash" value="33d1d76421b32dbd2a9093f4e453898a4874f7947e614b11281a791107ecdeb8"/></canvas><canvas name="22" width="335" height="222"><vector name="origin" x="209" y="211"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-207" y="-157"/><vector name="rb" x="128" y="1"/><string name="_hash" value="2287f67b576cf55ab251a38d5460bae23f70df33aaf161267a6042bf1ed7f0e5"/></canvas><canvas name="23" width="335" height="222"><vector name="origin" x="209" y="211"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-207" y="-157"/><vector name="rb" x="128" y="1"/><string name="_hash" value="f6c1d84d74e86ccd0f4d6f016fc8bfe7904b7051c59c7cbfe4c42d3d0b9b8574"/></canvas><canvas name="24" width="293" height="210"><vector name="origin" x="167" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-121" y="-152"/><vector name="rb" x="128" y="1"/><string name="_hash" value="8d3f195e2e96210c14c5d92a780d547f50ec2954b1d72dc3869e557d3807af60"/></canvas><canvas name="25" width="250" height="219"><vector name="origin" x="125" y="208"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-123" y="-157"/><vector name="rb" x="128" y="1"/><string name="_hash" value="0cd6e7a6cad3c16fc29d8bef29603aebd927e2d60f7e3e4aa7f14d069da61b9b"/></canvas><canvas name="26" width="251" height="208"><vector name="origin" x="125" y="197"/><int name="z" value="0"/><int name="delay" value="240"/><vector name="head" x="14" y="-116"/><vector name="lt" x="-84" y="-151"/><vector name="rb" x="128" y="1"/><string name="_hash" value="d0d37cd3226c21b089326085f1174e2a9bb60c357249b496901b9ae6ec18bbac"/></canvas><uol name="32" value="../stand/5"/><uol name="33" value="../stand/6"/><uol name="34" value="../stand/7"/><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="目標発見"/><string name="1" value="攻撃開始"/></imgdir></imgdir><imgdir name="hit1"><canvas name="0" width="215" height="243"><vector name="origin" x="57" y="242"/><int name="z" value="0"/><vector name="head" x="32" y="-163"/><vector name="lt" x="-57" y="-216"/><vector name="rb" x="150" y="-14"/><int name="delay" value="300"/><string name="_hash" value="2841e714edf29d7c5cf569b13bbaaaacdc8a9c8be09aed05af5e4aad97f178cf"/></canvas><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="損傷軽微"/></imgdir></imgdir><imgdir name="die1"><canvas name="0" width="202" height="242"><vector name="origin" x="77" y="242"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="150"/><string name="_hash" value="ff60285aaf9135506d27c4ccfe8c5ec2d0fcf85ba37a4b91e3f58cbb7680960c"/></canvas><canvas name="1" width="215" height="243"><vector name="origin" x="57" y="242"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="150"/></canvas><canvas name="2" width="213" height="231"><vector name="origin" x="53" y="230"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="180"/><string name="_hash" value="16cb5586737c7e4c22a8e3c74b01c226c839d14174c78707374dd97d63643ce7"/></canvas><canvas name="3" width="214" height="236"><vector name="origin" x="51" y="236"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="8fc1ad55aee619ca485ba1de982160b500122f2d5d2cd15e06ce33f480fc7d91"/></canvas><canvas name="4" width="215" height="239"><vector name="origin" x="50" y="239"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="240"/><string name="_hash" value="0e65ed47cbb1698fcffd5d2c5e62c6587110b4659dda6bf29a52874d5d35af8a"/></canvas><canvas name="5" width="215" height="240"><vector name="origin" x="49" y="240"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="240"/><string name="_hash" value="e0de94986fdb296c05f0e6225329b34736094563ea13a910c90b2688a950bf4b"/></canvas><canvas name="6" width="215" height="236"><vector name="origin" x="48" y="236"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="424950f9dd5717c683ce5adc6854d8df70e79b710107b8f731642351f76717cf"/></canvas><canvas name="7" width="215" height="202"><vector name="origin" x="47" y="202"/><int name="z" value="0"/><string name="_hash" value="debcd4abb4977553fd92f738374c4c45e7c112380798d8a5507062f6871bf94e"/></canvas><canvas name="8" width="215" height="202"><vector name="origin" x="46" y="202"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="58c0e04cd3941598c3737d260ff6d7bd8573ccf748c4c2b0f8b41e704220ace6"/></canvas><canvas name="9" width="213" height="200"><vector name="origin" x="45" y="200"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="d182be7835f50156e2e1b58494facc676159a0967913b46d94aafe6ca153e229"/></canvas><canvas name="10" width="210" height="182"><vector name="origin" x="43" y="182"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="aa547b4b896793e7e2d489e04c094757085b37dbffd49bf8d0f3c59372669ef9"/></canvas><canvas name="11" width="200" height="174"><vector name="origin" x="35" y="176"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="df7a6e802c6870d7a17a7ea7b3413f07b6e0eeb43bf4582c743ac39609d71e75"/></canvas><canvas name="12" width="187" height="150"><vector name="origin" x="28" y="155"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="5eb24184e5903aeb7a000088fc72aafd5238acd4a3987b18cca87c297c47b253"/></canvas><canvas name="13" width="160" height="141"><vector name="origin" x="3" y="150"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="79c11bc2a11013764e63316e433236ba84844af677f13e69f54b0f655b736b40"/></canvas><canvas name="14" width="96" height="98"><vector name="origin" x="-53" y="110"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="210"/><string name="_hash" value="71c2d51f154349c7b471154e2f30becb4c00da6ac0f6946ed5d49a68c4649129"/></canvas><canvas name="15" width="35" height="86"><vector name="origin" x="-59" y="106"/><int name="z" value="0"/><vector name="head" x="1" y="-161"/><int name="delay" value="150"/><string name="_hash" value="7a00cc8a984c5fac82290df21e764bf3a766e883b0bbf73478d89c1a528c0981"/></canvas><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="……任務失敗"/></imgdir></imgdir><imgdir name="regen"><canvas name="0" width="163" height="121"><vector name="origin" x="-104" y="103"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="57a89999d9c0bbccccf4dba3f28db80650922d400b5fd32b95a3dc589d4d4204"/></canvas><canvas name="1" width="183" height="159"><vector name="origin" x="-102" y="142"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f109b72f34a4ec6cccfcede898555aa03d6ad743e6ce67df8d307268edf94d08"/></canvas><canvas name="2" width="562" height="486"><vector name="origin" x="136" y="468"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f6129f7d5eda7c22e85d20f6680eaa5bddd883a577679f44c1adacf6471cd228"/></canvas><canvas name="3" width="857" height="510"><vector name="origin" x="433" y="466"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="4b7b7f746e27173490d2c29020e3383be44f48b4c7b6a56fd1812db3b1cacd5f"/></canvas><canvas name="4" width="845" height="498"><vector name="origin" x="426" y="468"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="73c48f904bfa996f484daf6c8bd75d3a906e6062ee8b7e4d59be08fd1d6c7e26"/></canvas><canvas name="5" width="836" height="483"><vector name="origin" x="425" y="466"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="a3555d08b8389f19a2490e8be341f8f8228b48bdda7f4d83ab0afee9e8f80edb"/></canvas><canvas name="6" width="793" height="482"><vector name="origin" x="420" y="465"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="367742ee8378daa836e08608ba3349af345609bb246ea091ff41100141c7cff4"/></canvas><canvas name="7" width="726" height="463"><vector name="origin" x="361" y="451"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="fec84c56d448e65e2a0e31fd2913c2dc6f404c45aa00cf3e6b4ef90c3e8582e8"/></canvas><canvas name="8" width="533" height="444"><vector name="origin" x="347" y="432"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c433019575a8293f68bf5d497c8307b0875e3bc1489e41a5f78da90008f5d996"/></canvas><canvas name="9" width="371" height="425"><vector name="origin" x="180" y="421"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="12b043fa95704094cc4d1ca782547374c4f63ffd5723d29ff5144de5a81330b4"/></canvas><canvas name="10" width="424" height="397"><vector name="origin" x="252" y="337"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="737d3ae9a0a82a1283ae699caffedd979865c726fa0d518927c30329fe7c3842"/></canvas><canvas name="11" width="385" height="301"><vector name="origin" x="202" y="291"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="3fe014c7c50355cf66baedf861914fe6e6c6e5606ec432fb8f5ccfbb7cc39c2b"/></canvas><canvas name="12" width="435" height="346"><vector name="origin" x="175" y="336"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="817edc2561f595d5bf87b0d73809a08d6567dd22bcd50c101f5cbdc72f5823fc"/></canvas><canvas name="13" width="468" height="432"><vector name="origin" x="261" y="273"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="60cfae5e25ee9ea73e02aa18bf179b839abf90428ccaf52f1567f41098c00225"/></canvas><canvas name="14" width="418" height="240"><vector name="origin" x="246" y="236"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0800c3544486ee85cdd938afb4d869540c78865845d66ea95a21b96a3c5c1fda"/></canvas><canvas name="15" width="374" height="375"><vector name="origin" x="191" y="233"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="320aea99666789b5e2c9453c9d8b60d19deea4ebe881b82d64eb0e710a01afdf"/></canvas><canvas name="16" width="457" height="398"><vector name="origin" x="150" y="229"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="ce133fbad599f9d399b999a71b5c8bee6c23af208c6fa65041493411fe64b313"/></canvas><canvas name="17" width="423" height="463"><vector name="origin" x="232" y="316"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="ec2ae9eda06e0dfe6a8de9f698c3b98c006ace578801a165bcae046d32e6a27a"/></canvas><canvas name="18" width="386" height="400"><vector name="origin" x="214" y="241"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="989119d8252ce7ee95da633b0dc3a363b45d7d6160d3012c50aa98758eb641be"/></canvas><canvas name="19" width="458" height="430"><vector name="origin" x="147" y="277"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="4e810ebaf36c9a92dedebd4d97e32537140de05248428e0b0243612250861ac9"/></canvas><canvas name="20" width="549" height="530"><vector name="origin" x="264" y="389"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="dfa1626cb67e07c0956715b1b6ed1839ab4aa62e1b4184e5c66e51b001a89b87"/></canvas><canvas name="21" width="440" height="308"><vector name="origin" x="249" y="221"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="47494a0455d55c3d0164b5a72a29dfe443e9bc4634a00e4ea1ba106b464d77c4"/></canvas><canvas name="22" width="350" height="334"><vector name="origin" x="166" y="281"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="2e4c7101635614718ce9bef2b741a50d6d8f49e0996c515b82eb369efe87b643"/></canvas><canvas name="23" width="396" height="360"><vector name="origin" x="186" y="293"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1b9d151601fa15ff30357903d418982976fa617dc61e3be2c1482124b09fe79c"/></canvas><canvas name="24" width="396" height="376"><vector name="origin" x="184" y="301"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="197f3e82f73eeff1e3bcca3dab42a1edc10ad9c409fa4ed2fa5c7836862fac54"/></canvas><canvas name="25" width="383" height="382"><vector name="origin" x="179" y="304"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f7f16428a721af3cf533eb8f7da6936aea1b95ec84897d22943b11f26e7d7fed"/></canvas><canvas name="26" width="382" height="382"><vector name="origin" x="178" y="304"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b54486a9a83b72f88eb27c05cca20338798fd924439c83f752a452dfc9f2c494"/></canvas><canvas name="27" width="378" height="378"><vector name="origin" x="176" y="302"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="906e8f4447fea7af6ae5893ac8951af516766c8672ddcdcc0fe812e92b887fd4"/></canvas><canvas name="28" width="331" height="348"><vector name="origin" x="176" y="288"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c3091841a62e6db3a8726d5292b654262a294250118f7b9ca95a757f9ce8cfd8"/></canvas><canvas name="29" width="330" height="350"><vector name="origin" x="177" y="290"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8aed8ede89e93a648dec20fa05072377156a880cd95393ab201df2a7fe0d884e"/></canvas><canvas name="30" width="320" height="320"><vector name="origin" x="170" y="277"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="405d5a1e019623c8a31b11fc8c150609039331b24beef9f31f552f52517cd49c"/></canvas><canvas name="31" width="315" height="315"><vector name="origin" x="172" y="279"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="2834a375ab9ae8471180ead3d94b768fb3b757b6f05aba9a15a8b7620267eaef"/></canvas><canvas name="32" width="206" height="251"><vector name="origin" x="78" y="250"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="16a0c5e3bd363e9cc7492dd9d51837fbf9cdc11f85297fbb68d875d65cb819eb"/></canvas><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="目標発見。除去行動に入る。"/></imgdir></imgdir><imgdir name="attack2"><canvas name="0" width="204" height="244"><vector name="origin" x="77" y="242"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="120"/><string name="_hash" value="d14494a3b5675b9bda2f6f1112b96aa344d46788b7756a2ef26d6e6c685936fc"/></canvas><canvas name="1" width="448" height="244"><vector name="origin" x="351" y="229"/><int name="z" value="0"/><vector name="head" x="-16" y="-139"/><vector name="lt" x="-348" y="-151"/><vector name="rb" x="86" y="1"/><int name="delay" value="90"/><string name="_hash" value="18c1627de5c43ae47e4d191c70fd3addb86d8de87449e31947a2563e1a360a2b"/></canvas><canvas name="2" width="456" height="232"><vector name="origin" x="362" y="214"/><int name="z" value="0"/><vector name="head" x="-28" y="-133"/><vector name="lt" x="-247" y="-165"/><vector name="rb" x="86" y="1"/><int name="delay" value="90"/><string name="_hash" value="936b495391185a95f60bb070cefc7d6ec1c35b6ecc3e43c525fe8bf8b88df162"/></canvas><canvas name="3" width="468" height="244"><vector name="origin" x="370" y="226"/><int name="z" value="0"/><vector name="head" x="-28" y="-133"/><vector name="lt" x="-309" y="-189"/><vector name="rb" x="86" y="1"/><int name="delay" value="90"/><string name="_hash" value="38f6ebee6965fea8e5d633292f68c2299358a4395ca53a1d8e58bb258e4cf6d9"/></canvas><canvas name="4" width="464" height="232"><vector name="origin" x="360" y="213"/><int name="z" value="0"/><vector name="head" x="-6" y="-136"/><vector name="lt" x="-326" y="-187"/><vector name="rb" x="86" y="1"/><int name="delay" value="90"/><string name="_hash" value="ba58596e713d25a12c13a85dd2b9845d8908baeb0d6e5c30b1028501b6c5e331"/></canvas><canvas name="5" width="444" height="244"><vector name="origin" x="367" y="228"/><int name="z" value="0"/><vector name="head" x="-46" y="-140"/><vector name="lt" x="-361" y="-138"/><vector name="rb" x="69" y="-1"/><int name="delay" value="90"/><string name="_hash" value="b1f64c29d9c980dd18b6b1b6fbe16ea77acb6b0d8459b0867686dc1edc148e13"/></canvas><canvas name="6" width="460" height="236"><vector name="origin" x="377" y="235"/><int name="z" value="0"/><vector name="head" x="-54" y="-127"/><vector name="lt" x="-373" y="-137"/><vector name="rb" x="74" y="-9"/><int name="delay" value="90"/><string name="_hash" value="e0fe7302c9321080d0d2d285f6c0330fd29052008349c688fadf048c85488a2b"/></canvas><canvas name="7" width="448" height="256"><vector name="origin" x="390" y="247"/><int name="z" value="0"/><vector name="head" x="-79" y="-139"/><vector name="lt" x="-376" y="-136"/><vector name="rb" x="50" y="-4"/><int name="delay" value="90"/><string name="_hash" value="3a41850f9d5dc56a022748c0e518a82d5195743d33f4a3ce6e1cb34d2d0af11e"/></canvas><canvas name="8" width="424" height="252"><vector name="origin" x="401" y="239"/><int name="z" value="0"/><vector name="head" x="-95" y="-142"/><vector name="lt" x="-398" y="-155"/><vector name="rb" x="15" y="-4"/><int name="delay" value="90"/><string name="_hash" value="414e8762f8afcb082d0686cf01b48af08e97a0dcac74eddaaf3a7cb1bf600efd"/></canvas><canvas name="9" width="424" height="256"><vector name="origin" x="405" y="245"/><int name="z" value="0"/><vector name="head" x="-95" y="-144"/><vector name="lt" x="-402" y="-160"/><vector name="rb" x="14" y="-4"/><int name="delay" value="90"/><string name="_hash" value="48df81bc8051a488aad258aef74ca41c1d0f1ca2bebe784f1cce771e759d80c5"/></canvas><canvas name="10" width="380" height="244"><vector name="origin" x="361" y="234"/><int name="z" value="0"/><vector name="head" x="-101" y="-145"/><vector name="lt" x="-216" y="-142"/><vector name="rb" x="13" y="-5"/><int name="delay" value="90"/><string name="_hash" value="70f041254bdbf5354371fb0f04b3bb78509519f568aae157c08feecfbe6434e7"/></canvas><canvas name="11" width="202" height="242"><vector name="origin" x="170" y="242"/><int name="z" value="0"/><vector name="head" x="-88" y="-156"/><vector name="lt" x="-170" y="-161"/><vector name="rb" x="23" y="-9"/><int name="delay" value="90"/></canvas><canvas name="12" width="202" height="239"><vector name="origin" x="140" y="243"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="60"/></canvas><canvas name="13" width="202" height="250"><vector name="origin" x="109" y="253"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="60"/></canvas><canvas name="14" width="202" height="250"><vector name="origin" x="77" y="252"/><int name="z" value="0"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-78" y="-168"/><vector name="rb" x="122" y="-12"/><int name="delay" value="60"/></canvas><uol name="15" value="../stand/6"/><uol name="16" value="../stand/7"/><imgdir name="info"><imgdir name="range"><vector name="lt" x="-471" y="-192"/><vector name="rb" x="0" y="0"/></imgdir><imgdir name="hit"><canvas name="0" width="98" height="126"><vector name="origin" x="49" y="63"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0be27986f4af3a6f70bf4ea8c24f71ea70101ce9e65a5817f8feb627bd01bec6"/></canvas><canvas name="1" width="99" height="124"><vector name="origin" x="49" y="62"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b2115db9d9cc4575ccc141471d8ff61b0a214fe3c40aa3d9e2910f02c2b74644"/></canvas><canvas name="2" width="97" height="104"><vector name="origin" x="48" y="52"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="dc2b872017c48e5b213e13ce656b69ba546923e5cb27bb77d84481412e8eea62"/></canvas><canvas name="3" width="100" height="91"><vector name="origin" x="50" y="45"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b01695807d8d166acafb60143a1f19ebd757f62d1e2f54007a77bbaee82fc8f2"/></canvas><canvas name="4" width="101" height="91"><vector name="origin" x="50" y="45"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0636f3fbc9203b254f2d701993cc222a8583baf61e965a0d02a9bbd344e46eb7"/></canvas><canvas name="5" width="99" height="88"><vector name="origin" x="49" y="44"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="718af6e4a522fe73161025ec5fbe5a46f69597acc859e037bd0378a573e8c4b8"/></canvas><int name="attach" value="1"/></imgdir><int name="attackAfter" value="780"/></imgdir></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787128.img">
+  <imgdir name="info">
+    <int name="level" value="100"/>
+    <int name="maxHP" value="999999999"/>
+    <int name="maxMP" value="50000"/>
+    <int name="speed" value="5"/>
+    <int name="PADamage" value="1500"/>
+    <int name="MADamage" value="1500"/>
+    <int name="PDRate" value="25"/>
+    <int name="MDRate" value="25"/>
+    <int name="acc" value="600"/>
+    <string name="elemAttr" value="P2"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="500000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="magic" value="1"/>
+        <int name="rush" value="1"/>
+        <int name="knockback" value="1"/>
+        <int name="ignoreStance" value="100"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <int name="nonLevelCheckACC" value="1"/>
+    <int name="nonLevelCheckEVA" value="1"/>
+    <int name="notConsiderFieldSet" value="1"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="I will make you regret this!"/>
+      </imgdir>
+    </imgdir>
+    <int name="hpTagBgcolor" value="3"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="202" height="242">
+      <vector name="origin" x="77" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9af6f81a1ab95b0e0c4f55c0a53f8f2f635bcfd706301d4aa995e5d4a9c4eb0d"/>
+    </canvas>
+    <canvas name="1" width="201" height="243">
+      <vector name="origin" x="77" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d707327d6bee4545ec95ccd3f4fcf6c1161d673f7efe94cf565c66bc1768c124"/>
+    </canvas>
+    <canvas name="2" width="202" height="230">
+      <vector name="origin" x="77" y="230"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7c83ff901cb3faea57d33cb638db973498aa1a1f5dbcce932d5cb9575a2b3d26"/>
+    </canvas>
+    <canvas name="3" width="202" height="237">
+      <vector name="origin" x="77" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e07750e90046d1a1960344001286c5ec26199031caed0b7459d7d54ab248df3f"/>
+    </canvas>
+    <canvas name="4" width="202" height="225">
+      <vector name="origin" x="77" y="228"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0954b0fa686369d05d9a4f11861be60a4d8f32a99a877d9b255771130b576b99"/>
+    </canvas>
+    <canvas name="5" width="202" height="239">
+      <vector name="origin" x="77" y="243"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d920cb060a062489fe62e53f4a31d791a706134036615cbf43cc3865b51fdd76"/>
+    </canvas>
+    <canvas name="6" width="202" height="250">
+      <vector name="origin" x="77" y="253"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f9a152963ba5d59af7a05ce5cd81c504df234d1466f8162465f897f0d325e64c"/>
+    </canvas>
+    <canvas name="7" width="202" height="250">
+      <vector name="origin" x="77" y="252"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8cba5c517a90c09bb5b0b450d4af4f962e97f64b025b53c19687eb24ce9137e9"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="206" height="242">
+      <vector name="origin" x="81" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b979d6cde026396b625c94835b84c71850af63340493b43ad85c3834827557e3"/>
+    </canvas>
+    <canvas name="1" width="204" height="243">
+      <vector name="origin" x="80" y="241"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c0ac3dac95654d89e3cefe605bc60e7fb30e1366fa057b68f3e816809f197f56"/>
+    </canvas>
+    <canvas name="2" width="206" height="230">
+      <vector name="origin" x="81" y="230"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dd3bb5d40ed54f37310bb2e142075fc3d883308a7144ee760926e37cdac1c02d"/>
+    </canvas>
+    <canvas name="3" width="207" height="225">
+      <vector name="origin" x="82" y="228"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3d98aa4231cf6b5a9b8b2774ba8979cabed08ecfd557233ee2730a775fffdac6"/>
+    </canvas>
+    <canvas name="4" width="208" height="239">
+      <vector name="origin" x="83" y="244"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="aadc7791cdb288a3fab6437f1a6d3f3b83844b1abbeef5524958102ed3ad557a"/>
+    </canvas>
+    <canvas name="5" width="207" height="250">
+      <vector name="origin" x="82" y="253"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="64cc5e674d8c4e791e9555ae406b23efa6dd03267cbc0b951942a57aac11c474"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="30"/>
+      <string name="0" value="Beginning pursuit."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-571" y="-192"/>
+        <vector name="rb" x="0" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="98" height="126">
+          <vector name="origin" x="49" y="63"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0be27986f4af3a6f70bf4ea8c24f71ea70101ce9e65a5817f8feb627bd01bec6"/>
+        </canvas>
+        <canvas name="1" width="99" height="124">
+          <vector name="origin" x="49" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b2115db9d9cc4575ccc141471d8ff61b0a214fe3c40aa3d9e2910f02c2b74644"/>
+        </canvas>
+        <canvas name="2" width="97" height="104">
+          <vector name="origin" x="48" y="52"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="dc2b872017c48e5b213e13ce656b69ba546923e5cb27bb77d84481412e8eea62"/>
+        </canvas>
+        <canvas name="3" width="100" height="91">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b01695807d8d166acafb60143a1f19ebd757f62d1e2f54007a77bbaee82fc8f2"/>
+        </canvas>
+        <canvas name="4" width="101" height="91">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0636f3fbc9203b254f2d701993cc222a8583baf61e965a0d02a9bbd344e46eb7"/>
+        </canvas>
+        <canvas name="5" width="99" height="88">
+          <vector name="origin" x="49" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="718af6e4a522fe73161025ec5fbe5a46f69597acc859e037bd0378a573e8c4b8"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="attackAfter" value="780"/>
+    </imgdir>
+    <canvas name="0" width="202" height="242">
+      <vector name="origin" x="77" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="e6476f77cb542b59cacfa41762e1e7290317fa3e8b3fb648bd7bfe0ad95ffb73"/>
+    </canvas>
+    <canvas name="1" width="255" height="240">
+      <vector name="origin" x="148" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="bf7b09da821e6ed8bf5d43339982965be49e6ac315c62b78dfa3f9217e93bd4a"/>
+    </canvas>
+    <canvas name="2" width="258" height="240">
+      <vector name="origin" x="149" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="78c202668b3421033468c3a2f3943cecd502114c559b71f64937445ca3eb5b71"/>
+    </canvas>
+    <canvas name="3" width="261" height="228">
+      <vector name="origin" x="150" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="54734a5c538e8df9f1a3d2e826d0f711788ff24a87ffe4e888fea580845c76df"/>
+    </canvas>
+    <canvas name="4" width="263" height="237">
+      <vector name="origin" x="151" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="0b7cfd9a9f7eaebe6e7ab8bd382be3f2b748d6c349c1e00c2520c5202e55de86"/>
+    </canvas>
+    <canvas name="5" width="263" height="226">
+      <vector name="origin" x="151" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="b306af63eab31a6a5f1f58ea3fd0883b43a4fa3bc118ce45ace549356a44e105"/>
+    </canvas>
+    <canvas name="6" width="261" height="241">
+      <vector name="origin" x="149" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="1973af609752a4a3116cfce81a35d1ddc67762b909dd582dfc8d87f7adda6b8b"/>
+    </canvas>
+    <canvas name="7" width="263" height="251">
+      <vector name="origin" x="151" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="cffadff5aa2484f24f578de5cd222e26a970692a15eff5503c1e207b22956c1f"/>
+    </canvas>
+    <canvas name="8" width="263" height="270">
+      <vector name="origin" x="151" y="249"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="13c9a2cbd1ef43aa38754b7173c261c46fc31d8d581d3d9a9cc28c70cc9874c6"/>
+    </canvas>
+    <canvas name="9" width="263" height="258">
+      <vector name="origin" x="151" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="5360aacafb9719c59698760e3a0946126e0e9fb4c78e27ba4dec653bb1ac7b67"/>
+    </canvas>
+    <canvas name="10" width="261" height="254">
+      <vector name="origin" x="150" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="65ae2616de6dea6566c569297628af03bc24ec0284902ec86a858328712aa952"/>
+    </canvas>
+    <canvas name="11" width="260" height="240">
+      <vector name="origin" x="149" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="a9f25ea830ead9c9979097cda2843c230ee92a8b0ddcb7dd9784b4033f4e9da5"/>
+    </canvas>
+    <canvas name="12" width="255" height="243">
+      <vector name="origin" x="148" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-77" y="-225"/>
+      <vector name="rb" x="122" y="-12"/>
+      <string name="_hash" value="80aeaf08de5aaba6a0ae139e427161da4ba1f53b704ae773edb2d0341cc95893"/>
+    </canvas>
+    <canvas name="13" width="593" height="176">
+      <vector name="origin" x="193" y="155"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="82" y="-116"/>
+      <vector name="lt" x="-194" y="-157"/>
+      <vector name="rb" x="398" y="19"/>
+      <string name="_hash" value="ade621a108c79ecbbc322ab70193822eea48140caeee928d5cd4eb6217711546"/>
+    </canvas>
+    <canvas name="14" width="595" height="222">
+      <vector name="origin" x="198" y="211"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-194" y="-157"/>
+      <vector name="rb" x="398" y="19"/>
+      <string name="_hash" value="3ca45c00decc1cfc64834dcc0ab9ebe68530174c61f8040529ddec2ba54e9a9b"/>
+    </canvas>
+    <canvas name="15" width="339" height="222">
+      <vector name="origin" x="209" y="211"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-206" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="492b7a29819a026a5620819b4ad86f18d8db8e1c33454d8178b8147442c8fe11"/>
+    </canvas>
+    <canvas name="16" width="343" height="210">
+      <vector name="origin" x="211" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="da979da6dddacdb7155c6b23856e41e31d713883ee55f527d8104961d08d4a35"/>
+    </canvas>
+    <canvas name="17" width="335" height="219">
+      <vector name="origin" x="207" y="208"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="70d5c1f37acd19ba89787389e80cac7ff71360f34ab39dffcc844eb8ff190992"/>
+    </canvas>
+    <canvas name="18" width="336" height="208">
+      <vector name="origin" x="208" y="197"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="3b81d891c78a9c48aef0122e4f08e8e79372dc74492214a69f8584782cca1117"/>
+    </canvas>
+    <canvas name="19" width="334" height="223">
+      <vector name="origin" x="209" y="212"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="9455a3b0c431291399ce787cc4a916ed0f1e1bb9be9794ed8707e300e299a195"/>
+    </canvas>
+    <canvas name="20" width="335" height="233">
+      <vector name="origin" x="209" y="222"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="214f7371a02a3c93a5f5eac40e26e638a54000445e1efdcb74f345c0cd857faf"/>
+    </canvas>
+    <canvas name="21" width="335" height="232">
+      <vector name="origin" x="209" y="221"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="33d1d76421b32dbd2a9093f4e453898a4874f7947e614b11281a791107ecdeb8"/>
+    </canvas>
+    <canvas name="22" width="335" height="222">
+      <vector name="origin" x="209" y="211"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="2287f67b576cf55ab251a38d5460bae23f70df33aaf161267a6042bf1ed7f0e5"/>
+    </canvas>
+    <canvas name="23" width="335" height="222">
+      <vector name="origin" x="209" y="211"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-207" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="f6c1d84d74e86ccd0f4d6f016fc8bfe7904b7051c59c7cbfe4c42d3d0b9b8574"/>
+    </canvas>
+    <canvas name="24" width="293" height="210">
+      <vector name="origin" x="167" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-121" y="-152"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="8d3f195e2e96210c14c5d92a780d547f50ec2954b1d72dc3869e557d3807af60"/>
+    </canvas>
+    <canvas name="25" width="250" height="219">
+      <vector name="origin" x="125" y="208"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-123" y="-157"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="0cd6e7a6cad3c16fc29d8bef29603aebd927e2d60f7e3e4aa7f14d069da61b9b"/>
+    </canvas>
+    <canvas name="26" width="251" height="208">
+      <vector name="origin" x="125" y="197"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <vector name="head" x="14" y="-116"/>
+      <vector name="lt" x="-84" y="-151"/>
+      <vector name="rb" x="128" y="1"/>
+      <string name="_hash" value="d0d37cd3226c21b089326085f1174e2a9bb60c357249b496901b9ae6ec18bbac"/>
+    </canvas>
+    <uol name="32" value="../stand/5"/>
+    <uol name="33" value="../stand/6"/>
+    <uol name="34" value="../stand/7"/>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Target found."/>
+      <string name="1" value="Beginning attack."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="215" height="243">
+      <vector name="origin" x="57" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="32" y="-163"/>
+      <vector name="lt" x="-57" y="-216"/>
+      <vector name="rb" x="150" y="-14"/>
+      <int name="delay" value="300"/>
+      <string name="_hash" value="2841e714edf29d7c5cf569b13bbaaaacdc8a9c8be09aed05af5e4aad97f178cf"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Damage is minor."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="202" height="242">
+      <vector name="origin" x="77" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="ff60285aaf9135506d27c4ccfe8c5ec2d0fcf85ba37a4b91e3f58cbb7680960c"/>
+    </canvas>
+    <canvas name="1" width="215" height="243">
+      <vector name="origin" x="57" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="213" height="231">
+      <vector name="origin" x="53" y="230"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="16cb5586737c7e4c22a8e3c74b01c226c839d14174c78707374dd97d63643ce7"/>
+    </canvas>
+    <canvas name="3" width="214" height="236">
+      <vector name="origin" x="51" y="236"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="8fc1ad55aee619ca485ba1de982160b500122f2d5d2cd15e06ce33f480fc7d91"/>
+    </canvas>
+    <canvas name="4" width="215" height="239">
+      <vector name="origin" x="50" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="0e65ed47cbb1698fcffd5d2c5e62c6587110b4659dda6bf29a52874d5d35af8a"/>
+    </canvas>
+    <canvas name="5" width="215" height="240">
+      <vector name="origin" x="49" y="240"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="e0de94986fdb296c05f0e6225329b34736094563ea13a910c90b2688a950bf4b"/>
+    </canvas>
+    <canvas name="6" width="215" height="236">
+      <vector name="origin" x="48" y="236"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="424950f9dd5717c683ce5adc6854d8df70e79b710107b8f731642351f76717cf"/>
+    </canvas>
+    <canvas name="7" width="215" height="202">
+      <vector name="origin" x="47" y="202"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="debcd4abb4977553fd92f738374c4c45e7c112380798d8a5507062f6871bf94e"/>
+    </canvas>
+    <canvas name="8" width="215" height="202">
+      <vector name="origin" x="46" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="58c0e04cd3941598c3737d260ff6d7bd8573ccf748c4c2b0f8b41e704220ace6"/>
+    </canvas>
+    <canvas name="9" width="213" height="200">
+      <vector name="origin" x="45" y="200"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="d182be7835f50156e2e1b58494facc676159a0967913b46d94aafe6ca153e229"/>
+    </canvas>
+    <canvas name="10" width="210" height="182">
+      <vector name="origin" x="43" y="182"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="aa547b4b896793e7e2d489e04c094757085b37dbffd49bf8d0f3c59372669ef9"/>
+    </canvas>
+    <canvas name="11" width="200" height="174">
+      <vector name="origin" x="35" y="176"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="df7a6e802c6870d7a17a7ea7b3413f07b6e0eeb43bf4582c743ac39609d71e75"/>
+    </canvas>
+    <canvas name="12" width="187" height="150">
+      <vector name="origin" x="28" y="155"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="5eb24184e5903aeb7a000088fc72aafd5238acd4a3987b18cca87c297c47b253"/>
+    </canvas>
+    <canvas name="13" width="160" height="141">
+      <vector name="origin" x="3" y="150"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="79c11bc2a11013764e63316e433236ba84844af677f13e69f54b0f655b736b40"/>
+    </canvas>
+    <canvas name="14" width="96" height="98">
+      <vector name="origin" x="-53" y="110"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="71c2d51f154349c7b471154e2f30becb4c00da6ac0f6946ed5d49a68c4649129"/>
+    </canvas>
+    <canvas name="15" width="35" height="86">
+      <vector name="origin" x="-59" y="106"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="1" y="-161"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="7a00cc8a984c5fac82290df21e764bf3a766e883b0bbf73478d89c1a528c0981"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="...Mission failed."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="regen">
+    <canvas name="0" width="163" height="121">
+      <vector name="origin" x="-104" y="103"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="57a89999d9c0bbccccf4dba3f28db80650922d400b5fd32b95a3dc589d4d4204"/>
+    </canvas>
+    <canvas name="1" width="183" height="159">
+      <vector name="origin" x="-102" y="142"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f109b72f34a4ec6cccfcede898555aa03d6ad743e6ce67df8d307268edf94d08"/>
+    </canvas>
+    <canvas name="2" width="562" height="486">
+      <vector name="origin" x="136" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f6129f7d5eda7c22e85d20f6680eaa5bddd883a577679f44c1adacf6471cd228"/>
+    </canvas>
+    <canvas name="3" width="857" height="510">
+      <vector name="origin" x="433" y="466"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4b7b7f746e27173490d2c29020e3383be44f48b4c7b6a56fd1812db3b1cacd5f"/>
+    </canvas>
+    <canvas name="4" width="845" height="498">
+      <vector name="origin" x="426" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="73c48f904bfa996f484daf6c8bd75d3a906e6062ee8b7e4d59be08fd1d6c7e26"/>
+    </canvas>
+    <canvas name="5" width="836" height="483">
+      <vector name="origin" x="425" y="466"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a3555d08b8389f19a2490e8be341f8f8228b48bdda7f4d83ab0afee9e8f80edb"/>
+    </canvas>
+    <canvas name="6" width="793" height="482">
+      <vector name="origin" x="420" y="465"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="367742ee8378daa836e08608ba3349af345609bb246ea091ff41100141c7cff4"/>
+    </canvas>
+    <canvas name="7" width="726" height="463">
+      <vector name="origin" x="361" y="451"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fec84c56d448e65e2a0e31fd2913c2dc6f404c45aa00cf3e6b4ef90c3e8582e8"/>
+    </canvas>
+    <canvas name="8" width="533" height="444">
+      <vector name="origin" x="347" y="432"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c433019575a8293f68bf5d497c8307b0875e3bc1489e41a5f78da90008f5d996"/>
+    </canvas>
+    <canvas name="9" width="371" height="425">
+      <vector name="origin" x="180" y="421"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="12b043fa95704094cc4d1ca782547374c4f63ffd5723d29ff5144de5a81330b4"/>
+    </canvas>
+    <canvas name="10" width="424" height="397">
+      <vector name="origin" x="252" y="337"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="737d3ae9a0a82a1283ae699caffedd979865c726fa0d518927c30329fe7c3842"/>
+    </canvas>
+    <canvas name="11" width="385" height="301">
+      <vector name="origin" x="202" y="291"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3fe014c7c50355cf66baedf861914fe6e6c6e5606ec432fb8f5ccfbb7cc39c2b"/>
+    </canvas>
+    <canvas name="12" width="435" height="346">
+      <vector name="origin" x="175" y="336"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="817edc2561f595d5bf87b0d73809a08d6567dd22bcd50c101f5cbdc72f5823fc"/>
+    </canvas>
+    <canvas name="13" width="468" height="432">
+      <vector name="origin" x="261" y="273"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="60cfae5e25ee9ea73e02aa18bf179b839abf90428ccaf52f1567f41098c00225"/>
+    </canvas>
+    <canvas name="14" width="418" height="240">
+      <vector name="origin" x="246" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0800c3544486ee85cdd938afb4d869540c78865845d66ea95a21b96a3c5c1fda"/>
+    </canvas>
+    <canvas name="15" width="374" height="375">
+      <vector name="origin" x="191" y="233"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="320aea99666789b5e2c9453c9d8b60d19deea4ebe881b82d64eb0e710a01afdf"/>
+    </canvas>
+    <canvas name="16" width="457" height="398">
+      <vector name="origin" x="150" y="229"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce133fbad599f9d399b999a71b5c8bee6c23af208c6fa65041493411fe64b313"/>
+    </canvas>
+    <canvas name="17" width="423" height="463">
+      <vector name="origin" x="232" y="316"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ec2ae9eda06e0dfe6a8de9f698c3b98c006ace578801a165bcae046d32e6a27a"/>
+    </canvas>
+    <canvas name="18" width="386" height="400">
+      <vector name="origin" x="214" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="989119d8252ce7ee95da633b0dc3a363b45d7d6160d3012c50aa98758eb641be"/>
+    </canvas>
+    <canvas name="19" width="458" height="430">
+      <vector name="origin" x="147" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4e810ebaf36c9a92dedebd4d97e32537140de05248428e0b0243612250861ac9"/>
+    </canvas>
+    <canvas name="20" width="549" height="530">
+      <vector name="origin" x="264" y="389"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dfa1626cb67e07c0956715b1b6ed1839ab4aa62e1b4184e5c66e51b001a89b87"/>
+    </canvas>
+    <canvas name="21" width="440" height="308">
+      <vector name="origin" x="249" y="221"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="47494a0455d55c3d0164b5a72a29dfe443e9bc4634a00e4ea1ba106b464d77c4"/>
+    </canvas>
+    <canvas name="22" width="350" height="334">
+      <vector name="origin" x="166" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2e4c7101635614718ce9bef2b741a50d6d8f49e0996c515b82eb369efe87b643"/>
+    </canvas>
+    <canvas name="23" width="396" height="360">
+      <vector name="origin" x="186" y="293"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1b9d151601fa15ff30357903d418982976fa617dc61e3be2c1482124b09fe79c"/>
+    </canvas>
+    <canvas name="24" width="396" height="376">
+      <vector name="origin" x="184" y="301"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="197f3e82f73eeff1e3bcca3dab42a1edc10ad9c409fa4ed2fa5c7836862fac54"/>
+    </canvas>
+    <canvas name="25" width="383" height="382">
+      <vector name="origin" x="179" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f7f16428a721af3cf533eb8f7da6936aea1b95ec84897d22943b11f26e7d7fed"/>
+    </canvas>
+    <canvas name="26" width="382" height="382">
+      <vector name="origin" x="178" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b54486a9a83b72f88eb27c05cca20338798fd924439c83f752a452dfc9f2c494"/>
+    </canvas>
+    <canvas name="27" width="378" height="378">
+      <vector name="origin" x="176" y="302"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="906e8f4447fea7af6ae5893ac8951af516766c8672ddcdcc0fe812e92b887fd4"/>
+    </canvas>
+    <canvas name="28" width="331" height="348">
+      <vector name="origin" x="176" y="288"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c3091841a62e6db3a8726d5292b654262a294250118f7b9ca95a757f9ce8cfd8"/>
+    </canvas>
+    <canvas name="29" width="330" height="350">
+      <vector name="origin" x="177" y="290"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8aed8ede89e93a648dec20fa05072377156a880cd95393ab201df2a7fe0d884e"/>
+    </canvas>
+    <canvas name="30" width="320" height="320">
+      <vector name="origin" x="170" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="405d5a1e019623c8a31b11fc8c150609039331b24beef9f31f552f52517cd49c"/>
+    </canvas>
+    <canvas name="31" width="315" height="315">
+      <vector name="origin" x="172" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2834a375ab9ae8471180ead3d94b768fb3b757b6f05aba9a15a8b7620267eaef"/>
+    </canvas>
+    <canvas name="32" width="206" height="251">
+      <vector name="origin" x="78" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="16a0c5e3bd363e9cc7492dd9d51837fbf9cdc11f85297fbb68d875d65cb819eb"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Target found. Commencing elimination."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack2">
+    <canvas name="0" width="204" height="244">
+      <vector name="origin" x="77" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d14494a3b5675b9bda2f6f1112b96aa344d46788b7756a2ef26d6e6c685936fc"/>
+    </canvas>
+    <canvas name="1" width="448" height="244">
+      <vector name="origin" x="351" y="229"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-16" y="-139"/>
+      <vector name="lt" x="-348" y="-151"/>
+      <vector name="rb" x="86" y="1"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="18c1627de5c43ae47e4d191c70fd3addb86d8de87449e31947a2563e1a360a2b"/>
+    </canvas>
+    <canvas name="2" width="456" height="232">
+      <vector name="origin" x="362" y="214"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-28" y="-133"/>
+      <vector name="lt" x="-247" y="-165"/>
+      <vector name="rb" x="86" y="1"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="936b495391185a95f60bb070cefc7d6ec1c35b6ecc3e43c525fe8bf8b88df162"/>
+    </canvas>
+    <canvas name="3" width="468" height="244">
+      <vector name="origin" x="370" y="226"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-28" y="-133"/>
+      <vector name="lt" x="-309" y="-189"/>
+      <vector name="rb" x="86" y="1"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="38f6ebee6965fea8e5d633292f68c2299358a4395ca53a1d8e58bb258e4cf6d9"/>
+    </canvas>
+    <canvas name="4" width="464" height="232">
+      <vector name="origin" x="360" y="213"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-6" y="-136"/>
+      <vector name="lt" x="-326" y="-187"/>
+      <vector name="rb" x="86" y="1"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="ba58596e713d25a12c13a85dd2b9845d8908baeb0d6e5c30b1028501b6c5e331"/>
+    </canvas>
+    <canvas name="5" width="444" height="244">
+      <vector name="origin" x="367" y="228"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-46" y="-140"/>
+      <vector name="lt" x="-361" y="-138"/>
+      <vector name="rb" x="69" y="-1"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="b1f64c29d9c980dd18b6b1b6fbe16ea77acb6b0d8459b0867686dc1edc148e13"/>
+    </canvas>
+    <canvas name="6" width="460" height="236">
+      <vector name="origin" x="377" y="235"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-54" y="-127"/>
+      <vector name="lt" x="-373" y="-137"/>
+      <vector name="rb" x="74" y="-9"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="e0fe7302c9321080d0d2d285f6c0330fd29052008349c688fadf048c85488a2b"/>
+    </canvas>
+    <canvas name="7" width="448" height="256">
+      <vector name="origin" x="390" y="247"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-79" y="-139"/>
+      <vector name="lt" x="-376" y="-136"/>
+      <vector name="rb" x="50" y="-4"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="3a41850f9d5dc56a022748c0e518a82d5195743d33f4a3ce6e1cb34d2d0af11e"/>
+    </canvas>
+    <canvas name="8" width="424" height="252">
+      <vector name="origin" x="401" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-95" y="-142"/>
+      <vector name="lt" x="-398" y="-155"/>
+      <vector name="rb" x="15" y="-4"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="414e8762f8afcb082d0686cf01b48af08e97a0dcac74eddaaf3a7cb1bf600efd"/>
+    </canvas>
+    <canvas name="9" width="424" height="256">
+      <vector name="origin" x="405" y="245"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-95" y="-144"/>
+      <vector name="lt" x="-402" y="-160"/>
+      <vector name="rb" x="14" y="-4"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="48df81bc8051a488aad258aef74ca41c1d0f1ca2bebe784f1cce771e759d80c5"/>
+    </canvas>
+    <canvas name="10" width="380" height="244">
+      <vector name="origin" x="361" y="234"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-101" y="-145"/>
+      <vector name="lt" x="-216" y="-142"/>
+      <vector name="rb" x="13" y="-5"/>
+      <int name="delay" value="90"/>
+      <string name="_hash" value="70f041254bdbf5354371fb0f04b3bb78509519f568aae157c08feecfbe6434e7"/>
+    </canvas>
+    <canvas name="11" width="202" height="242">
+      <vector name="origin" x="170" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-88" y="-156"/>
+      <vector name="lt" x="-170" y="-161"/>
+      <vector name="rb" x="23" y="-9"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="202" height="239">
+      <vector name="origin" x="140" y="243"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="13" width="202" height="250">
+      <vector name="origin" x="109" y="253"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="14" width="202" height="250">
+      <vector name="origin" x="77" y="252"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-78" y="-168"/>
+      <vector name="rb" x="122" y="-12"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <uol name="15" value="../stand/6"/>
+    <uol name="16" value="../stand/7"/>
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-471" y="-192"/>
+        <vector name="rb" x="0" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="98" height="126">
+          <vector name="origin" x="49" y="63"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0be27986f4af3a6f70bf4ea8c24f71ea70101ce9e65a5817f8feb627bd01bec6"/>
+        </canvas>
+        <canvas name="1" width="99" height="124">
+          <vector name="origin" x="49" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b2115db9d9cc4575ccc141471d8ff61b0a214fe3c40aa3d9e2910f02c2b74644"/>
+        </canvas>
+        <canvas name="2" width="97" height="104">
+          <vector name="origin" x="48" y="52"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="dc2b872017c48e5b213e13ce656b69ba546923e5cb27bb77d84481412e8eea62"/>
+        </canvas>
+        <canvas name="3" width="100" height="91">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b01695807d8d166acafb60143a1f19ebd757f62d1e2f54007a77bbaee82fc8f2"/>
+        </canvas>
+        <canvas name="4" width="101" height="91">
+          <vector name="origin" x="50" y="45"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0636f3fbc9203b254f2d701993cc222a8583baf61e965a0d02a9bbd344e46eb7"/>
+        </canvas>
+        <canvas name="5" width="99" height="88">
+          <vector name="origin" x="49" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="718af6e4a522fe73161025ec5fbe5a46f69597acc859e037bd0378a573e8c4b8"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="attackAfter" value="780"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787129.img.xml
+++ b/gms-server/wz/Mob.wz/8787129.img.xml
@@ -1,1 +1,935 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787129.img"><imgdir name="info"><int name="level" value="100"/><int name="maxHP" value="999999999"/><int name="mpRecovery" value="10000"/><int name="PADamage" value="1500"/><int name="MADamage" value="1500"/><int name="PDRate" value="25"/><int name="MDRate" value="25"/><int name="acc" value="600"/><string name="elemAttr" value="P2"/><int name="eva" value="80"/><int name="pushed" value="100000"/><float name="fs" value="10.0"/><int name="exp" value="500000"/><int name="summonType" value="1"/><int name="category" value="8"/><int name="firstAttack" value="1"/><string name="mobType" value="1N"/><int name="boss" value="1"/><imgdir name="attack"><imgdir name="0"><int name="action" value="1"/><int name="attackRatio" value="100"/><int name="type" value="2"/><int name="conMP" value="1"/><int name="magic" value="1"/><int name="disease" value="122"/><int name="level" value="18"/><int name="bulletSpeed" value="700"/><int name="attackCount" value="2"/></imgdir></imgdir><int name="ignoreMoveImpact" value="1"/><int name="bodyAttack" value="1"/><int name="speed" value="5"/><int name="PDDamage" value="3000"/><int name="MDDamage" value="3000"/><int name="nonLevelCheckACC" value="1"/><int name="nonLevelCheckEVA" value="1"/><int name="notConsiderFieldSet" value="1"/><imgdir name="skill"><imgdir name="0"><int name="skill" value="123"/><int name="action" value="1"/><int name="level" value="5"/><int name="effectAfter" value="0"/></imgdir></imgdir><imgdir name="speak"><int name="chatBalloon" value="0"/><imgdir name="0"><string name="0" value="讓你後悔！"/></imgdir></imgdir><int name="hpTagBgcolor" value="3"/><int name="hpTagColor" value="1"/></imgdir><imgdir name="stand"><canvas name="0" width="225" height="248"><vector name="origin" x="100" y="244"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-77" y="-205"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="79ca2ec48344ab18770db140448badc8d9f5bb0de305abe27087b8d4766f161f"/></canvas><canvas name="1" width="224" height="247"><vector name="origin" x="100" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-77" y="-205"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="3bcf0b871f98606500bdf953274f082342661517393d8983f8c04531da713c52"/></canvas><canvas name="2" width="225" height="234"><vector name="origin" x="100" y="230"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-77" y="-205"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="2577232515851fafa34e7db4f1be256ce42816c58620259cfd3176ba4772b7ce"/></canvas><canvas name="3" width="225" height="240"><vector name="origin" x="100" y="238"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-77" y="-205"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="713ef6aab3e4d5369163148c50f6dd09c76811f1343d3ab05728cc6ba4073365"/></canvas><canvas name="4" width="225" height="228"><vector name="origin" x="100" y="227"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-77" y="-205"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="8754730aa52722e181aa5d79a6b2b880c6796df8b50c3d38142a0db98da998d5"/></canvas><canvas name="5" width="225" height="242"><vector name="origin" x="100" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-77" y="-205"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="cca465d244097d605f8889ee2cba7d8e2560789f2235dcc472a466b6eb86fb82"/></canvas><canvas name="6" width="225" height="252"><vector name="origin" x="100" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-77" y="-205"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="e6c65f892d2d7b52d9a7beb44d3caad24d52ec6a8f92ecfe03314a5299d99733"/></canvas><canvas name="7" width="225" height="253"><vector name="origin" x="100" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="4" y="-159"/><vector name="lt" x="-77" y="-205"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="3bc433e96c3d690744cb2c507ee86ee14e3b33fada9f71370379b6c013f0c1aa"/></canvas></imgdir><imgdir name="move"><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="逃げる獲物を追うのも楽しみの一つだ。"/></imgdir><canvas name="0" width="226" height="246"><vector name="origin" x="101" y="242"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="3eeffa970f29a2863097777b6919aca828788232e331728c368eabb311fd7d8e"/></canvas><canvas name="1" width="224" height="247"><vector name="origin" x="100" y="241"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="6b84a97e5a9ac6fbccfda7a0c54d3f1218a4b899b27ccddc48351cc7e82d1b8b"/></canvas><canvas name="2" width="226" height="234"><vector name="origin" x="101" y="230"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="cd7d6ee7407ad2e334f13f6f504ad135b11c7c511b9c6d52455539aebf54387d"/></canvas><canvas name="3" width="227" height="228"><vector name="origin" x="102" y="227"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="25b58d6be8d401356cd7b1c9ea9f3dd6bb4a15af514deffabd6fe2bd9e965f89"/></canvas><canvas name="4" width="228" height="242"><vector name="origin" x="103" y="243"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="a55aa9106f052051cdf14d65484f0880f7048a6dcc3333d289109fed35b46612"/></canvas><canvas name="5" width="227" height="252"><vector name="origin" x="102" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="5bcf3d4befac0fa239c6d22b00f22883e2e3569856d80585e1be461bd837357b"/></canvas></imgdir><imgdir name="hit1"><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="クッ…"/></imgdir><canvas name="0" width="228" height="251"><vector name="origin" x="70" y="242"/><int name="z" value="0"/><int name="delay" value="300"/><vector name="head" x="47" y="-157"/><vector name="lt" x="-47" y="-183"/><vector name="rb" x="150" y="-14"/><string name="_hash" value="4b76eadd3da9bb5afd0e6a3435c041eec53975ebdb81938750808241ef91dec3"/></canvas></imgdir><imgdir name="die1"><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="我太大意了,不能就這樣結束...."/><string name="1" value="被獵物擊中要害....."/></imgdir><canvas name="0" width="225" height="248"><vector name="origin" x="100" y="244"/><int name="z" value="0"/><vector name="head" x="9" y="-158"/><int name="delay" value="150"/><string name="_hash" value="319644088fa89730261a06b0d8359484d60e8caa04dd39a74e6a2e52eced1cfa"/></canvas><canvas name="1" width="228" height="251"><vector name="origin" x="70" y="242"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="048bad989af1c25e7ae439fca2af4cb51f8b016b1ebb8277513ddf1bcffaeda7"/></canvas><canvas name="2" width="226" height="239"><vector name="origin" x="66" y="230"/><int name="z" value="0"/><int name="delay" value="180"/><string name="_hash" value="c9c6d90e34bc086d03778051db1cd39d29a7b2df4f272c1fa7be38f65c41445b"/></canvas><canvas name="3" width="227" height="245"><vector name="origin" x="64" y="236"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="bbe95c381369f53e157e402f86a78dfb9443118aec1920a62365ef5fd84baf47"/></canvas><canvas name="4" width="228" height="248"><vector name="origin" x="63" y="239"/><int name="z" value="0"/><int name="delay" value="240"/><string name="_hash" value="c322d84f117a3d5ec3a7d46ebdca54bc2e81b770c299c612562dc9033b80fb8b"/></canvas><canvas name="5" width="228" height="249"><vector name="origin" x="62" y="240"/><int name="z" value="0"/><int name="delay" value="240"/><string name="_hash" value="c8a4055ff352a1d11b2a96cae51413f76db7741b7b1168c5787cb58dd2a81787"/></canvas><canvas name="6" width="228" height="245"><vector name="origin" x="61" y="236"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="52d727d71147f8dfeb0f8b1ca5074e4137c26f1bab2ef306b7a288bebf5b8b22"/></canvas><canvas name="7" width="228" height="211"><vector name="origin" x="60" y="202"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="03ccfcbbc45e29a913574d7b62ac4e3a7a2bb4f681a7231c04f15e604c7d233b"/></canvas><canvas name="8" width="228" height="211"><vector name="origin" x="59" y="202"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="1a3d22b1d0af8da7e65b2d4f817a462d23267109cfc778502beed26ec34d4213"/></canvas><canvas name="9" width="224" height="209"><vector name="origin" x="56" y="200"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="71fef80464d3d6a7b1970646d9123d49e340fdeb0ed8b09f06614bbd22874b82"/></canvas><canvas name="10" width="214" height="186"><vector name="origin" x="47" y="182"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="2f1d3cac376b5fe82e03b116895817b70bafee6921fd1277628cd673ea9fddff"/></canvas><canvas name="11" width="196" height="179"><vector name="origin" x="31" y="176"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="22bc197b44f80c6d6038322422c1f526f28ecfa8788113e2f2ec1de0570c1f54"/></canvas><canvas name="12" width="177" height="150"><vector name="origin" x="18" y="155"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="4e5889b77638472ac007dd05dbeb926dc84fecaae8dd4eb22a9aade6d584fb6b"/></canvas><canvas name="13" width="162" height="141"><vector name="origin" x="5" y="150"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="ab88f085490fa4eec4ea305753927560f329ff2d4bc0463cf18ee43139de58c2"/></canvas><canvas name="14" width="96" height="98"><vector name="origin" x="-53" y="110"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="158a723fe3a93a5be88b64a7759f121ec0a13cc9c24e1ec868a47d67a709b4a4"/></canvas><canvas name="15" width="35" height="86"><vector name="origin" x="-59" y="106"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="e3c11fdda7e8d36ac6bb08408225b5401d1e3837b42833d39efbcb04a971b527"/></canvas></imgdir><imgdir name="regen"><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="獲物が現れたな。"/><string name="1" value="狩りを始めるか。"/></imgdir><canvas name="0" width="163" height="121"><vector name="origin" x="-104" y="105"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bcf3f049a42ecff3a35fce04ad578177ee96a2c63c9fffd6a6ca447d0b9277fe"/></canvas><canvas name="1" width="183" height="159"><vector name="origin" x="-102" y="144"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="eab0b5f10900dfbefa707435a14cfcdf1abee3f86df647afb8f719a80d73bb52"/></canvas><canvas name="2" width="562" height="486"><vector name="origin" x="136" y="470"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="a1aac6031e70dfa9a0fd0f1bdc145d61b1e2bed8579d8cc3543d847cb807ff75"/></canvas><canvas name="3" width="857" height="510"><vector name="origin" x="433" y="468"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e04ab1b777e398d3fd96c80eb990d6e78880bf91ccce52c2de23e40b5cf2be16"/></canvas><canvas name="4" width="845" height="498"><vector name="origin" x="426" y="470"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="aafda4f5f91d5ada9cb0b8ec027695b10a47a1ab906ea9e226dd5c8f50ad713d"/></canvas><canvas name="5" width="836" height="483"><vector name="origin" x="425" y="468"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9181f27f7303f76736bb814bed9baa01ade9e20b84230188b626503f77076322"/></canvas><canvas name="6" width="793" height="482"><vector name="origin" x="420" y="467"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1198cb880c3226498fac1830f936e57883f4423ce34b6306cbbeed5d74012e6c"/></canvas><canvas name="7" width="726" height="463"><vector name="origin" x="361" y="453"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="ed00d92ead6c917199914f5c26aa575f22207b939a1a364d229e57a8f5b1b364"/></canvas><canvas name="8" width="533" height="444"><vector name="origin" x="347" y="434"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="829ae55e68098eb5961b3ac05d041e6ab9b7141641b7a7d9a4ad8bc6b7e75408"/></canvas><canvas name="9" width="371" height="425"><vector name="origin" x="180" y="423"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="28b068dc401f59886f3d43b83a1c3db9a8d8500c2664b7dd92100cbcb3b6886b"/></canvas><canvas name="10" width="424" height="397"><vector name="origin" x="252" y="339"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b47747bed5e698b54ea9135629f6ae7dca7c01558ca814b487fa23f5212d7385"/></canvas><canvas name="11" width="385" height="301"><vector name="origin" x="202" y="293"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="011318b3090b0cfa57808cf4c02df432d452ff194a9d5d6f8f8bdba02a02a3d0"/></canvas><canvas name="12" width="435" height="346"><vector name="origin" x="175" y="338"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b946e26788820a0da621c7aec3e4e5d62f50360fdccd4ed204249bcb161d8d52"/></canvas><canvas name="13" width="468" height="432"><vector name="origin" x="261" y="275"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d568063e2c8d85e2002604808c248b6181f1f6c94b2a8accbb46ae9811849269"/></canvas><canvas name="14" width="418" height="240"><vector name="origin" x="246" y="238"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0c86470e1fe4da7b95ad5ef3330a411a7e8bab494edd60c644d1275caa5f0297"/></canvas><canvas name="15" width="374" height="375"><vector name="origin" x="191" y="235"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e1b55dc1e3e422f01db08aa3e35d4f110d6567cdf2b760907cf75ea298a9f4f8"/></canvas><canvas name="16" width="457" height="398"><vector name="origin" x="150" y="231"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9fa9403b0d86c50282862171c7527e50bc10bd114e1f8ac2b801d41522a73079"/></canvas><canvas name="17" width="423" height="463"><vector name="origin" x="232" y="318"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="258e8e2bee9bf8670113ea7de8dd5b37b0a2e93e3ee475b1dd10c16a6ad2ca6d"/></canvas><canvas name="18" width="386" height="400"><vector name="origin" x="214" y="243"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="176eb124744931f1c5b1b991897cc203beace44aa6dc091aa97e2796502985dc"/></canvas><canvas name="19" width="458" height="430"><vector name="origin" x="147" y="279"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c5eb7d31f2808fa35f3f95adb2f1e94bfc46c65fba3b232831378239f17a5a8d"/></canvas><canvas name="20" width="549" height="530"><vector name="origin" x="264" y="391"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="66c1224d9e63b9d0e17d5b0c62081132cda169368985d9cf9aca318a2d234171"/></canvas><canvas name="21" width="440" height="308"><vector name="origin" x="249" y="223"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b98e4ac2c23608ac95391c584d8e526cdc05e927c3b93571514e837bd8833a27"/></canvas><canvas name="22" width="350" height="334"><vector name="origin" x="166" y="283"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="227bf706372c9fe38beb6a589dd33e82777b88259166b616dc586a51eaec4fb6"/></canvas><canvas name="23" width="396" height="360"><vector name="origin" x="186" y="295"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="146f1da4afafda906b376875c9af89a6302fa02c9c802225630f0a75dd68471a"/></canvas><canvas name="24" width="396" height="376"><vector name="origin" x="184" y="303"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7c93142dd2dcb54c8ea55d8d566d893c019217f88205731f52aff203cacf522b"/></canvas><canvas name="25" width="383" height="382"><vector name="origin" x="179" y="306"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="a892d9fbbac39ef66f5e57c3ead605d9980dcff123cd2bbc1802231b277944ee"/></canvas><canvas name="26" width="382" height="382"><vector name="origin" x="178" y="306"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="3815f0942328c1ed019f0df9d265510e9a99c15d11dc2bde76e8eff096b70be3"/></canvas><canvas name="27" width="378" height="378"><vector name="origin" x="176" y="304"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8d7d49eadf1947dffea2caf3843073f241687f4323ed1f030c05b382ce89a27b"/></canvas><canvas name="28" width="331" height="348"><vector name="origin" x="176" y="290"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="06a36f38e484372b98717c6b124e6e9773aec073fe1275669f41816c09370d07"/></canvas><canvas name="29" width="330" height="350"><vector name="origin" x="177" y="292"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="38123f4c9f010f29958d1f06c48b7f5eb61fccbf5a290d94a12294b1e8042b5d"/></canvas><canvas name="30" width="320" height="320"><vector name="origin" x="170" y="279"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="152d4c1dae67f0102dc1ebec3ed82246b0fe3758709c4b31a3740f1554cc6607"/></canvas><canvas name="31" width="315" height="315"><vector name="origin" x="172" y="281"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="47d51e1009a5ac4384bff16df563ae1461eb6667336892beb8d7ca541a010cc9"/></canvas><canvas name="32" width="228" height="254"><vector name="origin" x="100" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="cf3996bc1912816a29514f8bc3f96af15c71c21591326d8d678dbdce047d1318"/></canvas></imgdir><imgdir name="attack1"><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="我的箭絕對不會錯過獵物."/></imgdir><canvas name="0" width="228" height="248"><vector name="origin" x="100" y="244"/><int name="z" value="0"/><vector name="head" x="14" y="-163"/><vector name="lt" x="-78" y="-185"/><vector name="rb" x="113" y="-11"/><int name="delay" value="60"/><string name="_hash" value="b2adc10333e6b827c51e6dc5a1aaf61125312cbe2b373f401e0612a80621b2e9"/></canvas><canvas name="1" width="228" height="248"><vector name="origin" x="83" y="263"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="34" y="-175"/><vector name="lt" x="-46" y="-189"/><vector name="rb" x="133" y="-28"/><string name="_hash" value="ff256d2efbd8827d3ecd33c64552d2942ad6c2117f55aec1afa766eb904556d0"/></canvas><canvas name="2" width="240" height="232"><vector name="origin" x="85" y="243"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="47" y="-171"/><vector name="lt" x="-37" y="-182"/><vector name="rb" x="141" y="-23"/><string name="_hash" value="9e63105163b6f822d76f6f3442433be4c868db7727cf3e320ce35cd2b6fb4ade"/></canvas><canvas name="3" width="244" height="228"><vector name="origin" x="86" y="234"/><int name="z" value="0"/><int name="delay" value="60"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="93f5e4bbf4760eb20220b9b15090ddebf4376b9d0e007f147ff1ec342a103ee9"/></canvas><canvas name="4" width="244" height="260"><vector name="origin" x="86" y="247"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="a4bfe561a7dae4998b59bd5763dfb6549adf1dbfcaefc3cdc937849738dcd5f0"/></canvas><canvas name="5" width="344" height="288"><vector name="origin" x="184" y="256"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="a4f117097d0a5456b57176cefa7172a1a74ff2ac3806d5c55b553c7110462ce8"/></canvas><canvas name="6" width="336" height="280"><vector name="origin" x="176" y="250"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="68cdd7de4af7062d56f7f22452507db5279d5f02a898e3d8c1ab5ae7adb2651a"/></canvas><canvas name="7" width="300" height="280"><vector name="origin" x="142" y="251"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="9d12447a5cb2b4713cb8227ecf0e53baa9310e9f0145807dd0ed64a9f06be2a1"/></canvas><canvas name="8" width="340" height="248"><vector name="origin" x="181" y="238"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="9ba7487a67d9ca7401992554313695310addd1cb10b7d037a74f4069bf651cba"/></canvas><canvas name="9" width="300" height="244"><vector name="origin" x="142" y="232"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="49972a087da143ebdba3be6f47d2c9aad54103ce931ec0ea636ba0e0e31f9ebf"/></canvas><canvas name="10" width="276" height="268"><vector name="origin" x="116" y="246"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="e4a9f9b13f0f3838d1b7f06ad8c4ee37c4dba3f1fcb21ea55c97b40ee2b1513e"/></canvas><canvas name="11" width="276" height="288"><vector name="origin" x="116" y="256"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="333bbbce3f3b508f0ec7ebd64539d9d2945a1ffced523e585d6485828dfee5a4"/></canvas><canvas name="12" width="276" height="284"><vector name="origin" x="115" y="250"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="da19e1e288420baac6270193bd948af831a90f641e85dd38e14638f12b10a143"/></canvas><canvas name="13" width="272" height="284"><vector name="origin" x="113" y="251"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="a399407948d3fcb27d5f4680594ec05c1ce9afe2a8bf5f4bc716b3625c102ab5"/></canvas><canvas name="14" width="272" height="272"><vector name="origin" x="112" y="238"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="8921ada9598d9bab8920a2d75e80e064f4080c43df0dd4ef30b9157fe5080833"/></canvas><canvas name="15" width="336" height="296"><vector name="origin" x="177" y="248"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="ee00495474e1ddc68e787d0cdc4c0e8b714804bf7e13ad2071cedae61ee287f6"/></canvas><canvas name="16" width="336" height="284"><vector name="origin" x="176" y="246"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="bbbab73b2a7a167ee11275136a7be9bc28953255cc1332ad7ad7d4ca29fc5d0d"/></canvas><canvas name="17" width="336" height="284"><vector name="origin" x="176" y="256"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="dec3d11dd75a9d8ab335159ebe084cf923c2d631d1b14e56325b3d97e4303351"/></canvas><canvas name="18" width="340" height="280"><vector name="origin" x="179" y="250"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="cffa55bf8b6aa0fecf5c9b506e47e8f82493942e5ffd3312d468ea0a64ee4202"/></canvas><canvas name="19" width="256" height="276"><vector name="origin" x="95" y="251"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="ca794f94ffc6b298b2328f6606c70200d6e7e71de7051e9532ec70e3ccc14f3d"/></canvas><canvas name="20" width="212" height="264"><vector name="origin" x="55" y="238"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="47" y="-173"/><vector name="lt" x="-43" y="-185"/><vector name="rb" x="143" y="-19"/><string name="_hash" value="9dc3fb5cc2bfe9f4ba0aee2403ed3271e01d2e5dab373c4b30fe2e3dddd13e0b"/></canvas><canvas name="21" width="212" height="264"><vector name="origin" x="68" y="240"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="30" y="-181"/><vector name="lt" x="-58" y="-190"/><vector name="rb" x="132" y="-26"/><string name="_hash" value="0c6d1c64e27fa4262277161d03b8ee8a4c049e8a08035dc72d2cc9b30b157c3e"/></canvas><canvas name="22" width="212" height="272"><vector name="origin" x="78" y="261"/><int name="z" value="0"/><int name="delay" value="90"/><vector name="head" x="21" y="-186"/><vector name="lt" x="-72" y="-200"/><vector name="rb" x="124" y="-31"/><string name="_hash" value="83599e08fe61b39cb9206d1a26171fcf8da164425f08c8187f06c12185b82847"/></canvas><uol name="23" value="../stand/4"/><uol name="24" value="../stand/5"/><uol name="25" value="../stand/6"/><uol name="26" value="../stand/7"/><imgdir name="info"><imgdir name="range"><vector name="sp" x="-50" y="-100"/><int name="r" value="700"/></imgdir><imgdir name="ball"><canvas name="0" width="188" height="59"><vector name="origin" x="94" y="29"/><int name="delay" value="150"/></canvas><canvas name="1" width="204" height="55"><vector name="origin" x="94" y="27"/><int name="delay" value="150"/></canvas><canvas name="2" width="188" height="51"><vector name="origin" x="94" y="25"/><int name="delay" value="150"/></canvas></imgdir><imgdir name="hit"><canvas name="0" width="200" height="245"><vector name="origin" x="93" y="124"/><int name="delay" value="150"/></canvas><canvas name="1" width="222" height="229"><vector name="origin" x="102" y="118"/><int name="delay" value="150"/></canvas><canvas name="2" width="225" height="254"><vector name="origin" x="102" y="131"/><int name="delay" value="150"/></canvas><canvas name="3" width="228" height="268"><vector name="origin" x="102" y="138"/><int name="delay" value="150"/></canvas><canvas name="4" width="134" height="274"><vector name="origin" x="65" y="141"/><int name="delay" value="60"/></canvas><canvas name="5" width="22" height="222"><vector name="origin" x="11" y="112"/><int name="delay" value="150"/></canvas></imgdir><int name="attackAfter" value="660"/><int name="type" value="2"/><int name="magic" value="1"/><int name="bulletSpeed" value="200"/></imgdir></imgdir><imgdir name="skill1"><canvas name="0" width="228" height="248"><vector name="origin" x="100" y="242"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="cd652ea06aaded2e72afb169a5db3a2bc0070b09de9aaafd0b61aabdc5d7672f"/></canvas><canvas name="1" width="236" height="408"><vector name="origin" x="100" y="391"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="b94e3e6db458a555dbcd96426cf7633f877f1ecba7d05232f30503a181638c7f"/></canvas><canvas name="2" width="240" height="416"><vector name="origin" x="100" y="396"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="be0d30dfb92b0306d086442d52833b9e1d2541bd88f9a5d3ebdc6354a63cbd02"/></canvas><canvas name="3" width="240" height="420"><vector name="origin" x="103" y="395"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="2bac2e9c6d307c2115c8fc21f1b27de2e17acd80e2f890a6d27f8c3ec5e4c377"/></canvas><canvas name="4" width="228" height="404"><vector name="origin" x="100" y="379"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="674be33523464aa3c00d88e74f564f0fbb8cf4a2faec79d48a95fcfdab0e597f"/></canvas><canvas name="5" width="228" height="368"><vector name="origin" x="100" y="342"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="4f827b3663f28cf79f0b7d3a64bf321fa2ef4c18528d5bee0c35295e7bc2125e"/></canvas><canvas name="6" width="228" height="368"><vector name="origin" x="100" y="342"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="cdd0556f1a283306fafe5da4e0c652a3d97b332323d97d92102766f82180d401"/></canvas><canvas name="7" width="228" height="372"><vector name="origin" x="100" y="341"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="3ea5c4b06acd49cd9b1444395a4fff2d9e6f4efa4020eb68120b250cc1a1d783"/></canvas><canvas name="8" width="216" height="360"><vector name="origin" x="88" y="355"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="ae2842860106bb94cb8ac83b86f1667dc49baa1e934e9cacbb46081b295c0e8c"/></canvas><canvas name="9" width="220" height="376"><vector name="origin" x="94" y="373"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="2ccb349a268f70e23bdab295d864d25e1647194c7d12a2b8ad4f96b437d1027b"/></canvas><canvas name="10" width="220" height="388"><vector name="origin" x="95" y="384"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="d8b1e716d000e04cc4aedbb0d771f1136ea2165b6fd1652e10730baf072d6e1e"/></canvas><canvas name="11" width="224" height="396"><vector name="origin" x="96" y="390"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="058f75dec752fb37463894ee70aabcccc8888fa1950a54c9f0ca20bd22679eef"/></canvas><canvas name="12" width="224" height="392"><vector name="origin" x="96" y="393"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="5e0cb4feb1f890ff1d1beeeec1b4a29a9224800920e6eb0dd66a71ba074e5186"/></canvas><canvas name="13" width="220" height="372"><vector name="origin" x="95" y="393"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="4c2b033687f0b2124a474f1ace55ba64d9cdf1f7d304ff0d433ac4372be9e8bc"/></canvas><canvas name="14" width="228" height="396"><vector name="origin" x="100" y="395"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="e9a2c5d35ec8e33260339e622d5f0eb30ab6a7f6a74180aa4b344e878602e1ec"/></canvas><canvas name="15" width="228" height="392"><vector name="origin" x="100" y="388"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-79" y="-196"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="32273fd3bb30cf2467c9b714863eb408863c8a18061c0678d0e866542125a34b"/></canvas><uol name="19" value="../stand/4"/><uol name="20" value="../stand/5"/><uol name="21" value="../stand/6"/><uol name="22" value="../stand/7"/></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787129.img">
+  <imgdir name="info">
+    <int name="level" value="100"/>
+    <int name="maxHP" value="999999999"/>
+    <int name="mpRecovery" value="10000"/>
+    <int name="PADamage" value="1500"/>
+    <int name="MADamage" value="1500"/>
+    <int name="PDRate" value="25"/>
+    <int name="MDRate" value="25"/>
+    <int name="acc" value="600"/>
+    <string name="elemAttr" value="P2"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="500000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="2"/>
+        <int name="conMP" value="1"/>
+        <int name="magic" value="1"/>
+        <int name="disease" value="122"/>
+        <int name="level" value="18"/>
+        <int name="bulletSpeed" value="700"/>
+        <int name="attackCount" value="2"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="speed" value="5"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <int name="nonLevelCheckACC" value="1"/>
+    <int name="nonLevelCheckEVA" value="1"/>
+    <int name="notConsiderFieldSet" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="123"/>
+        <int name="action" value="1"/>
+        <int name="level" value="5"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="I will make you regret this!"/>
+      </imgdir>
+    </imgdir>
+    <int name="hpTagBgcolor" value="3"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="225" height="248">
+      <vector name="origin" x="100" y="244"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="79ca2ec48344ab18770db140448badc8d9f5bb0de305abe27087b8d4766f161f"/>
+    </canvas>
+    <canvas name="1" width="224" height="247">
+      <vector name="origin" x="100" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="3bcf0b871f98606500bdf953274f082342661517393d8983f8c04531da713c52"/>
+    </canvas>
+    <canvas name="2" width="225" height="234">
+      <vector name="origin" x="100" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="2577232515851fafa34e7db4f1be256ce42816c58620259cfd3176ba4772b7ce"/>
+    </canvas>
+    <canvas name="3" width="225" height="240">
+      <vector name="origin" x="100" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="713ef6aab3e4d5369163148c50f6dd09c76811f1343d3ab05728cc6ba4073365"/>
+    </canvas>
+    <canvas name="4" width="225" height="228">
+      <vector name="origin" x="100" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="8754730aa52722e181aa5d79a6b2b880c6796df8b50c3d38142a0db98da998d5"/>
+    </canvas>
+    <canvas name="5" width="225" height="242">
+      <vector name="origin" x="100" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="cca465d244097d605f8889ee2cba7d8e2560789f2235dcc472a466b6eb86fb82"/>
+    </canvas>
+    <canvas name="6" width="225" height="252">
+      <vector name="origin" x="100" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="e6c65f892d2d7b52d9a7beb44d3caad24d52ec6a8f92ecfe03314a5299d99733"/>
+    </canvas>
+    <canvas name="7" width="225" height="253">
+      <vector name="origin" x="100" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="4" y="-159"/>
+      <vector name="lt" x="-77" y="-205"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="3bc433e96c3d690744cb2c507ee86ee14e3b33fada9f71370379b6c013f0c1aa"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Chasing fleeing prey is part of the fun."/>
+    </imgdir>
+    <canvas name="0" width="226" height="246">
+      <vector name="origin" x="101" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3eeffa970f29a2863097777b6919aca828788232e331728c368eabb311fd7d8e"/>
+    </canvas>
+    <canvas name="1" width="224" height="247">
+      <vector name="origin" x="100" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="6b84a97e5a9ac6fbccfda7a0c54d3f1218a4b899b27ccddc48351cc7e82d1b8b"/>
+    </canvas>
+    <canvas name="2" width="226" height="234">
+      <vector name="origin" x="101" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="cd7d6ee7407ad2e334f13f6f504ad135b11c7c511b9c6d52455539aebf54387d"/>
+    </canvas>
+    <canvas name="3" width="227" height="228">
+      <vector name="origin" x="102" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="25b58d6be8d401356cd7b1c9ea9f3dd6bb4a15af514deffabd6fe2bd9e965f89"/>
+    </canvas>
+    <canvas name="4" width="228" height="242">
+      <vector name="origin" x="103" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="a55aa9106f052051cdf14d65484f0880f7048a6dcc3333d289109fed35b46612"/>
+    </canvas>
+    <canvas name="5" width="227" height="252">
+      <vector name="origin" x="102" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="5bcf3d4befac0fa239c6d22b00f22883e2e3569856d80585e1be461bd837357b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Guh..."/>
+    </imgdir>
+    <canvas name="0" width="228" height="251">
+      <vector name="origin" x="70" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="300"/>
+      <vector name="head" x="47" y="-157"/>
+      <vector name="lt" x="-47" y="-183"/>
+      <vector name="rb" x="150" y="-14"/>
+      <string name="_hash" value="4b76eadd3da9bb5afd0e6a3435c041eec53975ebdb81938750808241ef91dec3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="I was too careless. It cannot end like this..."/>
+      <string name="1" value="The prey struck my weak point..."/>
+    </imgdir>
+    <canvas name="0" width="225" height="248">
+      <vector name="origin" x="100" y="244"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="9" y="-158"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="319644088fa89730261a06b0d8359484d60e8caa04dd39a74e6a2e52eced1cfa"/>
+    </canvas>
+    <canvas name="1" width="228" height="251">
+      <vector name="origin" x="70" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="048bad989af1c25e7ae439fca2af4cb51f8b016b1ebb8277513ddf1bcffaeda7"/>
+    </canvas>
+    <canvas name="2" width="226" height="239">
+      <vector name="origin" x="66" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="c9c6d90e34bc086d03778051db1cd39d29a7b2df4f272c1fa7be38f65c41445b"/>
+    </canvas>
+    <canvas name="3" width="227" height="245">
+      <vector name="origin" x="64" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="bbe95c381369f53e157e402f86a78dfb9443118aec1920a62365ef5fd84baf47"/>
+    </canvas>
+    <canvas name="4" width="228" height="248">
+      <vector name="origin" x="63" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="c322d84f117a3d5ec3a7d46ebdca54bc2e81b770c299c612562dc9033b80fb8b"/>
+    </canvas>
+    <canvas name="5" width="228" height="249">
+      <vector name="origin" x="62" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="c8a4055ff352a1d11b2a96cae51413f76db7741b7b1168c5787cb58dd2a81787"/>
+    </canvas>
+    <canvas name="6" width="228" height="245">
+      <vector name="origin" x="61" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="52d727d71147f8dfeb0f8b1ca5074e4137c26f1bab2ef306b7a288bebf5b8b22"/>
+    </canvas>
+    <canvas name="7" width="228" height="211">
+      <vector name="origin" x="60" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="03ccfcbbc45e29a913574d7b62ac4e3a7a2bb4f681a7231c04f15e604c7d233b"/>
+    </canvas>
+    <canvas name="8" width="228" height="211">
+      <vector name="origin" x="59" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="1a3d22b1d0af8da7e65b2d4f817a462d23267109cfc778502beed26ec34d4213"/>
+    </canvas>
+    <canvas name="9" width="224" height="209">
+      <vector name="origin" x="56" y="200"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="71fef80464d3d6a7b1970646d9123d49e340fdeb0ed8b09f06614bbd22874b82"/>
+    </canvas>
+    <canvas name="10" width="214" height="186">
+      <vector name="origin" x="47" y="182"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="2f1d3cac376b5fe82e03b116895817b70bafee6921fd1277628cd673ea9fddff"/>
+    </canvas>
+    <canvas name="11" width="196" height="179">
+      <vector name="origin" x="31" y="176"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="22bc197b44f80c6d6038322422c1f526f28ecfa8788113e2f2ec1de0570c1f54"/>
+    </canvas>
+    <canvas name="12" width="177" height="150">
+      <vector name="origin" x="18" y="155"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="4e5889b77638472ac007dd05dbeb926dc84fecaae8dd4eb22a9aade6d584fb6b"/>
+    </canvas>
+    <canvas name="13" width="162" height="141">
+      <vector name="origin" x="5" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="ab88f085490fa4eec4ea305753927560f329ff2d4bc0463cf18ee43139de58c2"/>
+    </canvas>
+    <canvas name="14" width="96" height="98">
+      <vector name="origin" x="-53" y="110"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="158a723fe3a93a5be88b64a7759f121ec0a13cc9c24e1ec868a47d67a709b4a4"/>
+    </canvas>
+    <canvas name="15" width="35" height="86">
+      <vector name="origin" x="-59" y="106"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="e3c11fdda7e8d36ac6bb08408225b5401d1e3837b42833d39efbcb04a971b527"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="regen">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="The prey has appeared."/>
+      <string name="1" value="Let the hunt begin."/>
+    </imgdir>
+    <canvas name="0" width="163" height="121">
+      <vector name="origin" x="-104" y="105"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bcf3f049a42ecff3a35fce04ad578177ee96a2c63c9fffd6a6ca447d0b9277fe"/>
+    </canvas>
+    <canvas name="1" width="183" height="159">
+      <vector name="origin" x="-102" y="144"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="eab0b5f10900dfbefa707435a14cfcdf1abee3f86df647afb8f719a80d73bb52"/>
+    </canvas>
+    <canvas name="2" width="562" height="486">
+      <vector name="origin" x="136" y="470"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a1aac6031e70dfa9a0fd0f1bdc145d61b1e2bed8579d8cc3543d847cb807ff75"/>
+    </canvas>
+    <canvas name="3" width="857" height="510">
+      <vector name="origin" x="433" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e04ab1b777e398d3fd96c80eb990d6e78880bf91ccce52c2de23e40b5cf2be16"/>
+    </canvas>
+    <canvas name="4" width="845" height="498">
+      <vector name="origin" x="426" y="470"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="aafda4f5f91d5ada9cb0b8ec027695b10a47a1ab906ea9e226dd5c8f50ad713d"/>
+    </canvas>
+    <canvas name="5" width="836" height="483">
+      <vector name="origin" x="425" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9181f27f7303f76736bb814bed9baa01ade9e20b84230188b626503f77076322"/>
+    </canvas>
+    <canvas name="6" width="793" height="482">
+      <vector name="origin" x="420" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1198cb880c3226498fac1830f936e57883f4423ce34b6306cbbeed5d74012e6c"/>
+    </canvas>
+    <canvas name="7" width="726" height="463">
+      <vector name="origin" x="361" y="453"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ed00d92ead6c917199914f5c26aa575f22207b939a1a364d229e57a8f5b1b364"/>
+    </canvas>
+    <canvas name="8" width="533" height="444">
+      <vector name="origin" x="347" y="434"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="829ae55e68098eb5961b3ac05d041e6ab9b7141641b7a7d9a4ad8bc6b7e75408"/>
+    </canvas>
+    <canvas name="9" width="371" height="425">
+      <vector name="origin" x="180" y="423"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="28b068dc401f59886f3d43b83a1c3db9a8d8500c2664b7dd92100cbcb3b6886b"/>
+    </canvas>
+    <canvas name="10" width="424" height="397">
+      <vector name="origin" x="252" y="339"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b47747bed5e698b54ea9135629f6ae7dca7c01558ca814b487fa23f5212d7385"/>
+    </canvas>
+    <canvas name="11" width="385" height="301">
+      <vector name="origin" x="202" y="293"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="011318b3090b0cfa57808cf4c02df432d452ff194a9d5d6f8f8bdba02a02a3d0"/>
+    </canvas>
+    <canvas name="12" width="435" height="346">
+      <vector name="origin" x="175" y="338"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b946e26788820a0da621c7aec3e4e5d62f50360fdccd4ed204249bcb161d8d52"/>
+    </canvas>
+    <canvas name="13" width="468" height="432">
+      <vector name="origin" x="261" y="275"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d568063e2c8d85e2002604808c248b6181f1f6c94b2a8accbb46ae9811849269"/>
+    </canvas>
+    <canvas name="14" width="418" height="240">
+      <vector name="origin" x="246" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0c86470e1fe4da7b95ad5ef3330a411a7e8bab494edd60c644d1275caa5f0297"/>
+    </canvas>
+    <canvas name="15" width="374" height="375">
+      <vector name="origin" x="191" y="235"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e1b55dc1e3e422f01db08aa3e35d4f110d6567cdf2b760907cf75ea298a9f4f8"/>
+    </canvas>
+    <canvas name="16" width="457" height="398">
+      <vector name="origin" x="150" y="231"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9fa9403b0d86c50282862171c7527e50bc10bd114e1f8ac2b801d41522a73079"/>
+    </canvas>
+    <canvas name="17" width="423" height="463">
+      <vector name="origin" x="232" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="258e8e2bee9bf8670113ea7de8dd5b37b0a2e93e3ee475b1dd10c16a6ad2ca6d"/>
+    </canvas>
+    <canvas name="18" width="386" height="400">
+      <vector name="origin" x="214" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="176eb124744931f1c5b1b991897cc203beace44aa6dc091aa97e2796502985dc"/>
+    </canvas>
+    <canvas name="19" width="458" height="430">
+      <vector name="origin" x="147" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c5eb7d31f2808fa35f3f95adb2f1e94bfc46c65fba3b232831378239f17a5a8d"/>
+    </canvas>
+    <canvas name="20" width="549" height="530">
+      <vector name="origin" x="264" y="391"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="66c1224d9e63b9d0e17d5b0c62081132cda169368985d9cf9aca318a2d234171"/>
+    </canvas>
+    <canvas name="21" width="440" height="308">
+      <vector name="origin" x="249" y="223"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b98e4ac2c23608ac95391c584d8e526cdc05e927c3b93571514e837bd8833a27"/>
+    </canvas>
+    <canvas name="22" width="350" height="334">
+      <vector name="origin" x="166" y="283"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="227bf706372c9fe38beb6a589dd33e82777b88259166b616dc586a51eaec4fb6"/>
+    </canvas>
+    <canvas name="23" width="396" height="360">
+      <vector name="origin" x="186" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="146f1da4afafda906b376875c9af89a6302fa02c9c802225630f0a75dd68471a"/>
+    </canvas>
+    <canvas name="24" width="396" height="376">
+      <vector name="origin" x="184" y="303"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7c93142dd2dcb54c8ea55d8d566d893c019217f88205731f52aff203cacf522b"/>
+    </canvas>
+    <canvas name="25" width="383" height="382">
+      <vector name="origin" x="179" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a892d9fbbac39ef66f5e57c3ead605d9980dcff123cd2bbc1802231b277944ee"/>
+    </canvas>
+    <canvas name="26" width="382" height="382">
+      <vector name="origin" x="178" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3815f0942328c1ed019f0df9d265510e9a99c15d11dc2bde76e8eff096b70be3"/>
+    </canvas>
+    <canvas name="27" width="378" height="378">
+      <vector name="origin" x="176" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8d7d49eadf1947dffea2caf3843073f241687f4323ed1f030c05b382ce89a27b"/>
+    </canvas>
+    <canvas name="28" width="331" height="348">
+      <vector name="origin" x="176" y="290"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="06a36f38e484372b98717c6b124e6e9773aec073fe1275669f41816c09370d07"/>
+    </canvas>
+    <canvas name="29" width="330" height="350">
+      <vector name="origin" x="177" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="38123f4c9f010f29958d1f06c48b7f5eb61fccbf5a290d94a12294b1e8042b5d"/>
+    </canvas>
+    <canvas name="30" width="320" height="320">
+      <vector name="origin" x="170" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="152d4c1dae67f0102dc1ebec3ed82246b0fe3758709c4b31a3740f1554cc6607"/>
+    </canvas>
+    <canvas name="31" width="315" height="315">
+      <vector name="origin" x="172" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="47d51e1009a5ac4384bff16df563ae1461eb6667336892beb8d7ca541a010cc9"/>
+    </canvas>
+    <canvas name="32" width="228" height="254">
+      <vector name="origin" x="100" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cf3996bc1912816a29514f8bc3f96af15c71c21591326d8d678dbdce047d1318"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="My arrows never miss their prey."/>
+    </imgdir>
+    <canvas name="0" width="228" height="248">
+      <vector name="origin" x="100" y="244"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="14" y="-163"/>
+      <vector name="lt" x="-78" y="-185"/>
+      <vector name="rb" x="113" y="-11"/>
+      <int name="delay" value="60"/>
+      <string name="_hash" value="b2adc10333e6b827c51e6dc5a1aaf61125312cbe2b373f401e0612a80621b2e9"/>
+    </canvas>
+    <canvas name="1" width="228" height="248">
+      <vector name="origin" x="83" y="263"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="34" y="-175"/>
+      <vector name="lt" x="-46" y="-189"/>
+      <vector name="rb" x="133" y="-28"/>
+      <string name="_hash" value="ff256d2efbd8827d3ecd33c64552d2942ad6c2117f55aec1afa766eb904556d0"/>
+    </canvas>
+    <canvas name="2" width="240" height="232">
+      <vector name="origin" x="85" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="47" y="-171"/>
+      <vector name="lt" x="-37" y="-182"/>
+      <vector name="rb" x="141" y="-23"/>
+      <string name="_hash" value="9e63105163b6f822d76f6f3442433be4c868db7727cf3e320ce35cd2b6fb4ade"/>
+    </canvas>
+    <canvas name="3" width="244" height="228">
+      <vector name="origin" x="86" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="60"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="93f5e4bbf4760eb20220b9b15090ddebf4376b9d0e007f147ff1ec342a103ee9"/>
+    </canvas>
+    <canvas name="4" width="244" height="260">
+      <vector name="origin" x="86" y="247"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="a4bfe561a7dae4998b59bd5763dfb6549adf1dbfcaefc3cdc937849738dcd5f0"/>
+    </canvas>
+    <canvas name="5" width="344" height="288">
+      <vector name="origin" x="184" y="256"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="a4f117097d0a5456b57176cefa7172a1a74ff2ac3806d5c55b553c7110462ce8"/>
+    </canvas>
+    <canvas name="6" width="336" height="280">
+      <vector name="origin" x="176" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="68cdd7de4af7062d56f7f22452507db5279d5f02a898e3d8c1ab5ae7adb2651a"/>
+    </canvas>
+    <canvas name="7" width="300" height="280">
+      <vector name="origin" x="142" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="9d12447a5cb2b4713cb8227ecf0e53baa9310e9f0145807dd0ed64a9f06be2a1"/>
+    </canvas>
+    <canvas name="8" width="340" height="248">
+      <vector name="origin" x="181" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="9ba7487a67d9ca7401992554313695310addd1cb10b7d037a74f4069bf651cba"/>
+    </canvas>
+    <canvas name="9" width="300" height="244">
+      <vector name="origin" x="142" y="232"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="49972a087da143ebdba3be6f47d2c9aad54103ce931ec0ea636ba0e0e31f9ebf"/>
+    </canvas>
+    <canvas name="10" width="276" height="268">
+      <vector name="origin" x="116" y="246"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="e4a9f9b13f0f3838d1b7f06ad8c4ee37c4dba3f1fcb21ea55c97b40ee2b1513e"/>
+    </canvas>
+    <canvas name="11" width="276" height="288">
+      <vector name="origin" x="116" y="256"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="333bbbce3f3b508f0ec7ebd64539d9d2945a1ffced523e585d6485828dfee5a4"/>
+    </canvas>
+    <canvas name="12" width="276" height="284">
+      <vector name="origin" x="115" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="da19e1e288420baac6270193bd948af831a90f641e85dd38e14638f12b10a143"/>
+    </canvas>
+    <canvas name="13" width="272" height="284">
+      <vector name="origin" x="113" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="a399407948d3fcb27d5f4680594ec05c1ce9afe2a8bf5f4bc716b3625c102ab5"/>
+    </canvas>
+    <canvas name="14" width="272" height="272">
+      <vector name="origin" x="112" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="8921ada9598d9bab8920a2d75e80e064f4080c43df0dd4ef30b9157fe5080833"/>
+    </canvas>
+    <canvas name="15" width="336" height="296">
+      <vector name="origin" x="177" y="248"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="ee00495474e1ddc68e787d0cdc4c0e8b714804bf7e13ad2071cedae61ee287f6"/>
+    </canvas>
+    <canvas name="16" width="336" height="284">
+      <vector name="origin" x="176" y="246"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="bbbab73b2a7a167ee11275136a7be9bc28953255cc1332ad7ad7d4ca29fc5d0d"/>
+    </canvas>
+    <canvas name="17" width="336" height="284">
+      <vector name="origin" x="176" y="256"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="dec3d11dd75a9d8ab335159ebe084cf923c2d631d1b14e56325b3d97e4303351"/>
+    </canvas>
+    <canvas name="18" width="340" height="280">
+      <vector name="origin" x="179" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="cffa55bf8b6aa0fecf5c9b506e47e8f82493942e5ffd3312d468ea0a64ee4202"/>
+    </canvas>
+    <canvas name="19" width="256" height="276">
+      <vector name="origin" x="95" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="ca794f94ffc6b298b2328f6606c70200d6e7e71de7051e9532ec70e3ccc14f3d"/>
+    </canvas>
+    <canvas name="20" width="212" height="264">
+      <vector name="origin" x="55" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="47" y="-173"/>
+      <vector name="lt" x="-43" y="-185"/>
+      <vector name="rb" x="143" y="-19"/>
+      <string name="_hash" value="9dc3fb5cc2bfe9f4ba0aee2403ed3271e01d2e5dab373c4b30fe2e3dddd13e0b"/>
+    </canvas>
+    <canvas name="21" width="212" height="264">
+      <vector name="origin" x="68" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="30" y="-181"/>
+      <vector name="lt" x="-58" y="-190"/>
+      <vector name="rb" x="132" y="-26"/>
+      <string name="_hash" value="0c6d1c64e27fa4262277161d03b8ee8a4c049e8a08035dc72d2cc9b30b157c3e"/>
+    </canvas>
+    <canvas name="22" width="212" height="272">
+      <vector name="origin" x="78" y="261"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="90"/>
+      <vector name="head" x="21" y="-186"/>
+      <vector name="lt" x="-72" y="-200"/>
+      <vector name="rb" x="124" y="-31"/>
+      <string name="_hash" value="83599e08fe61b39cb9206d1a26171fcf8da164425f08c8187f06c12185b82847"/>
+    </canvas>
+    <uol name="23" value="../stand/4"/>
+    <uol name="24" value="../stand/5"/>
+    <uol name="25" value="../stand/6"/>
+    <uol name="26" value="../stand/7"/>
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-50" y="-100"/>
+        <int name="r" value="700"/>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="188" height="59">
+          <vector name="origin" x="94" y="29"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="1" width="204" height="55">
+          <vector name="origin" x="94" y="27"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="2" width="188" height="51">
+          <vector name="origin" x="94" y="25"/>
+          <int name="delay" value="150"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="200" height="245">
+          <vector name="origin" x="93" y="124"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="1" width="222" height="229">
+          <vector name="origin" x="102" y="118"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="2" width="225" height="254">
+          <vector name="origin" x="102" y="131"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="3" width="228" height="268">
+          <vector name="origin" x="102" y="138"/>
+          <int name="delay" value="150"/>
+        </canvas>
+        <canvas name="4" width="134" height="274">
+          <vector name="origin" x="65" y="141"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="5" width="22" height="222">
+          <vector name="origin" x="11" y="112"/>
+          <int name="delay" value="150"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="660"/>
+      <int name="type" value="2"/>
+      <int name="magic" value="1"/>
+      <int name="bulletSpeed" value="200"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="228" height="248">
+      <vector name="origin" x="100" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cd652ea06aaded2e72afb169a5db3a2bc0070b09de9aaafd0b61aabdc5d7672f"/>
+    </canvas>
+    <canvas name="1" width="236" height="408">
+      <vector name="origin" x="100" y="391"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b94e3e6db458a555dbcd96426cf7633f877f1ecba7d05232f30503a181638c7f"/>
+    </canvas>
+    <canvas name="2" width="240" height="416">
+      <vector name="origin" x="100" y="396"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="be0d30dfb92b0306d086442d52833b9e1d2541bd88f9a5d3ebdc6354a63cbd02"/>
+    </canvas>
+    <canvas name="3" width="240" height="420">
+      <vector name="origin" x="103" y="395"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2bac2e9c6d307c2115c8fc21f1b27de2e17acd80e2f890a6d27f8c3ec5e4c377"/>
+    </canvas>
+    <canvas name="4" width="228" height="404">
+      <vector name="origin" x="100" y="379"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="674be33523464aa3c00d88e74f564f0fbb8cf4a2faec79d48a95fcfdab0e597f"/>
+    </canvas>
+    <canvas name="5" width="228" height="368">
+      <vector name="origin" x="100" y="342"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4f827b3663f28cf79f0b7d3a64bf321fa2ef4c18528d5bee0c35295e7bc2125e"/>
+    </canvas>
+    <canvas name="6" width="228" height="368">
+      <vector name="origin" x="100" y="342"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cdd0556f1a283306fafe5da4e0c652a3d97b332323d97d92102766f82180d401"/>
+    </canvas>
+    <canvas name="7" width="228" height="372">
+      <vector name="origin" x="100" y="341"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3ea5c4b06acd49cd9b1444395a4fff2d9e6f4efa4020eb68120b250cc1a1d783"/>
+    </canvas>
+    <canvas name="8" width="216" height="360">
+      <vector name="origin" x="88" y="355"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ae2842860106bb94cb8ac83b86f1667dc49baa1e934e9cacbb46081b295c0e8c"/>
+    </canvas>
+    <canvas name="9" width="220" height="376">
+      <vector name="origin" x="94" y="373"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2ccb349a268f70e23bdab295d864d25e1647194c7d12a2b8ad4f96b437d1027b"/>
+    </canvas>
+    <canvas name="10" width="220" height="388">
+      <vector name="origin" x="95" y="384"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d8b1e716d000e04cc4aedbb0d771f1136ea2165b6fd1652e10730baf072d6e1e"/>
+    </canvas>
+    <canvas name="11" width="224" height="396">
+      <vector name="origin" x="96" y="390"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="058f75dec752fb37463894ee70aabcccc8888fa1950a54c9f0ca20bd22679eef"/>
+    </canvas>
+    <canvas name="12" width="224" height="392">
+      <vector name="origin" x="96" y="393"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5e0cb4feb1f890ff1d1beeeec1b4a29a9224800920e6eb0dd66a71ba074e5186"/>
+    </canvas>
+    <canvas name="13" width="220" height="372">
+      <vector name="origin" x="95" y="393"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4c2b033687f0b2124a474f1ace55ba64d9cdf1f7d304ff0d433ac4372be9e8bc"/>
+    </canvas>
+    <canvas name="14" width="228" height="396">
+      <vector name="origin" x="100" y="395"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e9a2c5d35ec8e33260339e622d5f0eb30ab6a7f6a74180aa4b344e878602e1ec"/>
+    </canvas>
+    <canvas name="15" width="228" height="392">
+      <vector name="origin" x="100" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-79" y="-196"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="32273fd3bb30cf2467c9b714863eb408863c8a18061c0678d0e866542125a34b"/>
+    </canvas>
+    <uol name="19" value="../stand/4"/>
+    <uol name="20" value="../stand/5"/>
+    <uol name="21" value="../stand/6"/>
+    <uol name="22" value="../stand/7"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787130.img.xml
+++ b/gms-server/wz/Mob.wz/8787130.img.xml
@@ -1,1 +1,955 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787130.img"><imgdir name="info"><int name="level" value="100"/><int name="maxHP" value="999999999"/><int name="maxMP" value="50000"/><int name="PADamage" value="1500"/><int name="MADamage" value="1500"/><int name="PDRate" value="25"/><int name="MDRate" value="25"/><int name="acc" value="600"/><string name="elemAttr" value="P2"/><int name="eva" value="80"/><int name="pushed" value="100000"/><float name="fs" value="10.0"/><int name="exp" value="500000"/><int name="summonType" value="1"/><int name="category" value="8"/><int name="firstAttack" value="1"/><string name="mobType" value="1N"/><int name="boss" value="1"/><imgdir name="attack"><imgdir name="0"><int name="action" value="1"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="1"/><int name="magic" value="1"/><int name="fixDamR" value="5"/><int name="attackCount" value="5"/></imgdir></imgdir><int name="ignoreMoveImpact" value="1"/><int name="bodyAttack" value="1"/><int name="speed" value="5"/><int name="PDDamage" value="3000"/><int name="MDDamage" value="3000"/><int name="nonLevelCheckACC" value="1"/><int name="nonLevelCheckEVA" value="1"/><int name="notConsiderFieldSet" value="1"/><imgdir name="speak"><int name="chatBalloon" value="0"/></imgdir><int name="hpTagBgcolor" value="3"/><int name="hpTagColor" value="1"/></imgdir><imgdir name="stand"><canvas name="0" width="185" height="242"><vector name="origin" x="60" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="fc9ba56bd94044025cb23122cc7c18019ab6b127d335227baae967595db34058"/></canvas><canvas name="1" width="184" height="243"><vector name="origin" x="60" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="8ca880e17973af3bc04bb9801b5885c0b4b13c2a880c7a2f321d90a728e3cee8"/></canvas><canvas name="2" width="185" height="230"><vector name="origin" x="60" y="230"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="39b07ffe23d3de3dbdf39612b3a8a7428bc00512314eedcd3f0aba1c1532991b"/></canvas><canvas name="3" width="185" height="236"><vector name="origin" x="60" y="238"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="3ca4fcc2af804a418916aa29ea4c12d10747c348c49dc9fb83b0b0a8e7ce27ad"/></canvas><canvas name="4" width="185" height="224"><vector name="origin" x="60" y="227"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="9ea35b5fc28e1ba36b6e07d19072b2d16aaa9f17efc008d0ffde294303d07952"/></canvas><canvas name="5" width="185" height="238"><vector name="origin" x="60" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="bcf8b5043707e3646ee59e436d925e0e742df347bef3871bef767f4449fe834b"/></canvas><canvas name="6" width="185" height="248"><vector name="origin" x="60" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="f4b2b4a5a01d5657713b0fc633e071adfcd31060b9993c74f7c24249d73e6189"/></canvas><canvas name="7" width="185" height="249"><vector name="origin" x="60" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/><string name="_hash" value="157a37f103e90ecee3680d88fc4a9aa3a24cef2e1e9bd7c3d080bd3e6c5fd443"/></canvas></imgdir><imgdir name="move"><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="おい、逃げるな。"/></imgdir><canvas name="0" width="191" height="242"><vector name="origin" x="66" y="242"/><int name="z" value="0"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-65" y="-160"/><vector name="rb" x="115" y="-6"/><int name="delay" value="120"/><string name="_hash" value="cb8226ccf54c5d1ee37977b088889c89b7ccfbbe32d07882ff6dcba827734e92"/></canvas><canvas name="1" width="189" height="243"><vector name="origin" x="65" y="241"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-65" y="-160"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="4a7f1cb18c80851737756763511b50f4e97ff420265382c4f5123322eebc5165"/></canvas><canvas name="2" width="191" height="230"><vector name="origin" x="66" y="230"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-65" y="-160"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="09a39671bde8f7da801d1c358652fc43bec0ea8802a66ed4cb8f05295044aab3"/></canvas><canvas name="3" width="192" height="224"><vector name="origin" x="67" y="227"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-65" y="-160"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="acb1f5f96440bfee8fafab7c8f920ccdfd4533faac0151cfe9091cee1c3b4bf8"/></canvas><canvas name="4" width="193" height="238"><vector name="origin" x="68" y="243"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-65" y="-160"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="e7e22eb3ebe9037c2a3c09013ed07c3a016141f75445e6cdd534fcf89833b078"/></canvas><canvas name="5" width="192" height="248"><vector name="origin" x="67" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-65" y="-160"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="976504d6d5e81faf508107861a1528a2ac35cec101e4309322e6615d4a7c1fe1"/></canvas></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-435" y="-228"/><vector name="rb" x="190" y="0"/></imgdir><imgdir name="hit"><canvas name="0" width="115" height="118"><vector name="origin" x="57" y="59"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="9d86bbdebb64d57f7f8ffde218b880c9a2eda0d1dfd0277b8c047d8bb531c2bb"/></canvas><canvas name="1" width="143" height="162"><vector name="origin" x="71" y="81"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="3ebace547aea903279411e7c1a409df81a7db270dc4d6851c34a6006b5f9132e"/></canvas><canvas name="2" width="140" height="164"><vector name="origin" x="70" y="82"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="5078d0b2b67c9737b7d81d440cb521ad865d440b6a024c706820f329048aacd1"/></canvas><canvas name="3" width="148" height="148"><vector name="origin" x="74" y="74"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="605c6e7fb994ad9c4b7233763db479794bcd3b0eb3f29b16ea2449d268fa7c88"/></canvas><canvas name="4" width="133" height="141"><vector name="origin" x="66" y="70"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="6a1f159386ca9886b7ecc61065351e365235754d7d2fce15773ca85320bf61d9"/></canvas><canvas name="5" width="174" height="230"><vector name="origin" x="87" y="115"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="53492d2bd78373169a20bf30a158e53734ed9529182a0c912c00b400fbf5441c"/></canvas><canvas name="6" width="243" height="225"><vector name="origin" x="121" y="112"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="bbbd8a95fe48a471f4cf82d2197da4d20c2c2880d41b02bb1b5bdd01bce75942"/></canvas><canvas name="7" width="239" height="214"><vector name="origin" x="119" y="107"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="6ffc3e05f2df48ed119738ae0625ccdaf93636c1d4e91e8e321fd8702413aab5"/></canvas><canvas name="8" width="227" height="194"><vector name="origin" x="113" y="97"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="266171cffb2c739b18cecea0ec70ddd50680c1d88f7c05fb8d3d89e5d1c4406d"/></canvas><canvas name="9" width="200" height="164"><vector name="origin" x="100" y="82"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="f15b3c8af5876dfedd42bf5e0f0a5dd230aac7f7891ec2a3bbc7f592f1e9f0e4"/></canvas></imgdir><int name="attackAfter" value="120"/></imgdir><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="パンチパンチパンチ！"/><string name="1" value="やはり戦いは撃ち合いに限るな！"/></imgdir><canvas name="0" width="185" height="242"><vector name="origin" x="60" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="8" y="-160"/><vector name="lt" x="-61" y="-160"/><vector name="rb" x="115" y="-6"/><string name="_hash" value="6b25f3e402af7e8679c7966a8e5433074f8b0b985acecf32f18ef636a2ba3be4"/></canvas><canvas name="1" width="441" height="270"><vector name="origin" x="257" y="240"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-23" y="-159"/><vector name="lt" x="-82" y="-159"/><vector name="rb" x="85" y="-5"/><string name="_hash" value="cd006a056ee26e365a512167cc286e2091db1bc78079495b4ca963838b2787b6"/></canvas><canvas name="2" width="485" height="260"><vector name="origin" x="284" y="229"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-30" y="-159"/><vector name="lt" x="-88" y="-158"/><vector name="rb" x="85" y="-5"/><string name="_hash" value="4b1abdcb8b5d330b610d4ab85b62830c823dcfce493e5768467dd77adfaf2d21"/></canvas><canvas name="3" width="504" height="274"><vector name="origin" x="305" y="226"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-35" y="-159"/><vector name="lt" x="-95" y="-158"/><vector name="rb" x="80" y="-5"/><string name="_hash" value="1c8248dca779c715f92e01cae4f5026589f8d4dd3ca6e3f7c74b94a2b2798094"/></canvas><canvas name="4" width="532" height="317"><vector name="origin" x="322" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-30" y="-159"/><vector name="lt" x="-94" y="-158"/><vector name="rb" x="85" y="-5"/><string name="_hash" value="d793b1b180a671c265ac9fd4a59bf17d1ed66edfcd35d0ae5c19c019e7a48b7c"/></canvas><canvas name="5" width="530" height="264"><vector name="origin" x="310" y="250"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="21" y="-158"/><vector name="lt" x="-35" y="-158"/><vector name="rb" x="153" y="-6"/><string name="_hash" value="809607fe1a2d4014dc521442bf431d40eed55ab80d04741c1ba0b0d98f2ee756"/></canvas><canvas name="6" width="640" height="329"><vector name="origin" x="373" y="241"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-10" y="-157"/><vector name="lt" x="-114" y="-156"/><vector name="rb" x="104" y="-5"/><string name="_hash" value="20a2614efbbc29f3a13793f3c6645eaa27796d20e4a50e870f141a432c91493e"/></canvas><canvas name="7" width="672" height="331"><vector name="origin" x="421" y="240"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-26" y="-159"/><vector name="lt" x="-134" y="-158"/><vector name="rb" x="85" y="-5"/><string name="_hash" value="f3124c327948be5960b6b19b8a508a145eb52b15dc9887c178e251f5d73dbfff"/></canvas><canvas name="8" width="675" height="319"><vector name="origin" x="436" y="229"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-37" y="-160"/><vector name="lt" x="-138" y="-159"/><vector name="rb" x="85" y="-5"/><string name="_hash" value="ad3c2b3ab7003fadbb6983598374055e7a32807e05be04e4daf922ac9633538b"/></canvas><canvas name="9" width="667" height="300"><vector name="origin" x="436" y="226"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="-38" y="-159"/><vector name="lt" x="-135" y="-157"/><vector name="rb" x="85" y="-5"/><string name="_hash" value="dfc398da8bd980d7a0c1aad0e833331228143a28f627b2293eb1821bf91a1052"/></canvas><canvas name="10" width="651" height="318"><vector name="origin" x="415" y="242"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="-38" y="-159"/><vector name="lt" x="-143" y="-161"/><vector name="rb" x="85" y="-5"/><string name="_hash" value="c1d4b6c2fd6f424e6b8812d91ed8f7eba9e6942a19cf0dee0c15fd36c61d778e"/></canvas><canvas name="11" width="185" height="224"><vector name="origin" x="89" y="227"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/></canvas><canvas name="12" width="185" height="238"><vector name="origin" x="70" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/></canvas><canvas name="13" width="185" height="248"><vector name="origin" x="60" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/></canvas><canvas name="14" width="185" height="249"><vector name="origin" x="60" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/></canvas></imgdir><imgdir name="hit1"><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="やるな！"/><string name="1" value="なかなかじゃないか。"/></imgdir><canvas name="0" width="200" height="243"><vector name="origin" x="42" y="242"/><int name="z" value="0"/><int name="delay" value="300"/><vector name="head" x="47" y="-157"/><vector name="lt" x="-40" y="-164"/><vector name="rb" x="150" y="-14"/><string name="_hash" value="5daa75c8f71eeb9ad3c9196029b39825f78e33323c6b1254ad037f707cd494a0"/></canvas></imgdir><imgdir name="die1"><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="哈哈..這還真有意思.."/><string name="1" value="下次再說.."/></imgdir><canvas name="0" width="185" height="242"><vector name="origin" x="60" y="242"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="8eff19a074671b027a87c118d653646ec0453ef55b6bd30642ec99fc08139cdd"/></canvas><canvas name="1" width="200" height="243"><vector name="origin" x="42" y="242"/><int name="z" value="0"/><int name="delay" value="150"/></canvas><canvas name="2" width="198" height="231"><vector name="origin" x="38" y="230"/><int name="z" value="0"/><int name="delay" value="180"/><string name="_hash" value="e8db6d4a3a287932088fcd760e265bfa1ae030abf5dfbf65501e2c3481da384e"/></canvas><canvas name="3" width="199" height="236"><vector name="origin" x="36" y="236"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="e74f9a99ce5cf1ecf8747361f94b43fdfbe01dbe4f3fffcc31afe69f42ab1de5"/></canvas><canvas name="4" width="200" height="239"><vector name="origin" x="35" y="239"/><int name="z" value="0"/><int name="delay" value="240"/><string name="_hash" value="5f89070096c05f04831d1854f239fe67a98b490f91779062bc8c34fb0e9855ab"/></canvas><canvas name="5" width="200" height="240"><vector name="origin" x="34" y="240"/><int name="z" value="0"/><int name="delay" value="240"/><string name="_hash" value="78ae5d69b216143abce1bcf5b9fe075d2ecd3db2d2f83958e15459196cd5c59c"/></canvas><canvas name="6" width="200" height="236"><vector name="origin" x="33" y="236"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="1ccf042d952d64139f253a0f18ef3eb9340835990c326c2265eb513a3a442e4f"/></canvas><canvas name="7" width="200" height="202"><vector name="origin" x="32" y="202"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="72864690ff5f729fabd3983461ebcfb552b83ca7be3ef24fa5b2beb5279aec26"/></canvas><canvas name="8" width="199" height="202"><vector name="origin" x="30" y="202"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="a0c76146479a450270bb0b4fc9b663d7f16751281db0f399b6ef6c8afbe29750"/></canvas><canvas name="9" width="195" height="200"><vector name="origin" x="27" y="200"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="7b900e327ea9d7d1046f6697b048f66e9f54615f90750e25f8a728633b1a9e46"/></canvas><canvas name="10" width="188" height="182"><vector name="origin" x="21" y="182"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="7dde0e84c5e76d44d56dd65c5d327baff7a42515663109872607872064edd6ff"/></canvas><canvas name="11" width="180" height="174"><vector name="origin" x="15" y="176"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="f9615ffda2d9f8c8300dfba8ce7dad3b34733eb13400a743b96b5f3520b67ae1"/></canvas><canvas name="12" width="164" height="150"><vector name="origin" x="5" y="155"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="1f21c670619af9a830b28198b6dd44bf4a16ee26a6067890d2440532905a66bb"/></canvas><canvas name="13" width="134" height="141"><vector name="origin" x="-23" y="150"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="3e1584e9160683f37b7826d65595f04b3d544741428fab15e5684cef17942b9c"/></canvas><canvas name="14" width="96" height="98"><vector name="origin" x="-53" y="110"/><int name="z" value="0"/><int name="delay" value="210"/><string name="_hash" value="aafe0ced749eb915c875fc6bd30419a5ae860cf70873765859d044027eafac7a"/></canvas><canvas name="15" width="35" height="86"><vector name="origin" x="-59" y="106"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="3f23ee118356dc364bf5f273ef98188d4f45151e8eef7b577a2b0c757e8adbf5"/></canvas></imgdir><imgdir name="regen"><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="さて、遊んでやるか。"/></imgdir><canvas name="0" width="163" height="121"><vector name="origin" x="-104" y="105"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="91c2ee9ab467f619ae8675a5b3b699520b806eab61ef0a69f9dbe6bf9b8c2793"/></canvas><canvas name="1" width="183" height="159"><vector name="origin" x="-102" y="144"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1976a5d2184c9f9154544109512c6b9af08407390d161cfa6acc696b412af23e"/></canvas><canvas name="2" width="562" height="486"><vector name="origin" x="136" y="470"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c2a7b07b1de4791293acc483c79376b9362b008864adf8cebe60aa0da4c34955"/></canvas><canvas name="3" width="857" height="510"><vector name="origin" x="433" y="468"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="02fdb09232f268255af3be55eef84d5c555b8ff7d7444699581e6690f9679d90"/></canvas><canvas name="4" width="845" height="498"><vector name="origin" x="426" y="470"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="fc165ebe1a21759319692592572806dae139f04b6e97ecc70216912eb3d4ddec"/></canvas><canvas name="5" width="836" height="483"><vector name="origin" x="425" y="468"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="a52d3106302948e49156b0cedd836c19fa39e9dea15880917717df4436704879"/></canvas><canvas name="6" width="793" height="482"><vector name="origin" x="420" y="467"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="820e0a2d2536ddf12b3e1ca30acf05aed9a78ef6189a6d8750b9dc5ab74a16af"/></canvas><canvas name="7" width="726" height="463"><vector name="origin" x="361" y="453"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="4409c657b01d9195ac2f9d2fd9d776331d6b1984485a8f55181b183c1ad4e069"/></canvas><canvas name="8" width="533" height="444"><vector name="origin" x="347" y="434"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="71a9659753612fcf010c031004a245b8ef68b27f5917d7b9f527efe65368a99f"/></canvas><canvas name="9" width="371" height="425"><vector name="origin" x="180" y="423"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="be68aea284fc195787a7b09ec9df9fd707e3b4bc7e0a8bdcbf0284541d6f7b31"/></canvas><canvas name="10" width="424" height="397"><vector name="origin" x="252" y="339"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="99d8297ced2be46c98e9f7b7f2ebfa05aa634fcae0670ee30117895b299f58a3"/></canvas><canvas name="11" width="385" height="301"><vector name="origin" x="202" y="293"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="5e5a197f1b4ec2bdd82b3aa4e4458eb594df2f46c21524bbdafe38a426f3734d"/></canvas><canvas name="12" width="435" height="346"><vector name="origin" x="175" y="338"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="54cf206ecaa96801253da4a884a166d0de3acc7c5c5d9cb2605a7d27be78d44a"/></canvas><canvas name="13" width="468" height="432"><vector name="origin" x="261" y="275"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f47b24f453020aebb0d04e4f5b18210dd014b0cbdabcf70e2f68dc1f7adfff82"/></canvas><canvas name="14" width="418" height="240"><vector name="origin" x="246" y="238"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="01d6048e047f4f3f0e9cc8f1b3b0c61a71cf059e72f4525b62a81526414476fc"/></canvas><canvas name="15" width="374" height="375"><vector name="origin" x="191" y="235"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="fe35198d1192f0b2c2423eeec44a4a2d6dd01c577dddc35fd90468d5d714ebcf"/></canvas><canvas name="16" width="457" height="398"><vector name="origin" x="150" y="231"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="fe2728f8d7c7e3d7e6156bc49bef0b73470d6e53e7df39a01177123965402a47"/></canvas><canvas name="17" width="423" height="463"><vector name="origin" x="232" y="318"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7a4afd4837bbf03d263f606a74c83ce39eb576d27c4ac54b28c72183a704a4a2"/></canvas><canvas name="18" width="386" height="400"><vector name="origin" x="214" y="243"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="6afdd054e97e20ccd20c2d29a370e96ea75da95e59e2162b19925583368452a9"/></canvas><canvas name="19" width="458" height="430"><vector name="origin" x="147" y="279"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="fcbc1d497400841218f69f842c2ff11c939ded189291b6f9e74443cf0e24c6bc"/></canvas><canvas name="20" width="549" height="530"><vector name="origin" x="264" y="391"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7b837f5d967d04bff2b3b22d0fc80e065630d7dc82097cafad36ec77a828a802"/></canvas><canvas name="21" width="440" height="308"><vector name="origin" x="249" y="223"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="cd1082839f33c179d2ab468e78475f7dac95aaf9baa7a915cd131572d4290fbc"/></canvas><canvas name="22" width="350" height="334"><vector name="origin" x="166" y="283"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="576ff27217b5f08c1c7189941c31b431539d776a9dfc1fd335e6ca42b92c7864"/></canvas><canvas name="23" width="396" height="360"><vector name="origin" x="186" y="295"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="02c536f8d1b0309b9072e700e6f907e405b21171ab49b171d2c54502ccbf7104"/></canvas><canvas name="24" width="396" height="376"><vector name="origin" x="184" y="303"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c789cd0e023022ed247ce8f791b47bc668079bb6a397c4f85584b63be551bd2e"/></canvas><canvas name="25" width="383" height="382"><vector name="origin" x="179" y="306"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="24db6f24fc260ddc8b4f2efd69bb7f4a2dfa694be87c3e308f89c4cad4042a54"/></canvas><canvas name="26" width="382" height="382"><vector name="origin" x="178" y="306"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="643135538586b9035f9fd736b3340a40d62077a2a0d4c799f0de2384cee4c071"/></canvas><canvas name="27" width="378" height="378"><vector name="origin" x="176" y="304"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="98d74aa139e963df272005156e82d767f465322b90833cf71306622b0fa8e04f"/></canvas><canvas name="28" width="331" height="348"><vector name="origin" x="176" y="290"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="be98dfc1b485b249771faf3ca6d7765d89ca61417ae249625661dd73383311cc"/></canvas><canvas name="29" width="330" height="350"><vector name="origin" x="177" y="292"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="fddab123b8bd0a608448445886c37262dd257f5e47137dacef1d95af4ac803ce"/></canvas><canvas name="30" width="320" height="320"><vector name="origin" x="170" y="279"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d60774dd0af428efb7b76ebfa8c56c3f7d9a174ab367334b59d53b6a9449a5fe"/></canvas><canvas name="31" width="315" height="315"><vector name="origin" x="172" y="281"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8f99880f25f2a66ef8bcc98901e48b7b0131e6e8ae11763a7f6f38f5e6e15776"/></canvas><canvas name="32" width="190" height="250"><vector name="origin" x="62" y="251"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="48683e2e74032776cbbec17ac480e8a53d92a4876d29a0b62c4c873ce305d7fe"/></canvas></imgdir><imgdir name="attack2"><imgdir name="speak"><int name="prob" value="10"/><string name="0" value="爆頭!"/></imgdir><canvas name="0" width="188" height="244"><vector name="origin" x="60" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/></canvas><canvas name="1" width="232" height="256"><vector name="origin" x="77" y="245"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="42" y="-153"/><vector name="lt" x="-69" y="-153"/><vector name="rb" x="142" y="-2"/><string name="_hash" value="214537a5cc36de5d151a10c4f9d689540c196d105b123da5de1c6177544ac1ca"/></canvas><canvas name="2" width="232" height="244"><vector name="origin" x="71" y="236"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="49" y="-153"/><vector name="lt" x="-63" y="-153"/><vector name="rb" x="151" y="-2"/><string name="_hash" value="f8db04b9b68b730585a724931bf43ba474d7568604bddfbbbea5e757d558c66b"/></canvas><canvas name="3" width="328" height="244"><vector name="origin" x="166" y="236"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="51" y="-152"/><vector name="lt" x="-61" y="-153"/><vector name="rb" x="149" y="-2"/><string name="_hash" value="b8b515c48a5c2f450d8d119984291e175a9b3a826a3f6a4305fec1c1787354e9"/></canvas><canvas name="4" width="360" height="244"><vector name="origin" x="196" y="233"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="50" y="-153"/><vector name="lt" x="-63" y="-151"/><vector name="rb" x="153" y="-1"/><string name="_hash" value="adc0cb94e8e34478f0052ca7ff2dbd8e648fc591b6b757a8fc0a84a735e4b4a6"/></canvas><canvas name="5" width="356" height="240"><vector name="origin" x="189" y="231"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="51" y="-154"/><vector name="lt" x="-60" y="-153"/><vector name="rb" x="151" y="-2"/><string name="_hash" value="8ab19516c08e02325c9480e9a43a4ff4801492d43a6922d2149afa2c5a6d15a6"/></canvas><canvas name="6" width="352" height="248"><vector name="origin" x="185" y="237"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="52" y="-153"/><vector name="lt" x="-59" y="-153"/><vector name="rb" x="152" y="-2"/><string name="_hash" value="258386dbd7b797a83b954934171db3b244bccb7e1f82d6e297989162956caa63"/></canvas><canvas name="7" width="344" height="256"><vector name="origin" x="177" y="245"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="52" y="-153"/><vector name="lt" x="-59" y="-153"/><vector name="rb" x="152" y="-2"/><string name="_hash" value="5edd8f9fbd413cbc185417bde1570b03c6abe6ed6c6cda4e810e7a5925329933"/></canvas><canvas name="8" width="328" height="244"><vector name="origin" x="161" y="236"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="52" y="-153"/><vector name="lt" x="-59" y="-153"/><vector name="rb" x="152" y="-2"/><string name="_hash" value="9c580e5fa29a90b9df257e68eca3fb4a4be744c86c1e7672547ad7eeb2b7a180"/></canvas><canvas name="9" width="320" height="244"><vector name="origin" x="154" y="234"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="52" y="-153"/><vector name="lt" x="-59" y="-153"/><vector name="rb" x="152" y="-2"/><string name="_hash" value="4a3e083512c203bddc7e5e494cb1f23a5dc27412f10c910442e6761d188c0f9c"/></canvas><canvas name="10" width="288" height="232"><vector name="origin" x="121" y="223"/><int name="z" value="0"/><int name="delay" value="150"/><vector name="head" x="52" y="-153"/><vector name="lt" x="-59" y="-153"/><vector name="rb" x="152" y="-2"/><string name="_hash" value="e91e6c206bff96edba103a21511757d61eb1444c752b4081528daa33b04c72f8"/></canvas><canvas name="11" width="344" height="232"><vector name="origin" x="153" y="221"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="81" y="-155"/><vector name="lt" x="-143" y="-156"/><vector name="rb" x="176" y="-2"/><string name="_hash" value="f5eaf3bdf8af3ca13d6e2eaff8911ad830589f54c6515a1cee918d233fd5db65"/></canvas><canvas name="12" width="364" height="248"><vector name="origin" x="165" y="237"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="52" y="-153"/><vector name="lt" x="-157" y="-153"/><vector name="rb" x="152" y="-2"/><string name="_hash" value="a2b3d3aee0f878622b454496f8fa6aa385319a4c3da23294129abf4b815d1655"/></canvas><canvas name="13" width="372" height="256"><vector name="origin" x="169" y="244"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="87" y="-152"/><vector name="lt" x="-157" y="-150"/><vector name="rb" x="189" y="-2"/><string name="_hash" value="330dacea6074288362e9f41c3dfae1ef81564d30e6ad6f56c5f187b865a375d4"/></canvas><canvas name="14" width="376" height="244"><vector name="origin" x="172" y="235"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="86" y="-153"/><vector name="lt" x="-9" y="-153"/><vector name="rb" x="190" y="-3"/><string name="_hash" value="74e276b3d4579d23f957ed0ef2c3e3bb9cc85201d417dcf8b25c97edf1106eb4"/></canvas><canvas name="15" width="376" height="244"><vector name="origin" x="173" y="234"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="86" y="-153"/><vector name="lt" x="0" y="-153"/><vector name="rb" x="190" y="-3"/><string name="_hash" value="ec0df6b8d0dc410405bdf40fac51bc1eefd9dca5cf0bed4b551396dc64196b92"/></canvas><canvas name="16" width="212" height="232"><vector name="origin" x="10" y="223"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="86" y="-153"/><vector name="lt" x="-5" y="-152"/><vector name="rb" x="190" y="-3"/><string name="_hash" value="cc2c425e688dd55b8416aec87cecb2356867ce1adc0c9d377e6618bd48e3c680"/></canvas><canvas name="17" width="188" height="244"><vector name="origin" x="8" y="238"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/></canvas><canvas name="18" width="188" height="244"><vector name="origin" x="44" y="242"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-61" y="-169"/><vector name="rb" x="116" y="-4"/></canvas><uol name="19" value="../stand/5"/><uol name="20" value="../stand/7"/><imgdir name="info"><imgdir name="range"><vector name="lt" x="-435" y="-228"/><vector name="rb" x="190" y="0"/></imgdir><imgdir name="hit"><canvas name="0" width="76" height="76"><vector name="origin" x="57" y="59"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="9d86bbdebb64d57f7f8ffde218b880c9a2eda0d1dfd0277b8c047d8bb531c2bb"/></canvas><canvas name="1" width="92" height="92"><vector name="origin" x="71" y="81"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="3ebace547aea903279411e7c1a409df81a7db270dc4d6851c34a6006b5f9132e"/></canvas><canvas name="2" width="112" height="116"><vector name="origin" x="70" y="82"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="5078d0b2b67c9737b7d81d440cb521ad865d440b6a024c706820f329048aacd1"/></canvas><canvas name="3" width="116" height="120"><vector name="origin" x="74" y="74"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="605c6e7fb994ad9c4b7233763db479794bcd3b0eb3f29b16ea2449d268fa7c88"/></canvas><canvas name="4" width="120" height="124"><vector name="origin" x="66" y="70"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="6a1f159386ca9886b7ecc61065351e365235754d7d2fce15773ca85320bf61d9"/></canvas><canvas name="5" width="120" height="124"><vector name="origin" x="87" y="115"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="53492d2bd78373169a20bf30a158e53734ed9529182a0c912c00b400fbf5441c"/></canvas><canvas name="6" width="120" height="124"><vector name="origin" x="121" y="112"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="bbbd8a95fe48a471f4cf82d2197da4d20c2c2880d41b02bb1b5bdd01bce75942"/></canvas><canvas name="7" width="120" height="124"><vector name="origin" x="119" y="107"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="6ffc3e05f2df48ed119738ae0625ccdaf93636c1d4e91e8e321fd8702413aab5"/></canvas><canvas name="8" width="120" height="124"><vector name="origin" x="113" y="97"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="266171cffb2c739b18cecea0ec70ddd50680c1d88f7c05fb8d3d89e5d1c4406d"/></canvas><canvas name="9" width="120" height="124"><vector name="origin" x="100" y="82"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="f15b3c8af5876dfedd42bf5e0f0a5dd230aac7f7891ec2a3bbc7f592f1e9f0e4"/></canvas></imgdir><int name="attackAfter" value="120"/></imgdir></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787130.img">
+  <imgdir name="info">
+    <int name="level" value="100"/>
+    <int name="maxHP" value="999999999"/>
+    <int name="maxMP" value="50000"/>
+    <int name="PADamage" value="1500"/>
+    <int name="MADamage" value="1500"/>
+    <int name="PDRate" value="25"/>
+    <int name="MDRate" value="25"/>
+    <int name="acc" value="600"/>
+    <string name="elemAttr" value="P2"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="500000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="1"/>
+        <int name="magic" value="1"/>
+        <int name="fixDamR" value="5"/>
+        <int name="attackCount" value="5"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="speed" value="5"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <int name="nonLevelCheckACC" value="1"/>
+    <int name="nonLevelCheckEVA" value="1"/>
+    <int name="notConsiderFieldSet" value="1"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+    </imgdir>
+    <int name="hpTagBgcolor" value="3"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="185" height="242">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="fc9ba56bd94044025cb23122cc7c18019ab6b127d335227baae967595db34058"/>
+    </canvas>
+    <canvas name="1" width="184" height="243">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="8ca880e17973af3bc04bb9801b5885c0b4b13c2a880c7a2f321d90a728e3cee8"/>
+    </canvas>
+    <canvas name="2" width="185" height="230">
+      <vector name="origin" x="60" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="39b07ffe23d3de3dbdf39612b3a8a7428bc00512314eedcd3f0aba1c1532991b"/>
+    </canvas>
+    <canvas name="3" width="185" height="236">
+      <vector name="origin" x="60" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="3ca4fcc2af804a418916aa29ea4c12d10747c348c49dc9fb83b0b0a8e7ce27ad"/>
+    </canvas>
+    <canvas name="4" width="185" height="224">
+      <vector name="origin" x="60" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="9ea35b5fc28e1ba36b6e07d19072b2d16aaa9f17efc008d0ffde294303d07952"/>
+    </canvas>
+    <canvas name="5" width="185" height="238">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="bcf8b5043707e3646ee59e436d925e0e742df347bef3871bef767f4449fe834b"/>
+    </canvas>
+    <canvas name="6" width="185" height="248">
+      <vector name="origin" x="60" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="f4b2b4a5a01d5657713b0fc633e071adfcd31060b9993c74f7c24249d73e6189"/>
+    </canvas>
+    <canvas name="7" width="185" height="249">
+      <vector name="origin" x="60" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+      <string name="_hash" value="157a37f103e90ecee3680d88fc4a9aa3a24cef2e1e9bd7c3d080bd3e6c5fd443"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Hey, do not run."/>
+    </imgdir>
+    <canvas name="0" width="191" height="242">
+      <vector name="origin" x="66" y="242"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cb8226ccf54c5d1ee37977b088889c89b7ccfbbe32d07882ff6dcba827734e92"/>
+    </canvas>
+    <canvas name="1" width="189" height="243">
+      <vector name="origin" x="65" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="4a7f1cb18c80851737756763511b50f4e97ff420265382c4f5123322eebc5165"/>
+    </canvas>
+    <canvas name="2" width="191" height="230">
+      <vector name="origin" x="66" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="09a39671bde8f7da801d1c358652fc43bec0ea8802a66ed4cb8f05295044aab3"/>
+    </canvas>
+    <canvas name="3" width="192" height="224">
+      <vector name="origin" x="67" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="acb1f5f96440bfee8fafab7c8f920ccdfd4533faac0151cfe9091cee1c3b4bf8"/>
+    </canvas>
+    <canvas name="4" width="193" height="238">
+      <vector name="origin" x="68" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="e7e22eb3ebe9037c2a3c09013ed07c3a016141f75445e6cdd534fcf89833b078"/>
+    </canvas>
+    <canvas name="5" width="192" height="248">
+      <vector name="origin" x="67" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="976504d6d5e81faf508107861a1528a2ac35cec101e4309322e6615d4a7c1fe1"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-435" y="-228"/>
+        <vector name="rb" x="190" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="115" height="118">
+          <vector name="origin" x="57" y="59"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="9d86bbdebb64d57f7f8ffde218b880c9a2eda0d1dfd0277b8c047d8bb531c2bb"/>
+        </canvas>
+        <canvas name="1" width="143" height="162">
+          <vector name="origin" x="71" y="81"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="3ebace547aea903279411e7c1a409df81a7db270dc4d6851c34a6006b5f9132e"/>
+        </canvas>
+        <canvas name="2" width="140" height="164">
+          <vector name="origin" x="70" y="82"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="5078d0b2b67c9737b7d81d440cb521ad865d440b6a024c706820f329048aacd1"/>
+        </canvas>
+        <canvas name="3" width="148" height="148">
+          <vector name="origin" x="74" y="74"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="605c6e7fb994ad9c4b7233763db479794bcd3b0eb3f29b16ea2449d268fa7c88"/>
+        </canvas>
+        <canvas name="4" width="133" height="141">
+          <vector name="origin" x="66" y="70"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6a1f159386ca9886b7ecc61065351e365235754d7d2fce15773ca85320bf61d9"/>
+        </canvas>
+        <canvas name="5" width="174" height="230">
+          <vector name="origin" x="87" y="115"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="53492d2bd78373169a20bf30a158e53734ed9529182a0c912c00b400fbf5441c"/>
+        </canvas>
+        <canvas name="6" width="243" height="225">
+          <vector name="origin" x="121" y="112"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="bbbd8a95fe48a471f4cf82d2197da4d20c2c2880d41b02bb1b5bdd01bce75942"/>
+        </canvas>
+        <canvas name="7" width="239" height="214">
+          <vector name="origin" x="119" y="107"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6ffc3e05f2df48ed119738ae0625ccdaf93636c1d4e91e8e321fd8702413aab5"/>
+        </canvas>
+        <canvas name="8" width="227" height="194">
+          <vector name="origin" x="113" y="97"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="266171cffb2c739b18cecea0ec70ddd50680c1d88f7c05fb8d3d89e5d1c4406d"/>
+        </canvas>
+        <canvas name="9" width="200" height="164">
+          <vector name="origin" x="100" y="82"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="f15b3c8af5876dfedd42bf5e0f0a5dd230aac7f7891ec2a3bbc7f592f1e9f0e4"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="120"/>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Punch, punch, punch!"/>
+      <string name="1" value="A real fight is best when blows are traded head-on!"/>
+    </imgdir>
+    <canvas name="0" width="185" height="242">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="8" y="-160"/>
+      <vector name="lt" x="-61" y="-160"/>
+      <vector name="rb" x="115" y="-6"/>
+      <string name="_hash" value="6b25f3e402af7e8679c7966a8e5433074f8b0b985acecf32f18ef636a2ba3be4"/>
+    </canvas>
+    <canvas name="1" width="441" height="270">
+      <vector name="origin" x="257" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-23" y="-159"/>
+      <vector name="lt" x="-82" y="-159"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="cd006a056ee26e365a512167cc286e2091db1bc78079495b4ca963838b2787b6"/>
+    </canvas>
+    <canvas name="2" width="485" height="260">
+      <vector name="origin" x="284" y="229"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-30" y="-159"/>
+      <vector name="lt" x="-88" y="-158"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="4b1abdcb8b5d330b610d4ab85b62830c823dcfce493e5768467dd77adfaf2d21"/>
+    </canvas>
+    <canvas name="3" width="504" height="274">
+      <vector name="origin" x="305" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-35" y="-159"/>
+      <vector name="lt" x="-95" y="-158"/>
+      <vector name="rb" x="80" y="-5"/>
+      <string name="_hash" value="1c8248dca779c715f92e01cae4f5026589f8d4dd3ca6e3f7c74b94a2b2798094"/>
+    </canvas>
+    <canvas name="4" width="532" height="317">
+      <vector name="origin" x="322" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-30" y="-159"/>
+      <vector name="lt" x="-94" y="-158"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="d793b1b180a671c265ac9fd4a59bf17d1ed66edfcd35d0ae5c19c019e7a48b7c"/>
+    </canvas>
+    <canvas name="5" width="530" height="264">
+      <vector name="origin" x="310" y="250"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="21" y="-158"/>
+      <vector name="lt" x="-35" y="-158"/>
+      <vector name="rb" x="153" y="-6"/>
+      <string name="_hash" value="809607fe1a2d4014dc521442bf431d40eed55ab80d04741c1ba0b0d98f2ee756"/>
+    </canvas>
+    <canvas name="6" width="640" height="329">
+      <vector name="origin" x="373" y="241"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-10" y="-157"/>
+      <vector name="lt" x="-114" y="-156"/>
+      <vector name="rb" x="104" y="-5"/>
+      <string name="_hash" value="20a2614efbbc29f3a13793f3c6645eaa27796d20e4a50e870f141a432c91493e"/>
+    </canvas>
+    <canvas name="7" width="672" height="331">
+      <vector name="origin" x="421" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-26" y="-159"/>
+      <vector name="lt" x="-134" y="-158"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="f3124c327948be5960b6b19b8a508a145eb52b15dc9887c178e251f5d73dbfff"/>
+    </canvas>
+    <canvas name="8" width="675" height="319">
+      <vector name="origin" x="436" y="229"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-37" y="-160"/>
+      <vector name="lt" x="-138" y="-159"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="ad3c2b3ab7003fadbb6983598374055e7a32807e05be04e4daf922ac9633538b"/>
+    </canvas>
+    <canvas name="9" width="667" height="300">
+      <vector name="origin" x="436" y="226"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="-38" y="-159"/>
+      <vector name="lt" x="-135" y="-157"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="dfc398da8bd980d7a0c1aad0e833331228143a28f627b2293eb1821bf91a1052"/>
+    </canvas>
+    <canvas name="10" width="651" height="318">
+      <vector name="origin" x="415" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="-38" y="-159"/>
+      <vector name="lt" x="-143" y="-161"/>
+      <vector name="rb" x="85" y="-5"/>
+      <string name="_hash" value="c1d4b6c2fd6f424e6b8812d91ed8f7eba9e6942a19cf0dee0c15fd36c61d778e"/>
+    </canvas>
+    <canvas name="11" width="185" height="224">
+      <vector name="origin" x="89" y="227"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <canvas name="12" width="185" height="238">
+      <vector name="origin" x="70" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <canvas name="13" width="185" height="248">
+      <vector name="origin" x="60" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <canvas name="14" width="185" height="249">
+      <vector name="origin" x="60" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Not bad!"/>
+      <string name="1" value="You are pretty good."/>
+    </imgdir>
+    <canvas name="0" width="200" height="243">
+      <vector name="origin" x="42" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="300"/>
+      <vector name="head" x="47" y="-157"/>
+      <vector name="lt" x="-40" y="-164"/>
+      <vector name="rb" x="150" y="-14"/>
+      <string name="_hash" value="5daa75c8f71eeb9ad3c9196029b39825f78e33323c6b1254ad037f707cd494a0"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Haha... This is quite interesting..."/>
+      <string name="1" value="We will continue this next time..."/>
+    </imgdir>
+    <canvas name="0" width="185" height="242">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="8eff19a074671b027a87c118d653646ec0453ef55b6bd30642ec99fc08139cdd"/>
+    </canvas>
+    <canvas name="1" width="200" height="243">
+      <vector name="origin" x="42" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="198" height="231">
+      <vector name="origin" x="38" y="230"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="e8db6d4a3a287932088fcd760e265bfa1ae030abf5dfbf65501e2c3481da384e"/>
+    </canvas>
+    <canvas name="3" width="199" height="236">
+      <vector name="origin" x="36" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="e74f9a99ce5cf1ecf8747361f94b43fdfbe01dbe4f3fffcc31afe69f42ab1de5"/>
+    </canvas>
+    <canvas name="4" width="200" height="239">
+      <vector name="origin" x="35" y="239"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="5f89070096c05f04831d1854f239fe67a98b490f91779062bc8c34fb0e9855ab"/>
+    </canvas>
+    <canvas name="5" width="200" height="240">
+      <vector name="origin" x="34" y="240"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="240"/>
+      <string name="_hash" value="78ae5d69b216143abce1bcf5b9fe075d2ecd3db2d2f83958e15459196cd5c59c"/>
+    </canvas>
+    <canvas name="6" width="200" height="236">
+      <vector name="origin" x="33" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="1ccf042d952d64139f253a0f18ef3eb9340835990c326c2265eb513a3a442e4f"/>
+    </canvas>
+    <canvas name="7" width="200" height="202">
+      <vector name="origin" x="32" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="72864690ff5f729fabd3983461ebcfb552b83ca7be3ef24fa5b2beb5279aec26"/>
+    </canvas>
+    <canvas name="8" width="199" height="202">
+      <vector name="origin" x="30" y="202"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="a0c76146479a450270bb0b4fc9b663d7f16751281db0f399b6ef6c8afbe29750"/>
+    </canvas>
+    <canvas name="9" width="195" height="200">
+      <vector name="origin" x="27" y="200"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="7b900e327ea9d7d1046f6697b048f66e9f54615f90750e25f8a728633b1a9e46"/>
+    </canvas>
+    <canvas name="10" width="188" height="182">
+      <vector name="origin" x="21" y="182"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="7dde0e84c5e76d44d56dd65c5d327baff7a42515663109872607872064edd6ff"/>
+    </canvas>
+    <canvas name="11" width="180" height="174">
+      <vector name="origin" x="15" y="176"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="f9615ffda2d9f8c8300dfba8ce7dad3b34733eb13400a743b96b5f3520b67ae1"/>
+    </canvas>
+    <canvas name="12" width="164" height="150">
+      <vector name="origin" x="5" y="155"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="1f21c670619af9a830b28198b6dd44bf4a16ee26a6067890d2440532905a66bb"/>
+    </canvas>
+    <canvas name="13" width="134" height="141">
+      <vector name="origin" x="-23" y="150"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="3e1584e9160683f37b7826d65595f04b3d544741428fab15e5684cef17942b9c"/>
+    </canvas>
+    <canvas name="14" width="96" height="98">
+      <vector name="origin" x="-53" y="110"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <string name="_hash" value="aafe0ced749eb915c875fc6bd30419a5ae860cf70873765859d044027eafac7a"/>
+    </canvas>
+    <canvas name="15" width="35" height="86">
+      <vector name="origin" x="-59" y="106"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="3f23ee118356dc364bf5f273ef98188d4f45151e8eef7b577a2b0c757e8adbf5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="regen">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Now then, I will play with you."/>
+    </imgdir>
+    <canvas name="0" width="163" height="121">
+      <vector name="origin" x="-104" y="105"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="91c2ee9ab467f619ae8675a5b3b699520b806eab61ef0a69f9dbe6bf9b8c2793"/>
+    </canvas>
+    <canvas name="1" width="183" height="159">
+      <vector name="origin" x="-102" y="144"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1976a5d2184c9f9154544109512c6b9af08407390d161cfa6acc696b412af23e"/>
+    </canvas>
+    <canvas name="2" width="562" height="486">
+      <vector name="origin" x="136" y="470"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c2a7b07b1de4791293acc483c79376b9362b008864adf8cebe60aa0da4c34955"/>
+    </canvas>
+    <canvas name="3" width="857" height="510">
+      <vector name="origin" x="433" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="02fdb09232f268255af3be55eef84d5c555b8ff7d7444699581e6690f9679d90"/>
+    </canvas>
+    <canvas name="4" width="845" height="498">
+      <vector name="origin" x="426" y="470"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fc165ebe1a21759319692592572806dae139f04b6e97ecc70216912eb3d4ddec"/>
+    </canvas>
+    <canvas name="5" width="836" height="483">
+      <vector name="origin" x="425" y="468"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a52d3106302948e49156b0cedd836c19fa39e9dea15880917717df4436704879"/>
+    </canvas>
+    <canvas name="6" width="793" height="482">
+      <vector name="origin" x="420" y="467"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="820e0a2d2536ddf12b3e1ca30acf05aed9a78ef6189a6d8750b9dc5ab74a16af"/>
+    </canvas>
+    <canvas name="7" width="726" height="463">
+      <vector name="origin" x="361" y="453"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4409c657b01d9195ac2f9d2fd9d776331d6b1984485a8f55181b183c1ad4e069"/>
+    </canvas>
+    <canvas name="8" width="533" height="444">
+      <vector name="origin" x="347" y="434"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="71a9659753612fcf010c031004a245b8ef68b27f5917d7b9f527efe65368a99f"/>
+    </canvas>
+    <canvas name="9" width="371" height="425">
+      <vector name="origin" x="180" y="423"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="be68aea284fc195787a7b09ec9df9fd707e3b4bc7e0a8bdcbf0284541d6f7b31"/>
+    </canvas>
+    <canvas name="10" width="424" height="397">
+      <vector name="origin" x="252" y="339"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="99d8297ced2be46c98e9f7b7f2ebfa05aa634fcae0670ee30117895b299f58a3"/>
+    </canvas>
+    <canvas name="11" width="385" height="301">
+      <vector name="origin" x="202" y="293"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5e5a197f1b4ec2bdd82b3aa4e4458eb594df2f46c21524bbdafe38a426f3734d"/>
+    </canvas>
+    <canvas name="12" width="435" height="346">
+      <vector name="origin" x="175" y="338"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="54cf206ecaa96801253da4a884a166d0de3acc7c5c5d9cb2605a7d27be78d44a"/>
+    </canvas>
+    <canvas name="13" width="468" height="432">
+      <vector name="origin" x="261" y="275"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f47b24f453020aebb0d04e4f5b18210dd014b0cbdabcf70e2f68dc1f7adfff82"/>
+    </canvas>
+    <canvas name="14" width="418" height="240">
+      <vector name="origin" x="246" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="01d6048e047f4f3f0e9cc8f1b3b0c61a71cf059e72f4525b62a81526414476fc"/>
+    </canvas>
+    <canvas name="15" width="374" height="375">
+      <vector name="origin" x="191" y="235"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fe35198d1192f0b2c2423eeec44a4a2d6dd01c577dddc35fd90468d5d714ebcf"/>
+    </canvas>
+    <canvas name="16" width="457" height="398">
+      <vector name="origin" x="150" y="231"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fe2728f8d7c7e3d7e6156bc49bef0b73470d6e53e7df39a01177123965402a47"/>
+    </canvas>
+    <canvas name="17" width="423" height="463">
+      <vector name="origin" x="232" y="318"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7a4afd4837bbf03d263f606a74c83ce39eb576d27c4ac54b28c72183a704a4a2"/>
+    </canvas>
+    <canvas name="18" width="386" height="400">
+      <vector name="origin" x="214" y="243"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6afdd054e97e20ccd20c2d29a370e96ea75da95e59e2162b19925583368452a9"/>
+    </canvas>
+    <canvas name="19" width="458" height="430">
+      <vector name="origin" x="147" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fcbc1d497400841218f69f842c2ff11c939ded189291b6f9e74443cf0e24c6bc"/>
+    </canvas>
+    <canvas name="20" width="549" height="530">
+      <vector name="origin" x="264" y="391"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7b837f5d967d04bff2b3b22d0fc80e065630d7dc82097cafad36ec77a828a802"/>
+    </canvas>
+    <canvas name="21" width="440" height="308">
+      <vector name="origin" x="249" y="223"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cd1082839f33c179d2ab468e78475f7dac95aaf9baa7a915cd131572d4290fbc"/>
+    </canvas>
+    <canvas name="22" width="350" height="334">
+      <vector name="origin" x="166" y="283"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="576ff27217b5f08c1c7189941c31b431539d776a9dfc1fd335e6ca42b92c7864"/>
+    </canvas>
+    <canvas name="23" width="396" height="360">
+      <vector name="origin" x="186" y="295"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="02c536f8d1b0309b9072e700e6f907e405b21171ab49b171d2c54502ccbf7104"/>
+    </canvas>
+    <canvas name="24" width="396" height="376">
+      <vector name="origin" x="184" y="303"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c789cd0e023022ed247ce8f791b47bc668079bb6a397c4f85584b63be551bd2e"/>
+    </canvas>
+    <canvas name="25" width="383" height="382">
+      <vector name="origin" x="179" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="24db6f24fc260ddc8b4f2efd69bb7f4a2dfa694be87c3e308f89c4cad4042a54"/>
+    </canvas>
+    <canvas name="26" width="382" height="382">
+      <vector name="origin" x="178" y="306"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="643135538586b9035f9fd736b3340a40d62077a2a0d4c799f0de2384cee4c071"/>
+    </canvas>
+    <canvas name="27" width="378" height="378">
+      <vector name="origin" x="176" y="304"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="98d74aa139e963df272005156e82d767f465322b90833cf71306622b0fa8e04f"/>
+    </canvas>
+    <canvas name="28" width="331" height="348">
+      <vector name="origin" x="176" y="290"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="be98dfc1b485b249771faf3ca6d7765d89ca61417ae249625661dd73383311cc"/>
+    </canvas>
+    <canvas name="29" width="330" height="350">
+      <vector name="origin" x="177" y="292"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fddab123b8bd0a608448445886c37262dd257f5e47137dacef1d95af4ac803ce"/>
+    </canvas>
+    <canvas name="30" width="320" height="320">
+      <vector name="origin" x="170" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d60774dd0af428efb7b76ebfa8c56c3f7d9a174ab367334b59d53b6a9449a5fe"/>
+    </canvas>
+    <canvas name="31" width="315" height="315">
+      <vector name="origin" x="172" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8f99880f25f2a66ef8bcc98901e48b7b0131e6e8ae11763a7f6f38f5e6e15776"/>
+    </canvas>
+    <canvas name="32" width="190" height="250">
+      <vector name="origin" x="62" y="251"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="48683e2e74032776cbbec17ac480e8a53d92a4876d29a0b62c4c873ce305d7fe"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="speak">
+      <int name="prob" value="10"/>
+      <string name="0" value="Headshot!"/>
+    </imgdir>
+    <canvas name="0" width="188" height="244">
+      <vector name="origin" x="60" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <canvas name="1" width="232" height="256">
+      <vector name="origin" x="77" y="245"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="42" y="-153"/>
+      <vector name="lt" x="-69" y="-153"/>
+      <vector name="rb" x="142" y="-2"/>
+      <string name="_hash" value="214537a5cc36de5d151a10c4f9d689540c196d105b123da5de1c6177544ac1ca"/>
+    </canvas>
+    <canvas name="2" width="232" height="244">
+      <vector name="origin" x="71" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="49" y="-153"/>
+      <vector name="lt" x="-63" y="-153"/>
+      <vector name="rb" x="151" y="-2"/>
+      <string name="_hash" value="f8db04b9b68b730585a724931bf43ba474d7568604bddfbbbea5e757d558c66b"/>
+    </canvas>
+    <canvas name="3" width="328" height="244">
+      <vector name="origin" x="166" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="51" y="-152"/>
+      <vector name="lt" x="-61" y="-153"/>
+      <vector name="rb" x="149" y="-2"/>
+      <string name="_hash" value="b8b515c48a5c2f450d8d119984291e175a9b3a826a3f6a4305fec1c1787354e9"/>
+    </canvas>
+    <canvas name="4" width="360" height="244">
+      <vector name="origin" x="196" y="233"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="50" y="-153"/>
+      <vector name="lt" x="-63" y="-151"/>
+      <vector name="rb" x="153" y="-1"/>
+      <string name="_hash" value="adc0cb94e8e34478f0052ca7ff2dbd8e648fc591b6b757a8fc0a84a735e4b4a6"/>
+    </canvas>
+    <canvas name="5" width="356" height="240">
+      <vector name="origin" x="189" y="231"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="51" y="-154"/>
+      <vector name="lt" x="-60" y="-153"/>
+      <vector name="rb" x="151" y="-2"/>
+      <string name="_hash" value="8ab19516c08e02325c9480e9a43a4ff4801492d43a6922d2149afa2c5a6d15a6"/>
+    </canvas>
+    <canvas name="6" width="352" height="248">
+      <vector name="origin" x="185" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-59" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="258386dbd7b797a83b954934171db3b244bccb7e1f82d6e297989162956caa63"/>
+    </canvas>
+    <canvas name="7" width="344" height="256">
+      <vector name="origin" x="177" y="245"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-59" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="5edd8f9fbd413cbc185417bde1570b03c6abe6ed6c6cda4e810e7a5925329933"/>
+    </canvas>
+    <canvas name="8" width="328" height="244">
+      <vector name="origin" x="161" y="236"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-59" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="9c580e5fa29a90b9df257e68eca3fb4a4be744c86c1e7672547ad7eeb2b7a180"/>
+    </canvas>
+    <canvas name="9" width="320" height="244">
+      <vector name="origin" x="154" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-59" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="4a3e083512c203bddc7e5e494cb1f23a5dc27412f10c910442e6761d188c0f9c"/>
+    </canvas>
+    <canvas name="10" width="288" height="232">
+      <vector name="origin" x="121" y="223"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-59" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="e91e6c206bff96edba103a21511757d61eb1444c752b4081528daa33b04c72f8"/>
+    </canvas>
+    <canvas name="11" width="344" height="232">
+      <vector name="origin" x="153" y="221"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="81" y="-155"/>
+      <vector name="lt" x="-143" y="-156"/>
+      <vector name="rb" x="176" y="-2"/>
+      <string name="_hash" value="f5eaf3bdf8af3ca13d6e2eaff8911ad830589f54c6515a1cee918d233fd5db65"/>
+    </canvas>
+    <canvas name="12" width="364" height="248">
+      <vector name="origin" x="165" y="237"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="52" y="-153"/>
+      <vector name="lt" x="-157" y="-153"/>
+      <vector name="rb" x="152" y="-2"/>
+      <string name="_hash" value="a2b3d3aee0f878622b454496f8fa6aa385319a4c3da23294129abf4b815d1655"/>
+    </canvas>
+    <canvas name="13" width="372" height="256">
+      <vector name="origin" x="169" y="244"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="87" y="-152"/>
+      <vector name="lt" x="-157" y="-150"/>
+      <vector name="rb" x="189" y="-2"/>
+      <string name="_hash" value="330dacea6074288362e9f41c3dfae1ef81564d30e6ad6f56c5f187b865a375d4"/>
+    </canvas>
+    <canvas name="14" width="376" height="244">
+      <vector name="origin" x="172" y="235"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="86" y="-153"/>
+      <vector name="lt" x="-9" y="-153"/>
+      <vector name="rb" x="190" y="-3"/>
+      <string name="_hash" value="74e276b3d4579d23f957ed0ef2c3e3bb9cc85201d417dcf8b25c97edf1106eb4"/>
+    </canvas>
+    <canvas name="15" width="376" height="244">
+      <vector name="origin" x="173" y="234"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="86" y="-153"/>
+      <vector name="lt" x="0" y="-153"/>
+      <vector name="rb" x="190" y="-3"/>
+      <string name="_hash" value="ec0df6b8d0dc410405bdf40fac51bc1eefd9dca5cf0bed4b551396dc64196b92"/>
+    </canvas>
+    <canvas name="16" width="212" height="232">
+      <vector name="origin" x="10" y="223"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="86" y="-153"/>
+      <vector name="lt" x="-5" y="-152"/>
+      <vector name="rb" x="190" y="-3"/>
+      <string name="_hash" value="cc2c425e688dd55b8416aec87cecb2356867ce1adc0c9d377e6618bd48e3c680"/>
+    </canvas>
+    <canvas name="17" width="188" height="244">
+      <vector name="origin" x="8" y="238"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <canvas name="18" width="188" height="244">
+      <vector name="origin" x="44" y="242"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-61" y="-169"/>
+      <vector name="rb" x="116" y="-4"/>
+    </canvas>
+    <uol name="19" value="../stand/5"/>
+    <uol name="20" value="../stand/7"/>
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-435" y="-228"/>
+        <vector name="rb" x="190" y="0"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="76" height="76">
+          <vector name="origin" x="57" y="59"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="9d86bbdebb64d57f7f8ffde218b880c9a2eda0d1dfd0277b8c047d8bb531c2bb"/>
+        </canvas>
+        <canvas name="1" width="92" height="92">
+          <vector name="origin" x="71" y="81"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="3ebace547aea903279411e7c1a409df81a7db270dc4d6851c34a6006b5f9132e"/>
+        </canvas>
+        <canvas name="2" width="112" height="116">
+          <vector name="origin" x="70" y="82"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="5078d0b2b67c9737b7d81d440cb521ad865d440b6a024c706820f329048aacd1"/>
+        </canvas>
+        <canvas name="3" width="116" height="120">
+          <vector name="origin" x="74" y="74"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="605c6e7fb994ad9c4b7233763db479794bcd3b0eb3f29b16ea2449d268fa7c88"/>
+        </canvas>
+        <canvas name="4" width="120" height="124">
+          <vector name="origin" x="66" y="70"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6a1f159386ca9886b7ecc61065351e365235754d7d2fce15773ca85320bf61d9"/>
+        </canvas>
+        <canvas name="5" width="120" height="124">
+          <vector name="origin" x="87" y="115"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="53492d2bd78373169a20bf30a158e53734ed9529182a0c912c00b400fbf5441c"/>
+        </canvas>
+        <canvas name="6" width="120" height="124">
+          <vector name="origin" x="121" y="112"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="bbbd8a95fe48a471f4cf82d2197da4d20c2c2880d41b02bb1b5bdd01bce75942"/>
+        </canvas>
+        <canvas name="7" width="120" height="124">
+          <vector name="origin" x="119" y="107"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6ffc3e05f2df48ed119738ae0625ccdaf93636c1d4e91e8e321fd8702413aab5"/>
+        </canvas>
+        <canvas name="8" width="120" height="124">
+          <vector name="origin" x="113" y="97"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="266171cffb2c739b18cecea0ec70ddd50680c1d88f7c05fb8d3d89e5d1c4406d"/>
+        </canvas>
+        <canvas name="9" width="120" height="124">
+          <vector name="origin" x="100" y="82"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="f15b3c8af5876dfedd42bf5e0f0a5dd230aac7f7891ec2a3bbc7f592f1e9f0e4"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="120"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787131.img.xml
+++ b/gms-server/wz/Mob.wz/8787131.img.xml
@@ -1,1 +1,570 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787131.img"><imgdir name="move"><canvas name="0" width="74" height="82"><vector name="origin" x="34" y="90"/><vector name="head" x="-14" y="-72"/><vector name="lt" x="-34" y="-90"/><vector name="rb" x="40" y="-8"/><string name="_hash" value="628620a3281b39c6f6950a9e9d248bb8f2ab015f0872bee190b11b197fd75cb8"/></canvas><canvas name="1" width="73" height="83"><vector name="origin" x="34" y="91"/><vector name="head" x="-14" y="-73"/><vector name="lt" x="-34" y="-91"/><vector name="rb" x="39" y="-8"/><string name="_hash" value="9c764b528fdbd20872accec2f77da838d84f9eec697eba7fcc926637cb934feb"/></canvas><canvas name="2" width="71" height="86"><vector name="origin" x="34" y="93"/><vector name="head" x="-14" y="-75"/><vector name="lt" x="-34" y="-93"/><vector name="rb" x="37" y="-7"/><string name="_hash" value="a799ec13f86d4dc086f82c5559abfba1c50a5d4de3a25c9071e4e9b623201edc"/></canvas><canvas name="3" width="72" height="86"><vector name="origin" x="34" y="94"/><vector name="head" x="-14" y="-76"/><vector name="lt" x="-34" y="-94"/><vector name="rb" x="38" y="-8"/><string name="_hash" value="351677378cada20ca80e4ee74d19bd8a320e33752d65bcbb08d918bfee207ddd"/></canvas><canvas name="4" width="72" height="84"><vector name="origin" x="34" y="93"/><vector name="head" x="-14" y="-75"/><vector name="lt" x="-34" y="-93"/><vector name="rb" x="38" y="-9"/><string name="_hash" value="4d72fda183f0c7eded0da21816b198c1c7c81d51450ea55cc434da78b27ed8c6"/></canvas><canvas name="5" width="73" height="82"><vector name="origin" x="34" y="91"/><vector name="head" x="-14" y="-73"/><vector name="lt" x="-34" y="-91"/><vector name="rb" x="39" y="-9"/><string name="_hash" value="0e2333cb35e28ce79a5f1dbbe12c9b4098c19de2e66e16e8dcce638d944a3603"/></canvas></imgdir><imgdir name="stand"><canvas name="0" width="76" height="88"><vector name="origin" x="36" y="90"/><vector name="head" x="-14" y="-72"/><vector name="lt" x="-36" y="-90"/><vector name="rb" x="40" y="-2"/><string name="_hash" value="c49776a4f63086b60fae4ddcbacd7107b96867f42d4e560c62998b255a1d9e23"/></canvas><canvas name="1" width="75" height="87"><vector name="origin" x="36" y="91"/><vector name="head" x="-14" y="-73"/><vector name="lt" x="-36" y="-91"/><vector name="rb" x="39" y="-4"/><string name="_hash" value="b8cffb7c439cfef7fd21653c79418c374e02eff3b4ce02a49e6919de3fef6a8a"/></canvas><canvas name="2" width="74" height="87"><vector name="origin" x="36" y="92"/><vector name="head" x="-14" y="-74"/><vector name="lt" x="-36" y="-92"/><vector name="rb" x="38" y="-5"/><string name="_hash" value="c933af444c65403c423b100e1b5ae7737e8c693af64645e0a76c55ccb8554bdd"/></canvas><canvas name="3" width="73" height="88"><vector name="origin" x="36" y="93"/><vector name="head" x="-14" y="-75"/><vector name="lt" x="-36" y="-93"/><vector name="rb" x="37" y="-5"/><string name="_hash" value="36191bf243c863a2428926be45db263e155aa3a0b6a9cd2f63a203d8cddf064a"/></canvas><canvas name="4" width="74" height="87"><vector name="origin" x="36" y="92"/><vector name="head" x="-14" y="-74"/><vector name="lt" x="-36" y="-92"/><vector name="rb" x="38" y="-5"/><string name="_hash" value="bc6b13d51f81c4e68aba971025138185cfe12422810abda790d449dec7037165"/></canvas><canvas name="5" width="75" height="87"><vector name="origin" x="36" y="91"/><vector name="head" x="-14" y="-73"/><vector name="lt" x="-36" y="-91"/><vector name="rb" x="39" y="-4"/><string name="_hash" value="bb6579525f818beb44a9b841de716eb0b7336099473d8b8a3f8229456a036b60"/></canvas></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="hit"><canvas name="0" width="61" height="48"><vector name="origin" x="30" y="24"/><vector name="lt" x="-30" y="-24"/><vector name="rb" x="31" y="24"/><string name="_hash" value="ff0efbcf0b18f8503163b3479695ac8ad9e0f6dcf973a25c7b56a7f2459ac707"/></canvas><canvas name="1" width="81" height="80"><vector name="origin" x="29" y="56"/><vector name="lt" x="-29" y="-56"/><vector name="rb" x="52" y="24"/><string name="_hash" value="faef409b2c5cd95f40cc7d2814c64cd539245de97464b4a07b614d1d2981a1f0"/></canvas><canvas name="2" width="91" height="82"><vector name="origin" x="49" y="58"/><vector name="lt" x="-49" y="-58"/><vector name="rb" x="42" y="24"/><string name="_hash" value="0c9434c3b6c5d20de376bb7320af7c4c68d634e20145e7dc52c399663480a357"/></canvas><canvas name="3" width="90" height="84"><vector name="origin" x="48" y="60"/><vector name="lt" x="-48" y="-60"/><vector name="rb" x="42" y="24"/><string name="_hash" value="3cbca20aabaef328ad79121975216ed0e1c96a530f41a7fa45abe0fc21119bba"/></canvas><canvas name="4" width="92" height="92"><vector name="origin" x="50" y="70"/><vector name="lt" x="-50" y="-70"/><vector name="rb" x="42" y="22"/><string name="_hash" value="00787162f54bfa2f81bca14bbe8c98bbcf83cfa74edafd65f89f5da75dcfa88d"/></canvas><canvas name="5" width="92" height="86"><vector name="origin" x="50" y="70"/><vector name="lt" x="-50" y="-70"/><vector name="rb" x="42" y="16"/><string name="_hash" value="0529d2fa22961d9c20384b3cbbc43ecea6309726a7aa2241515eaa2fdd1cb81b"/></canvas><canvas name="6" width="53" height="76"><vector name="origin" x="51" y="70"/><vector name="lt" x="-51" y="-70"/><vector name="rb" x="2" y="6"/><string name="_hash" value="d7daac9bde5ab9866ffc3d8c03d8420173fdfec97752f272706c6c5306cab424"/></canvas><int name="attach" value="1"/></imgdir><int name="attackAfter" value="1320"/><imgdir name="range"><vector name="lt" x="-333" y="-325"/><vector name="rb" x="240" y="100"/></imgdir></imgdir><canvas name="0" width="76" height="88"><vector name="origin" x="36" y="90"/><vector name="head" x="-14" y="-72"/><vector name="lt" x="-36" y="-90"/><vector name="rb" x="40" y="-2"/><string name="_inlink" value="stand/0"/></canvas><canvas name="1" width="122" height="102"><vector name="origin" x="45" y="106"/><vector name="head" x="-14" y="-73"/><vector name="lt" x="-45" y="-106"/><vector name="rb" x="77" y="-4"/><string name="_hash" value="3536c51d260f142f2f7ad40a27d4d5679e4a5bf7e9e30fc70e7c109c2b7a1062"/></canvas><canvas name="2" width="109" height="96"><vector name="origin" x="38" y="101"/><vector name="head" x="-14" y="-74"/><vector name="lt" x="-38" y="-101"/><vector name="rb" x="71" y="-5"/><string name="_hash" value="72ca84875f46259fda6ba7c8d83a578193ef3a4104cd4b5953c6be5558ba9f5e"/></canvas><canvas name="3" width="104" height="91"><vector name="origin" x="37" y="97"/><vector name="head" x="-14" y="-76"/><vector name="lt" x="-37" y="-97"/><vector name="rb" x="67" y="-6"/><string name="_hash" value="4b5bbae813df785a441bc480327af8553f9fd4200f4beafe03e6a3b534414b9f"/></canvas><canvas name="4" width="99" height="87"><vector name="origin" x="35" y="97"/><vector name="head" x="-14" y="-79"/><vector name="lt" x="-35" y="-97"/><vector name="rb" x="64" y="-10"/><string name="_hash" value="7d72fcfc62ccef5e68bc92d15939f06bbb1819c9291de9c871c391be3151f2a9"/></canvas><canvas name="5" width="75" height="87"><vector name="origin" x="34" y="101"/><vector name="head" x="-14" y="-83"/><vector name="lt" x="-34" y="-101"/><vector name="rb" x="41" y="-14"/><string name="_hash" value="93f2582ef97f69337346310dfe6f8b71c58e212fc4582ea019881fb272eedc31"/></canvas><canvas name="6" width="130" height="106"><vector name="origin" x="90" y="104"/><vector name="head" x="-14" y="-86"/><vector name="lt" x="-90" y="-104"/><vector name="rb" x="40" y="2"/><string name="_hash" value="118f0176b19717a9c317d6ec4d1826510c56924ecc42494e485a6ee017722992"/></canvas><canvas name="7" width="277" height="107"><vector name="origin" x="238" y="105"/><vector name="head" x="-14" y="-87"/><vector name="lt" x="-238" y="-105"/><vector name="rb" x="39" y="2"/><string name="_hash" value="31c89813648fedae9b7ec1cec0cf8c57d962c21056541a987a6d603d31721f05"/></canvas><canvas name="8" width="335" height="108"><vector name="origin" x="297" y="106"/><vector name="head" x="-14" y="-88"/><vector name="lt" x="-297" y="-106"/><vector name="rb" x="38" y="2"/><string name="_hash" value="a410ba284d45e73cfe22ab93737557ea9da6fbcaca10153e1b9bb386353e2fb7"/></canvas><canvas name="9" width="322" height="107"><vector name="origin" x="285" y="105"/><vector name="head" x="-14" y="-87"/><vector name="lt" x="-285" y="-105"/><vector name="rb" x="37" y="2"/><string name="_hash" value="dfac6fe6dfb787b289ea570d7ea0e3aa5b1df792f843636d30e4e6eee74deb11"/></canvas><canvas name="10" width="332" height="162"><vector name="origin" x="294" y="161"/><vector name="head" x="-14" y="-86"/><vector name="lt" x="-294" y="-161"/><vector name="rb" x="38" y="1"/><string name="_hash" value="889fba822226331f5ff7dcb1e0e6ac6473dbb3f23b6e3438b6b917a24d04900b"/></canvas><canvas name="11" width="344" height="200"><vector name="origin" x="305" y="199"/><vector name="head" x="-14" y="-84"/><vector name="lt" x="-305" y="-199"/><vector name="rb" x="39" y="1"/><string name="_hash" value="c25a3a1f5ad07dae41633633d5eba8c01aec909c1a9a081dc86998debf65b6ac"/></canvas><canvas name="12" width="350" height="158"><vector name="origin" x="310" y="157"/><vector name="head" x="-14" y="-81"/><vector name="lt" x="-310" y="-157"/><vector name="rb" x="40" y="1"/><string name="_hash" value="84f613ac5e796a2b2ad65646523b7c640dd0593c7c35cc66f37ad0a8ac0cea94"/></canvas><canvas name="13" width="334" height="159"><vector name="origin" x="295" y="158"/><vector name="head" x="-14" y="-77"/><vector name="lt" x="-295" y="-158"/><vector name="rb" x="39" y="1"/><string name="_hash" value="4b38595a17476079c94a5892bb7fc62f190d611a4099ca5ad3d22b3cb8fa6535"/></canvas><canvas name="14" width="333" height="164"><vector name="origin" x="295" y="163"/><vector name="head" x="-14" y="-75"/><vector name="lt" x="-295" y="-163"/><vector name="rb" x="38" y="1"/><string name="_hash" value="10c0e68dc9933402a171eb58cb2553aa69dadf469b6ee8838487d8acde281e04"/></canvas><canvas name="15" width="307" height="164"><vector name="origin" x="270" y="163"/><vector name="head" x="-14" y="-74"/><vector name="lt" x="-270" y="-163"/><vector name="rb" x="37" y="1"/><string name="_hash" value="b8e549757135c3d6996ef0340f7ae92c6cc5800bba61c280535f4091c0ebd0d9"/></canvas><canvas name="16" width="303" height="161"><vector name="origin" x="265" y="160"/><vector name="head" x="-14" y="-73"/><vector name="lt" x="-265" y="-160"/><vector name="rb" x="38" y="1"/><string name="_hash" value="c5c912b0ff12033599edecdf67ac72ab028d951244dcce33616542b29add4234"/></canvas><canvas name="17" width="75" height="87"><vector name="origin" x="36" y="90"/><vector name="head" x="-14" y="-72"/><vector name="lt" x="-36" y="-90"/><vector name="rb" x="39" y="-3"/></canvas></imgdir><imgdir name="skill1"><canvas name="0" width="76" height="88"><vector name="origin" x="36" y="90"/><vector name="head" x="-14" y="-72"/><vector name="lt" x="-36" y="-90"/><vector name="rb" x="40" y="-2"/><int name="delay" value="120"/></canvas><canvas name="1" width="77" height="103"><vector name="origin" x="38" y="108"/><vector name="head" x="-14" y="-74"/><vector name="lt" x="-38" y="-108"/><vector name="rb" x="39" y="-5"/><int name="delay" value="120"/><string name="_hash" value="920b7afb1b45f5efe4f9c3c4b98ec3d3807573cf309a34ec655baf45f22da4e0"/></canvas><canvas name="2" width="81" height="89"><vector name="origin" x="40" y="97"/><vector name="head" x="-14" y="-77"/><vector name="lt" x="-40" y="-97"/><vector name="rb" x="41" y="-8"/><int name="delay" value="120"/><string name="_hash" value="324b7f69ceb764171767f6425b78bc7ecd55bf443380201b3806b079f0ff9dee"/></canvas><canvas name="3" width="85" height="101"><vector name="origin" x="42" y="99"/><vector name="head" x="-14" y="-81"/><vector name="lt" x="-42" y="-99"/><vector name="rb" x="43" y="2"/><int name="delay" value="120"/><string name="_hash" value="3c053b508b11d693a8ebfd2f39b0e93cb55191cf839f8d1f3828acac389f7da3"/></canvas><canvas name="4" width="89" height="112"><vector name="origin" x="44" y="107"/><vector name="head" x="-14" y="-89"/><vector name="lt" x="-44" y="-107"/><vector name="rb" x="45" y="5"/><int name="delay" value="120"/><string name="_hash" value="6660ec98be1e30f7d87229f14e1d97da5dc0e38eb83b2a5923b1b27126e652c1"/></canvas><canvas name="5" width="93" height="121"><vector name="origin" x="46" y="117"/><vector name="head" x="-14" y="-99"/><vector name="lt" x="-46" y="-117"/><vector name="rb" x="47" y="4"/><int name="delay" value="120"/><string name="_hash" value="fccd1fa592614aaeb65dc8d60c3830eb0f8806d648a7c90d1c6ba1221b786591"/></canvas><canvas name="6" width="97" height="127"><vector name="origin" x="48" y="123"/><vector name="head" x="-14" y="-105"/><vector name="lt" x="-48" y="-123"/><vector name="rb" x="49" y="4"/><int name="delay" value="120"/><string name="_hash" value="dbf9d6d6d0012292303a4ee906ff13656eebeca0962900a9b040893fe04498d2"/></canvas><canvas name="7" width="103" height="136"><vector name="origin" x="51" y="126"/><vector name="head" x="-14" y="-108"/><vector name="lt" x="-51" y="-126"/><vector name="rb" x="52" y="10"/><int name="delay" value="120"/><string name="_hash" value="199959138e821d5c48ceea019209e9c4a6ff1d26664a2d232a1b1a3b3fc6e7dd"/></canvas><canvas name="8" width="107" height="139"><vector name="origin" x="53" y="128"/><vector name="head" x="-14" y="-110"/><vector name="lt" x="-53" y="-128"/><vector name="rb" x="54" y="11"/><int name="delay" value="120"/><string name="_hash" value="0a42efef17c74412aafea98f45af84f0925b2366c12a00236e5a7104362e01c0"/></canvas><canvas name="9" width="113" height="131"><vector name="origin" x="56" y="129"/><vector name="head" x="-14" y="-111"/><vector name="lt" x="-56" y="-129"/><vector name="rb" x="57" y="2"/><int name="delay" value="120"/><string name="_hash" value="44fd71a73d10e5243c97f83ab860abba5041a5f19f028465bffce5e60425ffa3"/></canvas><canvas name="10" width="125" height="145"><vector name="origin" x="62" y="130"/><vector name="head" x="-14" y="-112"/><vector name="lt" x="-62" y="-130"/><vector name="rb" x="63" y="15"/><int name="delay" value="120"/><string name="_hash" value="572e5bf19da1da84a234de1f37ef248c2ab18282fcec44fdac424ae41351b650"/></canvas><canvas name="11" width="163" height="296"><vector name="origin" x="81" y="275"/><vector name="head" x="-14" y="-112"/><vector name="lt" x="-81" y="-275"/><vector name="rb" x="82" y="21"/><int name="delay" value="120"/><string name="_hash" value="0aabbb31efa735bbea969b270707de1e16ffd236caeaa5504f307501ad5851ee"/></canvas><canvas name="12" width="141" height="303"><vector name="origin" x="70" y="285"/><vector name="head" x="-14" y="-112"/><vector name="lt" x="-70" y="-285"/><vector name="rb" x="71" y="18"/><int name="delay" value="120"/><string name="_hash" value="ac6867882bc45392160dfbf0f7373d7fa05167fd83b30224c1192dafa5768a47"/></canvas><canvas name="13" width="137" height="310"><vector name="origin" x="68" y="285"/><vector name="head" x="-14" y="-111"/><vector name="lt" x="-68" y="-285"/><vector name="rb" x="69" y="25"/><int name="delay" value="120"/><string name="_hash" value="51f0e6836ea2c23e921830e08815242970dc68558f546777b89377c4986e3479"/></canvas><canvas name="14" width="138" height="300"><vector name="origin" x="68" y="271"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-68" y="-271"/><vector name="rb" x="70" y="29"/><int name="delay" value="120"/><string name="_hash" value="96b81a0956ee76f18f51e5b47245accd88488023f985ce1456b8574ca4fc4e25"/></canvas><canvas name="15" width="141" height="275"><vector name="origin" x="68" y="247"/><vector name="head" x="-14" y="-106"/><vector name="lt" x="-68" y="-247"/><vector name="rb" x="73" y="28"/><int name="delay" value="120"/><string name="_hash" value="0bbe17c920ad4e0a2674ba351766c1d9bc2c585e9ae9d2ff741b92152ea07d3b"/></canvas><canvas name="16" width="144" height="275"><vector name="origin" x="67" y="246"/><vector name="head" x="-14" y="-102"/><vector name="lt" x="-67" y="-246"/><vector name="rb" x="77" y="29"/><int name="delay" value="120"/><string name="_hash" value="f1423c5e82e2cf978fab70edbb6b6c588e77897e84b1ff92c9349533b2cbe6b2"/></canvas><canvas name="17" width="133" height="210"><vector name="origin" x="66" y="199"/><vector name="head" x="-14" y="-97"/><vector name="lt" x="-66" y="-199"/><vector name="rb" x="67" y="11"/><int name="delay" value="120"/><string name="_hash" value="c77e9b7d4569c337b0e97e4f2cc9ecfc20fee35ca57642a053767cc937a9bbf5"/></canvas><canvas name="18" width="142" height="82"><vector name="origin" x="64" y="109"/><vector name="head" x="-14" y="-91"/><vector name="lt" x="-64" y="-109"/><vector name="rb" x="78" y="-27"/><int name="delay" value="120"/><string name="_hash" value="a417855e33339c2aa8fc814b62b8ea73c54ffa7b896a8ae460d197ff738584d6"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="95" height="103"><vector name="origin" x="42" y="111"/><vector name="head" x="-6" y="-80"/><vector name="lt" x="-42" y="-111"/><vector name="rb" x="53" y="-8"/><int name="delay" value="600"/><string name="_hash" value="f633fa95ea6dc080fcc3c09dd7e31010be8668c4cabf9eb8edea05ec4364f042"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="95" height="103"><vector name="origin" x="33" y="111"/><int name="delay" value="120"/></canvas><canvas name="1" width="82" height="88"><vector name="origin" x="20" y="97"/><int name="delay" value="120"/><string name="_hash" value="01a7efa78e48640eb65ad86cf962fb11c148932a993dac31d9a0788eeeedc949"/></canvas><canvas name="2" width="68" height="81"><vector name="origin" x="2" y="90"/><int name="delay" value="120"/><string name="_hash" value="f2dd2f5010ac6db981cd081698c5b43b9950c319968e8adf471488530f9b9a54"/></canvas><canvas name="3" width="68" height="81"><vector name="origin" x="-1" y="90"/><int name="delay" value="120"/><string name="_hash" value="ff2ed666fbcd9a34e9f33034de97744375c2cb802ad3bc09c44319c2d63d7eaf"/></canvas><canvas name="4" width="134" height="99"><vector name="origin" x="33" y="94"/><int name="delay" value="120"/><string name="_hash" value="bedcfb1f30c1fd803e5768f3df35cef41297af372fecce35b6da9c887c542f61"/></canvas><canvas name="5" width="131" height="139"><vector name="origin" x="28" y="128"/><int name="delay" value="120"/><string name="_hash" value="06acf086cf0327f79587e9fcbd246a477dd779ec21ad53b6161749ed69e34b9c"/></canvas><canvas name="6" width="119" height="136"><vector name="origin" x="21" y="132"/><int name="delay" value="120"/><string name="_hash" value="ec3b27d89f38a6f8bdd2251582b9d34ea714c3507be23d16985925b023ac482c"/></canvas><canvas name="7" width="98" height="129"><vector name="origin" x="12" y="132"/><int name="delay" value="120"/><string name="_hash" value="725c80e5a4925680a8eb7dd59d06f58c6c92e4ab2d56b53169cb369b70085d38"/></canvas><canvas name="8" width="96" height="126"><vector name="origin" x="10" y="133"/><int name="delay" value="120"/><string name="_hash" value="530fdbec6c693b86116fb2530e335e5f343d418e6b7686a15646b394dccba9f6"/></canvas><canvas name="9" width="62" height="92"><vector name="origin" x="-4" y="93"/><int name="delay" value="120"/><string name="_hash" value="f3fb963fc078ae070f34f999fffb790a7ae1662eb00e77e684c3351c7f135d1d"/></canvas><canvas name="10" width="52" height="87"><vector name="origin" x="-8" y="90"/><int name="delay" value="120"/><string name="_hash" value="d94ef025c321517d6707c566d8dfad88fb019cef9fd7f2d67a1af75353bf409a"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="這只是前菜呢~"/></imgdir></imgdir><imgdir name="info"><int name="level" value="120"/><int name="maxHP" value="1500000"/><int name="maxMP" value="999999999"/><int name="PADamage" value="300"/><int name="MADamage" value="300"/><int name="acc" value="300"/><int name="eva" value="30"/><int name="pushed" value="100000"/><float name="fs" value="10.0"/><int name="exp" value="300000"/><int name="summonType" value="1"/><int name="category" value="8"/><int name="firstAttack" value="1"/><string name="mobType" value="1N"/><int name="boss" value="1"/><imgdir name="attack"><imgdir name="0"><int name="action" value="1"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="2"/><int name="magic" value="1"/><int name="attackCount" value="3"/><int name="disease" value="123"/><int name="level" value="9"/></imgdir></imgdir><int name="ignoreMoveImpact" value="1"/><int name="bodyAttack" value="1"/><int name="speed" value="30"/><int name="PDDamage" value="3000"/><int name="MDDamage" value="3000"/><imgdir name="speak"><int name="chatBalloon" value="0"/><imgdir name="0"><string name="0" value="讓你後悔！"/></imgdir></imgdir><imgdir name="skill"><imgdir name="0"><int name="skill" value="114"/><int name="action" value="1"/><int name="level" value="18"/><int name="effectAfter" value="0"/></imgdir><imgdir name="1"><int name="skill" value="110"/><int name="action" value="1"/><int name="level" value="1"/><int name="effectAfter" value="0"/></imgdir><imgdir name="2"><int name="skill" value="112"/><int name="action" value="1"/><int name="level" value="1"/><int name="effectAfter" value="0"/></imgdir><imgdir name="3"><int name="skill" value="140"/><int name="action" value="1"/><int name="level" value="12"/><int name="effectAfter" value="0"/></imgdir></imgdir><imgdir name="revive"><int name="0" value="8787137"/><int name="1" value="8787137"/><int name="2" value="8787137"/><int name="3" value="8787137"/><int name="4" value="8787137"/><int name="5" value="8787161"/><int name="6" value="8787137"/><int name="7" value="8787137"/><int name="8" value="8787137"/></imgdir></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787131.img">
+  <imgdir name="move">
+    <canvas name="0" width="74" height="82">
+      <vector name="origin" x="34" y="90"/>
+      <vector name="head" x="-14" y="-72"/>
+      <vector name="lt" x="-34" y="-90"/>
+      <vector name="rb" x="40" y="-8"/>
+      <string name="_hash" value="628620a3281b39c6f6950a9e9d248bb8f2ab015f0872bee190b11b197fd75cb8"/>
+    </canvas>
+    <canvas name="1" width="73" height="83">
+      <vector name="origin" x="34" y="91"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-34" y="-91"/>
+      <vector name="rb" x="39" y="-8"/>
+      <string name="_hash" value="9c764b528fdbd20872accec2f77da838d84f9eec697eba7fcc926637cb934feb"/>
+    </canvas>
+    <canvas name="2" width="71" height="86">
+      <vector name="origin" x="34" y="93"/>
+      <vector name="head" x="-14" y="-75"/>
+      <vector name="lt" x="-34" y="-93"/>
+      <vector name="rb" x="37" y="-7"/>
+      <string name="_hash" value="a799ec13f86d4dc086f82c5559abfba1c50a5d4de3a25c9071e4e9b623201edc"/>
+    </canvas>
+    <canvas name="3" width="72" height="86">
+      <vector name="origin" x="34" y="94"/>
+      <vector name="head" x="-14" y="-76"/>
+      <vector name="lt" x="-34" y="-94"/>
+      <vector name="rb" x="38" y="-8"/>
+      <string name="_hash" value="351677378cada20ca80e4ee74d19bd8a320e33752d65bcbb08d918bfee207ddd"/>
+    </canvas>
+    <canvas name="4" width="72" height="84">
+      <vector name="origin" x="34" y="93"/>
+      <vector name="head" x="-14" y="-75"/>
+      <vector name="lt" x="-34" y="-93"/>
+      <vector name="rb" x="38" y="-9"/>
+      <string name="_hash" value="4d72fda183f0c7eded0da21816b198c1c7c81d51450ea55cc434da78b27ed8c6"/>
+    </canvas>
+    <canvas name="5" width="73" height="82">
+      <vector name="origin" x="34" y="91"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-34" y="-91"/>
+      <vector name="rb" x="39" y="-9"/>
+      <string name="_hash" value="0e2333cb35e28ce79a5f1dbbe12c9b4098c19de2e66e16e8dcce638d944a3603"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="76" height="88">
+      <vector name="origin" x="36" y="90"/>
+      <vector name="head" x="-14" y="-72"/>
+      <vector name="lt" x="-36" y="-90"/>
+      <vector name="rb" x="40" y="-2"/>
+      <string name="_hash" value="c49776a4f63086b60fae4ddcbacd7107b96867f42d4e560c62998b255a1d9e23"/>
+    </canvas>
+    <canvas name="1" width="75" height="87">
+      <vector name="origin" x="36" y="91"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-36" y="-91"/>
+      <vector name="rb" x="39" y="-4"/>
+      <string name="_hash" value="b8cffb7c439cfef7fd21653c79418c374e02eff3b4ce02a49e6919de3fef6a8a"/>
+    </canvas>
+    <canvas name="2" width="74" height="87">
+      <vector name="origin" x="36" y="92"/>
+      <vector name="head" x="-14" y="-74"/>
+      <vector name="lt" x="-36" y="-92"/>
+      <vector name="rb" x="38" y="-5"/>
+      <string name="_hash" value="c933af444c65403c423b100e1b5ae7737e8c693af64645e0a76c55ccb8554bdd"/>
+    </canvas>
+    <canvas name="3" width="73" height="88">
+      <vector name="origin" x="36" y="93"/>
+      <vector name="head" x="-14" y="-75"/>
+      <vector name="lt" x="-36" y="-93"/>
+      <vector name="rb" x="37" y="-5"/>
+      <string name="_hash" value="36191bf243c863a2428926be45db263e155aa3a0b6a9cd2f63a203d8cddf064a"/>
+    </canvas>
+    <canvas name="4" width="74" height="87">
+      <vector name="origin" x="36" y="92"/>
+      <vector name="head" x="-14" y="-74"/>
+      <vector name="lt" x="-36" y="-92"/>
+      <vector name="rb" x="38" y="-5"/>
+      <string name="_hash" value="bc6b13d51f81c4e68aba971025138185cfe12422810abda790d449dec7037165"/>
+    </canvas>
+    <canvas name="5" width="75" height="87">
+      <vector name="origin" x="36" y="91"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-36" y="-91"/>
+      <vector name="rb" x="39" y="-4"/>
+      <string name="_hash" value="bb6579525f818beb44a9b841de716eb0b7336099473d8b8a3f8229456a036b60"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="hit">
+        <canvas name="0" width="61" height="48">
+          <vector name="origin" x="30" y="24"/>
+          <vector name="lt" x="-30" y="-24"/>
+          <vector name="rb" x="31" y="24"/>
+          <string name="_hash" value="ff0efbcf0b18f8503163b3479695ac8ad9e0f6dcf973a25c7b56a7f2459ac707"/>
+        </canvas>
+        <canvas name="1" width="81" height="80">
+          <vector name="origin" x="29" y="56"/>
+          <vector name="lt" x="-29" y="-56"/>
+          <vector name="rb" x="52" y="24"/>
+          <string name="_hash" value="faef409b2c5cd95f40cc7d2814c64cd539245de97464b4a07b614d1d2981a1f0"/>
+        </canvas>
+        <canvas name="2" width="91" height="82">
+          <vector name="origin" x="49" y="58"/>
+          <vector name="lt" x="-49" y="-58"/>
+          <vector name="rb" x="42" y="24"/>
+          <string name="_hash" value="0c9434c3b6c5d20de376bb7320af7c4c68d634e20145e7dc52c399663480a357"/>
+        </canvas>
+        <canvas name="3" width="90" height="84">
+          <vector name="origin" x="48" y="60"/>
+          <vector name="lt" x="-48" y="-60"/>
+          <vector name="rb" x="42" y="24"/>
+          <string name="_hash" value="3cbca20aabaef328ad79121975216ed0e1c96a530f41a7fa45abe0fc21119bba"/>
+        </canvas>
+        <canvas name="4" width="92" height="92">
+          <vector name="origin" x="50" y="70"/>
+          <vector name="lt" x="-50" y="-70"/>
+          <vector name="rb" x="42" y="22"/>
+          <string name="_hash" value="00787162f54bfa2f81bca14bbe8c98bbcf83cfa74edafd65f89f5da75dcfa88d"/>
+        </canvas>
+        <canvas name="5" width="92" height="86">
+          <vector name="origin" x="50" y="70"/>
+          <vector name="lt" x="-50" y="-70"/>
+          <vector name="rb" x="42" y="16"/>
+          <string name="_hash" value="0529d2fa22961d9c20384b3cbbc43ecea6309726a7aa2241515eaa2fdd1cb81b"/>
+        </canvas>
+        <canvas name="6" width="53" height="76">
+          <vector name="origin" x="51" y="70"/>
+          <vector name="lt" x="-51" y="-70"/>
+          <vector name="rb" x="2" y="6"/>
+          <string name="_hash" value="d7daac9bde5ab9866ffc3d8c03d8420173fdfec97752f272706c6c5306cab424"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="attackAfter" value="1320"/>
+      <imgdir name="range">
+        <vector name="lt" x="-333" y="-325"/>
+        <vector name="rb" x="240" y="100"/>
+      </imgdir>
+    </imgdir>
+    <canvas name="0" width="76" height="88">
+      <vector name="origin" x="36" y="90"/>
+      <vector name="head" x="-14" y="-72"/>
+      <vector name="lt" x="-36" y="-90"/>
+      <vector name="rb" x="40" y="-2"/>
+      <string name="_inlink" value="stand/0"/>
+    </canvas>
+    <canvas name="1" width="122" height="102">
+      <vector name="origin" x="45" y="106"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-45" y="-106"/>
+      <vector name="rb" x="77" y="-4"/>
+      <string name="_hash" value="3536c51d260f142f2f7ad40a27d4d5679e4a5bf7e9e30fc70e7c109c2b7a1062"/>
+    </canvas>
+    <canvas name="2" width="109" height="96">
+      <vector name="origin" x="38" y="101"/>
+      <vector name="head" x="-14" y="-74"/>
+      <vector name="lt" x="-38" y="-101"/>
+      <vector name="rb" x="71" y="-5"/>
+      <string name="_hash" value="72ca84875f46259fda6ba7c8d83a578193ef3a4104cd4b5953c6be5558ba9f5e"/>
+    </canvas>
+    <canvas name="3" width="104" height="91">
+      <vector name="origin" x="37" y="97"/>
+      <vector name="head" x="-14" y="-76"/>
+      <vector name="lt" x="-37" y="-97"/>
+      <vector name="rb" x="67" y="-6"/>
+      <string name="_hash" value="4b5bbae813df785a441bc480327af8553f9fd4200f4beafe03e6a3b534414b9f"/>
+    </canvas>
+    <canvas name="4" width="99" height="87">
+      <vector name="origin" x="35" y="97"/>
+      <vector name="head" x="-14" y="-79"/>
+      <vector name="lt" x="-35" y="-97"/>
+      <vector name="rb" x="64" y="-10"/>
+      <string name="_hash" value="7d72fcfc62ccef5e68bc92d15939f06bbb1819c9291de9c871c391be3151f2a9"/>
+    </canvas>
+    <canvas name="5" width="75" height="87">
+      <vector name="origin" x="34" y="101"/>
+      <vector name="head" x="-14" y="-83"/>
+      <vector name="lt" x="-34" y="-101"/>
+      <vector name="rb" x="41" y="-14"/>
+      <string name="_hash" value="93f2582ef97f69337346310dfe6f8b71c58e212fc4582ea019881fb272eedc31"/>
+    </canvas>
+    <canvas name="6" width="130" height="106">
+      <vector name="origin" x="90" y="104"/>
+      <vector name="head" x="-14" y="-86"/>
+      <vector name="lt" x="-90" y="-104"/>
+      <vector name="rb" x="40" y="2"/>
+      <string name="_hash" value="118f0176b19717a9c317d6ec4d1826510c56924ecc42494e485a6ee017722992"/>
+    </canvas>
+    <canvas name="7" width="277" height="107">
+      <vector name="origin" x="238" y="105"/>
+      <vector name="head" x="-14" y="-87"/>
+      <vector name="lt" x="-238" y="-105"/>
+      <vector name="rb" x="39" y="2"/>
+      <string name="_hash" value="31c89813648fedae9b7ec1cec0cf8c57d962c21056541a987a6d603d31721f05"/>
+    </canvas>
+    <canvas name="8" width="335" height="108">
+      <vector name="origin" x="297" y="106"/>
+      <vector name="head" x="-14" y="-88"/>
+      <vector name="lt" x="-297" y="-106"/>
+      <vector name="rb" x="38" y="2"/>
+      <string name="_hash" value="a410ba284d45e73cfe22ab93737557ea9da6fbcaca10153e1b9bb386353e2fb7"/>
+    </canvas>
+    <canvas name="9" width="322" height="107">
+      <vector name="origin" x="285" y="105"/>
+      <vector name="head" x="-14" y="-87"/>
+      <vector name="lt" x="-285" y="-105"/>
+      <vector name="rb" x="37" y="2"/>
+      <string name="_hash" value="dfac6fe6dfb787b289ea570d7ea0e3aa5b1df792f843636d30e4e6eee74deb11"/>
+    </canvas>
+    <canvas name="10" width="332" height="162">
+      <vector name="origin" x="294" y="161"/>
+      <vector name="head" x="-14" y="-86"/>
+      <vector name="lt" x="-294" y="-161"/>
+      <vector name="rb" x="38" y="1"/>
+      <string name="_hash" value="889fba822226331f5ff7dcb1e0e6ac6473dbb3f23b6e3438b6b917a24d04900b"/>
+    </canvas>
+    <canvas name="11" width="344" height="200">
+      <vector name="origin" x="305" y="199"/>
+      <vector name="head" x="-14" y="-84"/>
+      <vector name="lt" x="-305" y="-199"/>
+      <vector name="rb" x="39" y="1"/>
+      <string name="_hash" value="c25a3a1f5ad07dae41633633d5eba8c01aec909c1a9a081dc86998debf65b6ac"/>
+    </canvas>
+    <canvas name="12" width="350" height="158">
+      <vector name="origin" x="310" y="157"/>
+      <vector name="head" x="-14" y="-81"/>
+      <vector name="lt" x="-310" y="-157"/>
+      <vector name="rb" x="40" y="1"/>
+      <string name="_hash" value="84f613ac5e796a2b2ad65646523b7c640dd0593c7c35cc66f37ad0a8ac0cea94"/>
+    </canvas>
+    <canvas name="13" width="334" height="159">
+      <vector name="origin" x="295" y="158"/>
+      <vector name="head" x="-14" y="-77"/>
+      <vector name="lt" x="-295" y="-158"/>
+      <vector name="rb" x="39" y="1"/>
+      <string name="_hash" value="4b38595a17476079c94a5892bb7fc62f190d611a4099ca5ad3d22b3cb8fa6535"/>
+    </canvas>
+    <canvas name="14" width="333" height="164">
+      <vector name="origin" x="295" y="163"/>
+      <vector name="head" x="-14" y="-75"/>
+      <vector name="lt" x="-295" y="-163"/>
+      <vector name="rb" x="38" y="1"/>
+      <string name="_hash" value="10c0e68dc9933402a171eb58cb2553aa69dadf469b6ee8838487d8acde281e04"/>
+    </canvas>
+    <canvas name="15" width="307" height="164">
+      <vector name="origin" x="270" y="163"/>
+      <vector name="head" x="-14" y="-74"/>
+      <vector name="lt" x="-270" y="-163"/>
+      <vector name="rb" x="37" y="1"/>
+      <string name="_hash" value="b8e549757135c3d6996ef0340f7ae92c6cc5800bba61c280535f4091c0ebd0d9"/>
+    </canvas>
+    <canvas name="16" width="303" height="161">
+      <vector name="origin" x="265" y="160"/>
+      <vector name="head" x="-14" y="-73"/>
+      <vector name="lt" x="-265" y="-160"/>
+      <vector name="rb" x="38" y="1"/>
+      <string name="_hash" value="c5c912b0ff12033599edecdf67ac72ab028d951244dcce33616542b29add4234"/>
+    </canvas>
+    <canvas name="17" width="75" height="87">
+      <vector name="origin" x="36" y="90"/>
+      <vector name="head" x="-14" y="-72"/>
+      <vector name="lt" x="-36" y="-90"/>
+      <vector name="rb" x="39" y="-3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="76" height="88">
+      <vector name="origin" x="36" y="90"/>
+      <vector name="head" x="-14" y="-72"/>
+      <vector name="lt" x="-36" y="-90"/>
+      <vector name="rb" x="40" y="-2"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="77" height="103">
+      <vector name="origin" x="38" y="108"/>
+      <vector name="head" x="-14" y="-74"/>
+      <vector name="lt" x="-38" y="-108"/>
+      <vector name="rb" x="39" y="-5"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="920b7afb1b45f5efe4f9c3c4b98ec3d3807573cf309a34ec655baf45f22da4e0"/>
+    </canvas>
+    <canvas name="2" width="81" height="89">
+      <vector name="origin" x="40" y="97"/>
+      <vector name="head" x="-14" y="-77"/>
+      <vector name="lt" x="-40" y="-97"/>
+      <vector name="rb" x="41" y="-8"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="324b7f69ceb764171767f6425b78bc7ecd55bf443380201b3806b079f0ff9dee"/>
+    </canvas>
+    <canvas name="3" width="85" height="101">
+      <vector name="origin" x="42" y="99"/>
+      <vector name="head" x="-14" y="-81"/>
+      <vector name="lt" x="-42" y="-99"/>
+      <vector name="rb" x="43" y="2"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3c053b508b11d693a8ebfd2f39b0e93cb55191cf839f8d1f3828acac389f7da3"/>
+    </canvas>
+    <canvas name="4" width="89" height="112">
+      <vector name="origin" x="44" y="107"/>
+      <vector name="head" x="-14" y="-89"/>
+      <vector name="lt" x="-44" y="-107"/>
+      <vector name="rb" x="45" y="5"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6660ec98be1e30f7d87229f14e1d97da5dc0e38eb83b2a5923b1b27126e652c1"/>
+    </canvas>
+    <canvas name="5" width="93" height="121">
+      <vector name="origin" x="46" y="117"/>
+      <vector name="head" x="-14" y="-99"/>
+      <vector name="lt" x="-46" y="-117"/>
+      <vector name="rb" x="47" y="4"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fccd1fa592614aaeb65dc8d60c3830eb0f8806d648a7c90d1c6ba1221b786591"/>
+    </canvas>
+    <canvas name="6" width="97" height="127">
+      <vector name="origin" x="48" y="123"/>
+      <vector name="head" x="-14" y="-105"/>
+      <vector name="lt" x="-48" y="-123"/>
+      <vector name="rb" x="49" y="4"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dbf9d6d6d0012292303a4ee906ff13656eebeca0962900a9b040893fe04498d2"/>
+    </canvas>
+    <canvas name="7" width="103" height="136">
+      <vector name="origin" x="51" y="126"/>
+      <vector name="head" x="-14" y="-108"/>
+      <vector name="lt" x="-51" y="-126"/>
+      <vector name="rb" x="52" y="10"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="199959138e821d5c48ceea019209e9c4a6ff1d26664a2d232a1b1a3b3fc6e7dd"/>
+    </canvas>
+    <canvas name="8" width="107" height="139">
+      <vector name="origin" x="53" y="128"/>
+      <vector name="head" x="-14" y="-110"/>
+      <vector name="lt" x="-53" y="-128"/>
+      <vector name="rb" x="54" y="11"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0a42efef17c74412aafea98f45af84f0925b2366c12a00236e5a7104362e01c0"/>
+    </canvas>
+    <canvas name="9" width="113" height="131">
+      <vector name="origin" x="56" y="129"/>
+      <vector name="head" x="-14" y="-111"/>
+      <vector name="lt" x="-56" y="-129"/>
+      <vector name="rb" x="57" y="2"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="44fd71a73d10e5243c97f83ab860abba5041a5f19f028465bffce5e60425ffa3"/>
+    </canvas>
+    <canvas name="10" width="125" height="145">
+      <vector name="origin" x="62" y="130"/>
+      <vector name="head" x="-14" y="-112"/>
+      <vector name="lt" x="-62" y="-130"/>
+      <vector name="rb" x="63" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="572e5bf19da1da84a234de1f37ef248c2ab18282fcec44fdac424ae41351b650"/>
+    </canvas>
+    <canvas name="11" width="163" height="296">
+      <vector name="origin" x="81" y="275"/>
+      <vector name="head" x="-14" y="-112"/>
+      <vector name="lt" x="-81" y="-275"/>
+      <vector name="rb" x="82" y="21"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0aabbb31efa735bbea969b270707de1e16ffd236caeaa5504f307501ad5851ee"/>
+    </canvas>
+    <canvas name="12" width="141" height="303">
+      <vector name="origin" x="70" y="285"/>
+      <vector name="head" x="-14" y="-112"/>
+      <vector name="lt" x="-70" y="-285"/>
+      <vector name="rb" x="71" y="18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ac6867882bc45392160dfbf0f7373d7fa05167fd83b30224c1192dafa5768a47"/>
+    </canvas>
+    <canvas name="13" width="137" height="310">
+      <vector name="origin" x="68" y="285"/>
+      <vector name="head" x="-14" y="-111"/>
+      <vector name="lt" x="-68" y="-285"/>
+      <vector name="rb" x="69" y="25"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="51f0e6836ea2c23e921830e08815242970dc68558f546777b89377c4986e3479"/>
+    </canvas>
+    <canvas name="14" width="138" height="300">
+      <vector name="origin" x="68" y="271"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-68" y="-271"/>
+      <vector name="rb" x="70" y="29"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="96b81a0956ee76f18f51e5b47245accd88488023f985ce1456b8574ca4fc4e25"/>
+    </canvas>
+    <canvas name="15" width="141" height="275">
+      <vector name="origin" x="68" y="247"/>
+      <vector name="head" x="-14" y="-106"/>
+      <vector name="lt" x="-68" y="-247"/>
+      <vector name="rb" x="73" y="28"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0bbe17c920ad4e0a2674ba351766c1d9bc2c585e9ae9d2ff741b92152ea07d3b"/>
+    </canvas>
+    <canvas name="16" width="144" height="275">
+      <vector name="origin" x="67" y="246"/>
+      <vector name="head" x="-14" y="-102"/>
+      <vector name="lt" x="-67" y="-246"/>
+      <vector name="rb" x="77" y="29"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f1423c5e82e2cf978fab70edbb6b6c588e77897e84b1ff92c9349533b2cbe6b2"/>
+    </canvas>
+    <canvas name="17" width="133" height="210">
+      <vector name="origin" x="66" y="199"/>
+      <vector name="head" x="-14" y="-97"/>
+      <vector name="lt" x="-66" y="-199"/>
+      <vector name="rb" x="67" y="11"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c77e9b7d4569c337b0e97e4f2cc9ecfc20fee35ca57642a053767cc937a9bbf5"/>
+    </canvas>
+    <canvas name="18" width="142" height="82">
+      <vector name="origin" x="64" y="109"/>
+      <vector name="head" x="-14" y="-91"/>
+      <vector name="lt" x="-64" y="-109"/>
+      <vector name="rb" x="78" y="-27"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a417855e33339c2aa8fc814b62b8ea73c54ffa7b896a8ae460d197ff738584d6"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="95" height="103">
+      <vector name="origin" x="42" y="111"/>
+      <vector name="head" x="-6" y="-80"/>
+      <vector name="lt" x="-42" y="-111"/>
+      <vector name="rb" x="53" y="-8"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="f633fa95ea6dc080fcc3c09dd7e31010be8668c4cabf9eb8edea05ec4364f042"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="95" height="103">
+      <vector name="origin" x="33" y="111"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="82" height="88">
+      <vector name="origin" x="20" y="97"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="01a7efa78e48640eb65ad86cf962fb11c148932a993dac31d9a0788eeeedc949"/>
+    </canvas>
+    <canvas name="2" width="68" height="81">
+      <vector name="origin" x="2" y="90"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f2dd2f5010ac6db981cd081698c5b43b9950c319968e8adf471488530f9b9a54"/>
+    </canvas>
+    <canvas name="3" width="68" height="81">
+      <vector name="origin" x="-1" y="90"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ff2ed666fbcd9a34e9f33034de97744375c2cb802ad3bc09c44319c2d63d7eaf"/>
+    </canvas>
+    <canvas name="4" width="134" height="99">
+      <vector name="origin" x="33" y="94"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bedcfb1f30c1fd803e5768f3df35cef41297af372fecce35b6da9c887c542f61"/>
+    </canvas>
+    <canvas name="5" width="131" height="139">
+      <vector name="origin" x="28" y="128"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="06acf086cf0327f79587e9fcbd246a477dd779ec21ad53b6161749ed69e34b9c"/>
+    </canvas>
+    <canvas name="6" width="119" height="136">
+      <vector name="origin" x="21" y="132"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ec3b27d89f38a6f8bdd2251582b9d34ea714c3507be23d16985925b023ac482c"/>
+    </canvas>
+    <canvas name="7" width="98" height="129">
+      <vector name="origin" x="12" y="132"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="725c80e5a4925680a8eb7dd59d06f58c6c92e4ab2d56b53169cb369b70085d38"/>
+    </canvas>
+    <canvas name="8" width="96" height="126">
+      <vector name="origin" x="10" y="133"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="530fdbec6c693b86116fb2530e335e5f343d418e6b7686a15646b394dccba9f6"/>
+    </canvas>
+    <canvas name="9" width="62" height="92">
+      <vector name="origin" x="-4" y="93"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f3fb963fc078ae070f34f999fffb790a7ae1662eb00e77e684c3351c7f135d1d"/>
+    </canvas>
+    <canvas name="10" width="52" height="87">
+      <vector name="origin" x="-8" y="90"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d94ef025c321517d6707c566d8dfad88fb019cef9fd7f2d67a1af75353bf409a"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="This is only the appetizer."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="info">
+    <int name="level" value="120"/>
+    <int name="maxHP" value="1500000"/>
+    <int name="maxMP" value="999999999"/>
+    <int name="PADamage" value="300"/>
+    <int name="MADamage" value="300"/>
+    <int name="acc" value="300"/>
+    <int name="eva" value="30"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="300000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="magic" value="1"/>
+        <int name="attackCount" value="3"/>
+        <int name="disease" value="123"/>
+        <int name="level" value="9"/>
+      </imgdir>
+    </imgdir>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="speed" value="30"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="I will make you regret this!"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="114"/>
+        <int name="action" value="1"/>
+        <int name="level" value="18"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="110"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="112"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="140"/>
+        <int name="action" value="1"/>
+        <int name="level" value="12"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="revive">
+      <int name="0" value="8787137"/>
+      <int name="1" value="8787137"/>
+      <int name="2" value="8787137"/>
+      <int name="3" value="8787137"/>
+      <int name="4" value="8787137"/>
+      <int name="5" value="8787161"/>
+      <int name="6" value="8787137"/>
+      <int name="7" value="8787137"/>
+      <int name="8" value="8787137"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787148.img.xml
+++ b/gms-server/wz/Mob.wz/8787148.img.xml
@@ -1,1 +1,257 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787148.img"><imgdir name="stand"><canvas name="0" width="199" height="267"><vector name="origin" x="114" y="267"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-267"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="92296f27eade5010ac1ed7107c3e2d575e943557945a74dd49bda682e7e49870"/></canvas><canvas name="1" width="199" height="266"><vector name="origin" x="114" y="266"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-266"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="951af802f91ab83b8700966d5670dae997380ae3a37e5fec3c9a736ccf5b19fb"/></canvas><canvas name="2" width="199" height="267"><vector name="origin" x="114" y="267"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-267"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="ddda466ade9b271a4d8118e1d9b4bf6b12b2dc12b62be40f63062e7bfacd68b1"/></canvas><canvas name="3" width="199" height="268"><vector name="origin" x="114" y="268"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-268"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="8017382a12f25e58ae3a135a0fd3e1d1d4680b2949833e49580e7abfa4e3f003"/></canvas><canvas name="4" width="199" height="269"><vector name="origin" x="114" y="269"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-269"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="338ab1efafc6ac019bf0e5d6038f7866a86fd6746d006a714c144e4f0ba81eb1"/></canvas><canvas name="5" width="199" height="268"><vector name="origin" x="114" y="268"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-268"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="71dcae9511ad31579b130e6661388f3b27fb992b72a0891e47335dc00c503bf1"/></canvas><canvas name="6" width="199" height="267"><vector name="origin" x="114" y="267"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-267"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="50a18de487e93aa7b9f37ed3df42e705bcceb54b8b89a9783caba5466f8076d6"/></canvas><canvas name="7" width="199" height="266"><vector name="origin" x="114" y="266"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-266"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="9343dc529c14bdb26e874c6f96db88f0af473db306d0dc1fe31162820be99458"/></canvas><canvas name="8" width="199" height="267"><vector name="origin" x="114" y="267"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-267"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="e8ff0bd7ce308076f8915b9b21a6268fce3ed8c6d32e2c7101f61566b0b2fdfe"/></canvas><canvas name="9" width="199" height="268"><vector name="origin" x="114" y="268"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-268"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="2a9bb2657d008b88821ecb8c3206965ed52abc5cc68e4277ed5ae5bdb066a76c"/></canvas><canvas name="10" width="199" height="269"><vector name="origin" x="114" y="269"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-269"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="52dcf42b9f460299482ebd9d559803e62bc46407ac5d8e42153e909cc6a9a040"/></canvas><canvas name="11" width="199" height="268"><vector name="origin" x="114" y="268"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-268"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="37f49bafdbf6b289508efdb48c3d748ca2e962df30c9634eaf689604c262f51b"/></canvas></imgdir><imgdir name="move"><canvas name="0" width="199" height="268"><vector name="origin" x="114" y="268"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-268"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="11ed2431d7f0fb054f792b11cabe2e1c2ffd8ec10dde4bd5ae9949d0290ce376"/></canvas><canvas name="1" width="199" height="269"><vector name="origin" x="114" y="269"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-269"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="bf39cc5ab85cba52060e6b30eb0a563862a595ddc13a02706eb77206c0f165c1"/></canvas><canvas name="2" width="199" height="269"><vector name="origin" x="114" y="270"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-270"/><vector name="rb" x="85" y="-1"/><int name="delay" value="150"/><string name="_hash" value="b17df7f444630664483e9d9ca190a43ca5618fed6c7c327280f5f3c4aa39ed38"/></canvas><canvas name="3" width="199" height="268"><vector name="origin" x="114" y="271"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-271"/><vector name="rb" x="85" y="-3"/><int name="delay" value="150"/><string name="_hash" value="98cc69eb55f06519743940c509d3b05988b3b703d107ac2cd15f8ea292177ede"/></canvas><canvas name="4" width="199" height="267"><vector name="origin" x="114" y="270"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-270"/><vector name="rb" x="85" y="-3"/><int name="delay" value="150"/><string name="_hash" value="6a2edc96c6bea18774a527d3e64ef8684771cfc1ecf494946a87777354d5b8b7"/></canvas><canvas name="5" width="199" height="268"><vector name="origin" x="114" y="269"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-269"/><vector name="rb" x="85" y="-1"/><int name="delay" value="150"/><string name="_hash" value="4eaed9b5cba4eb409c932e2be65577d2f4ed1c27c8b224de33de5b268dca35a7"/></canvas><canvas name="6" width="199" height="268"><vector name="origin" x="114" y="268"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-268"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="710a897f6bb4fe87768b55978bad6c9b6b719a24d4dd653d6f6cb92341b3805f"/></canvas><canvas name="7" width="199" height="269"><vector name="origin" x="114" y="269"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-269"/><vector name="rb" x="85" y="0"/><int name="delay" value="150"/><string name="_hash" value="9b7c70d45fdc45e9aaff47ecb867a10bbeaa8c39112606f5c964a90fbce7ce75"/></canvas><canvas name="8" width="199" height="269"><vector name="origin" x="114" y="270"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-270"/><vector name="rb" x="85" y="-1"/><int name="delay" value="150"/><string name="_hash" value="8f58f453749ffa5d582a6c4b579d8c78b2dc74c541518624f329e0ce9a17bfb4"/></canvas><canvas name="9" width="199" height="268"><vector name="origin" x="114" y="271"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-271"/><vector name="rb" x="85" y="-3"/><int name="delay" value="150"/><string name="_hash" value="4ef91d5c356b1be2dfc5c284712d8f64dc1fa5232e064771de97c5286c37ac2e"/></canvas><canvas name="10" width="199" height="267"><vector name="origin" x="114" y="270"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-270"/><vector name="rb" x="85" y="-3"/><int name="delay" value="150"/><string name="_hash" value="1308c651011217d15b0667ad8279e816f812b7417de4955f03ae028df6c96a32"/></canvas><canvas name="11" width="199" height="268"><vector name="origin" x="114" y="269"/><vector name="head" x="-29" y="-244"/><vector name="lt" x="-114" y="-269"/><vector name="rb" x="85" y="-1"/><int name="delay" value="150"/><string name="_hash" value="91fd53542a970c6ad3cf154b1106f84d1512da2cdf0e942a2037e9ece051c53f"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="235" height="329"><vector name="origin" x="125" y="329"/><vector name="head" x="-26" y="-256"/><vector name="lt" x="-125" y="-329"/><vector name="rb" x="110" y="0"/><int name="delay" value="600"/><string name="_hash" value="59cd2f0069263309fe15798f415865c2d35e91d8d502834d0f39c6f96500ba6b"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="199" height="278"><vector name="origin" x="114" y="278"/><vector name="head" x="-28" y="-256"/><int name="delay" value="120"/></canvas><canvas name="1" width="199" height="298"><vector name="origin" x="104" y="298"/><vector name="head" x="-28" y="-256"/><int name="delay" value="120"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="別急著走呀~客人 主菜準備上桌!"/></imgdir></imgdir><imgdir name="info"><int name="level" value="120"/><int name="maxHP" value="2000000"/><int name="maxMP" value="999999999"/><int name="PADamage" value="350"/><int name="MADamage" value="400"/><int name="acc" value="300"/><string name="elemAttr" value="P2H2F2I2S2L2D2"/><int name="eva" value="30"/><int name="pushed" value="100000"/><float name="fs" value="10.0"/><int name="exp" value="300000"/><int name="summonType" value="1"/><int name="category" value="8"/><int name="firstAttack" value="1"/><string name="mobType" value="1N"/><int name="boss" value="1"/><int name="ignoreMoveImpact" value="1"/><int name="bodyAttack" value="1"/><int name="speed" value="30"/><int name="PDDamage" value="3000"/><int name="MDDamage" value="3000"/><imgdir name="speak"><int name="chatBalloon" value="0"/><imgdir name="0"><string name="0" value="讓你後悔！"/></imgdir></imgdir><imgdir name="revive"><int name="0" value="8787149"/></imgdir></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787148.img">
+  <imgdir name="stand">
+    <canvas name="0" width="199" height="267">
+      <vector name="origin" x="114" y="267"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-267"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="92296f27eade5010ac1ed7107c3e2d575e943557945a74dd49bda682e7e49870"/>
+    </canvas>
+    <canvas name="1" width="199" height="266">
+      <vector name="origin" x="114" y="266"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-266"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="951af802f91ab83b8700966d5670dae997380ae3a37e5fec3c9a736ccf5b19fb"/>
+    </canvas>
+    <canvas name="2" width="199" height="267">
+      <vector name="origin" x="114" y="267"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-267"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="ddda466ade9b271a4d8118e1d9b4bf6b12b2dc12b62be40f63062e7bfacd68b1"/>
+    </canvas>
+    <canvas name="3" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="8017382a12f25e58ae3a135a0fd3e1d1d4680b2949833e49580e7abfa4e3f003"/>
+    </canvas>
+    <canvas name="4" width="199" height="269">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="338ab1efafc6ac019bf0e5d6038f7866a86fd6746d006a714c144e4f0ba81eb1"/>
+    </canvas>
+    <canvas name="5" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="71dcae9511ad31579b130e6661388f3b27fb992b72a0891e47335dc00c503bf1"/>
+    </canvas>
+    <canvas name="6" width="199" height="267">
+      <vector name="origin" x="114" y="267"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-267"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="50a18de487e93aa7b9f37ed3df42e705bcceb54b8b89a9783caba5466f8076d6"/>
+    </canvas>
+    <canvas name="7" width="199" height="266">
+      <vector name="origin" x="114" y="266"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-266"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="9343dc529c14bdb26e874c6f96db88f0af473db306d0dc1fe31162820be99458"/>
+    </canvas>
+    <canvas name="8" width="199" height="267">
+      <vector name="origin" x="114" y="267"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-267"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="e8ff0bd7ce308076f8915b9b21a6268fce3ed8c6d32e2c7101f61566b0b2fdfe"/>
+    </canvas>
+    <canvas name="9" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="2a9bb2657d008b88821ecb8c3206965ed52abc5cc68e4277ed5ae5bdb066a76c"/>
+    </canvas>
+    <canvas name="10" width="199" height="269">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="52dcf42b9f460299482ebd9d559803e62bc46407ac5d8e42153e909cc6a9a040"/>
+    </canvas>
+    <canvas name="11" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="37f49bafdbf6b289508efdb48c3d748ca2e962df30c9634eaf689604c262f51b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="11ed2431d7f0fb054f792b11cabe2e1c2ffd8ec10dde4bd5ae9949d0290ce376"/>
+    </canvas>
+    <canvas name="1" width="199" height="269">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="bf39cc5ab85cba52060e6b30eb0a563862a595ddc13a02706eb77206c0f165c1"/>
+    </canvas>
+    <canvas name="2" width="199" height="269">
+      <vector name="origin" x="114" y="270"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-270"/>
+      <vector name="rb" x="85" y="-1"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="b17df7f444630664483e9d9ca190a43ca5618fed6c7c327280f5f3c4aa39ed38"/>
+    </canvas>
+    <canvas name="3" width="199" height="268">
+      <vector name="origin" x="114" y="271"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-271"/>
+      <vector name="rb" x="85" y="-3"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="98cc69eb55f06519743940c509d3b05988b3b703d107ac2cd15f8ea292177ede"/>
+    </canvas>
+    <canvas name="4" width="199" height="267">
+      <vector name="origin" x="114" y="270"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-270"/>
+      <vector name="rb" x="85" y="-3"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="6a2edc96c6bea18774a527d3e64ef8684771cfc1ecf494946a87777354d5b8b7"/>
+    </canvas>
+    <canvas name="5" width="199" height="268">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="-1"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="4eaed9b5cba4eb409c932e2be65577d2f4ed1c27c8b224de33de5b268dca35a7"/>
+    </canvas>
+    <canvas name="6" width="199" height="268">
+      <vector name="origin" x="114" y="268"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-268"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="710a897f6bb4fe87768b55978bad6c9b6b719a24d4dd653d6f6cb92341b3805f"/>
+    </canvas>
+    <canvas name="7" width="199" height="269">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="9b7c70d45fdc45e9aaff47ecb867a10bbeaa8c39112606f5c964a90fbce7ce75"/>
+    </canvas>
+    <canvas name="8" width="199" height="269">
+      <vector name="origin" x="114" y="270"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-270"/>
+      <vector name="rb" x="85" y="-1"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="8f58f453749ffa5d582a6c4b579d8c78b2dc74c541518624f329e0ce9a17bfb4"/>
+    </canvas>
+    <canvas name="9" width="199" height="268">
+      <vector name="origin" x="114" y="271"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-271"/>
+      <vector name="rb" x="85" y="-3"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="4ef91d5c356b1be2dfc5c284712d8f64dc1fa5232e064771de97c5286c37ac2e"/>
+    </canvas>
+    <canvas name="10" width="199" height="267">
+      <vector name="origin" x="114" y="270"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-270"/>
+      <vector name="rb" x="85" y="-3"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="1308c651011217d15b0667ad8279e816f812b7417de4955f03ae028df6c96a32"/>
+    </canvas>
+    <canvas name="11" width="199" height="268">
+      <vector name="origin" x="114" y="269"/>
+      <vector name="head" x="-29" y="-244"/>
+      <vector name="lt" x="-114" y="-269"/>
+      <vector name="rb" x="85" y="-1"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="91fd53542a970c6ad3cf154b1106f84d1512da2cdf0e942a2037e9ece051c53f"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="235" height="329">
+      <vector name="origin" x="125" y="329"/>
+      <vector name="head" x="-26" y="-256"/>
+      <vector name="lt" x="-125" y="-329"/>
+      <vector name="rb" x="110" y="0"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="59cd2f0069263309fe15798f415865c2d35e91d8d502834d0f39c6f96500ba6b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="199" height="278">
+      <vector name="origin" x="114" y="278"/>
+      <vector name="head" x="-28" y="-256"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="199" height="298">
+      <vector name="origin" x="104" y="298"/>
+      <vector name="head" x="-28" y="-256"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Do not leave so soon, guest. The main course is ready!"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="info">
+    <int name="level" value="120"/>
+    <int name="maxHP" value="2000000"/>
+    <int name="maxMP" value="999999999"/>
+    <int name="PADamage" value="350"/>
+    <int name="MADamage" value="400"/>
+    <int name="acc" value="300"/>
+    <string name="elemAttr" value="P2H2F2I2S2L2D2"/>
+    <int name="eva" value="30"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="300000"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="speed" value="30"/>
+    <int name="PDDamage" value="3000"/>
+    <int name="MDDamage" value="3000"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="I will make you regret this!"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="revive">
+      <int name="0" value="8787149"/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787154.img.xml
+++ b/gms-server/wz/Mob.wz/8787154.img.xml
@@ -1,1 +1,371 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787154.img"><imgdir name="info"><imgdir name="attack"><imgdir name="0"><int name="action" value="1"/><int name="attackRatio" value="100"/><int name="type" value="2"/></imgdir></imgdir><int name="level" value="130"/><int name="maxHP" value="2000000"/><int name="maxMP" value="50000"/><int name="speed" value="50"/><int name="PADamage" value="380"/><int name="PDDamage" value="235"/><int name="MADamage" value="400"/><int name="MDDamage" value="245"/><int name="acc" value="930"/><int name="eva" value="30"/><int name="pushed" value="5000"/><float name="fs" value="10.0"/><int name="exp" value="87"/><int name="summonType" value="1"/><int name="category" value="1"/><string name="elemAttr" value="S3"/><string name="mobType" value="1N"/><int name="firstAttack" value="1"/><int name="bodyAttack" value="1"/><imgdir name="speak"><int name="chatBalloon" value="0"/><imgdir name="0"><string name="0" value="讓你後悔！"/></imgdir></imgdir><int name="boss" value="1"/></imgdir><imgdir name="stand"><canvas name="0" width="111" height="108"><vector name="origin" x="46" y="108"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="460e24c469d66f2b704168f5b80e494e3911b5eada9db889fd4736af5b113577"/></canvas><canvas name="1" width="111" height="107"><vector name="origin" x="46" y="107"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="46f6bef0782fe0783f268fd6f1c636bfcf16063f91bec9f1c75ef9f9dc465ae4"/></canvas><canvas name="2" width="111" height="108"><vector name="origin" x="46" y="108"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/></canvas><canvas name="3" width="110" height="109"><vector name="origin" x="46" y="109"/><int name="z" value="0"/><int name="delay" value="210"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="d64775c23f9a259b9440779297dea5230a425c23a2c4356667aec54a7749f729"/></canvas></imgdir><imgdir name="move"><canvas name="0" width="107" height="109"><vector name="origin" x="42" y="109"/><int name="z" value="0"/><int name="delay" value="180"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="43e324252edc699c98a69569ad4a222213a0986231a422e9a33d83899e847549"/></canvas><canvas name="1" width="123" height="107"><vector name="origin" x="54" y="107"/><int name="z" value="0"/><int name="delay" value="180"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="d8b56a2826c6ac87374353bfad4201c23d25d2f3a14c6aefef51e51d196a7a22"/></canvas><canvas name="2" width="115" height="108"><vector name="origin" x="50" y="108"/><int name="z" value="0"/><int name="delay" value="180"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="178f33af5a5eef4b78cfd2aa092308d0a59e22f527ed341a0f251cdb827d537d"/></canvas><canvas name="3" width="104" height="109"><vector name="origin" x="42" y="109"/><int name="z" value="0"/><int name="delay" value="180"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="6997b376e2060ef93cd1969a2754005831246950047c9d9697a149cbb480dd43"/></canvas><canvas name="4" width="95" height="107"><vector name="origin" x="34" y="107"/><int name="z" value="0"/><int name="delay" value="180"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="70b4fa155884506fde27c20f562ee4021ce7cf177907f00ca2a129bd54c37a4c"/></canvas><canvas name="5" width="98" height="108"><vector name="origin" x="36" y="108"/><int name="z" value="0"/><int name="delay" value="180"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="cdf8838f5f687d0770f7db763a9dc0ea200268bcefdcc4fbff5c692aaeacca81"/></canvas></imgdir><imgdir name="attack1"><imgdir name="info"><int name="attackAfter" value="840"/><imgdir name="range"><int name="r" value="300"/><vector name="sp" x="-116" y="-65"/></imgdir><imgdir name="hit"><canvas name="0" width="122" height="135"><vector name="origin" x="62" y="68"/><int name="z" value="0"/><string name="_hash" value="06fdb5903a7bc5d2385008ad1b4e2959b23236314faaf5b29aabff9892fde576"/></canvas><canvas name="1" width="129" height="123"><vector name="origin" x="66" y="70"/><int name="z" value="0"/><string name="_hash" value="725f75613d738d6551df9d91e6f66fd76b819418c5bf246971f69938d79075e9"/></canvas><canvas name="2" width="148" height="135"><vector name="origin" x="81" y="79"/><int name="z" value="0"/><string name="_hash" value="d11d4965c52d76ba6014335a2ddd71105f7a859c98ac73df8c225a33b7bbd42d"/></canvas><canvas name="3" width="148" height="123"><vector name="origin" x="78" y="69"/><int name="z" value="0"/><string name="_hash" value="4b7d0009b3dfd94c6cdb081f0a9873660a882326e8b9b65bb0cc1d04e12d667d"/></canvas><canvas name="4" width="157" height="120"><vector name="origin" x="83" y="72"/><int name="z" value="0"/><string name="_hash" value="bf0a508067ee5d9c7dfcf6950a35e1a62a7092ecbda3b34af617db560767329b"/></canvas><canvas name="5" width="145" height="120"><vector name="origin" x="70" y="72"/><int name="z" value="0"/><string name="_hash" value="21aee41be529b867e4983f6d43ac1301d3e0ab65bbd457bc29f4d417c1213d10"/></canvas></imgdir><imgdir name="ball"><canvas name="0" width="123" height="77"><vector name="origin" x="62" y="32"/><int name="z" value="0"/><string name="_hash" value="ecb450a00dc08bd12e49a64ce4d9c93c541642a4d46bb37e49271a3830b6deef"/></canvas><canvas name="1" width="104" height="101"><vector name="origin" x="54" y="53"/><int name="z" value="0"/><string name="_hash" value="f57dc456b8fb1f8e6df8b8f9264fc3891fb0822078b866e9a328595f8431e580"/></canvas><canvas name="2" width="122" height="122"><vector name="origin" x="61" y="58"/><int name="z" value="0"/><string name="_hash" value="12155a1ba5549812be2471592c013d1b9a8debc03d4c772588f341ae3f1cece8"/></canvas></imgdir><int name="bulletSpeed" value="250"/><int name="conMP" value="3"/><int name="type" value="2"/></imgdir><canvas name="0" width="111" height="108"><vector name="origin" x="46" y="108"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="1894c2911a5a2b15061c1199cd20fac8c42bda7c49476d586585377bc0fd52fe"/></canvas><canvas name="1" width="149" height="176"><vector name="origin" x="48" y="166"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="90657cf3500703d44984fefa66fa5b400b671be3c0b9a7205a89a26a61c2eac2"/></canvas><canvas name="2" width="153" height="178"><vector name="origin" x="45" y="167"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="d5458cfe377ceaad956e6898ce2ba8e25ffe484a5d20daee77c1d93538d2f62a"/></canvas><canvas name="3" width="155" height="181"><vector name="origin" x="45" y="168"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="fcc7f000de4d974152a3d7d7bb7ae2979d1ef11fddb656faf251482790d0ddd5"/></canvas><canvas name="4" width="154" height="181"><vector name="origin" x="44" y="168"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="d609aebfa8cadf68c2adb06e72147aa4de4c0948e1765818b76c4415896d4ac8"/></canvas><canvas name="5" width="154" height="180"><vector name="origin" x="43" y="167"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="da9b25c5d6ea83ffc695e40f62ec821d72fbbce9d0996bbaba5b1f0bf3b81c5d"/></canvas><canvas name="6" width="155" height="180"><vector name="origin" x="43" y="167"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="fc1ca39bfa1ce2253d6fa53e734e4693260dced4e6937bac9945be66ca04d6e1"/></canvas><canvas name="7" width="184" height="130"><vector name="origin" x="125" y="117"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="a14d3276fb0a43f5aa43db1f4da080b804764cdcd866f5b9f7c3195f96daf604"/></canvas><canvas name="8" width="185" height="123"><vector name="origin" x="121" y="110"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="56ebf347f1f5eb4e6a541d063240f6d9056da7ef582fb78c1a7e22649ceb6230"/></canvas><canvas name="9" width="167" height="125"><vector name="origin" x="122" y="110"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="9802722a4b8d615a1ad854d2f31541ffd7681aed6a63a55c91b96f4c372f8210"/></canvas><canvas name="10" width="170" height="119"><vector name="origin" x="120" y="108"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="61999ccf4e7fefb9f649567d5a1d4d32eddd8cccee6a22745e8bb356ba9f3399"/></canvas><canvas name="11" width="172" height="117"><vector name="origin" x="119" y="107"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><string name="_hash" value="8f8985fd382ba62dfaba567bf0cad2d9577dcf4627c7fb4ec369cdfd21d8c94b"/></canvas><canvas name="12" width="111" height="108"><vector name="origin" x="46" y="108"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="108" height="119"><vector name="origin" x="44" y="119"/><int name="z" value="0"/><vector name="head" x="-1" y="-108"/><vector name="lt" x="-47" y="-109"/><vector name="rb" x="65" y="-2"/><int name="delay" value="150"/><string name="_hash" value="e72df47a892297cd0570ba2702f6c53cd5bc9574c822aa3cdb08291a47d638ec"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="111" height="108"><vector name="origin" x="46" y="108"/><int name="z" value="0"/><string name="_hash" value="c94d2aede301c6bf27da2695bca5729fabc8bffb9b68263aa6460ef6a2af7e2a"/></canvas><canvas name="1" width="117" height="119"><vector name="origin" x="38" y="119"/><int name="z" value="0"/><string name="_hash" value="f5b68d1488d52ad971520642d2a9c638b724fd31cd65e474324a61b82c38a5c5"/></canvas><canvas name="2" width="122" height="113"><vector name="origin" x="44" y="113"/><int name="z" value="0"/><string name="_hash" value="4c762a282b3059dda8936aa6eed7967bd984835f15ffae6c233047b5336deeb5"/></canvas><canvas name="3" width="123" height="108"><vector name="origin" x="47" y="108"/><int name="z" value="0"/><string name="_hash" value="6a0e80d64033fb0251d722add81421d61d7f84e5d13454579307fa20f3edf3fa"/></canvas><canvas name="4" width="97" height="103"><vector name="origin" x="19" y="103"/><int name="z" value="0"/><string name="_hash" value="fead3b15af1c6b152bca208cf6bfab5bfc5ac4d5fa3af21a7c5577122b8dab18"/></canvas><canvas name="5" width="97" height="103"><vector name="origin" x="18" y="103"/><int name="z" value="0"/></canvas><canvas name="6" width="142" height="115"><vector name="origin" x="26" y="105"/><int name="z" value="0"/><string name="_hash" value="365519ff842c6fe161872ab79b986a8af09b2a608f91cc9159ad9a4190600ec9"/></canvas><canvas name="7" width="158" height="117"><vector name="origin" x="33" y="107"/><int name="z" value="0"/><string name="_hash" value="7413e5070321eea2a61df710da3bd753255f9f62518d9d52af57dd8757069c61"/></canvas><canvas name="8" width="164" height="120"><vector name="origin" x="36" y="110"/><int name="z" value="0"/><string name="_hash" value="77df9b89e3e393e5917c33d3d7b107fee85900c9c70160c8817959bb240b8d17"/></canvas><canvas name="9" width="167" height="124"><vector name="origin" x="37" y="114"/><int name="z" value="0"/><string name="_hash" value="06a6e07fe28b65ed32a6ab4695e117c36bc269463780883f5c1872cd86dc0e4d"/></canvas><canvas name="10" width="169" height="129"><vector name="origin" x="38" y="119"/><int name="z" value="0"/><string name="_hash" value="24dae18ec9e399d32a86b3e9e465f7b5bce128e9cbbdd68cb7e02ba7bb7ef0b2"/></canvas><canvas name="11" width="93" height="99"><vector name="origin" x="21" y="122"/><int name="z" value="0"/><string name="_hash" value="28bdb79325ad8a271eb5232615acd1b1cb5affb8cefa8c35dd5555629db2d297"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="招....招待不周"/></imgdir></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787154.img">
+  <imgdir name="info">
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="2"/>
+      </imgdir>
+    </imgdir>
+    <int name="level" value="130"/>
+    <int name="maxHP" value="2000000"/>
+    <int name="maxMP" value="50000"/>
+    <int name="speed" value="50"/>
+    <int name="PADamage" value="380"/>
+    <int name="PDDamage" value="235"/>
+    <int name="MADamage" value="400"/>
+    <int name="MDDamage" value="245"/>
+    <int name="acc" value="930"/>
+    <int name="eva" value="30"/>
+    <int name="pushed" value="5000"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="87"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="1"/>
+    <string name="elemAttr" value="S3"/>
+    <string name="mobType" value="1N"/>
+    <int name="firstAttack" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="I will make you regret this!"/>
+      </imgdir>
+    </imgdir>
+    <int name="boss" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="111" height="108">
+      <vector name="origin" x="46" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="460e24c469d66f2b704168f5b80e494e3911b5eada9db889fd4736af5b113577"/>
+    </canvas>
+    <canvas name="1" width="111" height="107">
+      <vector name="origin" x="46" y="107"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="46f6bef0782fe0783f268fd6f1c636bfcf16063f91bec9f1c75ef9f9dc465ae4"/>
+    </canvas>
+    <canvas name="2" width="111" height="108">
+      <vector name="origin" x="46" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+    </canvas>
+    <canvas name="3" width="110" height="109">
+      <vector name="origin" x="46" y="109"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="210"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="d64775c23f9a259b9440779297dea5230a425c23a2c4356667aec54a7749f729"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="107" height="109">
+      <vector name="origin" x="42" y="109"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="43e324252edc699c98a69569ad4a222213a0986231a422e9a33d83899e847549"/>
+    </canvas>
+    <canvas name="1" width="123" height="107">
+      <vector name="origin" x="54" y="107"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="d8b56a2826c6ac87374353bfad4201c23d25d2f3a14c6aefef51e51d196a7a22"/>
+    </canvas>
+    <canvas name="2" width="115" height="108">
+      <vector name="origin" x="50" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="178f33af5a5eef4b78cfd2aa092308d0a59e22f527ed341a0f251cdb827d537d"/>
+    </canvas>
+    <canvas name="3" width="104" height="109">
+      <vector name="origin" x="42" y="109"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="6997b376e2060ef93cd1969a2754005831246950047c9d9697a149cbb480dd43"/>
+    </canvas>
+    <canvas name="4" width="95" height="107">
+      <vector name="origin" x="34" y="107"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="70b4fa155884506fde27c20f562ee4021ce7cf177907f00ca2a129bd54c37a4c"/>
+    </canvas>
+    <canvas name="5" width="98" height="108">
+      <vector name="origin" x="36" y="108"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="180"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="cdf8838f5f687d0770f7db763a9dc0ea200268bcefdcc4fbff5c692aaeacca81"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <int name="attackAfter" value="840"/>
+      <imgdir name="range">
+        <int name="r" value="300"/>
+        <vector name="sp" x="-116" y="-65"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="122" height="135">
+          <vector name="origin" x="62" y="68"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="06fdb5903a7bc5d2385008ad1b4e2959b23236314faaf5b29aabff9892fde576"/>
+        </canvas>
+        <canvas name="1" width="129" height="123">
+          <vector name="origin" x="66" y="70"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="725f75613d738d6551df9d91e6f66fd76b819418c5bf246971f69938d79075e9"/>
+        </canvas>
+        <canvas name="2" width="148" height="135">
+          <vector name="origin" x="81" y="79"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="d11d4965c52d76ba6014335a2ddd71105f7a859c98ac73df8c225a33b7bbd42d"/>
+        </canvas>
+        <canvas name="3" width="148" height="123">
+          <vector name="origin" x="78" y="69"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="4b7d0009b3dfd94c6cdb081f0a9873660a882326e8b9b65bb0cc1d04e12d667d"/>
+        </canvas>
+        <canvas name="4" width="157" height="120">
+          <vector name="origin" x="83" y="72"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="bf0a508067ee5d9c7dfcf6950a35e1a62a7092ecbda3b34af617db560767329b"/>
+        </canvas>
+        <canvas name="5" width="145" height="120">
+          <vector name="origin" x="70" y="72"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="21aee41be529b867e4983f6d43ac1301d3e0ab65bbd457bc29f4d417c1213d10"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="ball">
+        <canvas name="0" width="123" height="77">
+          <vector name="origin" x="62" y="32"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="ecb450a00dc08bd12e49a64ce4d9c93c541642a4d46bb37e49271a3830b6deef"/>
+        </canvas>
+        <canvas name="1" width="104" height="101">
+          <vector name="origin" x="54" y="53"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f57dc456b8fb1f8e6df8b8f9264fc3891fb0822078b866e9a328595f8431e580"/>
+        </canvas>
+        <canvas name="2" width="122" height="122">
+          <vector name="origin" x="61" y="58"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="12155a1ba5549812be2471592c013d1b9a8debc03d4c772588f341ae3f1cece8"/>
+        </canvas>
+      </imgdir>
+      <int name="bulletSpeed" value="250"/>
+      <int name="conMP" value="3"/>
+      <int name="type" value="2"/>
+    </imgdir>
+    <canvas name="0" width="111" height="108">
+      <vector name="origin" x="46" y="108"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="1894c2911a5a2b15061c1199cd20fac8c42bda7c49476d586585377bc0fd52fe"/>
+    </canvas>
+    <canvas name="1" width="149" height="176">
+      <vector name="origin" x="48" y="166"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="90657cf3500703d44984fefa66fa5b400b671be3c0b9a7205a89a26a61c2eac2"/>
+    </canvas>
+    <canvas name="2" width="153" height="178">
+      <vector name="origin" x="45" y="167"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="d5458cfe377ceaad956e6898ce2ba8e25ffe484a5d20daee77c1d93538d2f62a"/>
+    </canvas>
+    <canvas name="3" width="155" height="181">
+      <vector name="origin" x="45" y="168"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="fcc7f000de4d974152a3d7d7bb7ae2979d1ef11fddb656faf251482790d0ddd5"/>
+    </canvas>
+    <canvas name="4" width="154" height="181">
+      <vector name="origin" x="44" y="168"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="d609aebfa8cadf68c2adb06e72147aa4de4c0948e1765818b76c4415896d4ac8"/>
+    </canvas>
+    <canvas name="5" width="154" height="180">
+      <vector name="origin" x="43" y="167"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="da9b25c5d6ea83ffc695e40f62ec821d72fbbce9d0996bbaba5b1f0bf3b81c5d"/>
+    </canvas>
+    <canvas name="6" width="155" height="180">
+      <vector name="origin" x="43" y="167"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="fc1ca39bfa1ce2253d6fa53e734e4693260dced4e6937bac9945be66ca04d6e1"/>
+    </canvas>
+    <canvas name="7" width="184" height="130">
+      <vector name="origin" x="125" y="117"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="a14d3276fb0a43f5aa43db1f4da080b804764cdcd866f5b9f7c3195f96daf604"/>
+    </canvas>
+    <canvas name="8" width="185" height="123">
+      <vector name="origin" x="121" y="110"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="56ebf347f1f5eb4e6a541d063240f6d9056da7ef582fb78c1a7e22649ceb6230"/>
+    </canvas>
+    <canvas name="9" width="167" height="125">
+      <vector name="origin" x="122" y="110"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="9802722a4b8d615a1ad854d2f31541ffd7681aed6a63a55c91b96f4c372f8210"/>
+    </canvas>
+    <canvas name="10" width="170" height="119">
+      <vector name="origin" x="120" y="108"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="61999ccf4e7fefb9f649567d5a1d4d32eddd8cccee6a22745e8bb356ba9f3399"/>
+    </canvas>
+    <canvas name="11" width="172" height="117">
+      <vector name="origin" x="119" y="107"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <string name="_hash" value="8f8985fd382ba62dfaba567bf0cad2d9577dcf4627c7fb4ec369cdfd21d8c94b"/>
+    </canvas>
+    <canvas name="12" width="111" height="108">
+      <vector name="origin" x="46" y="108"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="108" height="119">
+      <vector name="origin" x="44" y="119"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-1" y="-108"/>
+      <vector name="lt" x="-47" y="-109"/>
+      <vector name="rb" x="65" y="-2"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="e72df47a892297cd0570ba2702f6c53cd5bc9574c822aa3cdb08291a47d638ec"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="111" height="108">
+      <vector name="origin" x="46" y="108"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="c94d2aede301c6bf27da2695bca5729fabc8bffb9b68263aa6460ef6a2af7e2a"/>
+    </canvas>
+    <canvas name="1" width="117" height="119">
+      <vector name="origin" x="38" y="119"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="f5b68d1488d52ad971520642d2a9c638b724fd31cd65e474324a61b82c38a5c5"/>
+    </canvas>
+    <canvas name="2" width="122" height="113">
+      <vector name="origin" x="44" y="113"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="4c762a282b3059dda8936aa6eed7967bd984835f15ffae6c233047b5336deeb5"/>
+    </canvas>
+    <canvas name="3" width="123" height="108">
+      <vector name="origin" x="47" y="108"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="6a0e80d64033fb0251d722add81421d61d7f84e5d13454579307fa20f3edf3fa"/>
+    </canvas>
+    <canvas name="4" width="97" height="103">
+      <vector name="origin" x="19" y="103"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="fead3b15af1c6b152bca208cf6bfab5bfc5ac4d5fa3af21a7c5577122b8dab18"/>
+    </canvas>
+    <canvas name="5" width="97" height="103">
+      <vector name="origin" x="18" y="103"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="6" width="142" height="115">
+      <vector name="origin" x="26" y="105"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="365519ff842c6fe161872ab79b986a8af09b2a608f91cc9159ad9a4190600ec9"/>
+    </canvas>
+    <canvas name="7" width="158" height="117">
+      <vector name="origin" x="33" y="107"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="7413e5070321eea2a61df710da3bd753255f9f62518d9d52af57dd8757069c61"/>
+    </canvas>
+    <canvas name="8" width="164" height="120">
+      <vector name="origin" x="36" y="110"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="77df9b89e3e393e5917c33d3d7b107fee85900c9c70160c8817959bb240b8d17"/>
+    </canvas>
+    <canvas name="9" width="167" height="124">
+      <vector name="origin" x="37" y="114"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="06a6e07fe28b65ed32a6ab4695e117c36bc269463780883f5c1872cd86dc0e4d"/>
+    </canvas>
+    <canvas name="10" width="169" height="129">
+      <vector name="origin" x="38" y="119"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="24dae18ec9e399d32a86b3e9e465f7b5bce128e9cbbdd68cb7e02ba7bb7ef0b2"/>
+    </canvas>
+    <canvas name="11" width="93" height="99">
+      <vector name="origin" x="21" y="122"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="28bdb79325ad8a271eb5232615acd1b1cb5affb8cefa8c35dd5555629db2d297"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="My... hospitality was lacking."/>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787155.img.xml
+++ b/gms-server/wz/Mob.wz/8787155.img.xml
@@ -1,1 +1,157 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787155.img"><imgdir name="stand"><canvas name="0" width="89" height="96"><vector name="origin" x="48" y="96"/><int name="z" value="0"/><vector name="lt" x="-42" y="-86"/><vector name="head" x="-9" y="-82"/><vector name="rb" x="36" y="0"/><int name="delay" value="180"/><string name="_hash" value="ae75c61c3692244fed0bd90a8074293d6c917896929b79b9214636871ef35332"/></canvas><canvas name="1" width="89" height="96"><vector name="origin" x="47" y="96"/><int name="z" value="0"/><vector name="lt" x="-41" y="-86"/><vector name="head" x="-7" y="-82"/><vector name="rb" x="37" y="0"/><int name="delay" value="180"/><string name="_hash" value="7d51fca313281b0eb78d637a6f5e0398c180ff2ffa1d6495955366f182744d9b"/></canvas><canvas name="2" width="89" height="96"><vector name="origin" x="46" y="96"/><int name="z" value="0"/><vector name="lt" x="-40" y="-86"/><vector name="head" x="-5" y="-82"/><vector name="rb" x="38" y="0"/><int name="delay" value="180"/><string name="_hash" value="c4fca248c488048566b3676a734515fbc5b161b28471738a1188f824cbd4bb54"/></canvas><canvas name="3" width="89" height="96"><vector name="origin" x="47" y="96"/><int name="z" value="0"/><vector name="lt" x="-41" y="-86"/><vector name="head" x="-7" y="-82"/><vector name="rb" x="37" y="0"/><int name="delay" value="180"/><string name="_hash" value="95f448d0a0707b9db556cc28de7b98c67467c411bc78e5c8e8bd29508e861e56"/></canvas><canvas name="4" width="89" height="96"><vector name="origin" x="48" y="96"/><int name="z" value="0"/><vector name="lt" x="-42" y="-86"/><vector name="head" x="-9" y="-82"/><vector name="rb" x="35" y="0"/><int name="delay" value="180"/><string name="_hash" value="5ae246f07e477bbeafc74bdbd54dd201d6f09d540e8e770ee949019c12af20da"/></canvas><canvas name="5" width="89" height="96"><vector name="origin" x="49" y="96"/><int name="z" value="0"/><vector name="lt" x="-44" y="-86"/><vector name="head" x="-11" y="-82"/><vector name="rb" x="35" y="0"/><int name="delay" value="180"/><string name="_hash" value="ec6c9e8cf1a1c2fba4cb1b737bad0c7561f194609da5a7384f6b2d82a0999334"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="93" height="108"><vector name="origin" x="44" y="109"/><int name="z" value="0"/><vector name="lt" x="-31" y="-90"/><vector name="head" x="3" y="-83"/><vector name="rb" x="50" y="0"/><int name="delay" value="600"/><string name="_hash" value="567a9c1e4fb9c90ca6bce795f5a0b73d73212e9a196a72721b2f428639a5712e"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="99" height="108"><vector name="origin" x="50" y="109"/><int name="z" value="0"/><vector name="head" x="2" y="-83"/><int name="delay" value="150"/><string name="_hash" value="96e921770abca91eb9833799506d946df53df1b245b87262156dafa03b494876"/></canvas><canvas name="1" width="98" height="102"><vector name="origin" x="52" y="105"/><int name="z" value="0"/><vector name="head" x="5" y="-83"/><int name="delay" value="150"/><string name="_hash" value="a772d5e1b2c9a5cb8c669b5c0ff24c1f2b986d19a9ed2c270d3957e315ea8626"/></canvas><canvas name="2" width="112" height="96"><vector name="origin" x="63" y="100"/><int name="z" value="0"/><vector name="head" x="7" y="-84"/><int name="delay" value="150"/><string name="_hash" value="d2b2765f0022db31d8a131f5cdd992755fe9d3bb698cd6fc6ee7238a710f6e61"/></canvas><canvas name="3" width="118" height="94"><vector name="origin" x="65" y="96"/><int name="z" value="0"/><vector name="head" x="10" y="-83"/><int name="delay" value="150"/><string name="_hash" value="212288307ec4f7ed9fdb5c69dcdb393633b41668bdc3e1e2cfca6eb36bdbea4c"/></canvas><canvas name="4" width="120" height="94"><vector name="origin" x="65" y="94"/><int name="z" value="0"/><vector name="head" x="12" y="-80"/><int name="delay" value="150"/><string name="_hash" value="ce6b690a8dcf503def4ffdffe8dcb00be621aee389c0e8f7326a06a570236f39"/></canvas><canvas name="5" width="121" height="94"><vector name="origin" x="65" y="91"/><int name="z" value="0"/><vector name="head" x="13" y="-77"/><int name="delay" value="300"/><int name="a0" value="255"/><int name="a1" value="0"/><string name="_hash" value="2de3aaa626b2818f047e5a4569a90c2ae2606cf134b0ff5657139f4e418c7a82"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="準備上菜囉!!!"/></imgdir></imgdir><imgdir name="info"><int name="bodyAttack" value="1"/><int name="level" value="105"/><int name="maxHP" value="100000"/><int name="maxMP" value="100"/><int name="speed" value="-20"/><int name="PADamage" value="130"/><int name="PDDamage" value="160"/><int name="MADamage" value="165"/><int name="MDDamage" value="160"/><int name="acc" value="140"/><int name="eva" value="10"/><int name="exp" value="800"/><int name="undead" value="0"/><int name="pushed" value="300"/><string name="elemAttr" value="I2F2L2H2"/><float name="fs" value="10.0"/><int name="summonType" value="0"/><int name="rareItemDropLevel" value="2"/><imgdir name="revive"><int name="0" value="8787132"/><int name="1" value="8787132"/><int name="2" value="8787132"/><int name="3" value="8787132"/><int name="4" value="8787132"/><int name="5" value="8787132"/><int name="6" value="8787132"/><int name="7" value="8787132"/><int name="8" value="8787156"/></imgdir><imgdir name="speak"><int name="chatBalloon" value="0"/><imgdir name="0"><string name="0" value="讓你後悔！"/></imgdir></imgdir></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787155.img">
+  <imgdir name="stand">
+    <canvas name="0" width="89" height="96">
+      <vector name="origin" x="48" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-42" y="-86"/>
+      <vector name="head" x="-9" y="-82"/>
+      <vector name="rb" x="36" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="ae75c61c3692244fed0bd90a8074293d6c917896929b79b9214636871ef35332"/>
+    </canvas>
+    <canvas name="1" width="89" height="96">
+      <vector name="origin" x="47" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-41" y="-86"/>
+      <vector name="head" x="-7" y="-82"/>
+      <vector name="rb" x="37" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="7d51fca313281b0eb78d637a6f5e0398c180ff2ffa1d6495955366f182744d9b"/>
+    </canvas>
+    <canvas name="2" width="89" height="96">
+      <vector name="origin" x="46" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-40" y="-86"/>
+      <vector name="head" x="-5" y="-82"/>
+      <vector name="rb" x="38" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="c4fca248c488048566b3676a734515fbc5b161b28471738a1188f824cbd4bb54"/>
+    </canvas>
+    <canvas name="3" width="89" height="96">
+      <vector name="origin" x="47" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-41" y="-86"/>
+      <vector name="head" x="-7" y="-82"/>
+      <vector name="rb" x="37" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="95f448d0a0707b9db556cc28de7b98c67467c411bc78e5c8e8bd29508e861e56"/>
+    </canvas>
+    <canvas name="4" width="89" height="96">
+      <vector name="origin" x="48" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-42" y="-86"/>
+      <vector name="head" x="-9" y="-82"/>
+      <vector name="rb" x="35" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="5ae246f07e477bbeafc74bdbd54dd201d6f09d540e8e770ee949019c12af20da"/>
+    </canvas>
+    <canvas name="5" width="89" height="96">
+      <vector name="origin" x="49" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-44" y="-86"/>
+      <vector name="head" x="-11" y="-82"/>
+      <vector name="rb" x="35" y="0"/>
+      <int name="delay" value="180"/>
+      <string name="_hash" value="ec6c9e8cf1a1c2fba4cb1b737bad0c7561f194609da5a7384f6b2d82a0999334"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="93" height="108">
+      <vector name="origin" x="44" y="109"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-31" y="-90"/>
+      <vector name="head" x="3" y="-83"/>
+      <vector name="rb" x="50" y="0"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="567a9c1e4fb9c90ca6bce795f5a0b73d73212e9a196a72721b2f428639a5712e"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="99" height="108">
+      <vector name="origin" x="50" y="109"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="2" y="-83"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="96e921770abca91eb9833799506d946df53df1b245b87262156dafa03b494876"/>
+    </canvas>
+    <canvas name="1" width="98" height="102">
+      <vector name="origin" x="52" y="105"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="5" y="-83"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="a772d5e1b2c9a5cb8c669b5c0ff24c1f2b986d19a9ed2c270d3957e315ea8626"/>
+    </canvas>
+    <canvas name="2" width="112" height="96">
+      <vector name="origin" x="63" y="100"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="7" y="-84"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="d2b2765f0022db31d8a131f5cdd992755fe9d3bb698cd6fc6ee7238a710f6e61"/>
+    </canvas>
+    <canvas name="3" width="118" height="94">
+      <vector name="origin" x="65" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="10" y="-83"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="212288307ec4f7ed9fdb5c69dcdb393633b41668bdc3e1e2cfca6eb36bdbea4c"/>
+    </canvas>
+    <canvas name="4" width="120" height="94">
+      <vector name="origin" x="65" y="94"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="12" y="-80"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="ce6b690a8dcf503def4ffdffe8dcb00be621aee389c0e8f7326a06a570236f39"/>
+    </canvas>
+    <canvas name="5" width="121" height="94">
+      <vector name="origin" x="65" y="91"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="13" y="-77"/>
+      <int name="delay" value="300"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+      <string name="_hash" value="2de3aaa626b2818f047e5a4569a90c2ae2606cf134b0ff5657139f4e418c7a82"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Dinner is ready!!!"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="105"/>
+    <int name="maxHP" value="100000"/>
+    <int name="maxMP" value="100"/>
+    <int name="speed" value="-20"/>
+    <int name="PADamage" value="130"/>
+    <int name="PDDamage" value="160"/>
+    <int name="MADamage" value="165"/>
+    <int name="MDDamage" value="160"/>
+    <int name="acc" value="140"/>
+    <int name="eva" value="10"/>
+    <int name="exp" value="800"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="300"/>
+    <string name="elemAttr" value="I2F2L2H2"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="revive">
+      <int name="0" value="8787132"/>
+      <int name="1" value="8787132"/>
+      <int name="2" value="8787132"/>
+      <int name="3" value="8787132"/>
+      <int name="4" value="8787132"/>
+      <int name="5" value="8787132"/>
+      <int name="6" value="8787132"/>
+      <int name="7" value="8787132"/>
+      <int name="8" value="8787156"/>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="chatBalloon" value="0"/>
+      <imgdir name="0">
+        <string name="0" value="I will make you regret this!"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787178.img.xml
+++ b/gms-server/wz/Mob.wz/8787178.img.xml
@@ -1,1 +1,539 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787178.img"><imgdir name="move"><canvas name="0" width="48" height="76"><vector name="origin" x="31" y="76"/><vector name="lt" x="-31" y="-76"/><vector name="rb" x="17" y="0"/><vector name="head" x="-12" y="-80"/><int name="delay" value="120"/><string name="_hash" value="420e4adee3b34d61d0c297c74301b0662b876fcc93fc0647315a02f75f102d56"/></canvas><canvas name="1" width="48" height="77"><vector name="origin" x="34" y="77"/><vector name="lt" x="-31" y="-76"/><vector name="rb" x="17" y="0"/><vector name="head" x="-12" y="-80"/><int name="delay" value="120"/><string name="_hash" value="fdd1927391a95d0e5ef718482b7a4a3ab44e4f983221a391ba256bb500ea13ca"/></canvas><canvas name="2" width="48" height="76"><vector name="origin" x="34" y="76"/><vector name="lt" x="-31" y="-76"/><vector name="rb" x="17" y="0"/><vector name="head" x="-12" y="-80"/><int name="delay" value="120"/><string name="_hash" value="87b58567962e4091438bac50be60429144621fd03c31742f67d18ad15a0475d6"/></canvas><canvas name="3" width="48" height="77"><vector name="origin" x="32" y="77"/><vector name="lt" x="-31" y="-76"/><vector name="rb" x="17" y="0"/><vector name="head" x="-12" y="-80"/><int name="delay" value="120"/><string name="_hash" value="a21f520a9be747778289bb7c9de01c9da7cf14f7df7df2e1166fa5cba9fbc58d"/></canvas></imgdir><imgdir name="stand"><canvas name="0" width="48" height="77"><vector name="origin" x="25" y="77"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/><string name="_hash" value="12b96a1ec4f82043d2982a22e36ba196916e6d8a2b77c881b607b9296d185020"/></canvas><canvas name="1" width="49" height="75"><vector name="origin" x="24" y="75"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/><string name="_hash" value="b846732a38cb9215ce4b3516b537170fb132b4554dae2b0406543e4298f5bda1"/></canvas><canvas name="2" width="48" height="77"><vector name="origin" x="25" y="77"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="3" width="48" height="78"><vector name="origin" x="27" y="78"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/><string name="_hash" value="328a5dbe03347b7dca59e5ee7ef4ad045709123b4d2b82cf97e36db4d35b1cae"/></canvas><canvas name="4" width="48" height="77"><vector name="origin" x="28" y="77"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/><string name="_hash" value="c549b9a131bdd60d657b6b75a7b804036069699f862187c4d1038514070491d2"/></canvas><canvas name="5" width="49" height="75"><vector name="origin" x="29" y="75"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/><string name="_hash" value="3e067372532efc0e548f9703311cecf6531750dda56b9c6b39d2e09be77f838c"/></canvas><canvas name="6" width="48" height="77"><vector name="origin" x="28" y="77"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="7" width="48" height="78"><vector name="origin" x="26" y="78"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="8" width="48" height="77"><vector name="origin" x="25" y="77"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="9" width="49" height="75"><vector name="origin" x="24" y="75"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="10" width="48" height="77"><vector name="origin" x="25" y="77"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="11" width="48" height="78"><vector name="origin" x="27" y="78"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="12" width="48" height="77"><vector name="origin" x="28" y="77"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="13" width="49" height="75"><vector name="origin" x="29" y="75"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="14" width="48" height="78"><vector name="origin" x="28" y="77"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="15" width="48" height="78"><vector name="origin" x="26" y="78"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/></canvas><canvas name="16" width="48" height="76"><vector name="origin" x="24" y="76"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/><string name="_hash" value="4bde60bb6983244684382504d29fb7a7f284d8d46eab815b7d670632e63c6c0e"/></canvas><canvas name="17" width="48" height="76"><vector name="origin" x="23" y="76"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/><string name="_hash" value="de19dde62123393a9fc1fb81ec3482a76cc3692908d5248ef8feccade241f4b5"/></canvas><canvas name="18" width="48" height="76"><vector name="origin" x="24" y="76"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/><string name="_hash" value="a029e661b4d3ef2c115ee5c976233e430344c06b4e0ae5aff469306113088fb5"/></canvas><canvas name="19" width="48" height="77"><vector name="origin" x="25" y="77"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><int name="delay" value="120"/><string name="_hash" value="258d8ee8ddf85707ad2d37c966f046238933530116e6857882f079a82c3fa913"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="71" height="84"><vector name="origin" x="45" y="84"/><vector name="lt" x="-23" y="-85"/><vector name="rb" x="26" y="0"/><vector name="head" x="-3" y="-82"/><int name="delay" value="600"/><string name="_hash" value="5fc58806e7bbd51b6cde7daa046329ed542951421933462ef788571d2b0568f2"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="48" height="77"><vector name="origin" x="27" y="77"/><vector name="head" x="-8" y="-81"/><int name="delay" value="120"/></canvas><canvas name="1" width="71" height="84"><vector name="origin" x="54" y="93"/><vector name="head" x="-12" y="-91"/><int name="delay" value="120"/></canvas><canvas name="2" width="73" height="87"><vector name="origin" x="56" y="91"/><vector name="head" x="-12" y="-85"/><int name="delay" value="120"/><string name="_hash" value="00736e9dad51bd5b0dc76c6b3148e3db4b2eddc0985709a7c95d3f487d9785eb"/></canvas><canvas name="3" width="50" height="74"><vector name="origin" x="34" y="74"/><vector name="head" x="-13" y="-78"/><int name="delay" value="120"/><string name="_hash" value="6f487fccd4dbeb722c97ab806f836d4a9d428f46949cf4d907a88feb45ae9193"/></canvas><canvas name="4" width="50" height="73"><vector name="origin" x="34" y="73"/><vector name="head" x="-13" y="-78"/><int name="delay" value="120"/><string name="_hash" value="086765faf40f6cd644ae83360886e95319d4f2d89436c1ef035d760d0bb2ff3e"/></canvas><canvas name="5" width="50" height="74"><vector name="origin" x="34" y="74"/><vector name="head" x="-13" y="-78"/><int name="delay" value="120"/></canvas><canvas name="6" width="50" height="73"><vector name="origin" x="34" y="73"/><vector name="head" x="-13" y="-78"/><int name="delay" value="120"/><string name="_hash" value="d1c8b0ce884d0d89118c690d1f0348a242cf81b62459a8bf2dc7a4a5b0feddc3"/></canvas><canvas name="7" width="50" height="74"><vector name="origin" x="34" y="74"/><vector name="head" x="-13" y="-78"/><int name="delay" value="120"/><string name="_hash" value="f974925437bae7719ce92ce3ab3ccf21bcbd6253bfef3e193e35091a135400b3"/></canvas><canvas name="8" width="50" height="73"><vector name="origin" x="34" y="73"/><vector name="head" x="-13" y="-78"/><int name="delay" value="120"/><string name="_hash" value="1a12c771acf7859aa05d6636466d229f7d9d84ff2a6a75c6382b2725cde017b1"/></canvas><canvas name="9" width="50" height="74"><vector name="origin" x="34" y="74"/><vector name="head" x="-13" y="-78"/><int name="delay" value="120"/><string name="_hash" value="f2a28ea2e01079463c70e87b1c3113e4aef1d0f4cb53e1f3682ffcf791aa351e"/></canvas><canvas name="10" width="50" height="73"><vector name="origin" x="34" y="73"/><vector name="head" x="-13" y="-78"/><int name="delay" value="120"/><string name="_hash" value="37fcd278494720c6600f0f9e49fb4ca24dda196a59e044779cd5e0ae59136744"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="哼~還沒結束呢!!我會在屋頂等你的"/></imgdir></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-291" y="-146"/><vector name="rb" x="72" y="1"/></imgdir><imgdir name="hit"><canvas name="0" width="137" height="106"><vector name="origin" x="75" y="92"/><int name="delay" value="100"/><string name="_hash" value="53fe57e191c187c8e2bbe1d82a71b618409a30b9b718dc03416d6f95a7c5db05"/></canvas><canvas name="1" width="145" height="104"><vector name="origin" x="80" y="92"/><int name="delay" value="100"/><string name="_hash" value="1a9cce56ee81acc0c5c9a73f7ad040b5da67a4180a9de599e3f04eefe95e426d"/></canvas><canvas name="2" width="206" height="111"><vector name="origin" x="94" y="98"/><int name="delay" value="100"/><string name="_hash" value="5f3167922d261220ba52f5aa73766d9c0f6920ef7ed203641c1ed28201eea6ec"/></canvas><canvas name="3" width="189" height="83"><vector name="origin" x="88" y="78"/><int name="delay" value="100"/><string name="_hash" value="561b503ea3f81b005d1be6ccd7aa470ed4d24a31eda8f321c681b59a8f844654"/></canvas></imgdir><int name="attackAfter" value="600"/></imgdir><canvas name="0" width="48" height="77"><vector name="origin" x="25" y="77"/><int name="delay" value="120"/><vector name="lt" x="-25" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-80"/><string name="_hash" value="0b0773f01e0f929812676344c5e74e92ff106c7d98822a5d8ab7d0d4e2a756f9"/></canvas><canvas name="1" width="49" height="76"><vector name="origin" x="27" y="75"/><int name="delay" value="120"/><vector name="lt" x="-27" y="-75"/><vector name="rb" x="22" y="1"/><vector name="head" x="-8" y="-78"/><string name="_hash" value="f94a5aa68493a9bc70227cee70c52b9b83bf17cf0855f7ea4fb4beacaabdaadd"/></canvas><canvas name="2" width="48" height="76"><vector name="origin" x="27" y="74"/><int name="delay" value="120"/><vector name="lt" x="-27" y="-74"/><vector name="rb" x="22" y="2"/><vector name="head" x="-8" y="-77"/><string name="_hash" value="08baf5ffd0f514311b59615dbbdeabeb3bf2f0fbb9919ea3e62b951f302a6d95"/></canvas><canvas name="3" width="56" height="74"><vector name="origin" x="20" y="74"/><int name="delay" value="120"/><vector name="lt" x="-20" y="-74"/><vector name="rb" x="36" y="0"/><vector name="head" x="7" y="-77"/><string name="_hash" value="c7dadeb9fc76cde30a38fd2c7fa035266631ae845200f892f0fb01787f524de6"/></canvas><canvas name="4" width="160" height="94"><vector name="origin" x="95" y="93"/><int name="delay" value="120"/><vector name="lt" x="-33" y="-81"/><vector name="rb" x="34" y="1"/><vector name="head" x="5" y="-80"/><string name="_hash" value="b71fddf11dc9585cdd264a08386f3e47a02c11ad54a40a8a945ef815ec7505ea"/></canvas><canvas name="5" width="165" height="120"><vector name="origin" x="110" y="119"/><int name="delay" value="120"/><vector name="lt" x="-33" y="-81"/><vector name="rb" x="34" y="1"/><vector name="head" x="5" y="-80"/><string name="_hash" value="014f80b85f2ecee66c2dd8b8507772491bcd245b6ad9cb8f054ff20c84fa852a"/></canvas><canvas name="6" width="165" height="118"><vector name="origin" x="131" y="118"/><int name="delay" value="120"/><vector name="lt" x="-33" y="-81"/><vector name="rb" x="34" y="1"/><vector name="head" x="5" y="-80"/><string name="_hash" value="2330f5e31245da02a9cce01cd75681f251f0e76e2e1f9799229bd27aa42af9af"/></canvas><canvas name="7" width="116" height="125"><vector name="origin" x="81" y="125"/><int name="delay" value="120"/><vector name="lt" x="-33" y="-81"/><vector name="rb" x="34" y="1"/><vector name="head" x="5" y="-80"/><string name="_hash" value="9f17736be05670a47fa86191789370cf6f83b7bf975478be4664e172391774cc"/></canvas><canvas name="8" width="119" height="112"><vector name="origin" x="82" y="112"/><int name="delay" value="120"/><vector name="lt" x="-24" y="-80"/><vector name="rb" x="37" y="0"/><vector name="head" x="7" y="-78"/><string name="_hash" value="60ee84a080a2e1b8f38c3a987ba04157f2c7d28725900c22d4a217cff28e0bbf"/></canvas></imgdir><imgdir name="attack2"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-210" y="-112"/><vector name="rb" x="62" y="23"/></imgdir><imgdir name="hit"><canvas name="0" width="109" height="126"><vector name="origin" x="64" y="110"/><int name="delay" value="90"/><string name="_hash" value="6a45abf3e5a613a123363b0a58b760d9ef93341d7a1baa2dbe53a90c201cbf54"/></canvas><canvas name="1" width="123" height="104"><vector name="origin" x="63" y="86"/><int name="delay" value="90"/><string name="_hash" value="b58a22ae3b4ffc742aa47d4f09f97e6a7ede77daf5668164fb0b15e7d24ad710"/></canvas><canvas name="2" width="115" height="114"><vector name="origin" x="51" y="98"/><int name="delay" value="90"/><string name="_hash" value="b6eaaea178ef5ee59193e7e184e57499874c1474e72b19904e8ea1173a5a0ed7"/></canvas><canvas name="3" width="117" height="126"><vector name="origin" x="53" y="110"/><int name="delay" value="90"/><string name="_hash" value="5e255fd8a0266df96ae4173ef0df852e0ac25f405f683ec2181e81d76b17defd"/></canvas><canvas name="4" width="120" height="124"><vector name="origin" x="56" y="109"/><int name="delay" value="90"/><string name="_hash" value="67e786b009fe0d1848d69e2cfbcac80130a5202d5d9ee0fc91876d5db771261f"/></canvas><canvas name="5" width="113" height="87"><vector name="origin" x="56" y="88"/><int name="delay" value="90"/><string name="_hash" value="f174142b4540c58306a7b7e453ebb00554a739991ac242c1b654052543f167c4"/></canvas></imgdir><int name="attackAfter" value="720"/></imgdir><canvas name="0" width="52" height="77"><vector name="origin" x="29" y="77"/><vector name="lt" x="-29" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-81"/><int name="delay" value="120"/><string name="_hash" value="2c61b6512347cac16c460bf69c757123caf6946e15dd3838e52ac1388dcd1356"/></canvas><canvas name="1" width="53" height="75"><vector name="origin" x="29" y="75"/><vector name="lt" x="-29" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-81"/><int name="delay" value="120"/><string name="_hash" value="a9bce25fe0dc3a87c281c1330d408e605abb785af25d69620be3411fb3f18392"/></canvas><canvas name="2" width="59" height="79"><vector name="origin" x="36" y="75"/><vector name="lt" x="-29" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-81"/><int name="delay" value="120"/><string name="_hash" value="29b5de526a406855f6fd4b27ecea640fc3b004119d9769a1db24485a9ed9ee99"/></canvas><canvas name="3" width="65" height="93"><vector name="origin" x="42" y="75"/><vector name="lt" x="-29" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-81"/><int name="delay" value="120"/><string name="_hash" value="426e3090f129a08b12b8ccb6babdc934a5ba55cb36e42e5875226056fb2c128a"/></canvas><canvas name="4" width="63" height="87"><vector name="origin" x="40" y="75"/><vector name="lt" x="-29" y="-77"/><vector name="rb" x="23" y="0"/><vector name="head" x="-6" y="-81"/><int name="delay" value="120"/><string name="_hash" value="a9b04d78a7c4a1a93ee4b11615e8fdbba4b2b8f58c07197b2ce8f2f44625ffd4"/></canvas><canvas name="5" width="51" height="77"><vector name="origin" x="32" y="77"/><vector name="lt" x="-32" y="-77"/><vector name="rb" x="19" y="0"/><vector name="head" x="-10" y="-81"/><int name="delay" value="120"/><string name="_hash" value="3e362b75ce071ba6dfb0d42254a3927b71666d7590af3a46fb76a1be9f6f5f5f"/></canvas><canvas name="6" width="95" height="78"><vector name="origin" x="78" y="78"/><vector name="lt" x="-54" y="-78"/><vector name="rb" x="17" y="0"/><vector name="head" x="-12" y="-82"/><int name="delay" value="120"/><string name="_hash" value="8f27cf525eae747562ea0489cf32e5b8f8dc33d6d7c66b90949f12e5313e971b"/></canvas><canvas name="7" width="136" height="128"><vector name="origin" x="117" y="115"/><vector name="lt" x="-32" y="-77"/><vector name="rb" x="19" y="0"/><vector name="head" x="-10" y="-81"/><int name="delay" value="120"/><string name="_hash" value="f6a69e63bad3dab1d07a22e21707e495070f6f637608fc2a3ab599a42189868e"/></canvas><canvas name="8" width="141" height="115"><vector name="origin" x="121" y="107"/><vector name="lt" x="-54" y="-78"/><vector name="rb" x="17" y="0"/><vector name="head" x="-12" y="-82"/><int name="delay" value="120"/><string name="_hash" value="2df77589fbe387286c087d0973510014dcb78c3916304cab54b67e2ee12f1688"/></canvas><canvas name="9" width="129" height="126"><vector name="origin" x="110" y="114"/><vector name="lt" x="-32" y="-77"/><vector name="rb" x="19" y="0"/><vector name="head" x="-10" y="-81"/><int name="delay" value="120"/><string name="_hash" value="44bfc058cb7fbd176d4eec3aead5f068f919a14f0fd95d332203d816078c044f"/></canvas><canvas name="10" width="134" height="110"><vector name="origin" x="117" y="104"/><vector name="lt" x="-54" y="-78"/><vector name="rb" x="17" y="0"/><vector name="head" x="-12" y="-82"/><int name="delay" value="120"/><string name="_hash" value="f28c87da6df48edc2ccc1fbf5c16cff42c891db754523cb8ee2ea58815137b51"/></canvas><canvas name="11" width="145" height="118"><vector name="origin" x="125" y="108"/><vector name="lt" x="-32" y="-77"/><vector name="rb" x="19" y="0"/><vector name="head" x="-10" y="-81"/><int name="delay" value="120"/><string name="_hash" value="5bd3ce94e1706d3b81ce6aa9d1aaea024878d93e70b1f3eadfaf3036467c8a69"/></canvas><canvas name="12" width="61" height="78"><vector name="origin" x="39" y="78"/><vector name="lt" x="-28" y="-78"/><vector name="rb" x="22" y="0"/><vector name="head" x="-7" y="-81"/><int name="delay" value="120"/><string name="_hash" value="64da4914b8a8401725cd8ceef007650fef0dfeb98b72fea9cb20770f4b0e6165"/></canvas></imgdir><imgdir name="info"><int name="bodyAttack" value="1"/><int name="level" value="180"/><int name="maxHP" value="4000000"/><int name="maxMP" value="8000"/><int name="speed" value="30"/><int name="PADamage" value="800"/><int name="PDDamage" value="920"/><int name="MADamage" value="700"/><int name="MDDamage" value="750"/><int name="acc" value="888"/><int name="eva" value="70"/><int name="exp" value="100000"/><int name="undead" value="0"/><int name="pushed" value="80000"/><float name="fs" value="10.0"/><int name="hpRecovery" value="500"/><int name="mpRecovery" value="50"/><int name="summonType" value="1"/><int name="boss" value="1"/><int name="firstAttack" value="1"/><int name="hpTagBgcolor" value="5"/><int name="hpTagColor" value="1"/></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787178.img">
+  <imgdir name="move">
+    <canvas name="0" width="48" height="76">
+      <vector name="origin" x="31" y="76"/>
+      <vector name="lt" x="-31" y="-76"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="420e4adee3b34d61d0c297c74301b0662b876fcc93fc0647315a02f75f102d56"/>
+    </canvas>
+    <canvas name="1" width="48" height="77">
+      <vector name="origin" x="34" y="77"/>
+      <vector name="lt" x="-31" y="-76"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fdd1927391a95d0e5ef718482b7a4a3ab44e4f983221a391ba256bb500ea13ca"/>
+    </canvas>
+    <canvas name="2" width="48" height="76">
+      <vector name="origin" x="34" y="76"/>
+      <vector name="lt" x="-31" y="-76"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="87b58567962e4091438bac50be60429144621fd03c31742f67d18ad15a0475d6"/>
+    </canvas>
+    <canvas name="3" width="48" height="77">
+      <vector name="origin" x="32" y="77"/>
+      <vector name="lt" x="-31" y="-76"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a21f520a9be747778289bb7c9de01c9da7cf14f7df7df2e1166fa5cba9fbc58d"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="12b96a1ec4f82043d2982a22e36ba196916e6d8a2b77c881b607b9296d185020"/>
+    </canvas>
+    <canvas name="1" width="49" height="75">
+      <vector name="origin" x="24" y="75"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b846732a38cb9215ce4b3516b537170fb132b4554dae2b0406543e4298f5bda1"/>
+    </canvas>
+    <canvas name="2" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="48" height="78">
+      <vector name="origin" x="27" y="78"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="328a5dbe03347b7dca59e5ee7ef4ad045709123b4d2b82cf97e36db4d35b1cae"/>
+    </canvas>
+    <canvas name="4" width="48" height="77">
+      <vector name="origin" x="28" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c549b9a131bdd60d657b6b75a7b804036069699f862187c4d1038514070491d2"/>
+    </canvas>
+    <canvas name="5" width="49" height="75">
+      <vector name="origin" x="29" y="75"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3e067372532efc0e548f9703311cecf6531750dda56b9c6b39d2e09be77f838c"/>
+    </canvas>
+    <canvas name="6" width="48" height="77">
+      <vector name="origin" x="28" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="48" height="78">
+      <vector name="origin" x="26" y="78"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="49" height="75">
+      <vector name="origin" x="24" y="75"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="48" height="78">
+      <vector name="origin" x="27" y="78"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="48" height="77">
+      <vector name="origin" x="28" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="49" height="75">
+      <vector name="origin" x="29" y="75"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="48" height="78">
+      <vector name="origin" x="28" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="48" height="78">
+      <vector name="origin" x="26" y="78"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="48" height="76">
+      <vector name="origin" x="24" y="76"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4bde60bb6983244684382504d29fb7a7f284d8d46eab815b7d670632e63c6c0e"/>
+    </canvas>
+    <canvas name="17" width="48" height="76">
+      <vector name="origin" x="23" y="76"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="de19dde62123393a9fc1fb81ec3482a76cc3692908d5248ef8feccade241f4b5"/>
+    </canvas>
+    <canvas name="18" width="48" height="76">
+      <vector name="origin" x="24" y="76"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a029e661b4d3ef2c115ee5c976233e430344c06b4e0ae5aff469306113088fb5"/>
+    </canvas>
+    <canvas name="19" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="258d8ee8ddf85707ad2d37c966f046238933530116e6857882f079a82c3fa913"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="71" height="84">
+      <vector name="origin" x="45" y="84"/>
+      <vector name="lt" x="-23" y="-85"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-3" y="-82"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="5fc58806e7bbd51b6cde7daa046329ed542951421933462ef788571d2b0568f2"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="48" height="77">
+      <vector name="origin" x="27" y="77"/>
+      <vector name="head" x="-8" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="71" height="84">
+      <vector name="origin" x="54" y="93"/>
+      <vector name="head" x="-12" y="-91"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="73" height="87">
+      <vector name="origin" x="56" y="91"/>
+      <vector name="head" x="-12" y="-85"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="00736e9dad51bd5b0dc76c6b3148e3db4b2eddc0985709a7c95d3f487d9785eb"/>
+    </canvas>
+    <canvas name="3" width="50" height="74">
+      <vector name="origin" x="34" y="74"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6f487fccd4dbeb722c97ab806f836d4a9d428f46949cf4d907a88feb45ae9193"/>
+    </canvas>
+    <canvas name="4" width="50" height="73">
+      <vector name="origin" x="34" y="73"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="086765faf40f6cd644ae83360886e95319d4f2d89436c1ef035d760d0bb2ff3e"/>
+    </canvas>
+    <canvas name="5" width="50" height="74">
+      <vector name="origin" x="34" y="74"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="50" height="73">
+      <vector name="origin" x="34" y="73"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d1c8b0ce884d0d89118c690d1f0348a242cf81b62459a8bf2dc7a4a5b0feddc3"/>
+    </canvas>
+    <canvas name="7" width="50" height="74">
+      <vector name="origin" x="34" y="74"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f974925437bae7719ce92ce3ab3ccf21bcbd6253bfef3e193e35091a135400b3"/>
+    </canvas>
+    <canvas name="8" width="50" height="73">
+      <vector name="origin" x="34" y="73"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1a12c771acf7859aa05d6636466d229f7d9d84ff2a6a75c6382b2725cde017b1"/>
+    </canvas>
+    <canvas name="9" width="50" height="74">
+      <vector name="origin" x="34" y="74"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f2a28ea2e01079463c70e87b1c3113e4aef1d0f4cb53e1f3682ffcf791aa351e"/>
+    </canvas>
+    <canvas name="10" width="50" height="73">
+      <vector name="origin" x="34" y="73"/>
+      <vector name="head" x="-13" y="-78"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="37fcd278494720c6600f0f9e49fb4ca24dda196a59e044779cd5e0ae59136744"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Hmph, this is not over! I will be waiting on the roof."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-291" y="-146"/>
+        <vector name="rb" x="72" y="1"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="137" height="106">
+          <vector name="origin" x="75" y="92"/>
+          <int name="delay" value="100"/>
+          <string name="_hash" value="53fe57e191c187c8e2bbe1d82a71b618409a30b9b718dc03416d6f95a7c5db05"/>
+        </canvas>
+        <canvas name="1" width="145" height="104">
+          <vector name="origin" x="80" y="92"/>
+          <int name="delay" value="100"/>
+          <string name="_hash" value="1a9cce56ee81acc0c5c9a73f7ad040b5da67a4180a9de599e3f04eefe95e426d"/>
+        </canvas>
+        <canvas name="2" width="206" height="111">
+          <vector name="origin" x="94" y="98"/>
+          <int name="delay" value="100"/>
+          <string name="_hash" value="5f3167922d261220ba52f5aa73766d9c0f6920ef7ed203641c1ed28201eea6ec"/>
+        </canvas>
+        <canvas name="3" width="189" height="83">
+          <vector name="origin" x="88" y="78"/>
+          <int name="delay" value="100"/>
+          <string name="_hash" value="561b503ea3f81b005d1be6ccd7aa470ed4d24a31eda8f321c681b59a8f844654"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="600"/>
+    </imgdir>
+    <canvas name="0" width="48" height="77">
+      <vector name="origin" x="25" y="77"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-25" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-80"/>
+      <string name="_hash" value="0b0773f01e0f929812676344c5e74e92ff106c7d98822a5d8ab7d0d4e2a756f9"/>
+    </canvas>
+    <canvas name="1" width="49" height="76">
+      <vector name="origin" x="27" y="75"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-27" y="-75"/>
+      <vector name="rb" x="22" y="1"/>
+      <vector name="head" x="-8" y="-78"/>
+      <string name="_hash" value="f94a5aa68493a9bc70227cee70c52b9b83bf17cf0855f7ea4fb4beacaabdaadd"/>
+    </canvas>
+    <canvas name="2" width="48" height="76">
+      <vector name="origin" x="27" y="74"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-27" y="-74"/>
+      <vector name="rb" x="22" y="2"/>
+      <vector name="head" x="-8" y="-77"/>
+      <string name="_hash" value="08baf5ffd0f514311b59615dbbdeabeb3bf2f0fbb9919ea3e62b951f302a6d95"/>
+    </canvas>
+    <canvas name="3" width="56" height="74">
+      <vector name="origin" x="20" y="74"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-20" y="-74"/>
+      <vector name="rb" x="36" y="0"/>
+      <vector name="head" x="7" y="-77"/>
+      <string name="_hash" value="c7dadeb9fc76cde30a38fd2c7fa035266631ae845200f892f0fb01787f524de6"/>
+    </canvas>
+    <canvas name="4" width="160" height="94">
+      <vector name="origin" x="95" y="93"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-33" y="-81"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="5" y="-80"/>
+      <string name="_hash" value="b71fddf11dc9585cdd264a08386f3e47a02c11ad54a40a8a945ef815ec7505ea"/>
+    </canvas>
+    <canvas name="5" width="165" height="120">
+      <vector name="origin" x="110" y="119"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-33" y="-81"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="5" y="-80"/>
+      <string name="_hash" value="014f80b85f2ecee66c2dd8b8507772491bcd245b6ad9cb8f054ff20c84fa852a"/>
+    </canvas>
+    <canvas name="6" width="165" height="118">
+      <vector name="origin" x="131" y="118"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-33" y="-81"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="5" y="-80"/>
+      <string name="_hash" value="2330f5e31245da02a9cce01cd75681f251f0e76e2e1f9799229bd27aa42af9af"/>
+    </canvas>
+    <canvas name="7" width="116" height="125">
+      <vector name="origin" x="81" y="125"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-33" y="-81"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="5" y="-80"/>
+      <string name="_hash" value="9f17736be05670a47fa86191789370cf6f83b7bf975478be4664e172391774cc"/>
+    </canvas>
+    <canvas name="8" width="119" height="112">
+      <vector name="origin" x="82" y="112"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-24" y="-80"/>
+      <vector name="rb" x="37" y="0"/>
+      <vector name="head" x="7" y="-78"/>
+      <string name="_hash" value="60ee84a080a2e1b8f38c3a987ba04157f2c7d28725900c22d4a217cff28e0bbf"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-210" y="-112"/>
+        <vector name="rb" x="62" y="23"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="109" height="126">
+          <vector name="origin" x="64" y="110"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6a45abf3e5a613a123363b0a58b760d9ef93341d7a1baa2dbe53a90c201cbf54"/>
+        </canvas>
+        <canvas name="1" width="123" height="104">
+          <vector name="origin" x="63" y="86"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="b58a22ae3b4ffc742aa47d4f09f97e6a7ede77daf5668164fb0b15e7d24ad710"/>
+        </canvas>
+        <canvas name="2" width="115" height="114">
+          <vector name="origin" x="51" y="98"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="b6eaaea178ef5ee59193e7e184e57499874c1474e72b19904e8ea1173a5a0ed7"/>
+        </canvas>
+        <canvas name="3" width="117" height="126">
+          <vector name="origin" x="53" y="110"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="5e255fd8a0266df96ae4173ef0df852e0ac25f405f683ec2181e81d76b17defd"/>
+        </canvas>
+        <canvas name="4" width="120" height="124">
+          <vector name="origin" x="56" y="109"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="67e786b009fe0d1848d69e2cfbcac80130a5202d5d9ee0fc91876d5db771261f"/>
+        </canvas>
+        <canvas name="5" width="113" height="87">
+          <vector name="origin" x="56" y="88"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="f174142b4540c58306a7b7e453ebb00554a739991ac242c1b654052543f167c4"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="720"/>
+    </imgdir>
+    <canvas name="0" width="52" height="77">
+      <vector name="origin" x="29" y="77"/>
+      <vector name="lt" x="-29" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2c61b6512347cac16c460bf69c757123caf6946e15dd3838e52ac1388dcd1356"/>
+    </canvas>
+    <canvas name="1" width="53" height="75">
+      <vector name="origin" x="29" y="75"/>
+      <vector name="lt" x="-29" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a9bce25fe0dc3a87c281c1330d408e605abb785af25d69620be3411fb3f18392"/>
+    </canvas>
+    <canvas name="2" width="59" height="79">
+      <vector name="origin" x="36" y="75"/>
+      <vector name="lt" x="-29" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="29b5de526a406855f6fd4b27ecea640fc3b004119d9769a1db24485a9ed9ee99"/>
+    </canvas>
+    <canvas name="3" width="65" height="93">
+      <vector name="origin" x="42" y="75"/>
+      <vector name="lt" x="-29" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="426e3090f129a08b12b8ccb6babdc934a5ba55cb36e42e5875226056fb2c128a"/>
+    </canvas>
+    <canvas name="4" width="63" height="87">
+      <vector name="origin" x="40" y="75"/>
+      <vector name="lt" x="-29" y="-77"/>
+      <vector name="rb" x="23" y="0"/>
+      <vector name="head" x="-6" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a9b04d78a7c4a1a93ee4b11615e8fdbba4b2b8f58c07197b2ce8f2f44625ffd4"/>
+    </canvas>
+    <canvas name="5" width="51" height="77">
+      <vector name="origin" x="32" y="77"/>
+      <vector name="lt" x="-32" y="-77"/>
+      <vector name="rb" x="19" y="0"/>
+      <vector name="head" x="-10" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3e362b75ce071ba6dfb0d42254a3927b71666d7590af3a46fb76a1be9f6f5f5f"/>
+    </canvas>
+    <canvas name="6" width="95" height="78">
+      <vector name="origin" x="78" y="78"/>
+      <vector name="lt" x="-54" y="-78"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8f27cf525eae747562ea0489cf32e5b8f8dc33d6d7c66b90949f12e5313e971b"/>
+    </canvas>
+    <canvas name="7" width="136" height="128">
+      <vector name="origin" x="117" y="115"/>
+      <vector name="lt" x="-32" y="-77"/>
+      <vector name="rb" x="19" y="0"/>
+      <vector name="head" x="-10" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f6a69e63bad3dab1d07a22e21707e495070f6f637608fc2a3ab599a42189868e"/>
+    </canvas>
+    <canvas name="8" width="141" height="115">
+      <vector name="origin" x="121" y="107"/>
+      <vector name="lt" x="-54" y="-78"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2df77589fbe387286c087d0973510014dcb78c3916304cab54b67e2ee12f1688"/>
+    </canvas>
+    <canvas name="9" width="129" height="126">
+      <vector name="origin" x="110" y="114"/>
+      <vector name="lt" x="-32" y="-77"/>
+      <vector name="rb" x="19" y="0"/>
+      <vector name="head" x="-10" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="44bfc058cb7fbd176d4eec3aead5f068f919a14f0fd95d332203d816078c044f"/>
+    </canvas>
+    <canvas name="10" width="134" height="110">
+      <vector name="origin" x="117" y="104"/>
+      <vector name="lt" x="-54" y="-78"/>
+      <vector name="rb" x="17" y="0"/>
+      <vector name="head" x="-12" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f28c87da6df48edc2ccc1fbf5c16cff42c891db754523cb8ee2ea58815137b51"/>
+    </canvas>
+    <canvas name="11" width="145" height="118">
+      <vector name="origin" x="125" y="108"/>
+      <vector name="lt" x="-32" y="-77"/>
+      <vector name="rb" x="19" y="0"/>
+      <vector name="head" x="-10" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5bd3ce94e1706d3b81ce6aa9d1aaea024878d93e70b1f3eadfaf3036467c8a69"/>
+    </canvas>
+    <canvas name="12" width="61" height="78">
+      <vector name="origin" x="39" y="78"/>
+      <vector name="lt" x="-28" y="-78"/>
+      <vector name="rb" x="22" y="0"/>
+      <vector name="head" x="-7" y="-81"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="64da4914b8a8401725cd8ceef007650fef0dfeb98b72fea9cb20770f4b0e6165"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="180"/>
+    <int name="maxHP" value="4000000"/>
+    <int name="maxMP" value="8000"/>
+    <int name="speed" value="30"/>
+    <int name="PADamage" value="800"/>
+    <int name="PDDamage" value="920"/>
+    <int name="MADamage" value="700"/>
+    <int name="MDDamage" value="750"/>
+    <int name="acc" value="888"/>
+    <int name="eva" value="70"/>
+    <int name="exp" value="100000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="80000"/>
+    <float name="fs" value="10.0"/>
+    <int name="hpRecovery" value="500"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787179.img.xml
+++ b/gms-server/wz/Mob.wz/8787179.img.xml
@@ -1,1 +1,550 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787179.img"><imgdir name="move"><canvas name="0" width="83" height="87"><vector name="origin" x="55" y="86"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="28" y="1"/><vector name="head" x="-25" y="-82"/><int name="delay" value="120"/><string name="_hash" value="1898e5f83eb1cb6648c818dab5e23bcf861906aeccd9a0a443ddf9a63e86747f"/></canvas><canvas name="1" width="86" height="85"><vector name="origin" x="58" y="84"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="28" y="1"/><vector name="head" x="-25" y="-82"/><int name="delay" value="120"/><string name="_hash" value="dd63c946ac2ee508236ca61ba65641fea196f63700f899d4923a8c93d16648b9"/></canvas><canvas name="2" width="83" height="87"><vector name="origin" x="55" y="86"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="28" y="1"/><vector name="head" x="-25" y="-82"/><int name="delay" value="120"/><string name="_hash" value="14a1b2f0a418b2173a45ea5fcaf80f781754e8c7ccd5af73ae3caffc3af52ef0"/></canvas><canvas name="3" width="81" height="88"><vector name="origin" x="53" y="87"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="28" y="1"/><vector name="head" x="-25" y="-82"/><int name="delay" value="120"/><string name="_hash" value="f640725a3005f02477a41b4a30bbe357a08ff2382aae5e55b8e345e7f47fb0ef"/></canvas></imgdir><imgdir name="stand"><canvas name="0" width="83" height="88"><vector name="origin" x="53" y="87"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="28" y="1"/><vector name="head" x="-25" y="-82"/><int name="delay" value="120"/><string name="_hash" value="e3742038950d70997f268297943f7fc553f52793dbb8c9b8272d631c79324e6e"/></canvas><canvas name="1" width="83" height="86"><vector name="origin" x="53" y="85"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="28" y="1"/><vector name="head" x="-25" y="-82"/><int name="delay" value="120"/><string name="_hash" value="97a22ecd1ff29367f294feba7d87d90511910f23d09a27f509f8661cd7610be0"/></canvas><canvas name="2" width="83" height="88"><vector name="origin" x="53" y="87"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="28" y="1"/><vector name="head" x="-25" y="-82"/><int name="delay" value="120"/><string name="_hash" value="215eefc49399aa18d0e3712d2c76dacfc845dcfa9223a1585439c1df3d85086a"/></canvas><canvas name="3" width="82" height="89"><vector name="origin" x="53" y="88"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="28" y="1"/><vector name="head" x="-25" y="-82"/><int name="delay" value="120"/><string name="_hash" value="82583c4c226bc252df7026a827358548f3ca4daee92a2c7dafbf78eccdd809e3"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="92" height="88"><vector name="origin" x="43" y="87"/><vector name="lt" x="-44" y="-88"/><vector name="rb" x="50" y="1"/><vector name="head" x="-17" y="-85"/><int name="delay" value="600"/><string name="_hash" value="a81cf292182137d7cc74008a892275fca8d6541f7428eee98eb4417f48d02ec3"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="86" height="88"><vector name="origin" x="42" y="87"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="3c4f212e229675eba5c050ca325fbe6662340dcdbee152fd404b453d5db4d73d"/></canvas><canvas name="1" width="83" height="88"><vector name="origin" x="41" y="87"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="f57ef084fa97fe409ba26ec2614cba616980efe52ca146d10b90eee2980408d8"/></canvas><canvas name="2" width="96" height="86"><vector name="origin" x="28" y="81"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="5ae5c1c7bbbb1c1b33cc38d77e0d8891bee5829e946d5a7efb408b6b32f303e1"/></canvas><canvas name="3" width="105" height="89"><vector name="origin" x="32" y="84"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="d61d6674f21637d5f485328d1296efb60bd748174286a83f551c9dcd00e9a9f2"/></canvas><canvas name="4" width="107" height="87"><vector name="origin" x="32" y="83"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="3aed8c6ba6627805294c7aafd3f4a5d59551cf9ec1497125463158cd79609a75"/></canvas><canvas name="5" width="109" height="84"><vector name="origin" x="32" y="82"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="5206d2c7bdf97a23188d963c9bb2831c1c6bd0c55f1af34cc1c7194f454814f5"/></canvas><canvas name="6" width="83" height="83"><vector name="origin" x="32" y="82"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="7d8d96a15738735e22a38e75bf6af59de60ef1b94b1e389049359a41c9e1ef53"/></canvas><canvas name="7" width="83" height="83"><vector name="origin" x="32" y="82"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="f2f0b2ee379c0d6c218d16f7bffc3b60b0dc5a41ff13bd1b98dc818b455ab9cf"/></canvas><canvas name="8" width="83" height="83"><vector name="origin" x="32" y="82"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="40026ffac9862ccf1dc8dc7556e5d9c16b4d61f8ea57a4e88151a01083b568cf"/></canvas><canvas name="9" width="83" height="83"><vector name="origin" x="32" y="82"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="cf7c5005119fb56a67cc7a92ce1b3fa2eb57b920742d12049e83cb674aacc0f5"/></canvas><canvas name="10" width="83" height="83"><vector name="origin" x="32" y="82"/><vector name="head" x="-11" y="-83"/><int name="delay" value="120"/><string name="_hash" value="a06a9959e9b98f23b974631b176196c521d718a4b6341723e8a2a7b6848f5179"/></canvas><canvas name="11" width="83" height="83"><vector name="origin" x="32" y="82"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="06d9f3da506a7a84b5fdc4ed395b4c400fdec816f61ecece92c5e6e6f11d154a"/></canvas><canvas name="12" width="83" height="83"><vector name="origin" x="32" y="82"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="3a461c0f7c95d8984df0723355568116312d49a05334514d6fb61e6837efc580"/></canvas><canvas name="13" width="83" height="83"><vector name="origin" x="32" y="82"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="1d2a05d7fba139804cbe0d6356739abc2d9efc2c3af6e0df23ae0eda8b485637"/></canvas><canvas name="14" width="83" height="83"><vector name="origin" x="32" y="82"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="e762aae19d4d38075dbcc18e13c94c92f1666c2ead808f2af768864652d5af47"/></canvas><canvas name="15" width="83" height="83"><vector name="origin" x="32" y="82"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="aede0bd33ad6ee4aa602f484c26b81d1b06659e27ab8f560ebcaa4849095d881"/></canvas><canvas name="18" width="83" height="83"><vector name="origin" x="32" y="82"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="f49423846ee434adea0f7c7062536b8141a4acd2d08f1e58e517a2db9a0deb4f"/></canvas><canvas name="19" width="83" height="83"><vector name="origin" x="32" y="82"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="fa97d46d6a710cc1c17f126ada5ec788b89baa39edaaf59771946fd99c514af1"/></canvas><canvas name="20" width="83" height="83"><vector name="origin" x="32" y="82"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="f0c1aa3acc117a73064a40692260fd631f57db4f155228853f668a64bf1c943a"/></canvas><canvas name="21" width="83" height="83"><vector name="origin" x="32" y="82"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="3493748479e30b561222683f926b4eb8a22846851cd8724adf5e50499187baa5"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="哼~還沒結束呢!!我會在屋頂等你的"/></imgdir></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-291" y="-146"/><vector name="rb" x="72" y="1"/></imgdir><imgdir name="hit"><canvas name="0" width="70" height="68"><vector name="origin" x="35" y="67"/><int name="delay" value="90"/><string name="_hash" value="4e3535ceecee873a87488f6693e58934e69f77d82260a1a1051e362caa101fdc"/></canvas><canvas name="1" width="118" height="155"><vector name="origin" x="51" y="116"/><int name="delay" value="90"/><string name="_hash" value="f7a7a8d418de5119d19ea2c5fb44d8eb04cfce4bdc4d939c59b3f5850e02366e"/></canvas><canvas name="2" width="164" height="153"><vector name="origin" x="86" y="114"/><int name="delay" value="90"/><string name="_hash" value="2b4e7308e6616deb1dd5a09149601e4d86eba68567c2c2b20f113e5d5dd9a266"/></canvas><canvas name="3" width="164" height="151"><vector name="origin" x="86" y="112"/><int name="delay" value="90"/><string name="_hash" value="6b95dba9a7437225a56c2b85f254cd3cf5796b57087fa4103537315b7e72fe7d"/></canvas><canvas name="4" width="153" height="132"><vector name="origin" x="81" y="107"/><int name="delay" value="90"/><string name="_hash" value="a925f554f7f750233cdf915c6da4e2e8810c7319321cd944d1bbd53b853f3d4d"/></canvas><canvas name="5" width="155" height="132"><vector name="origin" x="83" y="107"/><int name="delay" value="90"/><string name="_hash" value="9df74b9dbde2c11dba0a3890b95b4a9fe6b4501b7f47eb5cdec2bf2c7b49257c"/></canvas></imgdir><int name="attackAfter" value="960"/></imgdir><canvas name="0" width="170" height="181"><vector name="origin" x="107" y="139"/><int name="delay" value="120"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="33" y="1"/><vector name="head" x="-23" y="-80"/><string name="_hash" value="2ba0ae038391ef8e136b0d263c897df377a659713029ffd11ae04658b57bdc48"/></canvas><canvas name="1" width="122" height="166"><vector name="origin" x="70" y="117"/><int name="delay" value="120"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="33" y="1"/><vector name="head" x="-23" y="-80"/><string name="_hash" value="89432ba48111ed41427a035b68d04ffe74f8a7a87aa39039250f53bfdeae80d7"/></canvas><canvas name="2" width="150" height="130"><vector name="origin" x="87" y="88"/><int name="delay" value="120"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="33" y="1"/><vector name="head" x="-23" y="-80"/><string name="_hash" value="448b002724a759152289c72b399dd8d4dbf1462f6cf46780c22702f96da1b7f7"/></canvas><canvas name="3" width="154" height="192"><vector name="origin" x="75" y="166"/><int name="delay" value="120"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="33" y="1"/><vector name="head" x="-23" y="-80"/><string name="_hash" value="a38676471c7ef59ad1cb0578c34681c59eb616ba3b5976edf07d8a3427e290cb"/></canvas><canvas name="4" width="161" height="120"><vector name="origin" x="101" y="111"/><int name="delay" value="120"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="33" y="1"/><vector name="head" x="-23" y="-80"/><string name="_hash" value="a28c55b4a30e34359a3a4d97bd9583668b7efbf9bcbd6d8a97bf26109b35ba67"/></canvas><canvas name="5" width="100" height="86"><vector name="origin" x="53" y="85"/><int name="delay" value="120"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="33" y="1"/><vector name="head" x="-23" y="-80"/><string name="_hash" value="3605dd1b01a3d7da4a9b27260ecc2f5ad1b97adda800de74eedaa06a2ab07611"/></canvas><canvas name="6" width="83" height="85"><vector name="origin" x="57" y="84"/><int name="delay" value="120"/><vector name="lt" x="-58" y="-85"/><vector name="rb" x="27" y="1"/><vector name="head" x="-26" y="-79"/><string name="_hash" value="7686de38416d486ed36e96494e07903e0cd25e71954d31384dee7e372538e9e4"/></canvas><canvas name="7" width="235" height="169"><vector name="origin" x="146" y="146"/><int name="delay" value="120"/><vector name="lt" x="-50" y="-97"/><vector name="rb" x="35" y="2"/><vector name="head" x="-19" y="-91"/><string name="_hash" value="9f2e9fecab38d213d7a3e1249368bb1c1b12e464ad9cfef450f4f0e2cafdb7b2"/></canvas><canvas name="8" width="287" height="165"><vector name="origin" x="169" y="142"/><int name="delay" value="120"/><vector name="lt" x="-50" y="-97"/><vector name="rb" x="35" y="2"/><vector name="head" x="-19" y="-91"/><string name="_hash" value="cba20203be235e7371a650904cf1a30bf7979ab3057ca4f539c63982c741613e"/></canvas><canvas name="9" width="312" height="171"><vector name="origin" x="186" y="144"/><int name="delay" value="120"/><vector name="lt" x="-50" y="-97"/><vector name="rb" x="35" y="2"/><vector name="head" x="-19" y="-91"/><string name="_hash" value="c8f97deec1669eea0619c9056596c4c561252ee8df2c52fb51d4627a2fabf629"/></canvas><canvas name="10" width="339" height="174"><vector name="origin" x="206" y="146"/><int name="delay" value="120"/><vector name="lt" x="-50" y="-97"/><vector name="rb" x="35" y="2"/><vector name="head" x="-19" y="-91"/><string name="_hash" value="1f09ea164b9bfde4966e34f86fec218d98136d9122313707d2115b15709e7c98"/></canvas><canvas name="11" width="360" height="168"><vector name="origin" x="229" y="142"/><int name="delay" value="120"/><vector name="lt" x="-50" y="-97"/><vector name="rb" x="35" y="2"/><vector name="head" x="-19" y="-91"/><string name="_hash" value="756129d499a07b569bb915137d2f876ae6cdbeffa9b300c6c68f7da8b4c29135"/></canvas><canvas name="12" width="371" height="164"><vector name="origin" x="245" y="144"/><vector name="lt" x="-50" y="-97"/><vector name="rb" x="35" y="2"/><vector name="head" x="-19" y="-91"/><int name="delay" value="120"/><string name="_hash" value="08e2a08f0a0cf721e8f1950967518ea21b95d7b38bf3c1473497858f9b8e564a"/></canvas><canvas name="13" width="295" height="148"><vector name="origin" x="265" y="144"/><vector name="lt" x="-50" y="-97"/><vector name="rb" x="35" y="2"/><vector name="head" x="-19" y="-91"/><int name="delay" value="120"/><string name="_hash" value="0ea5b4eabde5397c3a40649ad983dd7477eed542593a0460185c85cf4b109132"/></canvas><canvas name="14" width="316" height="143"><vector name="origin" x="286" y="140"/><vector name="lt" x="-50" y="-97"/><vector name="rb" x="35" y="2"/><vector name="head" x="-19" y="-91"/><int name="delay" value="120"/><string name="_hash" value="aeb134f3dbf0f39cf0228f3c57399a23adf8d46297ba6c78df963c53f462c7e1"/></canvas><canvas name="15" width="327" height="138"><vector name="origin" x="298" y="137"/><vector name="lt" x="-50" y="-97"/><vector name="rb" x="35" y="2"/><vector name="head" x="-19" y="-91"/><int name="delay" value="120"/><string name="_hash" value="1e63335cea2431a053adbb4f46cb38937fbe9349f9777068e66215f776f19c68"/></canvas></imgdir><imgdir name="attack2"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-210" y="-112"/><vector name="rb" x="62" y="23"/></imgdir><imgdir name="hit"><canvas name="0" width="83" height="77"><vector name="origin" x="74" y="75"/><int name="delay" value="90"/><string name="_hash" value="fe8e961636db6d411931c6e63ea7ed4414bf81f07aa09cae69a3d7d05d5d5f13"/></canvas><canvas name="1" width="134" height="94"><vector name="origin" x="81" y="71"/><int name="delay" value="90"/><string name="_hash" value="6925815909794625ae0066db2548b80bb72484d673a62ce0b7b86194e7c23feb"/></canvas><canvas name="2" width="143" height="121"><vector name="origin" x="85" y="102"/><int name="delay" value="90"/><string name="_hash" value="a9e228684ee84cea9089d2c914596e8fa34018f5f9ab7f9317d18555f96d8667"/></canvas><canvas name="3" width="111" height="128"><vector name="origin" x="49" y="107"/><int name="delay" value="90"/><string name="_hash" value="efb473f9b387f7c76fda011ad9642c8933be5ed62fcd6fe97c9c4fe3cd057360"/></canvas><canvas name="4" width="94" height="128"><vector name="origin" x="46" y="111"/><int name="delay" value="90"/><string name="_hash" value="3beb1fbe5396cf9fba6d3100cbafd55cb9429cadf84aec9a49feaa07492e3681"/></canvas><canvas name="5" width="76" height="102"><vector name="origin" x="49" y="81"/><int name="delay" value="90"/><string name="_hash" value="351c9a1465ce0488c0d22d872cb64cbd514e3a8d3ebc7b48d655ccb65a0a9196"/></canvas></imgdir><int name="attackAfter" value="960"/></imgdir><canvas name="0" width="83" height="88"><vector name="origin" x="53" y="87"/><vector name="lt" x="-54" y="-88"/><vector name="rb" x="30" y="1"/><vector name="head" x="-24" y="-81"/><int name="delay" value="120"/></canvas><canvas name="1" width="87" height="97"><vector name="origin" x="53" y="92"/><vector name="lt" x="-54" y="-92"/><vector name="rb" x="34" y="1"/><vector name="head" x="-23" y="-83"/><int name="delay" value="120"/><string name="_hash" value="35ae5b154985cd700b34ef2067ea8c1a5d71b42a63b04c589ef63ec852779141"/></canvas><canvas name="2" width="94" height="102"><vector name="origin" x="56" y="95"/><vector name="lt" x="-54" y="-92"/><vector name="rb" x="34" y="1"/><vector name="head" x="-23" y="-83"/><int name="delay" value="120"/><string name="_hash" value="582a6e364f462348e42c386bdd68f83b49150f58b23bd3f0938d0aca817fd1eb"/></canvas><canvas name="3" width="93" height="106"><vector name="origin" x="52" y="98"/><vector name="lt" x="-53" y="-96"/><vector name="rb" x="37" y="1"/><vector name="head" x="-18" y="-86"/><int name="delay" value="120"/><string name="_hash" value="297b009e40508b01964c6b8584a969347384d189d99b6123c9922d73c129b4f5"/></canvas><canvas name="4" width="96" height="106"><vector name="origin" x="53" y="98"/><vector name="lt" x="-53" y="-96"/><vector name="rb" x="37" y="1"/><vector name="head" x="-18" y="-86"/><int name="delay" value="120"/><string name="_hash" value="731bb3c8b6de6e94bb0456ae7725cb69d6afb87eaedc2cfc80447e9da1c2f478"/></canvas><canvas name="5" width="96" height="108"><vector name="origin" x="53" y="99"/><vector name="lt" x="-53" y="-96"/><vector name="rb" x="37" y="1"/><vector name="head" x="-18" y="-86"/><int name="delay" value="120"/><string name="_hash" value="c10c706a73006e149cfc741ea11c91b61ba140b660d20b38f9266b9c6952cba8"/></canvas><canvas name="6" width="183" height="101"><vector name="origin" x="153" y="92"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="174f9140e8fac9366cfb1ee5d2f1d1c1151291c7daa99664f5c0256969af15ef"/></canvas><canvas name="7" width="201" height="99"><vector name="origin" x="154" y="91"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="01c524de8afff628eabec742f4f49d7295c4c6b624cc9c5f1cd9f089b8e19aef"/></canvas><canvas name="8" width="183" height="98"><vector name="origin" x="153" y="91"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="30566d42cb53419601b48c57fff8017692696c4386d8e592865b818a6302e033"/></canvas><canvas name="9" width="193" height="107"><vector name="origin" x="146" y="90"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="b2ea26c82b8731d9804e7c4cb891d4a5af0e15fdd32b9d1337058e78efee4c9b"/></canvas><canvas name="10" width="199" height="101"><vector name="origin" x="145" y="85"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="6f00715cac24509aa69ffab49d0b009da73115b6e378603af4036f0803faa2ba"/></canvas><canvas name="11" width="195" height="86"><vector name="origin" x="143" y="85"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="95dd9055b9388873a8fb1dd276f58cef33a212dabe8a6e39496050f0ca42346a"/></canvas><uol name="12" value="5"/><uol name="13" value="4"/><uol name="14" value="3"/><uol name="15" value="2"/><uol name="16" value="1"/></imgdir><imgdir name="jump"><canvas name="0" width="83" height="85"><vector name="origin" x="57" y="97"/><int name="delay" value="120"/><vector name="lt" x="-58" y="-98"/><vector name="rb" x="26" y="-12"/><vector name="head" x="-31" y="-100"/></canvas></imgdir><imgdir name="info"><int name="bodyAttack" value="1"/><int name="level" value="180"/><int name="maxHP" value="3900000"/><int name="maxMP" value="8000"/><int name="speed" value="30"/><int name="PADamage" value="800"/><int name="PDDamage" value="920"/><int name="MADamage" value="700"/><int name="MDDamage" value="750"/><int name="acc" value="688"/><int name="eva" value="65"/><int name="exp" value="100000"/><int name="undead" value="0"/><int name="pushed" value="100000"/><float name="fs" value="10.0"/><int name="hpRecovery" value="500"/><int name="mpRecovery" value="50"/><int name="summonType" value="1"/><int name="boss" value="1"/><int name="firstAttack" value="1"/><int name="hpTagBgcolor" value="5"/><int name="hpTagColor" value="1"/></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787179.img">
+  <imgdir name="move">
+    <canvas name="0" width="83" height="87">
+      <vector name="origin" x="55" y="86"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1898e5f83eb1cb6648c818dab5e23bcf861906aeccd9a0a443ddf9a63e86747f"/>
+    </canvas>
+    <canvas name="1" width="86" height="85">
+      <vector name="origin" x="58" y="84"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dd63c946ac2ee508236ca61ba65641fea196f63700f899d4923a8c93d16648b9"/>
+    </canvas>
+    <canvas name="2" width="83" height="87">
+      <vector name="origin" x="55" y="86"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="14a1b2f0a418b2173a45ea5fcaf80f781754e8c7ccd5af73ae3caffc3af52ef0"/>
+    </canvas>
+    <canvas name="3" width="81" height="88">
+      <vector name="origin" x="53" y="87"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f640725a3005f02477a41b4a30bbe357a08ff2382aae5e55b8e345e7f47fb0ef"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="83" height="88">
+      <vector name="origin" x="53" y="87"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e3742038950d70997f268297943f7fc553f52793dbb8c9b8272d631c79324e6e"/>
+    </canvas>
+    <canvas name="1" width="83" height="86">
+      <vector name="origin" x="53" y="85"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="97a22ecd1ff29367f294feba7d87d90511910f23d09a27f509f8661cd7610be0"/>
+    </canvas>
+    <canvas name="2" width="83" height="88">
+      <vector name="origin" x="53" y="87"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="215eefc49399aa18d0e3712d2c76dacfc845dcfa9223a1585439c1df3d85086a"/>
+    </canvas>
+    <canvas name="3" width="82" height="89">
+      <vector name="origin" x="53" y="88"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="28" y="1"/>
+      <vector name="head" x="-25" y="-82"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="82583c4c226bc252df7026a827358548f3ca4daee92a2c7dafbf78eccdd809e3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="92" height="88">
+      <vector name="origin" x="43" y="87"/>
+      <vector name="lt" x="-44" y="-88"/>
+      <vector name="rb" x="50" y="1"/>
+      <vector name="head" x="-17" y="-85"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="a81cf292182137d7cc74008a892275fca8d6541f7428eee98eb4417f48d02ec3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="86" height="88">
+      <vector name="origin" x="42" y="87"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3c4f212e229675eba5c050ca325fbe6662340dcdbee152fd404b453d5db4d73d"/>
+    </canvas>
+    <canvas name="1" width="83" height="88">
+      <vector name="origin" x="41" y="87"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f57ef084fa97fe409ba26ec2614cba616980efe52ca146d10b90eee2980408d8"/>
+    </canvas>
+    <canvas name="2" width="96" height="86">
+      <vector name="origin" x="28" y="81"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5ae5c1c7bbbb1c1b33cc38d77e0d8891bee5829e946d5a7efb408b6b32f303e1"/>
+    </canvas>
+    <canvas name="3" width="105" height="89">
+      <vector name="origin" x="32" y="84"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d61d6674f21637d5f485328d1296efb60bd748174286a83f551c9dcd00e9a9f2"/>
+    </canvas>
+    <canvas name="4" width="107" height="87">
+      <vector name="origin" x="32" y="83"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3aed8c6ba6627805294c7aafd3f4a5d59551cf9ec1497125463158cd79609a75"/>
+    </canvas>
+    <canvas name="5" width="109" height="84">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5206d2c7bdf97a23188d963c9bb2831c1c6bd0c55f1af34cc1c7194f454814f5"/>
+    </canvas>
+    <canvas name="6" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7d8d96a15738735e22a38e75bf6af59de60ef1b94b1e389049359a41c9e1ef53"/>
+    </canvas>
+    <canvas name="7" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f2f0b2ee379c0d6c218d16f7bffc3b60b0dc5a41ff13bd1b98dc818b455ab9cf"/>
+    </canvas>
+    <canvas name="8" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="40026ffac9862ccf1dc8dc7556e5d9c16b4d61f8ea57a4e88151a01083b568cf"/>
+    </canvas>
+    <canvas name="9" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cf7c5005119fb56a67cc7a92ce1b3fa2eb57b920742d12049e83cb674aacc0f5"/>
+    </canvas>
+    <canvas name="10" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <vector name="head" x="-11" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a06a9959e9b98f23b974631b176196c521d718a4b6341723e8a2a7b6848f5179"/>
+    </canvas>
+    <canvas name="11" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="06d9f3da506a7a84b5fdc4ed395b4c400fdec816f61ecece92c5e6e6f11d154a"/>
+    </canvas>
+    <canvas name="12" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="3a461c0f7c95d8984df0723355568116312d49a05334514d6fb61e6837efc580"/>
+    </canvas>
+    <canvas name="13" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="1d2a05d7fba139804cbe0d6356739abc2d9efc2c3af6e0df23ae0eda8b485637"/>
+    </canvas>
+    <canvas name="14" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="e762aae19d4d38075dbcc18e13c94c92f1666c2ead808f2af768864652d5af47"/>
+    </canvas>
+    <canvas name="15" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="aede0bd33ad6ee4aa602f484c26b81d1b06659e27ab8f560ebcaa4849095d881"/>
+    </canvas>
+    <canvas name="18" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="f49423846ee434adea0f7c7062536b8141a4acd2d08f1e58e517a2db9a0deb4f"/>
+    </canvas>
+    <canvas name="19" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="fa97d46d6a710cc1c17f126ada5ec788b89baa39edaaf59771946fd99c514af1"/>
+    </canvas>
+    <canvas name="20" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="f0c1aa3acc117a73064a40692260fd631f57db4f155228853f668a64bf1c943a"/>
+    </canvas>
+    <canvas name="21" width="83" height="83">
+      <vector name="origin" x="32" y="82"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="3493748479e30b561222683f926b4eb8a22846851cd8724adf5e50499187baa5"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Hmph, this is not over! I will be waiting on the roof."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-291" y="-146"/>
+        <vector name="rb" x="72" y="1"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="70" height="68">
+          <vector name="origin" x="35" y="67"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="4e3535ceecee873a87488f6693e58934e69f77d82260a1a1051e362caa101fdc"/>
+        </canvas>
+        <canvas name="1" width="118" height="155">
+          <vector name="origin" x="51" y="116"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="f7a7a8d418de5119d19ea2c5fb44d8eb04cfce4bdc4d939c59b3f5850e02366e"/>
+        </canvas>
+        <canvas name="2" width="164" height="153">
+          <vector name="origin" x="86" y="114"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="2b4e7308e6616deb1dd5a09149601e4d86eba68567c2c2b20f113e5d5dd9a266"/>
+        </canvas>
+        <canvas name="3" width="164" height="151">
+          <vector name="origin" x="86" y="112"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6b95dba9a7437225a56c2b85f254cd3cf5796b57087fa4103537315b7e72fe7d"/>
+        </canvas>
+        <canvas name="4" width="153" height="132">
+          <vector name="origin" x="81" y="107"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="a925f554f7f750233cdf915c6da4e2e8810c7319321cd944d1bbd53b853f3d4d"/>
+        </canvas>
+        <canvas name="5" width="155" height="132">
+          <vector name="origin" x="83" y="107"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="9df74b9dbde2c11dba0a3890b95b4a9fe6b4501b7f47eb5cdec2bf2c7b49257c"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="960"/>
+    </imgdir>
+    <canvas name="0" width="170" height="181">
+      <vector name="origin" x="107" y="139"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="2ba0ae038391ef8e136b0d263c897df377a659713029ffd11ae04658b57bdc48"/>
+    </canvas>
+    <canvas name="1" width="122" height="166">
+      <vector name="origin" x="70" y="117"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="89432ba48111ed41427a035b68d04ffe74f8a7a87aa39039250f53bfdeae80d7"/>
+    </canvas>
+    <canvas name="2" width="150" height="130">
+      <vector name="origin" x="87" y="88"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="448b002724a759152289c72b399dd8d4dbf1462f6cf46780c22702f96da1b7f7"/>
+    </canvas>
+    <canvas name="3" width="154" height="192">
+      <vector name="origin" x="75" y="166"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="a38676471c7ef59ad1cb0578c34681c59eb616ba3b5976edf07d8a3427e290cb"/>
+    </canvas>
+    <canvas name="4" width="161" height="120">
+      <vector name="origin" x="101" y="111"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="a28c55b4a30e34359a3a4d97bd9583668b7efbf9bcbd6d8a97bf26109b35ba67"/>
+    </canvas>
+    <canvas name="5" width="100" height="86">
+      <vector name="origin" x="53" y="85"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="33" y="1"/>
+      <vector name="head" x="-23" y="-80"/>
+      <string name="_hash" value="3605dd1b01a3d7da4a9b27260ecc2f5ad1b97adda800de74eedaa06a2ab07611"/>
+    </canvas>
+    <canvas name="6" width="83" height="85">
+      <vector name="origin" x="57" y="84"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-58" y="-85"/>
+      <vector name="rb" x="27" y="1"/>
+      <vector name="head" x="-26" y="-79"/>
+      <string name="_hash" value="7686de38416d486ed36e96494e07903e0cd25e71954d31384dee7e372538e9e4"/>
+    </canvas>
+    <canvas name="7" width="235" height="169">
+      <vector name="origin" x="146" y="146"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <string name="_hash" value="9f2e9fecab38d213d7a3e1249368bb1c1b12e464ad9cfef450f4f0e2cafdb7b2"/>
+    </canvas>
+    <canvas name="8" width="287" height="165">
+      <vector name="origin" x="169" y="142"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <string name="_hash" value="cba20203be235e7371a650904cf1a30bf7979ab3057ca4f539c63982c741613e"/>
+    </canvas>
+    <canvas name="9" width="312" height="171">
+      <vector name="origin" x="186" y="144"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <string name="_hash" value="c8f97deec1669eea0619c9056596c4c561252ee8df2c52fb51d4627a2fabf629"/>
+    </canvas>
+    <canvas name="10" width="339" height="174">
+      <vector name="origin" x="206" y="146"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <string name="_hash" value="1f09ea164b9bfde4966e34f86fec218d98136d9122313707d2115b15709e7c98"/>
+    </canvas>
+    <canvas name="11" width="360" height="168">
+      <vector name="origin" x="229" y="142"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <string name="_hash" value="756129d499a07b569bb915137d2f876ae6cdbeffa9b300c6c68f7da8b4c29135"/>
+    </canvas>
+    <canvas name="12" width="371" height="164">
+      <vector name="origin" x="245" y="144"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="08e2a08f0a0cf721e8f1950967518ea21b95d7b38bf3c1473497858f9b8e564a"/>
+    </canvas>
+    <canvas name="13" width="295" height="148">
+      <vector name="origin" x="265" y="144"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0ea5b4eabde5397c3a40649ad983dd7477eed542593a0460185c85cf4b109132"/>
+    </canvas>
+    <canvas name="14" width="316" height="143">
+      <vector name="origin" x="286" y="140"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="aeb134f3dbf0f39cf0228f3c57399a23adf8d46297ba6c78df963c53f462c7e1"/>
+    </canvas>
+    <canvas name="15" width="327" height="138">
+      <vector name="origin" x="298" y="137"/>
+      <vector name="lt" x="-50" y="-97"/>
+      <vector name="rb" x="35" y="2"/>
+      <vector name="head" x="-19" y="-91"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1e63335cea2431a053adbb4f46cb38937fbe9349f9777068e66215f776f19c68"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-210" y="-112"/>
+        <vector name="rb" x="62" y="23"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="83" height="77">
+          <vector name="origin" x="74" y="75"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="fe8e961636db6d411931c6e63ea7ed4414bf81f07aa09cae69a3d7d05d5d5f13"/>
+        </canvas>
+        <canvas name="1" width="134" height="94">
+          <vector name="origin" x="81" y="71"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="6925815909794625ae0066db2548b80bb72484d673a62ce0b7b86194e7c23feb"/>
+        </canvas>
+        <canvas name="2" width="143" height="121">
+          <vector name="origin" x="85" y="102"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="a9e228684ee84cea9089d2c914596e8fa34018f5f9ab7f9317d18555f96d8667"/>
+        </canvas>
+        <canvas name="3" width="111" height="128">
+          <vector name="origin" x="49" y="107"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="efb473f9b387f7c76fda011ad9642c8933be5ed62fcd6fe97c9c4fe3cd057360"/>
+        </canvas>
+        <canvas name="4" width="94" height="128">
+          <vector name="origin" x="46" y="111"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="3beb1fbe5396cf9fba6d3100cbafd55cb9429cadf84aec9a49feaa07492e3681"/>
+        </canvas>
+        <canvas name="5" width="76" height="102">
+          <vector name="origin" x="49" y="81"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="351c9a1465ce0488c0d22d872cb64cbd514e3a8d3ebc7b48d655ccb65a0a9196"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="960"/>
+    </imgdir>
+    <canvas name="0" width="83" height="88">
+      <vector name="origin" x="53" y="87"/>
+      <vector name="lt" x="-54" y="-88"/>
+      <vector name="rb" x="30" y="1"/>
+      <vector name="head" x="-24" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="87" height="97">
+      <vector name="origin" x="53" y="92"/>
+      <vector name="lt" x="-54" y="-92"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="-23" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="35ae5b154985cd700b34ef2067ea8c1a5d71b42a63b04c589ef63ec852779141"/>
+    </canvas>
+    <canvas name="2" width="94" height="102">
+      <vector name="origin" x="56" y="95"/>
+      <vector name="lt" x="-54" y="-92"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="-23" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="582a6e364f462348e42c386bdd68f83b49150f58b23bd3f0938d0aca817fd1eb"/>
+    </canvas>
+    <canvas name="3" width="93" height="106">
+      <vector name="origin" x="52" y="98"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="297b009e40508b01964c6b8584a969347384d189d99b6123c9922d73c129b4f5"/>
+    </canvas>
+    <canvas name="4" width="96" height="106">
+      <vector name="origin" x="53" y="98"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="731bb3c8b6de6e94bb0456ae7725cb69d6afb87eaedc2cfc80447e9da1c2f478"/>
+    </canvas>
+    <canvas name="5" width="96" height="108">
+      <vector name="origin" x="53" y="99"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c10c706a73006e149cfc741ea11c91b61ba140b660d20b38f9266b9c6952cba8"/>
+    </canvas>
+    <canvas name="6" width="183" height="101">
+      <vector name="origin" x="153" y="92"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="174f9140e8fac9366cfb1ee5d2f1d1c1151291c7daa99664f5c0256969af15ef"/>
+    </canvas>
+    <canvas name="7" width="201" height="99">
+      <vector name="origin" x="154" y="91"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="01c524de8afff628eabec742f4f49d7295c4c6b624cc9c5f1cd9f089b8e19aef"/>
+    </canvas>
+    <canvas name="8" width="183" height="98">
+      <vector name="origin" x="153" y="91"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="30566d42cb53419601b48c57fff8017692696c4386d8e592865b818a6302e033"/>
+    </canvas>
+    <canvas name="9" width="193" height="107">
+      <vector name="origin" x="146" y="90"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2ea26c82b8731d9804e7c4cb891d4a5af0e15fdd32b9d1337058e78efee4c9b"/>
+    </canvas>
+    <canvas name="10" width="199" height="101">
+      <vector name="origin" x="145" y="85"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6f00715cac24509aa69ffab49d0b009da73115b6e378603af4036f0803faa2ba"/>
+    </canvas>
+    <canvas name="11" width="195" height="86">
+      <vector name="origin" x="143" y="85"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="95dd9055b9388873a8fb1dd276f58cef33a212dabe8a6e39496050f0ca42346a"/>
+    </canvas>
+    <uol name="12" value="5"/>
+    <uol name="13" value="4"/>
+    <uol name="14" value="3"/>
+    <uol name="15" value="2"/>
+    <uol name="16" value="1"/>
+  </imgdir>
+  <imgdir name="jump">
+    <canvas name="0" width="83" height="85">
+      <vector name="origin" x="57" y="97"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-58" y="-98"/>
+      <vector name="rb" x="26" y="-12"/>
+      <vector name="head" x="-31" y="-100"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="180"/>
+    <int name="maxHP" value="3900000"/>
+    <int name="maxMP" value="8000"/>
+    <int name="speed" value="30"/>
+    <int name="PADamage" value="800"/>
+    <int name="PDDamage" value="920"/>
+    <int name="MADamage" value="700"/>
+    <int name="MDDamage" value="750"/>
+    <int name="acc" value="688"/>
+    <int name="eva" value="65"/>
+    <int name="exp" value="100000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="hpRecovery" value="500"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8787180.img.xml
+++ b/gms-server/wz/Mob.wz/8787180.img.xml
@@ -1,1 +1,1255 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8787180.img"><imgdir name="stand"><canvas name="0" width="115" height="86"><vector name="origin" x="56" y="86"/><vector name="lt" x="-56" y="-86"/><vector name="rb" x="59" y="0"/><vector name="head" x="-11" y="-53"/><int name="delay" value="120"/><string name="_hash" value="b0c47f42552e3d57c962b27e69f917dcee4b014a4f854517cd432503b31e59e3"/></canvas><canvas name="1" width="121" height="87"><vector name="origin" x="56" y="87"/><vector name="lt" x="-56" y="-87"/><vector name="rb" x="65" y="0"/><vector name="head" x="-7" y="-53"/><int name="delay" value="120"/><string name="_hash" value="c9735770149ba96efc0003479ab9188e4747af420408f10c240975a65252230e"/></canvas><canvas name="2" width="123" height="86"><vector name="origin" x="56" y="86"/><vector name="lt" x="-56" y="-86"/><vector name="rb" x="67" y="0"/><vector name="head" x="-6" y="-52"/><int name="delay" value="120"/><string name="_hash" value="21387399ca001c7d49713675de56269bb54a4f26a9a9e0889e57128d3be31b36"/></canvas><canvas name="3" width="116" height="85"><vector name="origin" x="56" y="85"/><vector name="lt" x="-56" y="-85"/><vector name="rb" x="60" y="0"/><vector name="head" x="-11" y="-52"/><int name="delay" value="120"/><string name="_hash" value="47d9ee3172ab83e0d1d15434413b05205eb8d76eb359f80c485a953395c9c2a4"/></canvas></imgdir><imgdir name="move"><canvas name="0" width="122" height="90"><vector name="origin" x="59" y="89"/><vector name="lt" x="-64" y="-89"/><vector name="rb" x="58" y="1"/><vector name="head" x="-11" y="-57"/><int name="delay" value="120"/><string name="_hash" value="6699f2c91583e81b7c42eac4475ccdbe50c15413d66b1b1b682167e1d98acab8"/></canvas><canvas name="1" width="117" height="87"><vector name="origin" x="60" y="86"/><vector name="lt" x="-60" y="-86"/><vector name="rb" x="57" y="1"/><vector name="head" x="-11" y="-55"/><int name="delay" value="120"/><string name="_hash" value="72cc07fef2d5029da94d9b359456938dcb732f5f85c1af5496e454c9924d63d2"/></canvas><canvas name="2" width="108" height="88"><vector name="origin" x="57" y="87"/><vector name="lt" x="-57" y="-87"/><vector name="rb" x="51" y="1"/><vector name="head" x="-12" y="-55"/><int name="delay" value="120"/><string name="_hash" value="d3a94301c3e3a1134f0ae292c3e55ec773f3d2fd0d32c8fa8e2498d30d8ae15d"/></canvas><canvas name="3" width="107" height="90"><vector name="origin" x="56" y="89"/><vector name="lt" x="-56" y="-89"/><vector name="rb" x="51" y="1"/><vector name="head" x="-12" y="-57"/><int name="delay" value="120"/><string name="_hash" value="12bdd1fdf51a82610313077ebe1fdf25bb53568e407a78a9cbc1deb9ec988640"/></canvas><canvas name="4" width="115" height="91"><vector name="origin" x="59" y="90"/><int name="z" value="0"/><vector name="lt" x="-59" y="-90"/><vector name="rb" x="56" y="1"/><vector name="head" x="-12" y="-57"/><int name="delay" value="120"/><string name="_hash" value="8f11ef41ccbdb23f4bc4154a36fad1333df612545e64420c37e1e757dbff7ab4"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="117" height="88"><vector name="origin" x="58" y="88"/><vector name="lt" x="-58" y="-88"/><vector name="rb" x="59" y="0"/><vector name="head" x="-11" y="-55"/><int name="delay" value="120"/><string name="_hash" value="bb7f7890765d6a0bd6f988de066aaca64beed8a469b23252932b23f378104fcb"/></canvas><canvas name="1" width="103" height="98"><vector name="origin" x="53" y="98"/><int name="z" value="0"/><vector name="lt" x="-28" y="-98"/><vector name="rb" x="50" y="0"/><vector name="head" x="4" y="-64"/><int name="delay" value="120"/><string name="_hash" value="e3f2bf31cd039f956fd17995a2bb9287cdc25b12586e00858c9259e629817eca"/></canvas><canvas name="2" width="136" height="146"><vector name="origin" x="86" y="137"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-28" y="-98"/><vector name="rb" x="50" y="0"/><vector name="head" x="4" y="-64"/><string name="_hash" value="7c03bc16e24b8e0ff087a6bf32b901e590af3e69f7d5d3b12bf8e40f22dd0454"/></canvas><canvas name="3" width="142" height="155"><vector name="origin" x="92" y="142"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-28" y="-98"/><vector name="rb" x="50" y="0"/><vector name="head" x="4" y="-64"/><string name="_hash" value="739bc4c0732333bf6aa33649bc2b69a756569a27b1d4e8156d2e39fe0e9d7d4a"/></canvas><canvas name="4" width="146" height="154"><vector name="origin" x="96" y="144"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-28" y="-98"/><vector name="rb" x="50" y="0"/><vector name="head" x="4" y="-64"/><string name="_hash" value="5426b26725f308692bb313e53af94d7b21ddb38f5badcaf0aa8e0c5fa07c5389"/></canvas><canvas name="5" width="142" height="146"><vector name="origin" x="92" y="137"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-28" y="-98"/><vector name="rb" x="50" y="0"/><vector name="head" x="4" y="-64"/><string name="_hash" value="457242ee495677b6cfa162e7f4a878cc8d35fdbabe0ff32888b6af470ad5dd59"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="117" height="88"><vector name="origin" x="58" y="88"/><vector name="head" x="-11" y="-56"/><int name="delay" value="120"/></canvas><canvas name="1" width="103" height="98"><vector name="origin" x="53" y="97"/><vector name="head" x="3" y="-63"/><int name="delay" value="120"/></canvas><canvas name="2" width="136" height="146"><vector name="origin" x="86" y="137"/><vector name="head" x="2" y="-64"/><int name="delay" value="120"/></canvas><canvas name="3" width="142" height="155"><vector name="origin" x="92" y="142"/><vector name="head" x="3" y="-64"/><int name="delay" value="120"/></canvas><canvas name="4" width="146" height="154"><vector name="origin" x="96" y="144"/><vector name="head" x="3" y="-65"/><int name="delay" value="120"/></canvas><canvas name="5" width="142" height="146"><vector name="origin" x="92" y="136"/><vector name="head" x="3" y="-64"/><int name="delay" value="120"/></canvas><canvas name="6" width="94" height="84"><vector name="origin" x="37" y="80"/><vector name="head" x="9" y="-48"/><int name="delay" value="120"/><string name="_hash" value="36ee7a35804990fac7466d146b53c04bc92de8d4912433e07b9fe397fcac57ad"/></canvas><canvas name="7" width="87" height="85"><vector name="origin" x="25" y="81"/><vector name="head" x="9" y="-49"/><int name="delay" value="120"/><string name="_hash" value="e22a9405668bfc587508d3e65806d1c41e220a50ac88a38d84d7cac4ee0c021c"/></canvas><canvas name="8" width="88" height="85"><vector name="origin" x="26" y="81"/><vector name="head" x="26" y="-17"/><int name="delay" value="120"/><string name="_hash" value="61eef33622c24101ef3a7ac6e3bf57618d17c3897ab50832b853f2b4cbcb732e"/></canvas><canvas name="9" width="87" height="84"><vector name="origin" x="25" y="80"/><vector name="head" x="9" y="-47"/><int name="delay" value="120"/><string name="_hash" value="771c998f701d4e6acb1b5b84f116f29d672cef8ecbe42f78663e6e15ad4b8f5c"/></canvas><canvas name="10" width="111" height="85"><vector name="origin" x="44" y="81"/><vector name="head" x="9" y="-48"/><int name="delay" value="120"/><string name="_hash" value="021ca92c572b44d5c7b20ead4dae243bb0e32198d4b39af1dffe39c0f439d8f3"/></canvas><canvas name="11" width="141" height="84"><vector name="origin" x="57" y="80"/><int name="delay" value="120"/><vector name="head" x="9" y="-47"/><string name="_hash" value="6895496dcc4f1649e817cb52b9cc560a39ea5abba980447ec0c9a77010a8ccd8"/></canvas><canvas name="12" width="146" height="85"><vector name="origin" x="59" y="81"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="e585aecaf74a5d50aead2d842f6bff2a9a2120d9076375d067aca41164734e6c"/></canvas><canvas name="13" width="146" height="84"><vector name="origin" x="59" y="80"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="08f60f4a863f3053542afd7cec74edd16b7b282ffd2499703fef60c073d637c6"/></canvas><canvas name="14" width="146" height="85"><vector name="origin" x="55" y="81"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="e6d190f92935a2bdeeea8b9fde1102a6976681fa56d51edaf7e2e5b269656fff"/></canvas><canvas name="15" width="146" height="84"><vector name="origin" x="58" y="80"/><int name="delay" value="120"/><vector name="head" x="-11" y="-83"/><string name="_hash" value="6e92f3274b442d80399fc35587bd7a338081b2a8de02a0345fa03f787b932a6e"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="哼~還沒結束呢!!我會在屋頂等你的"/></imgdir></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-95" y="-82"/><vector name="rb" x="60" y="1"/></imgdir><imgdir name="hit"><canvas name="0" width="92" height="125"><vector name="origin" x="46" y="62"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="5964f52b588e51495c01dd76a3095e4d521a9f80280dcb48ce5ecfcee331c7ee"/></canvas><canvas name="1" width="103" height="110"><vector name="origin" x="51" y="55"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="3975cd08395b9ab1a0083f696f42855f9e6ede6d5aae80379917d75acba74669"/></canvas><canvas name="2" width="101" height="136"><vector name="origin" x="50" y="68"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="50158431679cafeead31e810c246a6bb68151c7dea1797537786ad350ba54cc4"/></canvas><canvas name="3" width="105" height="135"><vector name="origin" x="52" y="67"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="763b29ad9baaca682b4f166aacd1265a5822594fa2412d039b13ae2484b465f8"/></canvas><canvas name="4" width="112" height="146"><vector name="origin" x="56" y="73"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="151c44b33a1891230c1f00b76aa384ed29fc40cb8ae9c24d4fb1479000b7918f"/></canvas><canvas name="5" width="102" height="124"><vector name="origin" x="51" y="62"/><int name="z" value="0"/><int name="delay" value="90"/><string name="_hash" value="74b40413cd7d9b0edede0f0696dc50a87988abe44535d970470d4c447087c36e"/></canvas></imgdir><int name="attackAfter" value="600"/></imgdir><canvas name="0" width="115" height="87"><vector name="origin" x="56" y="86"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-57" y="-86"/><vector name="rb" x="59" y="1"/><vector name="head" x="-11" y="-54"/><string name="_hash" value="685e9b1b3f5d9300628d52da39161a6a6fbbc7d46564f39de7b8225789e95bdb"/></canvas><canvas name="1" width="118" height="90"><vector name="origin" x="60" y="89"/><int name="z" value="0"/><vector name="lt" x="-60" y="-89"/><vector name="rb" x="58" y="1"/><vector name="head" x="-10" y="-55"/><int name="delay" value="120"/><string name="_hash" value="23c36ba4b352dea2ea5bb809c5877830708e96d81ac3d7bda2213195dc332d76"/></canvas><canvas name="2" width="88" height="99"><vector name="origin" x="37" y="98"/><int name="z" value="0"/><vector name="lt" x="-37" y="-98"/><vector name="rb" x="51" y="1"/><vector name="head" x="0" y="-63"/><int name="delay" value="120"/><string name="_hash" value="709f7b6c2c7bdd7455fa3c2694fe7d3fabacc137f5ebe3a6faf2405139c33c42"/></canvas><canvas name="3" width="77" height="106"><vector name="origin" x="30" y="105"/><int name="z" value="0"/><vector name="lt" x="-30" y="-105"/><vector name="rb" x="47" y="1"/><vector name="head" x="2" y="-66"/><int name="delay" value="120"/><string name="_hash" value="43efc94c2fa178b8fd9a86f3c67e5e9fb7a7426b1f2659f51c31c353fec356a0"/></canvas><canvas name="4" width="155" height="83"><vector name="origin" x="95" y="82"/><int name="z" value="0"/><vector name="lt" x="-95" y="-82"/><vector name="rb" x="60" y="1"/><vector name="head" x="-14" y="-48"/><int name="delay" value="120"/><string name="_hash" value="a7375189d575c5521dd1b4b62248ef0ac0613a269bca5afd8e2118b3737a1b26"/></canvas><canvas name="5" width="134" height="85"><vector name="origin" x="74" y="83"/><int name="z" value="0"/><vector name="lt" x="-74" y="-83"/><vector name="rb" x="60" y="2"/><vector name="head" x="-13" y="-51"/><int name="delay" value="120"/><string name="_hash" value="caf562430d91a87a0fb6e9cac55c70183e1c78b96dfadc79e00857194eb2c2a5"/></canvas><canvas name="6" width="122" height="85"><vector name="origin" x="64" y="83"/><int name="z" value="0"/><vector name="lt" x="-64" y="-83"/><vector name="rb" x="58" y="2"/><vector name="head" x="-12" y="-49"/><int name="delay" value="120"/><string name="_hash" value="9cd6d158688d92c72e6a8ff0448a20168092eb3cca4ca3caf54c96148e5e0935"/></canvas><canvas name="7" width="122" height="86"><vector name="origin" x="63" y="85"/><int name="z" value="0"/><vector name="lt" x="-63" y="-85"/><vector name="rb" x="59" y="1"/><vector name="head" x="-11" y="-52"/><int name="delay" value="120"/><string name="_hash" value="fe76201215705b58f94caf467fbbce1b9f4972c42eeadce0231782d517d16888"/></canvas><uol name="8" value="../stand/0"/><uol name="9" value="../stand/1"/><uol name="10" value="../stand/2"/><uol name="11" value="../stand/3"/></imgdir><imgdir name="attack2"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-711" y="-98"/><vector name="rb" x="726" y="-21"/></imgdir><imgdir name="hit"><canvas name="0" width="116" height="120"><vector name="origin" x="51" y="66"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8ed2c3d468cd983bcb517f87c318200d199ea02900510cfbc0e3439d27daa8c2"/></canvas><canvas name="1" width="108" height="113"><vector name="origin" x="54" y="56"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="2c057ef0f829620f079fb368c7d5594ca1339f33c040c387d69ffaff39cddba9"/></canvas><canvas name="2" width="117" height="119"><vector name="origin" x="58" y="59"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e4c279fba43ea074b3e109d6b56bfcf684003cbd78200ebc08334c5b943c6a37"/></canvas><canvas name="3" width="125" height="129"><vector name="origin" x="62" y="64"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d49a368d5430625319429ea7ca18057f147279f799d5e9740c15973b76b18e6d"/></canvas><canvas name="4" width="134" height="141"><vector name="origin" x="67" y="70"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="febd73dfe38eabcab918a83d219a7a5e45cd4678ffbd93b6a2fad9432c3de54e"/></canvas><canvas name="5" width="79" height="88"><vector name="origin" x="39" y="44"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="cc795793c247aeb3777e8f5c587226f20ce768ba7b236d8ee201583117431f64"/></canvas><canvas name="6" width="62" height="69"><vector name="origin" x="31" y="34"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="dbf5559c52b90fc9927a9a17bb7417dddef010396c54d580e8de32502b9d8292"/></canvas><canvas name="7" width="33" height="34"><vector name="origin" x="16" y="17"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="a2d2112016144bdcc85477047359db56a587c6b729f6956b8350656678c42c9b"/></canvas></imgdir><int name="attackAfter" value="1560"/></imgdir><canvas name="0" width="117" height="88"><vector name="origin" x="58" y="87"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-58" y="-87"/><vector name="rb" x="59" y="1"/><vector name="head" x="-11" y="-54"/></canvas><canvas name="1" width="128" height="154"><vector name="origin" x="64" y="149"/><int name="z" value="0"/><vector name="lt" x="-52" y="-87"/><vector name="rb" x="52" y="1"/><vector name="head" x="-11" y="-54"/><int name="delay" value="120"/><string name="_hash" value="3aa4a6c6d7887b986de9b50b059c770ff353046358079df21fb26b947327788c"/></canvas><canvas name="2" width="146" height="170"><vector name="origin" x="68" y="162"/><int name="z" value="0"/><vector name="lt" x="-51" y="-87"/><vector name="rb" x="44" y="1"/><vector name="head" x="-11" y="-54"/><int name="delay" value="120"/><string name="_hash" value="6f6a12458da560293be289e843e87b69f297211a404789c1978277f2c26262ec"/></canvas><canvas name="3" width="150" height="159"><vector name="origin" x="69" y="148"/><int name="z" value="0"/><vector name="lt" x="-47" y="-87"/><vector name="rb" x="42" y="3"/><vector name="head" x="-11" y="-54"/><int name="delay" value="120"/><string name="_hash" value="c9de3e8af271c8b1e9e78916de70e944771703f465a2340d76bdb6bed01b9dfa"/></canvas><canvas name="4" width="152" height="163"><vector name="origin" x="70" y="155"/><int name="z" value="0"/><vector name="lt" x="-48" y="-86"/><vector name="rb" x="45" y="2"/><vector name="head" x="-11" y="-54"/><int name="delay" value="120"/><string name="_hash" value="2472d3234c6f5329ed020ca480e1279945c1905d18099a0437b54dd2fa5c3806"/></canvas><canvas name="5" width="151" height="147"><vector name="origin" x="73" y="139"/><int name="z" value="0"/><vector name="lt" x="-47" y="-86"/><vector name="rb" x="42" y="2"/><vector name="head" x="-11" y="-54"/><int name="delay" value="120"/><string name="_hash" value="f47fd28508f2b6c474b2c187c5b00755631d01d14fe5c9884cd1a2b04cc1f61b"/></canvas><canvas name="6" width="155" height="159"><vector name="origin" x="77" y="153"/><int name="z" value="0"/><vector name="lt" x="-48" y="-86"/><vector name="rb" x="44" y="1"/><vector name="head" x="-11" y="-54"/><int name="delay" value="120"/><string name="_hash" value="95032a2d178ab58df57f93d3ce574ecc317859cff3b178913af5c1fc315e9232"/></canvas><canvas name="7" width="152" height="169"><vector name="origin" x="77" y="163"/><int name="z" value="0"/><vector name="lt" x="-47" y="-87"/><vector name="rb" x="42" y="2"/><vector name="head" x="-11" y="-54"/><int name="delay" value="120"/><string name="_hash" value="5b5a4838a0c020c1f992e779bd69b4f61b949395dd9b7b74275a07f242fc3d8a"/></canvas><canvas name="8" width="149" height="171"><vector name="origin" x="73" y="165"/><int name="z" value="0"/><vector name="lt" x="-49" y="-86"/><vector name="rb" x="44" y="2"/><vector name="head" x="-11" y="-54"/><int name="delay" value="120"/><string name="_hash" value="7b0dba85813d6f88df935802e62c77b152da4af42cb35b3738e3b2c52f0927eb"/></canvas><canvas name="9" width="144" height="159"><vector name="origin" x="67" y="153"/><int name="z" value="0"/><vector name="lt" x="-47" y="-86"/><vector name="rb" x="42" y="1"/><vector name="head" x="-11" y="-54"/><int name="delay" value="120"/><string name="_hash" value="b4e99f4956e87f2135f99e79bc4ac43ea117717a632775756b3ce942ef0346e9"/></canvas><canvas name="10" width="145" height="160"><vector name="origin" x="65" y="155"/><int name="z" value="0"/><vector name="lt" x="-50" y="-87"/><vector name="rb" x="46" y="1"/><vector name="head" x="-8" y="-55"/><int name="delay" value="120"/><string name="_hash" value="111b18303dd8d42cd4e62786ab1380772a0f2a2a0cd81b4fcd2361e20822aed6"/></canvas><canvas name="11" width="187" height="96"><vector name="origin" x="86" y="95"/><int name="z" value="0"/><vector name="lt" x="-59" y="-96"/><vector name="rb" x="78" y="0"/><vector name="head" x="0" y="-65"/><int name="delay" value="120"/><string name="_hash" value="1f5785057c87c223c7c0179e0669f6c2af9dfd8b7bec76af737af1c7179c3109"/></canvas><canvas name="12" width="319" height="128"><vector name="origin" x="152" y="124"/><int name="z" value="0"/><vector name="lt" x="-59" y="-96"/><vector name="rb" x="78" y="0"/><vector name="head" x="0" y="-65"/><int name="delay" value="120"/><string name="_hash" value="ddfeb0a3c60cb9044265b2f70ad3dadd637bc5d9a463eaaea913d3450f57eb80"/></canvas><canvas name="13" width="1529" height="158"><vector name="origin" x="757" y="143"/><int name="z" value="0"/><vector name="lt" x="-59" y="-96"/><vector name="rb" x="78" y="0"/><vector name="head" x="0" y="-65"/><int name="delay" value="120"/><string name="_hash" value="6b2189fb419c5f6fb18751025922a6853a68318fa82a628378725b5f1647731e"/></canvas><canvas name="14" width="1501" height="142"><vector name="origin" x="743" y="131"/><int name="z" value="0"/><vector name="lt" x="-59" y="-96"/><vector name="rb" x="78" y="0"/><vector name="head" x="0" y="-65"/><int name="delay" value="120"/><string name="_hash" value="64c552cfb6d646e1b58a623da5ac6957b2e1d37f44cb50a9ae7245b852ce6797"/></canvas><canvas name="15" width="1489" height="154"><vector name="origin" x="737" y="139"/><int name="z" value="0"/><vector name="lt" x="-59" y="-96"/><vector name="rb" x="78" y="0"/><vector name="head" x="0" y="-65"/><int name="delay" value="120"/><string name="_hash" value="999cfc7130a247bffe357f798007471aadabccdaee7c39237f5f6323ba861893"/></canvas><canvas name="16" width="1499" height="157"><vector name="origin" x="742" y="139"/><int name="z" value="0"/><vector name="lt" x="-59" y="-96"/><vector name="rb" x="78" y="0"/><vector name="head" x="0" y="-65"/><int name="delay" value="120"/><string name="_hash" value="dc7abac381aa585ee59dee7f6ffc1408c87c605314df97622334d085f2e65699"/></canvas><canvas name="17" width="1507" height="109"><vector name="origin" x="746" y="108"/><int name="z" value="0"/><vector name="lt" x="-59" y="-96"/><vector name="rb" x="72" y="0"/><vector name="head" x="0" y="-65"/><int name="delay" value="120"/><string name="_hash" value="f202a611429ed20dde74a9767760ccb24256262ade0c29f7802d754c154b2ffa"/></canvas><canvas name="18" width="1533" height="97"><vector name="origin" x="759" y="96"/><int name="z" value="0"/><vector name="lt" x="-59" y="-96"/><vector name="rb" x="72" y="0"/><vector name="head" x="0" y="-65"/><int name="delay" value="120"/><string name="_hash" value="da118e6d3541df760dcbbe20633edd0a568bc42102b6efa8052fd2df0e4c13b1"/></canvas><canvas name="19" width="1539" height="96"><vector name="origin" x="762" y="95"/><int name="z" value="0"/><vector name="lt" x="-59" y="-96"/><vector name="rb" x="72" y="0"/><vector name="head" x="0" y="-65"/><int name="delay" value="120"/><string name="_hash" value="1a4494b615db3e6426cce80b7b59346945000382dca1a9ada1e3485e4417afe9"/></canvas><canvas name="20" width="1453" height="97"><vector name="origin" x="719" y="96"/><int name="z" value="0"/><vector name="lt" x="-59" y="-96"/><vector name="rb" x="72" y="0"/><vector name="head" x="0" y="-65"/><int name="delay" value="120"/><string name="_hash" value="c38f3b9a9203832e40df9970bf9afa922d2030732555b495061b0b05a8fceaa6"/></canvas></imgdir><imgdir name="attack3"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-33" y="-309"/><vector name="rb" x="41" y="0"/><int name="start" value="-4"/><int name="areaCount" value="9"/><int name="attackCount" value="4"/></imgdir><imgdir name="hit"><canvas name="0" width="78" height="75"><vector name="origin" x="39" y="37"/><int name="delay" value="60"/><string name="_hash" value="badd9f56e36671cea02e387e50ff957982367af578845aeb0204c6d96bf14a59"/></canvas><canvas name="1" width="76" height="68"><vector name="origin" x="38" y="34"/><int name="delay" value="60"/><string name="_hash" value="0e7abffa83f8639089d8a8202eb310e77879637d3da5cce1a7d8e66f6dae3514"/></canvas><canvas name="2" width="73" height="74"><vector name="origin" x="36" y="37"/><int name="delay" value="60"/><string name="_hash" value="6fc6f3d534d4ea6a79ccef2e2d1cbc4ec7597eb99cc9491a979a325a47dd0717"/></canvas><canvas name="3" width="76" height="68"><vector name="origin" x="38" y="34"/><int name="z" value="0"/><int name="delay" value="60"/></canvas><canvas name="4" width="78" height="75"><vector name="origin" x="39" y="37"/><int name="z" value="0"/><int name="delay" value="60"/></canvas></imgdir><imgdir name="areaWarning"><canvas name="0" width="115" height="15"><vector name="origin" x="57" y="7"/><int name="delay" value="1680"/><string name="_hash" value="f90ae113b69b928cb639e4005e8a2f19f8ea9915d54c842ed822374678c927df"/></canvas><canvas name="1" width="1" height="1"><vector name="origin" x="57" y="7"/><int name="delay" value="120"/><string name="_inlink" value="attack3/info/areaWarning/0"/></canvas><canvas name="2" width="121" height="22"><vector name="origin" x="60" y="11"/><int name="delay" value="120"/><string name="_hash" value="6c786d03f298753d12d875dac7d1174123cf04aba011147cef83b5c071e05c2a"/></canvas><canvas name="3" width="125" height="36"><vector name="origin" x="62" y="25"/><int name="delay" value="120"/><string name="_hash" value="bf75b33260b78c6a1d978b365edadb6190c34268821cf07ca7e026d992792f17"/></canvas><canvas name="4" width="125" height="37"><vector name="origin" x="62" y="26"/><int name="delay" value="150"/><string name="_hash" value="02648ff11488ef2177ae6d3b2eab21d2fa0cc99a881ae142568aca8cb39d8d01"/></canvas><canvas name="5" width="125" height="39"><vector name="origin" x="62" y="28"/><int name="delay" value="150"/><string name="_hash" value="46312c0237515d0356fb638783e8124b21ce90e8f9472445ac02b01c70ac7be4"/></canvas><canvas name="6" width="125" height="39"><vector name="origin" x="62" y="28"/><int name="delay" value="150"/><string name="_hash" value="475b3e0cc1be75652ba868738a3c7f25f96be2a956c26525059e9d85f92084de"/></canvas><canvas name="7" width="125" height="39"><vector name="origin" x="62" y="28"/><int name="delay" value="150"/><string name="_hash" value="2f6039c636e35c2d8ce5fd2980da13c1bc63c4c889601478a48ad7509e93c040"/></canvas><canvas name="8" width="125" height="40"><vector name="origin" x="62" y="29"/><int name="delay" value="150"/><string name="_hash" value="7668d9c65a6afb24288d5adc4cd27acfccc0ec3ae12fad91e8af35a03aeb8433"/></canvas><canvas name="9" width="161" height="350"><vector name="origin" x="80" y="325"/><int name="delay" value="150"/><string name="_hash" value="04459d34cc6e142d1f7322d1b3638d9154c1b16aad6127dfe90bc6e186c98f3c"/></canvas><canvas name="10" width="165" height="339"><vector name="origin" x="86" y="325"/><int name="delay" value="150"/><string name="_hash" value="05800a06c5156a80d9f278a69896266417f54e69ce5ba3ac02aff11290872204"/></canvas><canvas name="11" width="165" height="345"><vector name="origin" x="86" y="330"/><int name="delay" value="150"/><string name="_hash" value="2cec2a7f92e3865db18fa5d33559d40443c4244735cc30a5cb8a0702aae2cb29"/></canvas><canvas name="12" width="163" height="339"><vector name="origin" x="82" y="325"/><int name="delay" value="150"/><string name="_hash" value="fa52d87f3215e5052f55534ba9e5a277f7a417aa0e878b80318153d0fc680fa5"/></canvas><canvas name="13" width="159" height="285"><vector name="origin" x="82" y="285"/><int name="delay" value="120"/><string name="_hash" value="1e4d2434a58092551f5bc70c66f0b827d5ebcc03586a8f988a1398b73bbf8525"/></canvas><canvas name="14" width="86" height="151"><vector name="origin" x="43" y="285"/><int name="delay" value="120"/><string name="_hash" value="89914a4e99f8eea4cae19231b054e786836b39e9cb0d6075bb6536d7501a1075"/></canvas><canvas name="15" width="88" height="149"><vector name="origin" x="44" y="285"/><int name="delay" value="120"/><string name="_hash" value="a65f4b7ff417a4cd13f4735754f2ebe3d98ca737cefc27e13d43b66dd4ec662d"/></canvas><canvas name="16" width="81" height="144"><vector name="origin" x="40" y="285"/><int name="delay" value="120"/><string name="_hash" value="69147b924ab412aedc58bdbe4764b20d6255a81e33b4430a9679aeb58097f714"/></canvas></imgdir><int name="attackAfter" value="2790"/></imgdir><canvas name="0" width="117" height="88"><vector name="origin" x="58" y="87"/><vector name="lt" x="-54" y="-88"/><vector name="rb" x="30" y="1"/><vector name="head" x="-24" y="-81"/><int name="delay" value="120"/></canvas><canvas name="1" width="128" height="154"><vector name="origin" x="64" y="149"/><vector name="lt" x="-54" y="-92"/><vector name="rb" x="34" y="1"/><vector name="head" x="-23" y="-83"/><int name="delay" value="120"/><string name="_hash" value="fd54515b0ad5a4252c53327e328703ef44c79e4b8558c0a4d8752eac34ffee10"/></canvas><canvas name="2" width="146" height="170"><vector name="origin" x="68" y="162"/><vector name="lt" x="-54" y="-92"/><vector name="rb" x="34" y="1"/><vector name="head" x="-23" y="-83"/><int name="delay" value="120"/><string name="_hash" value="dfd5f24937ef5ecc68abadba98c979406cca16c2b8c83d1c971bf28fc89104af"/></canvas><canvas name="3" width="150" height="157"><vector name="origin" x="69" y="148"/><vector name="lt" x="-53" y="-96"/><vector name="rb" x="37" y="1"/><vector name="head" x="-18" y="-86"/><int name="delay" value="120"/><string name="_hash" value="603fe6f3498aad15a4b2e552a7bba3836127b0c997bb7e2a6dfafde4341a65b7"/></canvas><canvas name="4" width="152" height="163"><vector name="origin" x="70" y="155"/><vector name="lt" x="-53" y="-96"/><vector name="rb" x="37" y="1"/><vector name="head" x="-18" y="-86"/><int name="delay" value="120"/><string name="_hash" value="ee1288610eb02e41eaf65063a5d23a0d6e332b7e00b1991b568ffb1037b06f29"/></canvas><canvas name="5" width="151" height="147"><vector name="origin" x="73" y="139"/><vector name="lt" x="-53" y="-96"/><vector name="rb" x="37" y="1"/><vector name="head" x="-18" y="-86"/><int name="delay" value="120"/><string name="_hash" value="83c965493262e16dc5a4217117fa493db44dc970d3a02d337f23108b652a0339"/></canvas><canvas name="6" width="155" height="159"><vector name="origin" x="77" y="153"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="8e2dc38ad54b13933afe647e103d66c3d63a81c207d42a44bba028502aefd499"/></canvas><canvas name="7" width="152" height="169"><vector name="origin" x="77" y="163"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="c0299b85b052dcc82d3c6d44a6fa065ba35bd562d1beb4a0a9886d96c25cdd7c"/></canvas><canvas name="8" width="149" height="171"><vector name="origin" x="73" y="165"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="2dba7d15ab60b5dd7d0137a7b7f66841a81a8983053dc6d23fd54ab2ebdc9b21"/></canvas><canvas name="9" width="144" height="161"><vector name="origin" x="67" y="155"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="a41b71af7399691f5f591496270a64cd9974c7c5f0e024557abf2623e93c663c"/></canvas><canvas name="10" width="148" height="168"><vector name="origin" x="68" y="162"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="a5e5d9c692172b73c95ee75d8777d93f067cb766f58dc10a396bdc8ae233c53f"/></canvas><canvas name="11" width="154" height="153"><vector name="origin" x="69" y="146"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="523fb8dab9e69c6ea3209a9b8c868183219498a0f2a3833450a256f84de5d401"/></canvas><canvas name="12" width="152" height="155"><vector name="origin" x="66" y="149"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="450c8c8811b4c0d8d84006f383aababe67080a48ae529bf3a65a909bee67a197"/></canvas><canvas name="13" width="144" height="136"><vector name="origin" x="69" y="131"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="417bcffe132d605ade7aeedc8c5afb085961f1a0d0226701fbba1f39aeff4fbb"/></canvas><canvas name="14" width="226" height="93"><vector name="origin" x="162" y="83"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="8e1bc6c102c27f816ec9479991e7570296cf556ca0964bebfa2a8ed43ef22fbf"/></canvas><canvas name="15" width="270" height="88"><vector name="origin" x="166" y="78"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="13f8bccc566f6f990f7ec69a780e2b4e34f309d05cd3e637338f26033550b693"/></canvas><canvas name="16" width="261" height="93"><vector name="origin" x="167" y="83"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="84eb38c28cae45fb12e9e58ecf33c89fed7913824a1d234407e23615c2c908fb"/></canvas><canvas name="17" width="257" height="93"><vector name="origin" x="167" y="85"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="aab8eb1264c8846aa9609e02d0591c784bf760121360e4ccd26f5a3a9fefb810"/></canvas><canvas name="18" width="216" height="88"><vector name="origin" x="130" y="83"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="efa4fba21fa318ae99bd0e68328d48d23187bf4a477d57f4468b6a817be57bf2"/></canvas><canvas name="19" width="252" height="91"><vector name="origin" x="167" y="83"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="40e3df5e1250762c247f727ef79f56250058292772e3235bdf29538eae6770e7"/></canvas><canvas name="20" width="135" height="90"><vector name="origin" x="51" y="89"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="0843fb182980ec77d4314cfa3347c922881158bdc8fbcbb588a39daadc40e894"/></canvas><canvas name="21" width="117" height="88"><vector name="origin" x="58" y="87"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/><string name="_hash" value="d02718ed1b5b880796baa331ee43b1a662be663c518a15917d6bf9c6cf5f4c67"/></canvas><canvas name="22" width="121" height="87"><vector name="origin" x="60" y="86"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="23" width="123" height="86"><vector name="origin" x="61" y="85"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="24" width="123" height="86"><vector name="origin" x="61" y="85"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="25" width="116" height="85"><vector name="origin" x="56" y="84"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="26" width="116" height="85"><vector name="origin" x="56" y="84"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="27" width="115" height="86"><vector name="origin" x="56" y="85"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="28" width="115" height="86"><vector name="origin" x="56" y="85"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="29" width="121" height="87"><vector name="origin" x="60" y="86"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="30" width="121" height="87"><vector name="origin" x="60" y="86"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="31" width="123" height="86"><vector name="origin" x="61" y="85"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="32" width="123" height="86"><vector name="origin" x="61" y="85"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="33" width="116" height="85"><vector name="origin" x="56" y="84"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="34" width="116" height="85"><vector name="origin" x="56" y="84"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="35" width="121" height="87"><vector name="origin" x="60" y="86"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="36" width="121" height="87"><vector name="origin" x="60" y="86"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas><canvas name="37" width="121" height="87"><vector name="origin" x="60" y="86"/><int name="z" value="0"/><vector name="lt" x="-145" y="-87"/><vector name="rb" x="-49" y="0"/><vector name="head" x="-117" y="-84"/><int name="delay" value="120"/></canvas></imgdir><imgdir name="attack4"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-230" y="-144"/><vector name="rb" x="240" y="17"/></imgdir><imgdir name="hit"><canvas name="0" width="136" height="127"><vector name="origin" x="68" y="63"/><int name="delay" value="90"/><string name="_hash" value="b387a30765e2fe4857dd72c0b46dd5d99d8da82d87f5eb89634a50d4e4e6969d"/></canvas><canvas name="1" width="139" height="124"><vector name="origin" x="69" y="62"/><int name="delay" value="90"/><string name="_hash" value="791795eeff7cc632ae8384cb0933c220a89c08b52b91926e5afce3ca136ed3f7"/></canvas><canvas name="2" width="143" height="129"><vector name="origin" x="71" y="64"/><int name="delay" value="90"/><string name="_hash" value="b9afed6b101039a16aa1b033e70be7884ddd713bca468b5fa759093871ca9eb7"/></canvas><canvas name="3" width="168" height="124"><vector name="origin" x="84" y="62"/><int name="delay" value="90"/><string name="_hash" value="0fb3119eadbedffb553986408c5c5c5f77dece4034ccb321f1de04adae7c83c8"/></canvas><canvas name="4" width="174" height="72"><vector name="origin" x="87" y="36"/><int name="delay" value="90"/><string name="_hash" value="e1a0f4ba8cad079740b7235c3402d05b5dbd97d79380f207b89d3d147a7c43e7"/></canvas><canvas name="5" width="128" height="23"><vector name="origin" x="64" y="11"/><int name="delay" value="90"/><string name="_hash" value="026d25ddcbe8c5d9e2d2d1322e79d84a6941a7459a9dec075e0bc82f3f1063b3"/></canvas></imgdir><int name="attackAfter" value="1200"/></imgdir><canvas name="0" width="1" height="1"><vector name="origin" x="58" y="87"/><vector name="lt" x="-58" y="-87"/><vector name="rb" x="59" y="1"/><vector name="head" x="-11" y="-55"/><int name="delay" value="120"/><string name="_inlink" value="hit1/0"/></canvas><canvas name="1" width="128" height="154"><vector name="origin" x="64" y="149"/><vector name="lt" x="-53" y="-85"/><vector name="rb" x="53" y="1"/><vector name="head" x="-11" y="-52"/><int name="delay" value="120"/><string name="_hash" value="401769c1caf411c6311dc8ee272c292f3e9c7a42df5cd7a629831c56848ab0c2"/></canvas><canvas name="2" width="146" height="170"><vector name="origin" x="68" y="162"/><vector name="lt" x="-49" y="-85"/><vector name="rb" x="44" y="2"/><vector name="head" x="-11" y="-52"/><int name="delay" value="120"/><string name="_hash" value="14e24acb769bf27153a77f95ca2e00cc88db528aeb299de675741a793f549c03"/></canvas><canvas name="3" width="150" height="157"><vector name="origin" x="69" y="148"/><vector name="lt" x="-47" y="-84"/><vector name="rb" x="42" y="2"/><vector name="head" x="-11" y="-50"/><int name="delay" value="120"/><string name="_hash" value="927d1446d8d620ae15ebac9a759cdd51aca908112b00f7122349aac67ba9c752"/></canvas><canvas name="4" width="152" height="163"><vector name="origin" x="70" y="155"/><vector name="lt" x="-47" y="-84"/><vector name="rb" x="42" y="2"/><vector name="head" x="-11" y="-50"/><int name="delay" value="120"/><string name="_hash" value="757a1dcd29f091223037f229cad99b96efe805d491ae4cddd14bbf474294e4b5"/></canvas><canvas name="5" width="151" height="147"><vector name="origin" x="73" y="139"/><vector name="lt" x="-47" y="-84"/><vector name="rb" x="42" y="2"/><vector name="head" x="-11" y="-50"/><int name="delay" value="120"/><string name="_hash" value="4e055fc01038f1ccd9e8b2fc974a82be8f74833b4791a1d6801fb27d204b892f"/></canvas><canvas name="6" width="155" height="159"><vector name="origin" x="77" y="153"/><vector name="lt" x="-47" y="-84"/><vector name="rb" x="42" y="2"/><vector name="head" x="-11" y="-50"/><int name="delay" value="120"/><string name="_hash" value="829bd8dc4039109cf4fb259ab31cc09c650438861ca3d55c983f6e0de9b9db39"/></canvas><canvas name="7" width="152" height="174"><vector name="origin" x="77" y="163"/><vector name="lt" x="-47" y="-84"/><vector name="rb" x="42" y="2"/><vector name="head" x="-11" y="-50"/><int name="delay" value="120"/><string name="_hash" value="ea7fb237c1b526a62f52294056bb98253adf391111c416e373406652ed43522d"/></canvas><canvas name="8" width="149" height="177"><vector name="origin" x="73" y="165"/><vector name="lt" x="-47" y="-84"/><vector name="rb" x="42" y="2"/><vector name="head" x="-11" y="-50"/><int name="delay" value="120"/><string name="_hash" value="eb3f901e10d9cdc913090a29f13ca20da2df30508cac858a7698db37ebb84dd4"/></canvas><canvas name="9" width="144" height="167"><vector name="origin" x="67" y="153"/><vector name="lt" x="-47" y="-84"/><vector name="rb" x="42" y="2"/><vector name="head" x="-11" y="-50"/><int name="delay" value="120"/><string name="_hash" value="30ce06aeae07639e40b60cf929a4c88f7ac1f79abc8902e20cb1c0f72221baf6"/></canvas><canvas name="10" width="145" height="170"><vector name="origin" x="65" y="155"/><vector name="lt" x="-51" y="-87"/><vector name="rb" x="46" y="1"/><vector name="head" x="-7" y="-55"/><int name="delay" value="120"/><string name="_hash" value="3ecd57322bbd6238441f2a5327f778e6497d8f4c73cdeeaf69285fb55a92c016"/></canvas><canvas name="11" width="344" height="178"><vector name="origin" x="171" y="150"/><vector name="lt" x="-60" y="-96"/><vector name="rb" x="73" y="-1"/><vector name="head" x="-2" y="-64"/><int name="delay" value="120"/><string name="_hash" value="b2bb0f09675dba22a7afe9379703853dc3f15707ea6efce7d9ac3480f4982518"/></canvas><canvas name="12" width="483" height="236"><vector name="origin" x="237" y="207"/><int name="z" value="0"/><vector name="lt" x="-60" y="-96"/><vector name="rb" x="73" y="-1"/><vector name="head" x="-2" y="-64"/><int name="delay" value="120"/><string name="_hash" value="3af83f6f598c43d0f73a76272b922395115198219315fb39bf48cb3accfa8b0b"/></canvas><canvas name="13" width="561" height="220"><vector name="origin" x="276" y="192"/><int name="z" value="0"/><vector name="lt" x="-60" y="-96"/><vector name="rb" x="73" y="-1"/><vector name="head" x="-2" y="-64"/><int name="delay" value="120"/><string name="_hash" value="87c207c05a537c4b2a900036ec7ac5ab06766c925532b2b3d65d3febd7387930"/></canvas><canvas name="14" width="603" height="225"><vector name="origin" x="297" y="197"/><int name="z" value="0"/><vector name="lt" x="-60" y="-96"/><vector name="rb" x="73" y="-1"/><vector name="head" x="-2" y="-64"/><int name="delay" value="120"/><string name="_hash" value="c4d7f8d7d9b6590ac927bd30605834bd634f1dbf033b7f69e9ed134d85620dc6"/></canvas><canvas name="15" width="601" height="220"><vector name="origin" x="296" y="195"/><int name="z" value="0"/><vector name="lt" x="-60" y="-96"/><vector name="rb" x="73" y="-1"/><vector name="head" x="-2" y="-64"/><int name="delay" value="120"/><string name="_hash" value="fb3604d34a2b1cc06f64b309afacb406811590f6b25b96fa832b88774faeb3b1"/></canvas><canvas name="16" width="591" height="212"><vector name="origin" x="291" y="189"/><int name="z" value="0"/><vector name="lt" x="-60" y="-96"/><vector name="rb" x="73" y="-1"/><vector name="head" x="-2" y="-64"/><int name="delay" value="120"/><string name="_hash" value="6df32e6afb60fc749530f161e3c4f7da7c1b51e287865448a5a1975f1d620eb9"/></canvas><canvas name="17" width="492" height="109"><vector name="origin" x="247" y="95"/><int name="z" value="0"/><vector name="lt" x="-60" y="-96"/><vector name="rb" x="73" y="-1"/><vector name="head" x="-2" y="-64"/><int name="delay" value="120"/><string name="_hash" value="738bac0f1bd3a02b9c55719c4aac33817dfc9218277963df765f2a4ab9beda3c"/></canvas></imgdir><imgdir name="info"><int name="bodyAttack" value="1"/><int name="level" value="180"/><int name="maxHP" value="8000000"/><int name="maxMP" value="8000"/><int name="speed" value="15"/><int name="PADamage" value="850"/><int name="PDDamage" value="920"/><int name="MADamage" value="800"/><int name="MDDamage" value="750"/><int name="acc" value="999"/><int name="eva" value="70"/><int name="exp" value="180000"/><int name="undead" value="0"/><int name="pushed" value="100000"/><float name="fs" value="10.0"/><int name="hpRecovery" value="500"/><int name="mpRecovery" value="50"/><int name="summonType" value="1"/><int name="boss" value="1"/><int name="firstAttack" value="1"/><int name="hpTagBgcolor" value="5"/><int name="hpTagColor" value="1"/></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8787180.img">
+  <imgdir name="stand">
+    <canvas name="0" width="115" height="86">
+      <vector name="origin" x="56" y="86"/>
+      <vector name="lt" x="-56" y="-86"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-11" y="-53"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b0c47f42552e3d57c962b27e69f917dcee4b014a4f854517cd432503b31e59e3"/>
+    </canvas>
+    <canvas name="1" width="121" height="87">
+      <vector name="origin" x="56" y="87"/>
+      <vector name="lt" x="-56" y="-87"/>
+      <vector name="rb" x="65" y="0"/>
+      <vector name="head" x="-7" y="-53"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c9735770149ba96efc0003479ab9188e4747af420408f10c240975a65252230e"/>
+    </canvas>
+    <canvas name="2" width="123" height="86">
+      <vector name="origin" x="56" y="86"/>
+      <vector name="lt" x="-56" y="-86"/>
+      <vector name="rb" x="67" y="0"/>
+      <vector name="head" x="-6" y="-52"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="21387399ca001c7d49713675de56269bb54a4f26a9a9e0889e57128d3be31b36"/>
+    </canvas>
+    <canvas name="3" width="116" height="85">
+      <vector name="origin" x="56" y="85"/>
+      <vector name="lt" x="-56" y="-85"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-11" y="-52"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="47d9ee3172ab83e0d1d15434413b05205eb8d76eb359f80c485a953395c9c2a4"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="122" height="90">
+      <vector name="origin" x="59" y="89"/>
+      <vector name="lt" x="-64" y="-89"/>
+      <vector name="rb" x="58" y="1"/>
+      <vector name="head" x="-11" y="-57"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6699f2c91583e81b7c42eac4475ccdbe50c15413d66b1b1b682167e1d98acab8"/>
+    </canvas>
+    <canvas name="1" width="117" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <vector name="lt" x="-60" y="-86"/>
+      <vector name="rb" x="57" y="1"/>
+      <vector name="head" x="-11" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="72cc07fef2d5029da94d9b359456938dcb732f5f85c1af5496e454c9924d63d2"/>
+    </canvas>
+    <canvas name="2" width="108" height="88">
+      <vector name="origin" x="57" y="87"/>
+      <vector name="lt" x="-57" y="-87"/>
+      <vector name="rb" x="51" y="1"/>
+      <vector name="head" x="-12" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3a94301c3e3a1134f0ae292c3e55ec773f3d2fd0d32c8fa8e2498d30d8ae15d"/>
+    </canvas>
+    <canvas name="3" width="107" height="90">
+      <vector name="origin" x="56" y="89"/>
+      <vector name="lt" x="-56" y="-89"/>
+      <vector name="rb" x="51" y="1"/>
+      <vector name="head" x="-12" y="-57"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="12bdd1fdf51a82610313077ebe1fdf25bb53568e407a78a9cbc1deb9ec988640"/>
+    </canvas>
+    <canvas name="4" width="115" height="91">
+      <vector name="origin" x="59" y="90"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-90"/>
+      <vector name="rb" x="56" y="1"/>
+      <vector name="head" x="-12" y="-57"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8f11ef41ccbdb23f4bc4154a36fad1333df612545e64420c37e1e757dbff7ab4"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="117" height="88">
+      <vector name="origin" x="58" y="88"/>
+      <vector name="lt" x="-58" y="-88"/>
+      <vector name="rb" x="59" y="0"/>
+      <vector name="head" x="-11" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bb7f7890765d6a0bd6f988de066aaca64beed8a469b23252932b23f378104fcb"/>
+    </canvas>
+    <canvas name="1" width="103" height="98">
+      <vector name="origin" x="53" y="98"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-28" y="-98"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="4" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e3f2bf31cd039f956fd17995a2bb9287cdc25b12586e00858c9259e629817eca"/>
+    </canvas>
+    <canvas name="2" width="136" height="146">
+      <vector name="origin" x="86" y="137"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-28" y="-98"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="4" y="-64"/>
+      <string name="_hash" value="7c03bc16e24b8e0ff087a6bf32b901e590af3e69f7d5d3b12bf8e40f22dd0454"/>
+    </canvas>
+    <canvas name="3" width="142" height="155">
+      <vector name="origin" x="92" y="142"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-28" y="-98"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="4" y="-64"/>
+      <string name="_hash" value="739bc4c0732333bf6aa33649bc2b69a756569a27b1d4e8156d2e39fe0e9d7d4a"/>
+    </canvas>
+    <canvas name="4" width="146" height="154">
+      <vector name="origin" x="96" y="144"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-28" y="-98"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="4" y="-64"/>
+      <string name="_hash" value="5426b26725f308692bb313e53af94d7b21ddb38f5badcaf0aa8e0c5fa07c5389"/>
+    </canvas>
+    <canvas name="5" width="142" height="146">
+      <vector name="origin" x="92" y="137"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-28" y="-98"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="4" y="-64"/>
+      <string name="_hash" value="457242ee495677b6cfa162e7f4a878cc8d35fdbabe0ff32888b6af470ad5dd59"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="117" height="88">
+      <vector name="origin" x="58" y="88"/>
+      <vector name="head" x="-11" y="-56"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="103" height="98">
+      <vector name="origin" x="53" y="97"/>
+      <vector name="head" x="3" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="136" height="146">
+      <vector name="origin" x="86" y="137"/>
+      <vector name="head" x="2" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="142" height="155">
+      <vector name="origin" x="92" y="142"/>
+      <vector name="head" x="3" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="146" height="154">
+      <vector name="origin" x="96" y="144"/>
+      <vector name="head" x="3" y="-65"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="142" height="146">
+      <vector name="origin" x="92" y="136"/>
+      <vector name="head" x="3" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="94" height="84">
+      <vector name="origin" x="37" y="80"/>
+      <vector name="head" x="9" y="-48"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="36ee7a35804990fac7466d146b53c04bc92de8d4912433e07b9fe397fcac57ad"/>
+    </canvas>
+    <canvas name="7" width="87" height="85">
+      <vector name="origin" x="25" y="81"/>
+      <vector name="head" x="9" y="-49"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e22a9405668bfc587508d3e65806d1c41e220a50ac88a38d84d7cac4ee0c021c"/>
+    </canvas>
+    <canvas name="8" width="88" height="85">
+      <vector name="origin" x="26" y="81"/>
+      <vector name="head" x="26" y="-17"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="61eef33622c24101ef3a7ac6e3bf57618d17c3897ab50832b853f2b4cbcb732e"/>
+    </canvas>
+    <canvas name="9" width="87" height="84">
+      <vector name="origin" x="25" y="80"/>
+      <vector name="head" x="9" y="-47"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="771c998f701d4e6acb1b5b84f116f29d672cef8ecbe42f78663e6e15ad4b8f5c"/>
+    </canvas>
+    <canvas name="10" width="111" height="85">
+      <vector name="origin" x="44" y="81"/>
+      <vector name="head" x="9" y="-48"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="021ca92c572b44d5c7b20ead4dae243bb0e32198d4b39af1dffe39c0f439d8f3"/>
+    </canvas>
+    <canvas name="11" width="141" height="84">
+      <vector name="origin" x="57" y="80"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="9" y="-47"/>
+      <string name="_hash" value="6895496dcc4f1649e817cb52b9cc560a39ea5abba980447ec0c9a77010a8ccd8"/>
+    </canvas>
+    <canvas name="12" width="146" height="85">
+      <vector name="origin" x="59" y="81"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="e585aecaf74a5d50aead2d842f6bff2a9a2120d9076375d067aca41164734e6c"/>
+    </canvas>
+    <canvas name="13" width="146" height="84">
+      <vector name="origin" x="59" y="80"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="08f60f4a863f3053542afd7cec74edd16b7b282ffd2499703fef60c073d637c6"/>
+    </canvas>
+    <canvas name="14" width="146" height="85">
+      <vector name="origin" x="55" y="81"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="e6d190f92935a2bdeeea8b9fde1102a6976681fa56d51edaf7e2e5b269656fff"/>
+    </canvas>
+    <canvas name="15" width="146" height="84">
+      <vector name="origin" x="58" y="80"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-11" y="-83"/>
+      <string name="_hash" value="6e92f3274b442d80399fc35587bd7a338081b2a8de02a0345fa03f787b932a6e"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Hmph, this is not over! I will be waiting on the roof."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-95" y="-82"/>
+        <vector name="rb" x="60" y="1"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="92" height="125">
+          <vector name="origin" x="46" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5964f52b588e51495c01dd76a3095e4d521a9f80280dcb48ce5ecfcee331c7ee"/>
+        </canvas>
+        <canvas name="1" width="103" height="110">
+          <vector name="origin" x="51" y="55"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="3975cd08395b9ab1a0083f696f42855f9e6ede6d5aae80379917d75acba74669"/>
+        </canvas>
+        <canvas name="2" width="101" height="136">
+          <vector name="origin" x="50" y="68"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="50158431679cafeead31e810c246a6bb68151c7dea1797537786ad350ba54cc4"/>
+        </canvas>
+        <canvas name="3" width="105" height="135">
+          <vector name="origin" x="52" y="67"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="763b29ad9baaca682b4f166aacd1265a5822594fa2412d039b13ae2484b465f8"/>
+        </canvas>
+        <canvas name="4" width="112" height="146">
+          <vector name="origin" x="56" y="73"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="151c44b33a1891230c1f00b76aa384ed29fc40cb8ae9c24d4fb1479000b7918f"/>
+        </canvas>
+        <canvas name="5" width="102" height="124">
+          <vector name="origin" x="51" y="62"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="74b40413cd7d9b0edede0f0696dc50a87988abe44535d970470d4c447087c36e"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="600"/>
+    </imgdir>
+    <canvas name="0" width="115" height="87">
+      <vector name="origin" x="56" y="86"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-57" y="-86"/>
+      <vector name="rb" x="59" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+      <string name="_hash" value="685e9b1b3f5d9300628d52da39161a6a6fbbc7d46564f39de7b8225789e95bdb"/>
+    </canvas>
+    <canvas name="1" width="118" height="90">
+      <vector name="origin" x="60" y="89"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-89"/>
+      <vector name="rb" x="58" y="1"/>
+      <vector name="head" x="-10" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="23c36ba4b352dea2ea5bb809c5877830708e96d81ac3d7bda2213195dc332d76"/>
+    </canvas>
+    <canvas name="2" width="88" height="99">
+      <vector name="origin" x="37" y="98"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-37" y="-98"/>
+      <vector name="rb" x="51" y="1"/>
+      <vector name="head" x="0" y="-63"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="709f7b6c2c7bdd7455fa3c2694fe7d3fabacc137f5ebe3a6faf2405139c33c42"/>
+    </canvas>
+    <canvas name="3" width="77" height="106">
+      <vector name="origin" x="30" y="105"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-30" y="-105"/>
+      <vector name="rb" x="47" y="1"/>
+      <vector name="head" x="2" y="-66"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="43efc94c2fa178b8fd9a86f3c67e5e9fb7a7426b1f2659f51c31c353fec356a0"/>
+    </canvas>
+    <canvas name="4" width="155" height="83">
+      <vector name="origin" x="95" y="82"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-95" y="-82"/>
+      <vector name="rb" x="60" y="1"/>
+      <vector name="head" x="-14" y="-48"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a7375189d575c5521dd1b4b62248ef0ac0613a269bca5afd8e2118b3737a1b26"/>
+    </canvas>
+    <canvas name="5" width="134" height="85">
+      <vector name="origin" x="74" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-74" y="-83"/>
+      <vector name="rb" x="60" y="2"/>
+      <vector name="head" x="-13" y="-51"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="caf562430d91a87a0fb6e9cac55c70183e1c78b96dfadc79e00857194eb2c2a5"/>
+    </canvas>
+    <canvas name="6" width="122" height="85">
+      <vector name="origin" x="64" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-64" y="-83"/>
+      <vector name="rb" x="58" y="2"/>
+      <vector name="head" x="-12" y="-49"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9cd6d158688d92c72e6a8ff0448a20168092eb3cca4ca3caf54c96148e5e0935"/>
+    </canvas>
+    <canvas name="7" width="122" height="86">
+      <vector name="origin" x="63" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-63" y="-85"/>
+      <vector name="rb" x="59" y="1"/>
+      <vector name="head" x="-11" y="-52"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fe76201215705b58f94caf467fbbce1b9f4972c42eeadce0231782d517d16888"/>
+    </canvas>
+    <uol name="8" value="../stand/0"/>
+    <uol name="9" value="../stand/1"/>
+    <uol name="10" value="../stand/2"/>
+    <uol name="11" value="../stand/3"/>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-711" y="-98"/>
+        <vector name="rb" x="726" y="-21"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="116" height="120">
+          <vector name="origin" x="51" y="66"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8ed2c3d468cd983bcb517f87c318200d199ea02900510cfbc0e3439d27daa8c2"/>
+        </canvas>
+        <canvas name="1" width="108" height="113">
+          <vector name="origin" x="54" y="56"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="2c057ef0f829620f079fb368c7d5594ca1339f33c040c387d69ffaff39cddba9"/>
+        </canvas>
+        <canvas name="2" width="117" height="119">
+          <vector name="origin" x="58" y="59"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e4c279fba43ea074b3e109d6b56bfcf684003cbd78200ebc08334c5b943c6a37"/>
+        </canvas>
+        <canvas name="3" width="125" height="129">
+          <vector name="origin" x="62" y="64"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d49a368d5430625319429ea7ca18057f147279f799d5e9740c15973b76b18e6d"/>
+        </canvas>
+        <canvas name="4" width="134" height="141">
+          <vector name="origin" x="67" y="70"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="febd73dfe38eabcab918a83d219a7a5e45cd4678ffbd93b6a2fad9432c3de54e"/>
+        </canvas>
+        <canvas name="5" width="79" height="88">
+          <vector name="origin" x="39" y="44"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="cc795793c247aeb3777e8f5c587226f20ce768ba7b236d8ee201583117431f64"/>
+        </canvas>
+        <canvas name="6" width="62" height="69">
+          <vector name="origin" x="31" y="34"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="dbf5559c52b90fc9927a9a17bb7417dddef010396c54d580e8de32502b9d8292"/>
+        </canvas>
+        <canvas name="7" width="33" height="34">
+          <vector name="origin" x="16" y="17"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="a2d2112016144bdcc85477047359db56a587c6b729f6956b8350656678c42c9b"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1560"/>
+    </imgdir>
+    <canvas name="0" width="117" height="88">
+      <vector name="origin" x="58" y="87"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-58" y="-87"/>
+      <vector name="rb" x="59" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+    </canvas>
+    <canvas name="1" width="128" height="154">
+      <vector name="origin" x="64" y="149"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-52" y="-87"/>
+      <vector name="rb" x="52" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3aa4a6c6d7887b986de9b50b059c770ff353046358079df21fb26b947327788c"/>
+    </canvas>
+    <canvas name="2" width="146" height="170">
+      <vector name="origin" x="68" y="162"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-51" y="-87"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6f6a12458da560293be289e843e87b69f297211a404789c1978277f2c26262ec"/>
+    </canvas>
+    <canvas name="3" width="150" height="159">
+      <vector name="origin" x="69" y="148"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-47" y="-87"/>
+      <vector name="rb" x="42" y="3"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c9de3e8af271c8b1e9e78916de70e944771703f465a2340d76bdb6bed01b9dfa"/>
+    </canvas>
+    <canvas name="4" width="152" height="163">
+      <vector name="origin" x="70" y="155"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-48" y="-86"/>
+      <vector name="rb" x="45" y="2"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2472d3234c6f5329ed020ca480e1279945c1905d18099a0437b54dd2fa5c3806"/>
+    </canvas>
+    <canvas name="5" width="151" height="147">
+      <vector name="origin" x="73" y="139"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-47" y="-86"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f47fd28508f2b6c474b2c187c5b00755631d01d14fe5c9884cd1a2b04cc1f61b"/>
+    </canvas>
+    <canvas name="6" width="155" height="159">
+      <vector name="origin" x="77" y="153"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-48" y="-86"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="95032a2d178ab58df57f93d3ce574ecc317859cff3b178913af5c1fc315e9232"/>
+    </canvas>
+    <canvas name="7" width="152" height="169">
+      <vector name="origin" x="77" y="163"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-47" y="-87"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="5b5a4838a0c020c1f992e779bd69b4f61b949395dd9b7b74275a07f242fc3d8a"/>
+    </canvas>
+    <canvas name="8" width="149" height="171">
+      <vector name="origin" x="73" y="165"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-49" y="-86"/>
+      <vector name="rb" x="44" y="2"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7b0dba85813d6f88df935802e62c77b152da4af42cb35b3738e3b2c52f0927eb"/>
+    </canvas>
+    <canvas name="9" width="144" height="159">
+      <vector name="origin" x="67" y="153"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-47" y="-86"/>
+      <vector name="rb" x="42" y="1"/>
+      <vector name="head" x="-11" y="-54"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b4e99f4956e87f2135f99e79bc4ac43ea117717a632775756b3ce942ef0346e9"/>
+    </canvas>
+    <canvas name="10" width="145" height="160">
+      <vector name="origin" x="65" y="155"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-50" y="-87"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-8" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="111b18303dd8d42cd4e62786ab1380772a0f2a2a0cd81b4fcd2361e20822aed6"/>
+    </canvas>
+    <canvas name="11" width="187" height="96">
+      <vector name="origin" x="86" y="95"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1f5785057c87c223c7c0179e0669f6c2af9dfd8b7bec76af737af1c7179c3109"/>
+    </canvas>
+    <canvas name="12" width="319" height="128">
+      <vector name="origin" x="152" y="124"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ddfeb0a3c60cb9044265b2f70ad3dadd637bc5d9a463eaaea913d3450f57eb80"/>
+    </canvas>
+    <canvas name="13" width="1529" height="158">
+      <vector name="origin" x="757" y="143"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6b2189fb419c5f6fb18751025922a6853a68318fa82a628378725b5f1647731e"/>
+    </canvas>
+    <canvas name="14" width="1501" height="142">
+      <vector name="origin" x="743" y="131"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="64c552cfb6d646e1b58a623da5ac6957b2e1d37f44cb50a9ae7245b852ce6797"/>
+    </canvas>
+    <canvas name="15" width="1489" height="154">
+      <vector name="origin" x="737" y="139"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="999cfc7130a247bffe357f798007471aadabccdaee7c39237f5f6323ba861893"/>
+    </canvas>
+    <canvas name="16" width="1499" height="157">
+      <vector name="origin" x="742" y="139"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="78" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dc7abac381aa585ee59dee7f6ffc1408c87c605314df97622334d085f2e65699"/>
+    </canvas>
+    <canvas name="17" width="1507" height="109">
+      <vector name="origin" x="746" y="108"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="72" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="f202a611429ed20dde74a9767760ccb24256262ade0c29f7802d754c154b2ffa"/>
+    </canvas>
+    <canvas name="18" width="1533" height="97">
+      <vector name="origin" x="759" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="72" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="da118e6d3541df760dcbbe20633edd0a568bc42102b6efa8052fd2df0e4c13b1"/>
+    </canvas>
+    <canvas name="19" width="1539" height="96">
+      <vector name="origin" x="762" y="95"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="72" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1a4494b615db3e6426cce80b7b59346945000382dca1a9ada1e3485e4417afe9"/>
+    </canvas>
+    <canvas name="20" width="1453" height="97">
+      <vector name="origin" x="719" y="96"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-59" y="-96"/>
+      <vector name="rb" x="72" y="0"/>
+      <vector name="head" x="0" y="-65"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c38f3b9a9203832e40df9970bf9afa922d2030732555b495061b0b05a8fceaa6"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-33" y="-309"/>
+        <vector name="rb" x="41" y="0"/>
+        <int name="start" value="-4"/>
+        <int name="areaCount" value="9"/>
+        <int name="attackCount" value="4"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="78" height="75">
+          <vector name="origin" x="39" y="37"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="badd9f56e36671cea02e387e50ff957982367af578845aeb0204c6d96bf14a59"/>
+        </canvas>
+        <canvas name="1" width="76" height="68">
+          <vector name="origin" x="38" y="34"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="0e7abffa83f8639089d8a8202eb310e77879637d3da5cce1a7d8e66f6dae3514"/>
+        </canvas>
+        <canvas name="2" width="73" height="74">
+          <vector name="origin" x="36" y="37"/>
+          <int name="delay" value="60"/>
+          <string name="_hash" value="6fc6f3d534d4ea6a79ccef2e2d1cbc4ec7597eb99cc9491a979a325a47dd0717"/>
+        </canvas>
+        <canvas name="3" width="76" height="68">
+          <vector name="origin" x="38" y="34"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="4" width="78" height="75">
+          <vector name="origin" x="39" y="37"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="60"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="115" height="15">
+          <vector name="origin" x="57" y="7"/>
+          <int name="delay" value="1680"/>
+          <string name="_hash" value="f90ae113b69b928cb639e4005e8a2f19f8ea9915d54c842ed822374678c927df"/>
+        </canvas>
+        <canvas name="1" width="1" height="1">
+          <vector name="origin" x="57" y="7"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack3/info/areaWarning/0"/>
+        </canvas>
+        <canvas name="2" width="121" height="22">
+          <vector name="origin" x="60" y="11"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6c786d03f298753d12d875dac7d1174123cf04aba011147cef83b5c071e05c2a"/>
+        </canvas>
+        <canvas name="3" width="125" height="36">
+          <vector name="origin" x="62" y="25"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bf75b33260b78c6a1d978b365edadb6190c34268821cf07ca7e026d992792f17"/>
+        </canvas>
+        <canvas name="4" width="125" height="37">
+          <vector name="origin" x="62" y="26"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="02648ff11488ef2177ae6d3b2eab21d2fa0cc99a881ae142568aca8cb39d8d01"/>
+        </canvas>
+        <canvas name="5" width="125" height="39">
+          <vector name="origin" x="62" y="28"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="46312c0237515d0356fb638783e8124b21ce90e8f9472445ac02b01c70ac7be4"/>
+        </canvas>
+        <canvas name="6" width="125" height="39">
+          <vector name="origin" x="62" y="28"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="475b3e0cc1be75652ba868738a3c7f25f96be2a956c26525059e9d85f92084de"/>
+        </canvas>
+        <canvas name="7" width="125" height="39">
+          <vector name="origin" x="62" y="28"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="2f6039c636e35c2d8ce5fd2980da13c1bc63c4c889601478a48ad7509e93c040"/>
+        </canvas>
+        <canvas name="8" width="125" height="40">
+          <vector name="origin" x="62" y="29"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="7668d9c65a6afb24288d5adc4cd27acfccc0ec3ae12fad91e8af35a03aeb8433"/>
+        </canvas>
+        <canvas name="9" width="161" height="350">
+          <vector name="origin" x="80" y="325"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="04459d34cc6e142d1f7322d1b3638d9154c1b16aad6127dfe90bc6e186c98f3c"/>
+        </canvas>
+        <canvas name="10" width="165" height="339">
+          <vector name="origin" x="86" y="325"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="05800a06c5156a80d9f278a69896266417f54e69ce5ba3ac02aff11290872204"/>
+        </canvas>
+        <canvas name="11" width="165" height="345">
+          <vector name="origin" x="86" y="330"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="2cec2a7f92e3865db18fa5d33559d40443c4244735cc30a5cb8a0702aae2cb29"/>
+        </canvas>
+        <canvas name="12" width="163" height="339">
+          <vector name="origin" x="82" y="325"/>
+          <int name="delay" value="150"/>
+          <string name="_hash" value="fa52d87f3215e5052f55534ba9e5a277f7a417aa0e878b80318153d0fc680fa5"/>
+        </canvas>
+        <canvas name="13" width="159" height="285">
+          <vector name="origin" x="82" y="285"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1e4d2434a58092551f5bc70c66f0b827d5ebcc03586a8f988a1398b73bbf8525"/>
+        </canvas>
+        <canvas name="14" width="86" height="151">
+          <vector name="origin" x="43" y="285"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="89914a4e99f8eea4cae19231b054e786836b39e9cb0d6075bb6536d7501a1075"/>
+        </canvas>
+        <canvas name="15" width="88" height="149">
+          <vector name="origin" x="44" y="285"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="a65f4b7ff417a4cd13f4735754f2ebe3d98ca737cefc27e13d43b66dd4ec662d"/>
+        </canvas>
+        <canvas name="16" width="81" height="144">
+          <vector name="origin" x="40" y="285"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="69147b924ab412aedc58bdbe4764b20d6255a81e33b4430a9679aeb58097f714"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="2790"/>
+    </imgdir>
+    <canvas name="0" width="117" height="88">
+      <vector name="origin" x="58" y="87"/>
+      <vector name="lt" x="-54" y="-88"/>
+      <vector name="rb" x="30" y="1"/>
+      <vector name="head" x="-24" y="-81"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="128" height="154">
+      <vector name="origin" x="64" y="149"/>
+      <vector name="lt" x="-54" y="-92"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="-23" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fd54515b0ad5a4252c53327e328703ef44c79e4b8558c0a4d8752eac34ffee10"/>
+    </canvas>
+    <canvas name="2" width="146" height="170">
+      <vector name="origin" x="68" y="162"/>
+      <vector name="lt" x="-54" y="-92"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="-23" y="-83"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="dfd5f24937ef5ecc68abadba98c979406cca16c2b8c83d1c971bf28fc89104af"/>
+    </canvas>
+    <canvas name="3" width="150" height="157">
+      <vector name="origin" x="69" y="148"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="603fe6f3498aad15a4b2e552a7bba3836127b0c997bb7e2a6dfafde4341a65b7"/>
+    </canvas>
+    <canvas name="4" width="152" height="163">
+      <vector name="origin" x="70" y="155"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ee1288610eb02e41eaf65063a5d23a0d6e332b7e00b1991b568ffb1037b06f29"/>
+    </canvas>
+    <canvas name="5" width="151" height="147">
+      <vector name="origin" x="73" y="139"/>
+      <vector name="lt" x="-53" y="-96"/>
+      <vector name="rb" x="37" y="1"/>
+      <vector name="head" x="-18" y="-86"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="83c965493262e16dc5a4217117fa493db44dc970d3a02d337f23108b652a0339"/>
+    </canvas>
+    <canvas name="6" width="155" height="159">
+      <vector name="origin" x="77" y="153"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8e2dc38ad54b13933afe647e103d66c3d63a81c207d42a44bba028502aefd499"/>
+    </canvas>
+    <canvas name="7" width="152" height="169">
+      <vector name="origin" x="77" y="163"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c0299b85b052dcc82d3c6d44a6fa065ba35bd562d1beb4a0a9886d96c25cdd7c"/>
+    </canvas>
+    <canvas name="8" width="149" height="171">
+      <vector name="origin" x="73" y="165"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2dba7d15ab60b5dd7d0137a7b7f66841a81a8983053dc6d23fd54ab2ebdc9b21"/>
+    </canvas>
+    <canvas name="9" width="144" height="161">
+      <vector name="origin" x="67" y="155"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a41b71af7399691f5f591496270a64cd9974c7c5f0e024557abf2623e93c663c"/>
+    </canvas>
+    <canvas name="10" width="148" height="168">
+      <vector name="origin" x="68" y="162"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a5e5d9c692172b73c95ee75d8777d93f067cb766f58dc10a396bdc8ae233c53f"/>
+    </canvas>
+    <canvas name="11" width="154" height="153">
+      <vector name="origin" x="69" y="146"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="523fb8dab9e69c6ea3209a9b8c868183219498a0f2a3833450a256f84de5d401"/>
+    </canvas>
+    <canvas name="12" width="152" height="155">
+      <vector name="origin" x="66" y="149"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="450c8c8811b4c0d8d84006f383aababe67080a48ae529bf3a65a909bee67a197"/>
+    </canvas>
+    <canvas name="13" width="144" height="136">
+      <vector name="origin" x="69" y="131"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="417bcffe132d605ade7aeedc8c5afb085961f1a0d0226701fbba1f39aeff4fbb"/>
+    </canvas>
+    <canvas name="14" width="226" height="93">
+      <vector name="origin" x="162" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8e1bc6c102c27f816ec9479991e7570296cf556ca0964bebfa2a8ed43ef22fbf"/>
+    </canvas>
+    <canvas name="15" width="270" height="88">
+      <vector name="origin" x="166" y="78"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="13f8bccc566f6f990f7ec69a780e2b4e34f309d05cd3e637338f26033550b693"/>
+    </canvas>
+    <canvas name="16" width="261" height="93">
+      <vector name="origin" x="167" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="84eb38c28cae45fb12e9e58ecf33c89fed7913824a1d234407e23615c2c908fb"/>
+    </canvas>
+    <canvas name="17" width="257" height="93">
+      <vector name="origin" x="167" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="aab8eb1264c8846aa9609e02d0591c784bf760121360e4ccd26f5a3a9fefb810"/>
+    </canvas>
+    <canvas name="18" width="216" height="88">
+      <vector name="origin" x="130" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="efa4fba21fa318ae99bd0e68328d48d23187bf4a477d57f4468b6a817be57bf2"/>
+    </canvas>
+    <canvas name="19" width="252" height="91">
+      <vector name="origin" x="167" y="83"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="40e3df5e1250762c247f727ef79f56250058292772e3235bdf29538eae6770e7"/>
+    </canvas>
+    <canvas name="20" width="135" height="90">
+      <vector name="origin" x="51" y="89"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="0843fb182980ec77d4314cfa3347c922881158bdc8fbcbb588a39daadc40e894"/>
+    </canvas>
+    <canvas name="21" width="117" height="88">
+      <vector name="origin" x="58" y="87"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d02718ed1b5b880796baa331ee43b1a662be663c518a15917d6bf9c6cf5f4c67"/>
+    </canvas>
+    <canvas name="22" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="123" height="86">
+      <vector name="origin" x="61" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="123" height="86">
+      <vector name="origin" x="61" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="116" height="85">
+      <vector name="origin" x="56" y="84"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="26" width="116" height="85">
+      <vector name="origin" x="56" y="84"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="27" width="115" height="86">
+      <vector name="origin" x="56" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="28" width="115" height="86">
+      <vector name="origin" x="56" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="29" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="30" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="31" width="123" height="86">
+      <vector name="origin" x="61" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="32" width="123" height="86">
+      <vector name="origin" x="61" y="85"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="33" width="116" height="85">
+      <vector name="origin" x="56" y="84"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="34" width="116" height="85">
+      <vector name="origin" x="56" y="84"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="35" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="36" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="37" width="121" height="87">
+      <vector name="origin" x="60" y="86"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-145" y="-87"/>
+      <vector name="rb" x="-49" y="0"/>
+      <vector name="head" x="-117" y="-84"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-230" y="-144"/>
+        <vector name="rb" x="240" y="17"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="136" height="127">
+          <vector name="origin" x="68" y="63"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="b387a30765e2fe4857dd72c0b46dd5d99d8da82d87f5eb89634a50d4e4e6969d"/>
+        </canvas>
+        <canvas name="1" width="139" height="124">
+          <vector name="origin" x="69" y="62"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="791795eeff7cc632ae8384cb0933c220a89c08b52b91926e5afce3ca136ed3f7"/>
+        </canvas>
+        <canvas name="2" width="143" height="129">
+          <vector name="origin" x="71" y="64"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="b9afed6b101039a16aa1b033e70be7884ddd713bca468b5fa759093871ca9eb7"/>
+        </canvas>
+        <canvas name="3" width="168" height="124">
+          <vector name="origin" x="84" y="62"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="0fb3119eadbedffb553986408c5c5c5f77dece4034ccb321f1de04adae7c83c8"/>
+        </canvas>
+        <canvas name="4" width="174" height="72">
+          <vector name="origin" x="87" y="36"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="e1a0f4ba8cad079740b7235c3402d05b5dbd97d79380f207b89d3d147a7c43e7"/>
+        </canvas>
+        <canvas name="5" width="128" height="23">
+          <vector name="origin" x="64" y="11"/>
+          <int name="delay" value="90"/>
+          <string name="_hash" value="026d25ddcbe8c5d9e2d2d1322e79d84a6941a7459a9dec075e0bc82f3f1063b3"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1200"/>
+    </imgdir>
+    <canvas name="0" width="1" height="1">
+      <vector name="origin" x="58" y="87"/>
+      <vector name="lt" x="-58" y="-87"/>
+      <vector name="rb" x="59" y="1"/>
+      <vector name="head" x="-11" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_inlink" value="hit1/0"/>
+    </canvas>
+    <canvas name="1" width="128" height="154">
+      <vector name="origin" x="64" y="149"/>
+      <vector name="lt" x="-53" y="-85"/>
+      <vector name="rb" x="53" y="1"/>
+      <vector name="head" x="-11" y="-52"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="401769c1caf411c6311dc8ee272c292f3e9c7a42df5cd7a629831c56848ab0c2"/>
+    </canvas>
+    <canvas name="2" width="146" height="170">
+      <vector name="origin" x="68" y="162"/>
+      <vector name="lt" x="-49" y="-85"/>
+      <vector name="rb" x="44" y="2"/>
+      <vector name="head" x="-11" y="-52"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="14e24acb769bf27153a77f95ca2e00cc88db528aeb299de675741a793f549c03"/>
+    </canvas>
+    <canvas name="3" width="150" height="157">
+      <vector name="origin" x="69" y="148"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="927d1446d8d620ae15ebac9a759cdd51aca908112b00f7122349aac67ba9c752"/>
+    </canvas>
+    <canvas name="4" width="152" height="163">
+      <vector name="origin" x="70" y="155"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="757a1dcd29f091223037f229cad99b96efe805d491ae4cddd14bbf474294e4b5"/>
+    </canvas>
+    <canvas name="5" width="151" height="147">
+      <vector name="origin" x="73" y="139"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4e055fc01038f1ccd9e8b2fc974a82be8f74833b4791a1d6801fb27d204b892f"/>
+    </canvas>
+    <canvas name="6" width="155" height="159">
+      <vector name="origin" x="77" y="153"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="829bd8dc4039109cf4fb259ab31cc09c650438861ca3d55c983f6e0de9b9db39"/>
+    </canvas>
+    <canvas name="7" width="152" height="174">
+      <vector name="origin" x="77" y="163"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ea7fb237c1b526a62f52294056bb98253adf391111c416e373406652ed43522d"/>
+    </canvas>
+    <canvas name="8" width="149" height="177">
+      <vector name="origin" x="73" y="165"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="eb3f901e10d9cdc913090a29f13ca20da2df30508cac858a7698db37ebb84dd4"/>
+    </canvas>
+    <canvas name="9" width="144" height="167">
+      <vector name="origin" x="67" y="153"/>
+      <vector name="lt" x="-47" y="-84"/>
+      <vector name="rb" x="42" y="2"/>
+      <vector name="head" x="-11" y="-50"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="30ce06aeae07639e40b60cf929a4c88f7ac1f79abc8902e20cb1c0f72221baf6"/>
+    </canvas>
+    <canvas name="10" width="145" height="170">
+      <vector name="origin" x="65" y="155"/>
+      <vector name="lt" x="-51" y="-87"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-7" y="-55"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3ecd57322bbd6238441f2a5327f778e6497d8f4c73cdeeaf69285fb55a92c016"/>
+    </canvas>
+    <canvas name="11" width="344" height="178">
+      <vector name="origin" x="171" y="150"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2bb0f09675dba22a7afe9379703853dc3f15707ea6efce7d9ac3480f4982518"/>
+    </canvas>
+    <canvas name="12" width="483" height="236">
+      <vector name="origin" x="237" y="207"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3af83f6f598c43d0f73a76272b922395115198219315fb39bf48cb3accfa8b0b"/>
+    </canvas>
+    <canvas name="13" width="561" height="220">
+      <vector name="origin" x="276" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="87c207c05a537c4b2a900036ec7ac5ab06766c925532b2b3d65d3febd7387930"/>
+    </canvas>
+    <canvas name="14" width="603" height="225">
+      <vector name="origin" x="297" y="197"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4d7f8d7d9b6590ac927bd30605834bd634f1dbf033b7f69e9ed134d85620dc6"/>
+    </canvas>
+    <canvas name="15" width="601" height="220">
+      <vector name="origin" x="296" y="195"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fb3604d34a2b1cc06f64b309afacb406811590f6b25b96fa832b88774faeb3b1"/>
+    </canvas>
+    <canvas name="16" width="591" height="212">
+      <vector name="origin" x="291" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6df32e6afb60fc749530f161e3c4f7da7c1b51e287865448a5a1975f1d620eb9"/>
+    </canvas>
+    <canvas name="17" width="492" height="109">
+      <vector name="origin" x="247" y="95"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-60" y="-96"/>
+      <vector name="rb" x="73" y="-1"/>
+      <vector name="head" x="-2" y="-64"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="738bac0f1bd3a02b9c55719c4aac33817dfc9218277963df765f2a4ab9beda3c"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="180"/>
+    <int name="maxHP" value="8000000"/>
+    <int name="maxMP" value="8000"/>
+    <int name="speed" value="15"/>
+    <int name="PADamage" value="850"/>
+    <int name="PDDamage" value="920"/>
+    <int name="MADamage" value="800"/>
+    <int name="MDDamage" value="750"/>
+    <int name="acc" value="999"/>
+    <int name="eva" value="70"/>
+    <int name="exp" value="180000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="100000"/>
+    <float name="fs" value="10.0"/>
+    <int name="hpRecovery" value="500"/>
+    <int name="mpRecovery" value="50"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/8890036.img.xml
+++ b/gms-server/wz/Mob.wz/8890036.img.xml
@@ -1,1 +1,3155 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="8890036.img"><imgdir name="info"><int name="level" value="160"/><int name="maxHP" value="210000000"/><int name="maxMP" value="100000"/><int name="mpRecovery" value="1000000"/><int name="hpRecovery" value="10000"/><int name="speed" value="100"/><int name="PADamage" value="1600"/><int name="MADamage" value="1600"/><int name="PDRate" value="100"/><int name="MDRate" value="100"/><int name="acc" value="270"/><int name="eva" value="47"/><int name="pushed" value="1000000000"/><float name="fs" value="10.0"/><int name="summonType" value="1"/><int name="category" value="8"/><int name="firstAttack" value="1"/><string name="mobType" value="1N"/><int name="boss" value="1"/><int name="explosiveReward" value="1"/><int name="hpTagColor" value="1"/><int name="hpTagBgcolor" value="5"/><int name="ignoreMoveImpact" value="1"/><int name="ignoreMovable" value="1"/><int name="ignoreFieldOut" value="1"/><int name="isRemoteRange" value="1"/><imgdir name="attack"><imgdir name="0"><int name="action" value="1"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="2"/><int name="knockback" value="1"/></imgdir><imgdir name="1"><int name="action" value="2"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="2"/><int name="disease" value="123"/><int name="level" value="55"/></imgdir><imgdir name="2"><int name="action" value="3"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="2"/><int name="disease" value="132"/><int name="level" value="19"/></imgdir><imgdir name="3"><int name="action" value="4"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="2"/><int name="disease" value="125"/><int name="level" value="33"/></imgdir><imgdir name="4"><int name="action" value="5"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="2"/><int name="disease" value="137"/><int name="level" value="4"/></imgdir><imgdir name="5"><int name="action" value="6"/><int name="attackRatio" value="100"/><int name="type" value="6"/><int name="tremble" value="1"/><int name="fixDamR" value="50"/></imgdir><imgdir name="6"><int name="action" value="7"/><int name="attackRatio" value="100"/><int name="type" value="3"/><int name="conMP" value="1"/><int name="magic" value="1"/><int name="disease" value="126"/><int name="level" value="30"/></imgdir><imgdir name="7"><int name="action" value="8"/><int name="attackRatio" value="100"/><int name="type" value="0"/><int name="conMP" value="1"/><int name="magic" value="1"/><int name="deadlyAttack" value="1"/></imgdir></imgdir><imgdir name="skill"><imgdir name="7"><int name="skill" value="145"/><int name="action" value="6"/><int name="level" value="1"/><int name="effectAfter" value="0"/></imgdir><imgdir name="0"><int name="skill" value="128"/><int name="action" value="3"/><int name="level" value="8"/><int name="skillAfter" value="1760"/></imgdir><imgdir name="1"><int name="skill" value="128"/><int name="action" value="1"/><int name="level" value="13"/><int name="skillAfter" value="990"/></imgdir><imgdir name="2"><int name="skill" value="200"/><int name="action" value="2"/><int name="level" value="223"/><int name="skillAfter" value="1440"/></imgdir><imgdir name="3"><int name="skill" value="128"/><int name="action" value="4"/><int name="level" value="1"/><int name="skillAfter" value="1260"/><int name="effectAfter" value="1260"/></imgdir><imgdir name="4"><int name="skill" value="145"/><int name="action" value="6"/><int name="level" value="4"/><int name="effectAfter" value="0"/></imgdir><imgdir name="5"><int name="skill" value="200"/><int name="action" value="5"/><int name="level" value="222"/><int name="skillAfter" value="1440"/><int name="preSkillIndex" value="7"/><int name="preSkillCount" value="5"/></imgdir><imgdir name="6"><int name="skill" value="128"/><int name="action" value="7"/><int name="level" value="1"/><int name="effectAfter" value="630"/><int name="skillAfter" value="630"/></imgdir></imgdir><int name="bodyAttack" value="1"/><int name="exp" value="0"/></imgdir><imgdir name="stand"><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="aacfdac6db9941a92082d4ff149e479f91f9b7f9b17d384ad091f8446779d0bc"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="9720c408116d2ab09e8295717dc11971cbd4d77a353c168ebb28c04f746e232d"/></canvas><canvas name="10" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="cc792d53d48c07a6c8c037fbe59907615b6fc0e8107e7f22c903ad06b7d79ebf"/></canvas><canvas name="11" width="196" height="198"><vector name="origin" x="89" y="189"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="e692398e07ba283472e8fca4e7e5a26b1cd3d5578ab92a5c37ce89719d8608dc"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="4a6ef4330261092c4be1be264c84fc9267ad1b48ba59fd0169d306b570993dc9"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="4c12eb8473e722e09eec99743488c040d27f1fa9c00e7c6efafd77212894159a"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a8f58b13a489ca5850848829e359f05b8eed60ac4a1cce456a03680c644faaef"/></canvas><canvas name="5" width="196" height="198"><vector name="origin" x="89" y="189"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="210cd2abd8fb276b8e1e08abe2f19994edf8f3d0b2dc66721b81898279ac7a99"/></canvas><canvas name="6" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="7" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="69d8a175e31fd46b141b4f142401142cf79d649dbfca8b5715643c53f64be086"/></canvas><canvas name="8" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="c46972e7aa48ef79b899a102749f46d3474c84ad99a34f47e4f79b3b9d68db74"/></canvas><canvas name="9" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="1a3792b751548391d8b5a72067e2b2ac1738725f97521f973bb3266166731fa3"/></canvas></imgdir><imgdir name="move"><canvas name="5" width="200" height="198"><vector name="origin" x="89" y="189"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="ace4d88aa5fca2f30ce1aba0361e59635ec9936e0d948d34100a6b20f6adcaa6"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="53f6e366da478b2bf97da582637682cba6e16f6426f884b8d7dd78e0f2b8b420"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="ea7498c7f47b52286a540fda3522c46e3eaa4477bee49736508c58a0e8eb847a"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="bcd85aa903f39e6f5211f04e64ab12f27968cebec541f04b2df1d55f7b3ccd82"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="de90f4fa91c5d222eb9a524c87f50fb11b4f1dcf5fd126d9bcdb7aa24f687f33"/></canvas><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="7ce12372921280cca8a391b4aeb4473e77e15d22d5fc854d965d4b8b1cb64eb5"/></canvas></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-280" y="-65"/><vector name="rb" x="-2" y="-34"/></imgdir><imgdir name="hit"><canvas name="0" width="199" height="194"><vector name="origin" x="99" y="97"/><int name="z" value="0"/><string name="_hash" value="ed173a097e57edeabd997764a1203fe48282c6b66b5b3c63b8959d1a68ab282c"/></canvas><canvas name="1" width="183" height="198"><vector name="origin" x="91" y="99"/><int name="z" value="0"/><string name="_hash" value="f561de600870aed73eefd738f90fc1043bed8280371cbb166f7dee0e66ffbd53"/></canvas><canvas name="2" width="201" height="206"><vector name="origin" x="100" y="103"/><int name="z" value="0"/><string name="_hash" value="3a0c130666d0a065906181c8bd7ba4cd7af1486cf095678d378ef485a4546848"/></canvas><canvas name="3" width="196" height="189"><vector name="origin" x="98" y="94"/><int name="z" value="0"/><string name="_hash" value="443e54e4c9419660510be8ff8bf49b240de73248fbd94c3b75eacb478cf445cc"/></canvas><canvas name="4" width="187" height="185"><vector name="origin" x="93" y="92"/><int name="z" value="0"/><string name="_hash" value="e9a9f905eaf9c7e697735d27789323e85fa1f1d8c8abb0892d7675da6e5de506"/></canvas><canvas name="5" width="193" height="191"><vector name="origin" x="96" y="95"/><int name="z" value="0"/><string name="_hash" value="9b1981507d06d898fde691f11b21c3f9778b978b01de082e32a5d753432e68cf"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="1" height="1"><vector name="origin" x="5" y="65"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="11" height="16"><vector name="origin" x="-25" y="79"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e14184568972a6e77906e675413433f8968c5075e9541f2d258de8ad38bcbabf"/></canvas><canvas name="2" width="19" height="24"><vector name="origin" x="-18" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="ddaf8bd5ce82b330d7edf018fd66ca865657a04d92f7d983afd279d03821bd84"/></canvas><canvas name="3" width="25" height="32"><vector name="origin" x="-14" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="5b965163288d1c34396f6416910f627c94261153a4bb4ef8e75d7c2b249209a6"/></canvas><canvas name="4" width="30" height="30"><vector name="origin" x="-12" y="95"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b468ebfb3b67e05d740ff415fbfaf1a6756f09d8c19ca9ec4d77141d3efd3752"/></canvas><canvas name="5" width="72" height="73"><vector name="origin" x="4" y="124"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c1c4886943ef4862b15d434a478a125dfa092481b1b250f91ce8c73154815684"/></canvas><canvas name="6" width="60" height="74"><vector name="origin" x="-4" y="130"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1c99b9631d1c854e130f4b548591d393fcd4721a089799389c82f668f3da2393"/></canvas><canvas name="7" width="64" height="71"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="39566a11077d123dcbd1d0032373d33c586b9a1e65d564da880520ac97ef671a"/></canvas><canvas name="8" width="53" height="72"><vector name="origin" x="-7" y="135"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="91fbe439bd6ffca9eaff288b2cda1c5be611ee89d34e4ca9a3946bc35ec66fd7"/></canvas><canvas name="9" width="60" height="74"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="14c22bb33a2f2c1bc0f9e138aadf315c219d4abbcb5adb96835640caf32e51cf"/></canvas><canvas name="10" width="64" height="71"><vector name="origin" x="-5" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7377d913b3e0e22893bcf9019a884a4c298f4bee7ec9a8c0c7fc2e10fdc263e7"/></canvas><canvas name="11" width="53" height="72"><vector name="origin" x="-7" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="84a10b45ceda775f338d1d62ff555ebe7ac9dfb2e0d90ebf5e42aaaba0ffa37d"/></canvas><canvas name="12" width="296" height="88"><vector name="origin" x="243" y="126"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="cf92e0ffc0a2e247486e0a5f56bd7c5c44d61bccd420ef0c4c91bac8d35fe293"/></canvas><canvas name="13" width="212" height="64"><vector name="origin" x="258" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7afbb566b04355530205cbf6ee22a58875587d460f6147bfb708d5bb90b0551e"/></canvas><canvas name="14" width="180" height="58"><vector name="origin" x="257" y="93"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="484249c5bc3dfa1b980be5f56a3e1d93bde25ca3dec81ef9bb9ad2ae1d761260"/></canvas><canvas name="15" width="160" height="49"><vector name="origin" x="247" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7bb927d4063b5272776e83cf201a25a418f2d4b9e5f9f43bd3bf373d46db0082"/></canvas><canvas name="16" width="60" height="49"><vector name="origin" x="143" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="5a3f8187e830f852440585186c0e3c6ab10225f0828dcb2144202500b17d788b"/></canvas></imgdir><int name="attackAfter" value="1440"/></imgdir><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="12" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/></canvas><canvas name="13" width="196" height="209"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/></canvas><canvas name="14" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/></canvas><canvas name="15" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/></canvas><canvas name="16" width="196" height="208"><vector name="origin" x="89" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/></canvas><canvas name="17" width="196" height="208"><vector name="origin" x="89" y="198"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/></canvas></imgdir><imgdir name="attack2"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-280" y="-65"/><vector name="rb" x="-2" y="-34"/></imgdir><imgdir name="hit"><canvas name="0" width="199" height="194"><vector name="origin" x="99" y="97"/><int name="z" value="0"/><string name="_hash" value="c06e0a1d53536be3f89cca6c459c632b72cbd79542e11ad04f9f9199008e775c"/></canvas><canvas name="1" width="183" height="198"><vector name="origin" x="91" y="99"/><int name="z" value="0"/><string name="_hash" value="6c9d0e2e3f6778eeaa44d9b6d34213e75a83e6c2e4b984b03ae49104300fc092"/></canvas><canvas name="2" width="201" height="206"><vector name="origin" x="100" y="103"/><int name="z" value="0"/><string name="_hash" value="47d401133797d76af401f7855fe44a3b0eeb388923bf0a2dcd9ca654f2279c28"/></canvas><canvas name="3" width="196" height="189"><vector name="origin" x="98" y="94"/><int name="z" value="0"/><string name="_hash" value="3cdf4b8968876423893686bb285c6d0c9729de34c4c661a726135e8c52133f59"/></canvas><canvas name="4" width="187" height="185"><vector name="origin" x="93" y="92"/><int name="z" value="0"/><string name="_hash" value="092042886657e04f11bcf14ef2b0f1ca5d651bd00ab9e31a2610744317b09c44"/></canvas><canvas name="5" width="1" height="1"><vector name="origin" x="96" y="95"/><int name="z" value="0"/><string name="_inlink" value="attack1/info/hit/5"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="1" height="1"><vector name="origin" x="5" y="65"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="1" height="1"><vector name="origin" x="-25" y="79"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/1"/></canvas><canvas name="2" width="1" height="1"><vector name="origin" x="-18" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/2"/></canvas><canvas name="3" width="25" height="32"><vector name="origin" x="-14" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="642855b4259104ce2ec98dd86be97d0a0d89d72f70999abbf9579c85affbd9cb"/></canvas><canvas name="4" width="30" height="30"><vector name="origin" x="-12" y="95"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="88c5b7ecac32cc860d00577f6105be5b15fd9f99f5d25a6b98b9cf029d1295c5"/></canvas><canvas name="5" width="72" height="73"><vector name="origin" x="4" y="124"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="dbc0d33c40fae2a166034f2ae1f50076866dfef4987fc1118baf95539e88e2a2"/></canvas><canvas name="6" width="60" height="74"><vector name="origin" x="-4" y="130"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bfbd90318e054646f09a5432bf3b2c765026a4905790c24904079c4773ad2928"/></canvas><canvas name="7" width="64" height="71"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8bafcbfd9edb6cc910b860acff509eed800ab8674b38dda99b16612211c07cbd"/></canvas><canvas name="8" width="53" height="72"><vector name="origin" x="-7" y="135"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="34abb4387224c37351708a0ce1f3a5815d798b538e58c752e4281f437c688cb8"/></canvas><canvas name="9" width="60" height="74"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e74d8967bce61233d379d4eb6a17f8f2aa2c1154af9a94eb8997a39c83ae024d"/></canvas><canvas name="10" width="64" height="71"><vector name="origin" x="-5" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="befec05e861886328728153a33ea56c55a94a2027fa05723733e0920e35e7970"/></canvas><canvas name="11" width="53" height="72"><vector name="origin" x="-7" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0cf7c84ca3d414cb33d6ba874928f742d29e2c61aa3b3f500359adbbb168ec5a"/></canvas><canvas name="12" width="296" height="88"><vector name="origin" x="243" y="126"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="174e922c141594c39b6bddafe2f37540e97a76fd04ada23fb2cdccdbaf3a9ba8"/></canvas><canvas name="13" width="212" height="64"><vector name="origin" x="131" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="80572942c58ca7a183d698294afdd76f7ecd842b34c191be6cd02f821b12ed9b"/></canvas><canvas name="14" width="180" height="58"><vector name="origin" x="257" y="93"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="75651698bb1a7372b7f7a180922219def3bc52bc55203e46ee357cb93ebb4e8c"/></canvas><canvas name="15" width="160" height="49"><vector name="origin" x="247" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b102caf9e5204ca94452ea072db696e6f957bfc0ec7b7343109b1a625f66390d"/></canvas><canvas name="16" width="60" height="49"><vector name="origin" x="143" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="39b8c41a36c92e6ba1040a5574908a6a52e5bcb5e4894afa8e414f3ea400d22e"/></canvas><int name="attackAfter" value="1440"/></imgdir></imgdir><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="17" width="196" height="208"><vector name="origin" x="89" y="198"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/></canvas><canvas name="16" width="196" height="208"><vector name="origin" x="89" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/></canvas><canvas name="15" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/></canvas><canvas name="14" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/></canvas><canvas name="13" width="196" height="209"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/></canvas><canvas name="12" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas></imgdir><imgdir name="attack3"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-280" y="-65"/><vector name="rb" x="-2" y="-34"/></imgdir><imgdir name="hit"><canvas name="0" width="199" height="194"><vector name="origin" x="99" y="97"/><int name="z" value="0"/><string name="_hash" value="86d5b7f06107a433030beb76025082080374cf85322cc2c3faf62f0d226b8402"/></canvas><canvas name="1" width="183" height="198"><vector name="origin" x="91" y="99"/><int name="z" value="0"/><string name="_hash" value="cf7d28621dd3989207c3164fdc7964b5148af1ce8f75a880ef45efe1b5e50033"/></canvas><canvas name="2" width="201" height="206"><vector name="origin" x="100" y="103"/><int name="z" value="0"/><string name="_hash" value="405951214f0a2f370941d42229a23ebb4ceb720fb99eb5f27acedb63a86dc5a7"/></canvas><canvas name="3" width="196" height="189"><vector name="origin" x="98" y="94"/><int name="z" value="0"/><string name="_hash" value="aa48d2503799de6a57c495166c73807468794a007631f7463f83b0fff6da4388"/></canvas><canvas name="4" width="187" height="185"><vector name="origin" x="93" y="92"/><int name="z" value="0"/><string name="_hash" value="b7ca770a9097eb89987acee55d3d7e1e4717b5649467050fa5d68b352415718b"/></canvas><canvas name="5" width="193" height="191"><vector name="origin" x="96" y="95"/><int name="z" value="0"/><string name="_hash" value="0e09dc6fa57eb7be950c839c37ebbb3b4ea54332b2eedf35688245e1c39bc440"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="1" height="1"><vector name="origin" x="5" y="65"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="11" height="16"><vector name="origin" x="-25" y="79"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f43ed4a87893b2f41ee84926f4d7ea92fe403907c32a9985d6f1186e7a2debd9"/></canvas><canvas name="2" width="19" height="24"><vector name="origin" x="-18" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d75724403e970496e4ab4e2415da47785a3b19c5512e37658199ef5be15107be"/></canvas><canvas name="3" width="25" height="32"><vector name="origin" x="-14" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="4bef2b6e975ea3d60ac5e267b62766c8f7b69110625e31e45da7af5989bb6def"/></canvas><canvas name="4" width="30" height="30"><vector name="origin" x="-12" y="95"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b04182cbe58f31aa5bd77c1f7eb2e317802b5628a7f4b35e1cbc0b511c7b7259"/></canvas><canvas name="5" width="72" height="73"><vector name="origin" x="4" y="124"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="685279ece87a51e566920b5a6b07a177b648822071db1c5a0f0bb5c0574cf50d"/></canvas><canvas name="6" width="60" height="74"><vector name="origin" x="-4" y="130"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bbeb8cddd55bdfb84063941c2da093e548fd70dc3be0116120157d7169c47fbf"/></canvas><canvas name="7" width="64" height="71"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0e58a86d405c0e81f5a60736d82467c33f7b495aac1f1300cd936ae21c43d4ea"/></canvas><canvas name="8" width="53" height="72"><vector name="origin" x="-7" y="135"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e589c7010946da5b996d44c8b50f56bf635b42fedab0fbd3617bbd2fc696da92"/></canvas><canvas name="9" width="60" height="74"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="25904a1f9dd3d353b62aabf2b47d9b04d6735dd28ceab5ed2402f6227912a08d"/></canvas><canvas name="10" width="64" height="71"><vector name="origin" x="-5" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0b9ef739ffb6dc0b6f89295de0f803a644f4fda8edd1a27268d80ac94c014b7d"/></canvas><canvas name="11" width="53" height="72"><vector name="origin" x="-9" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9fc588141e33ba8b19abbedf133417a7d698923cf1bb0f9da15aab94529bb564"/></canvas><canvas name="12" width="297" height="89"><vector name="origin" x="244" y="126"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bada5098ad663279b04f71dc98ac1ba223ff01e9a3a31d47971490faaf6d6b16"/></canvas><canvas name="13" width="212" height="64"><vector name="origin" x="258" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d0922c563583f11ffb5ce844c70e219a1a26e4a80a2f7243320c4a557d544715"/></canvas><canvas name="14" width="1" height="1"><vector name="origin" x="257" y="93"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/14"/></canvas><canvas name="15" width="1" height="1"><vector name="origin" x="247" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/15"/></canvas><canvas name="16" width="1" height="1"><vector name="origin" x="143" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack2/info/effect/16"/></canvas></imgdir><int name="attackAfter" value="1440"/></imgdir><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="17" width="196" height="208"><vector name="origin" x="89" y="198"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/></canvas><canvas name="16" width="196" height="208"><vector name="origin" x="89" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/></canvas><canvas name="15" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/></canvas><canvas name="14" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/></canvas><canvas name="13" width="196" height="209"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/></canvas><canvas name="12" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas></imgdir><imgdir name="attack4"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-280" y="-65"/><vector name="rb" x="-2" y="-34"/></imgdir><imgdir name="hit"><canvas name="0" width="199" height="194"><vector name="origin" x="99" y="97"/><int name="z" value="0"/><string name="_hash" value="611c4a8dbfab9d22ac8ff48e21fd7068528727bf09abc328af09466c1a582590"/></canvas><canvas name="1" width="183" height="198"><vector name="origin" x="91" y="99"/><int name="z" value="0"/><string name="_hash" value="3f4f0e69bdaa8e05ec683ef1a26e2cec9c381ef18125e6c3369e4f3336edae07"/></canvas><canvas name="2" width="201" height="206"><vector name="origin" x="100" y="103"/><int name="z" value="0"/><string name="_hash" value="e6a4ed00509cfd9864dc2e1ccbbdd53eeb1f8013dbf21938e5d3cc47c5fe5230"/></canvas><canvas name="3" width="196" height="189"><vector name="origin" x="98" y="94"/><int name="z" value="0"/><string name="_hash" value="6efdbddb5a7fe5c392ffc88bd51618db78f6c631c282ebbca0e37ca2d4a75d6d"/></canvas><canvas name="4" width="187" height="185"><vector name="origin" x="93" y="92"/><int name="z" value="0"/><string name="_hash" value="f23473659433f05ef05f07664365d638e4508aa1e14e6b15540c90275c949da4"/></canvas><canvas name="5" width="193" height="191"><vector name="origin" x="96" y="95"/><int name="z" value="0"/><string name="_hash" value="f551b946051b5a564a273336dcaee1db2d6e6a3a9b1a90d022638b88eae475df"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="1" height="1"><vector name="origin" x="5" y="65"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="11" height="16"><vector name="origin" x="-25" y="79"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="203e25bb1fd53b1a5e7d2cd80b3f8959bbba982fcf452bad93a0915ade08a653"/></canvas><canvas name="2" width="19" height="24"><vector name="origin" x="-18" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="4fa6ae3fc1b006099a97c27a170a757c9ff161a6855d75b7ca67e32d9e33eca1"/></canvas><canvas name="3" width="25" height="32"><vector name="origin" x="-14" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="ecaba8472e3eb0a8fd18e358df6a3341c54626abf6aa95f2ebd66b913ed97589"/></canvas><canvas name="4" width="30" height="30"><vector name="origin" x="-12" y="95"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="6577098e707bf33585d998f703eeb2d5c68d7bde9483ee3e399e388e9ac2a0a9"/></canvas><canvas name="5" width="72" height="73"><vector name="origin" x="4" y="124"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="24cf809e09060234dc560c73f4b5be22e1c04052d07d7c60fc7d2bc302076a64"/></canvas><canvas name="6" width="60" height="74"><vector name="origin" x="-4" y="130"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0a1ba0ddae1eb1c189d0d1f4a5672d6018b79891706bd5def4ffe135ed1e89c6"/></canvas><canvas name="7" width="64" height="71"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="65b514b10138bef0075d47585ee11cd2e633f21a7673c03e8568e095158c9016"/></canvas><canvas name="8" width="53" height="72"><vector name="origin" x="-7" y="135"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9ecddc089310016cdd8526ca2c4475c881176fd78a27b350b5e29e01c9389e93"/></canvas><canvas name="9" width="60" height="74"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c7cc7584fd2ad81d23d13f2367a5636c8fff3c74d10b9ddd936632d668af2946"/></canvas><canvas name="10" width="57" height="71"><vector name="origin" x="-5" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="6562d65d76730ec0f5a02700d0904269484c4d97617402b09b0011f60178235e"/></canvas><canvas name="11" width="53" height="72"><vector name="origin" x="-7" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d3030969d95ef8f505edbb401b97716a0cff5e70e3b8724a86d457bb8cdf4fb3"/></canvas><canvas name="12" width="296" height="88"><vector name="origin" x="243" y="126"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="55fc186417168611c03cca71cce0900a7ada6bd808ace00858680a6009207d1a"/></canvas><canvas name="13" width="212" height="64"><vector name="origin" x="258" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="641d5ae49645769d9bd9a4d338e9737473e91d7000b40f08aaa6d0f8c94cacbb"/></canvas><canvas name="14" width="180" height="58"><vector name="origin" x="257" y="93"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="a4740c7c3d1c09c98b009ed045fa3e3680c1cbcff89f058f9b6ff70a0bd18142"/></canvas><canvas name="15" width="1" height="1"><vector name="origin" x="247" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/15"/></canvas><canvas name="16" width="1" height="1"><vector name="origin" x="143" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/16"/></canvas></imgdir><int name="attackAfter" value="1440"/></imgdir><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="12" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/></canvas><canvas name="13" width="196" height="209"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/></canvas><canvas name="14" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/></canvas><canvas name="15" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/></canvas><canvas name="16" width="196" height="208"><vector name="origin" x="89" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/></canvas><canvas name="17" width="196" height="208"><vector name="origin" x="89" y="198"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas></imgdir><imgdir name="attack5"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-280" y="-65"/><vector name="rb" x="-2" y="-34"/></imgdir><imgdir name="hit"><canvas name="0" width="199" height="194"><vector name="origin" x="99" y="97"/><int name="z" value="0"/><string name="_hash" value="b16c000e92a26c2dea7b8e9d20ac3d359248873c4e5840e11a49da15a68d9d10"/></canvas><canvas name="1" width="183" height="198"><vector name="origin" x="91" y="99"/><int name="z" value="0"/><string name="_hash" value="a053dcb8c8ccd9dba6ac60a12d68d03420615738ab86e181bb752a6dab961d1b"/></canvas><canvas name="2" width="201" height="206"><vector name="origin" x="100" y="103"/><int name="z" value="0"/><string name="_hash" value="c38457d5b09126168e6ad1a5729bb5fbf8be4cab63276007d1d81f83ade87069"/></canvas><canvas name="3" width="196" height="189"><vector name="origin" x="98" y="94"/><int name="z" value="0"/><string name="_hash" value="f1e1600924557d89e7ad9367b9481af20a79b8b4188697a18a3bb5639c22dfeb"/></canvas><canvas name="4" width="187" height="185"><vector name="origin" x="93" y="92"/><int name="z" value="0"/><string name="_hash" value="db7e3f6c18a368186b4d7ae1802337f9eabc352bec2989541e05274bd431bf30"/></canvas><canvas name="5" width="1" height="1"><vector name="origin" x="96" y="95"/><int name="z" value="0"/><string name="_inlink" value="attack4/info/hit/5"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="1" height="1"><vector name="origin" x="5" y="65"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="11" height="16"><vector name="origin" x="-25" y="79"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="6a97cfc259437844155a80dedf1ae6c70a537f46a7b87880a792cd1a8158e9ad"/></canvas><canvas name="2" width="19" height="24"><vector name="origin" x="-18" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="5681468acc1da43e17b6275f84ee07a11e4cbd50db1dea71c70c0362833bf041"/></canvas><canvas name="3" width="25" height="32"><vector name="origin" x="-14" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8f744d8e1b573d08ded2b9d4bf9115b2da99e9dfbe9459ef12553b77e14e1e70"/></canvas><canvas name="4" width="30" height="30"><vector name="origin" x="-12" y="95"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="124a7cff5f9b3e2cdd9f2c88ceea049d5f8404ad97e11fe28078214bbfeb1739"/></canvas><canvas name="5" width="72" height="73"><vector name="origin" x="4" y="124"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1172cb339eb469aef3c2d1830f581e352b47c0256462f0aba2c104e781433e9e"/></canvas><canvas name="6" width="60" height="74"><vector name="origin" x="-4" y="130"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="2131e318abd89e9aeb577d1784fe7f4df0956b310ebe558a9695493326a90211"/></canvas><canvas name="7" width="57" height="71"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bb2495273f323718c161b84b590564c26037d905385b182378b57e6a3ff3d41e"/></canvas><canvas name="8" width="53" height="72"><vector name="origin" x="-7" y="135"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="db4e53724ecb0d6a42336494745ebcc4d9ca254098e4e8058818d23b6f2dd1a3"/></canvas><canvas name="9" width="60" height="74"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="22621db1db697143c85f915a1af45b368729a2d59f12a6b7f20d4596688d4c78"/></canvas><canvas name="10" width="57" height="71"><vector name="origin" x="-5" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1f783c6758d0201b88b495104b98d4142d0cf926d17f39f8799af47e8cec90bf"/></canvas><canvas name="11" width="53" height="72"><vector name="origin" x="-7" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9a5750d8e4107d9d925b59ba4c6448cb0ec671ebccb604af5c34a6357dff146a"/></canvas><canvas name="12" width="298" height="90"><vector name="origin" x="244" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="80169ca1211efeb069d6b6054af8f417f6e1fffc25ba37e02f807f84ce2dc5ad"/></canvas><canvas name="13" width="212" height="64"><vector name="origin" x="258" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="fadd8c8de8582e094bfdcb68d3408f51cceca443bb7a7671c72fa319ef471713"/></canvas><canvas name="14" width="180" height="58"><vector name="origin" x="257" y="93"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f5931134c84763e2714eeea51af1f123897a978882305f584236dad7ab4cfb9f"/></canvas><canvas name="15" width="1" height="1"><vector name="origin" x="247" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/15"/></canvas><canvas name="16" width="1" height="1"><vector name="origin" x="143" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/16"/></canvas></imgdir><int name="attackAfter" value="1440"/></imgdir><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="12" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/></canvas><canvas name="13" width="196" height="209"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/></canvas><canvas name="14" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/></canvas><canvas name="15" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/></canvas><canvas name="16" width="196" height="208"><vector name="origin" x="89" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/></canvas><canvas name="17" width="196" height="208"><vector name="origin" x="89" y="198"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas></imgdir><imgdir name="attack6"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-767" y="-30"/><vector name="rb" x="751" y="13"/></imgdir><imgdir name="hit"><canvas name="0" width="191" height="183"><vector name="origin" x="95" y="91"/><int name="z" value="0"/><string name="_hash" value="b23a4d491f7813fb2f0c8c5fa271c7fbd71514d6f56deccb866d385356b9e8fb"/></canvas><canvas name="1" width="178" height="181"><vector name="origin" x="89" y="90"/><int name="z" value="0"/><string name="_hash" value="f0644280d8a073519c5b0e8c7ce14811c644efc33597b73b8a454b1ef39f2271"/></canvas><canvas name="2" width="186" height="187"><vector name="origin" x="93" y="93"/><int name="z" value="0"/><string name="_hash" value="8a413ffb1efa0bf652dbed94868378cab7971850178ddcf4048689aed6022851"/></canvas><canvas name="3" width="183" height="190"><vector name="origin" x="91" y="95"/><int name="z" value="0"/><string name="_hash" value="6ee40481205f9562f733ec7bde2d841b0ef551f4375a0764c523f43a1cdf0da9"/></canvas><canvas name="4" width="125" height="118"><vector name="origin" x="62" y="59"/><int name="z" value="0"/><string name="_hash" value="53f010a10ce309a7f5d21259a86a2764f876a41f4d71b296497f6f98544a7efd"/></canvas></imgdir><int name="attackAfter" value="1920"/></imgdir><canvas name="0" width="196" height="193"><vector name="origin" x="89" y="185"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="a79760470787833c345ed030e861d371bfc98fee59ecfaf5c4ea0693ee9655cb"/></canvas><canvas name="1" width="196" height="194"><vector name="origin" x="89" y="208"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="a872a786293da41c92db4fd28fee9526a973d17504fcba08e522d5b9112b9e6f"/></canvas><canvas name="2" width="196" height="193"><vector name="origin" x="89" y="212"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="8af3419110e62ebcf50e11ba92e0e75b00360dd0fcdc9e3a7a811f67f12b8b2b"/></canvas><canvas name="3" width="394" height="290"><vector name="origin" x="211" y="279"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-175"/><vector name="rb" x="101" y="-28"/><string name="_hash" value="fae816367fb7d68fa46976a01b0b2a90c1a4b5087dc671632482ad5d8cc1b784"/></canvas><canvas name="4" width="385" height="280"><vector name="origin" x="207" y="274"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="090ceb9e8278e32f36a6d4c58005cb7420f32177eb4f2a4e28700bdcf560af5c"/></canvas><canvas name="5" width="362" height="260"><vector name="origin" x="195" y="264"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="7773304bbfd0645c946f3818588e9c2fad40903928e5d515a47e8f2158849673"/></canvas><canvas name="6" width="201" height="182"><vector name="origin" x="95" y="222"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="ff951bbb84e527c5d3f2c14381c01fbda4f71e479514326ae04f94a73702e0fe"/></canvas><canvas name="7" width="199" height="183"><vector name="origin" x="92" y="218"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="9c6d73dc138e9fdabeeb9421397491e8b6d75e809555001862a920c6e07c49a3"/></canvas><canvas name="8" width="190" height="176"><vector name="origin" x="89" y="215"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="e79175d8bb0431e5af92097e0bbed53fc33ffe9718ada7fbbf1b1d6e21c371cd"/></canvas><canvas name="9" width="181" height="165"><vector name="origin" x="87" y="213"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="d9a0fd8f01dadf112bade5f12c183fbb6dbe97717938a53add9da2083d4f5036"/></canvas><canvas name="10" width="1" height="1"><vector name="origin" x="0" y="-1"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="11" width="394" height="290"><vector name="origin" x="213" y="330"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-9" y="-205"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="84" y="-88"/><string name="_hash" value="84e520166895fc4810530c4caab159231e5c1119905a78cd0aba5cf3866f741a"/></canvas><canvas name="12" width="304" height="217"><vector name="origin" x="165" y="289"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-9" y="-205"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="84" y="-88"/><string name="_hash" value="76f064d25d2a7bac2bacdebaaf884baf83ad8c0e6b7454d2e99c2130e4fe64a4"/></canvas><canvas name="13" width="278" height="193"><vector name="origin" x="139" y="277"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-9" y="-205"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="84" y="-88"/><string name="_hash" value="b09268b9631049d8e06b7f0a2d277ae613e630723591e98ff18e02a546f95de2"/></canvas><canvas name="14" width="276" height="193"><vector name="origin" x="138" y="279"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-9" y="-205"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="84" y="-88"/><string name="_hash" value="308d00825addf25b8c031da29cdcea3754077e6411fc83224ee8d4ef71c43409"/></canvas><canvas name="15" width="198" height="193"><vector name="origin" x="91" y="281"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-9" y="-205"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="84" y="-88"/><string name="_hash" value="e87b46b78957d44a624c9decc23a053fbf2ea2af5881c50a547543d63bc0de93"/></canvas><canvas name="16" width="1171" height="293"><vector name="origin" x="580" y="247"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="15"/><string name="_hash" value="45b5e536f5213f312e54946008fb535a5cbbe43892aa8fdd810954f6005c70fc"/></canvas><canvas name="17" width="1189" height="283"><vector name="origin" x="589" y="238"/><int name="z" value="0"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="15"/><int name="delay" value="120"/><string name="_hash" value="1ae4b7dcb55cd2a0574e8bf712d2bfe3d4cae25368639e9a96281f01b94151e0"/></canvas><canvas name="18" width="1192" height="222"><vector name="origin" x="591" y="182"/><int name="z" value="0"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="15"/><int name="delay" value="120"/><string name="_hash" value="e15595dd07d247c539f19ed8557a028ae80d04159782cbc34255b7713a9724c2"/></canvas><canvas name="19" width="1199" height="221"><vector name="origin" x="594" y="184"/><int name="z" value="0"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="15"/><int name="delay" value="120"/><string name="_hash" value="be936249e6c16c13180ea19b769daab53c724731e851583479dab3a6e08c4b6d"/></canvas><canvas name="20" width="1199" height="193"><vector name="origin" x="595" y="156"/><int name="z" value="0"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="-4"/><int name="delay" value="120"/><string name="_hash" value="b91e4107908aa9d9215856c9cd3ca3d42d7fdb6ba627865e17f2ac5ba2f3ec43"/></canvas><canvas name="21" width="1195" height="193"><vector name="origin" x="592" y="156"/><int name="z" value="0"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="15"/><int name="delay" value="120"/><string name="_hash" value="1c2e58f311b27eb7ffb65051f54ba7c9e59b6d1fe370e057752afee8e39ea03a"/></canvas></imgdir><imgdir name="attack7"><canvas name="12" width="196" height="392"><vector name="origin" x="89" y="392"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/></canvas><canvas name="13" width="196" height="405"><vector name="origin" x="89" y="406"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/></canvas><canvas name="2" width="197" height="378"><vector name="origin" x="90" y="380"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="86893292f87ad179cf8e47634df1bdbcfa0d2e425ba7c7899ddee73317a94fa8"/></canvas><canvas name="15" width="196" height="393"><vector name="origin" x="89" y="394"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/></canvas><canvas name="16" width="196" height="362"><vector name="origin" x="89" y="362"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/></canvas><canvas name="17" width="196" height="389"><vector name="origin" x="89" y="388"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/></canvas><canvas name="6" width="197" height="407"><vector name="origin" x="90" y="407"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="eadebb118bef62fb27cca7c5d83c9981cfea514dc7364f4f3eef5ce23bfd8c6c"/></canvas><canvas name="7" width="196" height="412"><vector name="origin" x="89" y="413"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="88ff94607cac27e1e7f91cfab14280d57726d3b88c18e62e641f6d9cb1d83e4f"/></canvas><canvas name="8" width="196" height="405"><vector name="origin" x="89" y="407"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="7f87b481fab16131725a601b2d643cf86c8c0602dc21a4848a66c424a41a980b"/></canvas><canvas name="9" width="196" height="392"><vector name="origin" x="89" y="393"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="d8cfbd754bee92b4b8b2c44f4219d8669079eff901edfcd6d7b8f4983d807528"/></canvas><canvas name="10" width="197" height="388"><vector name="origin" x="90" y="388"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="b85da2f8c68b4183c71b3bb528f62ee9d0e1de070b7c2a9b514a9d6535519156"/></canvas><canvas name="11" width="196" height="412"><vector name="origin" x="89" y="411"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="a6bdf2a3dee1a24bafac31bbfbf31e885766650cf02d46bd53ea9e7884945551"/></canvas><imgdir name="info"><imgdir name="screenCenter"><canvas name="0" width="1366" height="606"><vector name="origin" x="678" y="355"/><int name="z" value="0"/><string name="_hash" value="961c56bb5d5d7dc7ad0f9d1672c952c63239ced1d00dac9a640f75c5a8a38db3"/></canvas><canvas name="1" width="1366" height="619"><vector name="origin" x="678" y="363"/><int name="z" value="0"/><string name="_hash" value="867aa6baaaafb5a67f6449347b80e1aedadf4826eac95adcf41a1e066e655cce"/></canvas><canvas name="2" width="1366" height="623"><vector name="origin" x="678" y="363"/><int name="z" value="0"/><string name="_hash" value="896019b3a7c82240f86eb00d90d3d41c00921d259e1334e39586cdd496be8da0"/></canvas><canvas name="3" width="1366" height="607"><vector name="origin" x="678" y="348"/><int name="z" value="0"/><string name="_hash" value="2b9af8374df735f89f113e445eee7291ed2c92a409c1bdcedd311a1ba8fa69f1"/></canvas><canvas name="4" width="1366" height="623"><vector name="origin" x="678" y="363"/><int name="z" value="0"/><string name="_hash" value="a99f7e4272142dcf40e9796215118c2c80f7193d5ebe14837da17fd9c7aa3a9b"/></canvas><canvas name="5" width="1366" height="630"><vector name="origin" x="678" y="363"/><int name="z" value="0"/><string name="_hash" value="49ddf77b31c2831af083047a841e6fb3b10eb0edcfc5e00c0c433cebceeba14e"/></canvas><canvas name="6" width="1366" height="611"><vector name="origin" x="678" y="359"/><int name="z" value="0"/><string name="_hash" value="e39edb718b12070548efe00dd6df6b54f6bc76635772eee6ab63c220523b3592"/></canvas><canvas name="7" width="1366" height="620"><vector name="origin" x="678" y="363"/><int name="z" value="0"/><string name="_hash" value="0f81bf6ef594a4d1b589443177195ed8c061ae6727faaf5077943ea4831254af"/></canvas><canvas name="8" width="1366" height="630"><vector name="origin" x="678" y="363"/><int name="z" value="0"/><string name="_hash" value="ca4565241d69c2df61ebbd52a7872290341fa1d64eb742a70656ef668a1733c0"/></canvas><canvas name="9" width="1366" height="616"><vector name="origin" x="678" y="359"/><int name="z" value="0"/><string name="_hash" value="753176c9a79a0b4bfbeb07e3c6f015593e51ff776d46c1605e04623bfc7d4f54"/></canvas><canvas name="10" width="1366" height="624"><vector name="origin" x="678" y="363"/><int name="z" value="0"/><string name="_hash" value="a4ea2e9d7c2acc943aadae7b91e89b7755272bf0776278fa636b3d1a3f79400c"/></canvas><canvas name="11" width="1366" height="630"><vector name="origin" x="678" y="363"/><int name="z" value="0"/><string name="_hash" value="f95b69436294394856c442369930fa30939d076d5ca931717229bce5b2650bcc"/></canvas></imgdir><imgdir name="hit"><canvas name="1" width="176" height="192"><vector name="origin" x="88" y="96"/><int name="z" value="0"/><string name="_hash" value="24297c65bd86f268e84f9da30bb28f28f6b3929df83c83ef4589743860586205"/></canvas><canvas name="2" width="165" height="192"><vector name="origin" x="82" y="96"/><int name="z" value="0"/><string name="_hash" value="8ee5c4999ed66f77eec4a6891728d0caae27aab78b95d7c394b46b2dd7503c0e"/></canvas><canvas name="3" width="163" height="135"><vector name="origin" x="81" y="67"/><int name="z" value="0"/><string name="_hash" value="710dd428dfead84cb3e570011283888350bc3cb4198c2276689f16c58a0159e8"/></canvas><canvas name="4" width="141" height="133"><vector name="origin" x="70" y="66"/><int name="z" value="0"/><string name="_hash" value="2037b1d2981b15bc1694bd5f572014e17c6753082e8b6c109cfa4a4be7b752b7"/></canvas><canvas name="5" width="145" height="140"><vector name="origin" x="72" y="70"/><int name="z" value="0"/><string name="_hash" value="65833d06e578de7367829fb27cdc203a3cec2d049cad8a50bbfa6bc4b11fa2c0"/></canvas><canvas name="6" width="149" height="152"><vector name="origin" x="74" y="76"/><int name="z" value="0"/><string name="_hash" value="854a7c1bcea63d31cce503d0be743a3e307cf39768b30f4fa0330c0c627ecd51"/></canvas></imgdir><imgdir name="range"><vector name="lt" x="-680" y="-1147"/><vector name="rb" x="680" y="99"/></imgdir><int name="onlyFsm" value="1"/></imgdir><imgdir name="speak"><int name="prop" value="100"/><string name="0" value="不覺得無法阻檔就是要承受嗎?"/></imgdir><canvas name="0" width="196" height="392"><vector name="origin" x="89" y="392"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/></canvas><canvas name="14" width="196" height="405"><vector name="origin" x="89" y="406"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/></canvas><canvas name="1" width="196" height="405"><vector name="origin" x="89" y="406"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/></canvas><canvas name="3" width="196" height="393"><vector name="origin" x="89" y="394"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/></canvas><canvas name="4" width="196" height="362"><vector name="origin" x="89" y="362"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/></canvas><canvas name="5" width="196" height="389"><vector name="origin" x="89" y="388"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/></canvas></imgdir><imgdir name="skill1"><canvas name="20" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/></canvas><canvas name="8" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/></canvas><canvas name="9" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/></canvas><canvas name="10" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/></canvas><canvas name="11" width="196" height="203"><vector name="origin" x="89" y="195"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/></canvas><canvas name="12" width="196" height="198"><vector name="origin" x="89" y="189"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/></canvas><canvas name="13" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/></canvas><canvas name="14" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="f2b1eb2b88b053721807e0d194e5b55f1b846b5a4b6e11939b92839ec267967e"/></canvas><canvas name="15" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="09afd8d8cf124fb4db9f0fec591e6a074ce56eacfae17b8135982d3dec438343"/></canvas><canvas name="16" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="2ad898a1542d67c7969aa86fc1c9882bd40dd32a60625b28a3b016346e1e2b38"/></canvas><canvas name="17" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="065bae5b5906dd8921a4e04933afa7f9535d191d86be631af646eac30f4cad82"/></canvas><canvas name="18" width="196" height="198"><vector name="origin" x="89" y="189"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="c6c3f56700e80cf51e3339a72040262411ec5986573968da20513049bd4707bd"/></canvas><canvas name="19" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="3297db2c984ffaa1befe4f0177259104027a50eeae88aa5472a5060efbe3f255"/></canvas><imgdir name="speak"><int name="prop" value="100"/><string name="0" value="?????"/></imgdir><canvas name="7" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/></canvas><canvas name="4" width="196" height="203"><vector name="origin" x="89" y="195"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/></canvas><canvas name="5" width="196" height="198"><vector name="origin" x="89" y="189"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/></canvas><canvas name="6" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/></canvas><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/></canvas></imgdir><imgdir name="skill2"><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_inlink" value="skill1/0"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="8b1c227836bc8294007f8ff45ce54f480d7907c0853f29319dea0b4cf614cea1"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_inlink" value="skill1/2"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_inlink" value="skill1/3"/></canvas><canvas name="4" width="196" height="203"><vector name="origin" x="89" y="195"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_inlink" value="skill1/4"/></canvas><canvas name="5" width="196" height="198"><vector name="origin" x="89" y="189"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_inlink" value="skill1/5"/></canvas><canvas name="6" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="1578c13f059d956d6aeb5ca636e1d72331eac87a8e1a01fbfdc0085f424d5bbe"/></canvas><canvas name="7" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="8c437997c9158a5e1ed3dc72ff559562816d8efc8f8a1c189f2c9eb0152b1a1a"/></canvas><canvas name="8" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="26bf7cb4e392126aad1038844de35edc4adb007a480996ecef1f9b5888f8f278"/></canvas><canvas name="9" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_inlink" value="skill1/16"/></canvas><canvas name="10" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_inlink" value="skill1/17"/></canvas><canvas name="11" width="196" height="198"><vector name="origin" x="89" y="189"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_inlink" value="skill1/18"/></canvas><canvas name="12" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="636d5a1e1597807ad66adb0d47e00ac24e7f97d8429234c736cdb9347601f604"/></canvas></imgdir><imgdir name="skill3"><canvas name="0" width="196" height="199"><vector name="origin" x="90" y="190"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="1d0aac14b0085e2ec724af30e7ceeb5ff32ef5c9e2de6922614e262e656e514b"/></canvas><canvas name="1" width="196" height="205"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="0270f3a6f9ceb6a83bce4ef665f0e03882a29be3faa0d4033b535baf2dd3756c"/></canvas><canvas name="2" width="196" height="213"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="0d0cf54e86e131e21d9f127146d0184889794fd198db889de8157c6c2efb5f3a"/></canvas><canvas name="3" width="196" height="215"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="982b9d39aa44f124d59dd5fac3014606b9cb5c3b59a98170605a9ac9e86f4bad"/></canvas><canvas name="4" width="197" height="218"><vector name="origin" x="90" y="192"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="c3e340e338054e1adece96d3ba11a501ee729046720b245c7020c22d7a222f4c"/></canvas><canvas name="5" width="198" height="220"><vector name="origin" x="91" y="192"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="af7f589835fd13d6b275c4cc1fe972c93d02207c7756cb4e581e41439ffa64ae"/></canvas><canvas name="6" width="197" height="214"><vector name="origin" x="90" y="206"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="1fe9c11f660642b36f07af486afbd56c2a2bc46edd912b7adb9ea0d6c9b70cbb"/></canvas><canvas name="7" width="197" height="210"><vector name="origin" x="89" y="202"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="400852cbca5268b0c396c6d5461fa99fa8d138d57ff64b3e6050e63f8e201151"/></canvas><canvas name="8" width="204" height="203"><vector name="origin" x="89" y="195"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="0a6937e946fd7494552cb09f1965afbd21e75b91d71fb16568211e09fde987c6"/></canvas><canvas name="9" width="204" height="202"><vector name="origin" x="89" y="194"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="e0efca09df704285e1cc5a59ad460c7cf3def9cc752c6f28e875106da8e6632a"/></canvas><canvas name="10" width="198" height="202"><vector name="origin" x="89" y="194"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="55eb33f9d5a8cabbc0ac37018e219811d6cbda349e3a81ed955236858876c60c"/></canvas><canvas name="11" width="199" height="204"><vector name="origin" x="89" y="196"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="c15a1b7a495533fbcc44b93ba70bc0e492c7e7f7427e326317f66e610412f72a"/></canvas></imgdir><imgdir name="skill4"><canvas name="0" width="956" height="363"><vector name="origin" x="459" y="316"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="da1c9306bf191db3b9ca6446a0c50fb859cb08dc059b3093da6af1a7af6a416d"/></canvas><canvas name="1" width="974" height="371"><vector name="origin" x="469" y="325"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="03ad3382983f4613b235848951dddb871f5b1407dd6869f93391e6f9a961911a"/></canvas><canvas name="2" width="962" height="377"><vector name="origin" x="462" y="331"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="e70a370621d4030bb0a82b3ec6f5edc55fc0f9948bf8cf19d2e3823a55d74f4a"/></canvas><canvas name="3" width="958" height="362"><vector name="origin" x="460" y="316"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="afdafc77cbc62d9f1755d099ab8d661be62fe32619c2906fa0030a50bb6e5e73"/></canvas><canvas name="4" width="956" height="363"><vector name="origin" x="459" y="316"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="9c3662fd377e82c8264734f8d9417e444f49d2812d4cf843ac5f3d94699f9ea6"/></canvas><canvas name="5" width="974" height="371"><vector name="origin" x="469" y="325"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="1c72e326b61263c5b09541c12852aee52a546bc2009f11ef94a6c6cb2784833b"/></canvas><canvas name="6" width="962" height="365"><vector name="origin" x="462" y="319"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="7f0b27d216229c86b8505e63c40d382e5bd5730c492928d14bd308eb6005e020"/></canvas><canvas name="7" width="958" height="362"><vector name="origin" x="460" y="316"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="abd5ca7492609f9c54319b080f892aa0cb5e714c3a1c6a35274972524483ef67"/></canvas><canvas name="8" width="956" height="363"><vector name="origin" x="459" y="316"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="2de73e35ee56d9fe4f7e02459e796f0e55a451916606ff2cb280919bc9aba71a"/></canvas><canvas name="9" width="974" height="371"><vector name="origin" x="469" y="325"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="01044fc53aa723c1c5d5eeef7dc12a36609cdb04326a7e8c76d19f5b3fb8444d"/></canvas><canvas name="10" width="962" height="377"><vector name="origin" x="462" y="331"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="9b4c61b524397e7a9e6657a6c4225553734ee5c48353393c6bcce9a6737f690f"/></canvas><canvas name="11" width="957" height="362"><vector name="origin" x="459" y="316"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="61e8a3c6f6bf6d4cca92bcf2a55f2ad4914d8287b42cad7f35783e70c112aca8"/></canvas></imgdir><imgdir name="sleep"><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="b2430fa639b89aa5288be7e776c5b288d9782c2d48f8feb6f0c988bbe56c9087"/></canvas><canvas name="1" width="196" height="199"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="cbfce70bc4aa789b671fd5e8b399b3181a9a7217c9eaf53e739ca7d73db54e67"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="622c48789a75abee11372071b4c17ac4bca3d6c331e3f2002ffb55c7812c01a3"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a1a00c60f5904e342e63e90375ef286a2dfed26169087d264a6cbba68a48637d"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="f76ed95f4848e01520006f427c3fc0d838ac7cb082e5ab7e3b2df583b5d7a01d"/></canvas><canvas name="5" width="196" height="203"><vector name="origin" x="89" y="194"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="3c8bd39163f7777ab7c09af8b678d21fe615a785b3ca0082c8ab3b33b8e39f75"/></canvas></imgdir><imgdir name="wakeup"><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="bb3a8529be1dd4f044e38b659cdcdcc31ea98e9b395b1ffeb79f9560a5069745"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="1539eb0621a8ae8ba73be693b113e5f3c4c99140f0fd21745db0f083b7015367"/></canvas><canvas name="5" width="196" height="203"><vector name="origin" x="89" y="194"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="3c8bd39163f7777ab7c09af8b678d21fe615a785b3ca0082c8ab3b33b8e39f75"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a1a00c60f5904e342e63e90375ef286a2dfed26169087d264a6cbba68a48637d"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="622c48789a75abee11372071b4c17ac4bca3d6c331e3f2002ffb55c7812c01a3"/></canvas><canvas name="1" width="196" height="199"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="cbfce70bc4aa789b671fd5e8b399b3181a9a7217c9eaf53e739ca7d73db54e67"/></canvas></imgdir><imgdir name="skill5"><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="fe6d85f38fadf27cb19d34d1fef7ed74b51708b21c45700339375e7f327c4d78"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="7474900d3708017e1d79cfaa0ad65b50c15866d1ab8258b1a303c610e9e0f737"/></canvas><canvas name="2" width="394" height="290"><vector name="origin" x="211" y="254"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="3" width="385" height="280"><vector name="origin" x="207" y="249"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="4" width="362" height="260"><vector name="origin" x="195" y="239"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="5" width="201" height="182"><vector name="origin" x="95" y="199"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="6" width="199" height="183"><vector name="origin" x="92" y="196"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="7" width="190" height="176"><vector name="origin" x="89" y="193"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_inlink" value="attack6/8"/></canvas><canvas name="8" width="181" height="165"><vector name="origin" x="87" y="191"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_inlink" value="attack6/9"/></canvas></imgdir><imgdir name="skill6"><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="b2430fa639b89aa5288be7e776c5b288d9782c2d48f8feb6f0c988bbe56c9087"/></canvas><canvas name="1" width="196" height="199"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="cbfce70bc4aa789b671fd5e8b399b3181a9a7217c9eaf53e739ca7d73db54e67"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="622c48789a75abee11372071b4c17ac4bca3d6c331e3f2002ffb55c7812c01a3"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a1a00c60f5904e342e63e90375ef286a2dfed26169087d264a6cbba68a48637d"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="f76ed95f4848e01520006f427c3fc0d838ac7cb082e5ab7e3b2df583b5d7a01d"/></canvas><canvas name="5" width="196" height="203"><vector name="origin" x="89" y="194"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="3c8bd39163f7777ab7c09af8b678d21fe615a785b3ca0082c8ab3b33b8e39f75"/></canvas></imgdir><imgdir name="skillAfter5"><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="fe6d85f38fadf27cb19d34d1fef7ed74b51708b21c45700339375e7f327c4d78"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="7474900d3708017e1d79cfaa0ad65b50c15866d1ab8258b1a303c610e9e0f737"/></canvas><canvas name="2" width="394" height="290"><vector name="origin" x="211" y="254"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="3" width="385" height="280"><vector name="origin" x="207" y="249"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="4" width="362" height="260"><vector name="origin" x="195" y="239"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="5" width="201" height="182"><vector name="origin" x="95" y="199"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="6" width="199" height="183"><vector name="origin" x="92" y="196"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/></canvas><canvas name="7" width="190" height="176"><vector name="origin" x="89" y="193"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_inlink" value="attack6/8"/></canvas><canvas name="8" width="181" height="165"><vector name="origin" x="87" y="191"/><int name="z" value="0"/><vector name="lt" x="-91" y="-169"/><vector name="rb" x="106" y="-3"/><vector name="head" x="-14" y="-109"/><string name="_inlink" value="attack6/9"/></canvas></imgdir><imgdir name="attack8"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-291" y="-103"/><vector name="rb" x="302" y="11"/></imgdir><imgdir name="hit"><canvas name="0" width="176" height="192"><vector name="origin" x="88" y="96"/><int name="delay" value="120"/><string name="_hash" value="5b5bbf90f935698fa22ffc6c04334cad0af96e7dd4211f4a606d4d9f01e8526b"/></canvas><canvas name="1" width="165" height="192"><vector name="origin" x="82" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f364f9d9613dbacb1f4ca3a01150f5587a4e7f51102e46b3cb327a5f415e5992"/></canvas><canvas name="2" width="163" height="135"><vector name="origin" x="81" y="67"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="75f7941cc775149f4006ffef198de7efda1e50c809f2bac2dbb1bf28af282106"/></canvas><canvas name="3" width="141" height="133"><vector name="origin" x="70" y="66"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f0d6a63a671be108aa176a9e1585dc7fcaf7f248cb2e85ffd823331564791147"/></canvas><canvas name="4" width="145" height="140"><vector name="origin" x="72" y="70"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0f91d203de252aa01a9054313f809952e0194ff222870b26d548f37565acaa4d"/></canvas><canvas name="5" width="1" height="1"><vector name="origin" x="74" y="73"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9f4f3d4b5d919ec75142aeeb50862ae7d41806fd7038b44a8323f00ba58716f8"/><string name="_outlink" value="Mob/9390624.img/attack2/info/hit/6"/></canvas></imgdir></imgdir><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="196" height="199"><vector name="origin" x="89" y="191"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="f9ff11c42be35e5e3fd109814f4e61b14dd109653833ad15bcd3335a56a891d5"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="196" height="199"><vector name="origin" x="89" y="191"/><int name="z" value="0"/></canvas><canvas name="1" width="196" height="179"><vector name="origin" x="89" y="171"/><int name="z" value="0"/><string name="_hash" value="029fc945fe7a87aea59c019b8a59e48364de0883dde4d4d6c540a9564507c8df"/></canvas><canvas name="2" width="192" height="164"><vector name="origin" x="87" y="159"/><int name="z" value="0"/><string name="_hash" value="1220215ee1bfd503e711d2fa75cb24bbdef2174b20b30cfda11a4f2037da070c"/></canvas><canvas name="3" width="187" height="156"><vector name="origin" x="86" y="157"/><int name="z" value="0"/><string name="_hash" value="8a7e19f2bffe98a8be6daa1e7043f1090cca13d46f8a3aa9ff25bb4f9938fc63"/></canvas><canvas name="4" width="175" height="151"><vector name="origin" x="78" y="155"/><int name="z" value="0"/><string name="_hash" value="3b219a21f7c6625ddc68d067fffd2186ddad543e2fc7be9454c1002b9e49d860"/></canvas><canvas name="5" width="156" height="136"><vector name="origin" x="69" y="156"/><int name="z" value="0"/><string name="_hash" value="086e3e5cf47d9b10c4c48aa15b38d0619c690f08e45e12c5e07d7c432decd957"/></canvas><canvas name="6" width="125" height="122"><vector name="origin" x="48" y="151"/><int name="z" value="0"/><string name="_hash" value="315f1dd0e72160d042c46b73c891f65113b2b6734dbbc25c21beb6c96a1676a8"/></canvas><canvas name="7" width="65" height="47"><vector name="origin" x="8" y="93"/><int name="z" value="0"/><string name="_hash" value="b828e2dc0153f7e04df420a0ddadbdbdfe8664baf63a1c4a5d8a16efdbe4df22"/></canvas></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="8890036.img">
+  <imgdir name="info">
+    <int name="level" value="160"/>
+    <int name="maxHP" value="210000000"/>
+    <int name="maxMP" value="100000"/>
+    <int name="mpRecovery" value="1000000"/>
+    <int name="hpRecovery" value="10000"/>
+    <int name="speed" value="100"/>
+    <int name="PADamage" value="1600"/>
+    <int name="MADamage" value="1600"/>
+    <int name="PDRate" value="100"/>
+    <int name="MDRate" value="100"/>
+    <int name="acc" value="270"/>
+    <int name="eva" value="47"/>
+    <int name="pushed" value="1000000000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="category" value="8"/>
+    <int name="firstAttack" value="1"/>
+    <string name="mobType" value="1N"/>
+    <int name="boss" value="1"/>
+    <int name="explosiveReward" value="1"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="ignoreMoveImpact" value="1"/>
+    <int name="ignoreMovable" value="1"/>
+    <int name="ignoreFieldOut" value="1"/>
+    <int name="isRemoteRange" value="1"/>
+    <imgdir name="attack">
+      <imgdir name="0">
+        <int name="action" value="1"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="knockback" value="1"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="action" value="2"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="disease" value="123"/>
+        <int name="level" value="55"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="action" value="3"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="disease" value="132"/>
+        <int name="level" value="19"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="action" value="4"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="disease" value="125"/>
+        <int name="level" value="33"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="action" value="5"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="2"/>
+        <int name="disease" value="137"/>
+        <int name="level" value="4"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="action" value="6"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="6"/>
+        <int name="tremble" value="1"/>
+        <int name="fixDamR" value="50"/>
+      </imgdir>
+      <imgdir name="6">
+        <int name="action" value="7"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="3"/>
+        <int name="conMP" value="1"/>
+        <int name="magic" value="1"/>
+        <int name="disease" value="126"/>
+        <int name="level" value="30"/>
+      </imgdir>
+      <imgdir name="7">
+        <int name="action" value="8"/>
+        <int name="attackRatio" value="100"/>
+        <int name="type" value="0"/>
+        <int name="conMP" value="1"/>
+        <int name="magic" value="1"/>
+        <int name="deadlyAttack" value="1"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="skill">
+      <imgdir name="7">
+        <int name="skill" value="145"/>
+        <int name="action" value="6"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="0">
+        <int name="skill" value="128"/>
+        <int name="action" value="3"/>
+        <int name="level" value="8"/>
+        <int name="skillAfter" value="1760"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="128"/>
+        <int name="action" value="1"/>
+        <int name="level" value="13"/>
+        <int name="skillAfter" value="990"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="200"/>
+        <int name="action" value="2"/>
+        <int name="level" value="223"/>
+        <int name="skillAfter" value="1440"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="128"/>
+        <int name="action" value="4"/>
+        <int name="level" value="1"/>
+        <int name="skillAfter" value="1260"/>
+        <int name="effectAfter" value="1260"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="145"/>
+        <int name="action" value="6"/>
+        <int name="level" value="4"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="skill" value="200"/>
+        <int name="action" value="5"/>
+        <int name="level" value="222"/>
+        <int name="skillAfter" value="1440"/>
+        <int name="preSkillIndex" value="7"/>
+        <int name="preSkillCount" value="5"/>
+      </imgdir>
+      <imgdir name="6">
+        <int name="skill" value="128"/>
+        <int name="action" value="7"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="630"/>
+        <int name="skillAfter" value="630"/>
+      </imgdir>
+    </imgdir>
+    <int name="bodyAttack" value="1"/>
+    <int name="exp" value="0"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="aacfdac6db9941a92082d4ff149e479f91f9b7f9b17d384ad091f8446779d0bc"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="9720c408116d2ab09e8295717dc11971cbd4d77a353c168ebb28c04f746e232d"/>
+    </canvas>
+    <canvas name="10" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="cc792d53d48c07a6c8c037fbe59907615b6fc0e8107e7f22c903ad06b7d79ebf"/>
+    </canvas>
+    <canvas name="11" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="e692398e07ba283472e8fca4e7e5a26b1cd3d5578ab92a5c37ce89719d8608dc"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="4a6ef4330261092c4be1be264c84fc9267ad1b48ba59fd0169d306b570993dc9"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="4c12eb8473e722e09eec99743488c040d27f1fa9c00e7c6efafd77212894159a"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a8f58b13a489ca5850848829e359f05b8eed60ac4a1cce456a03680c644faaef"/>
+    </canvas>
+    <canvas name="5" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="210cd2abd8fb276b8e1e08abe2f19994edf8f3d0b2dc66721b81898279ac7a99"/>
+    </canvas>
+    <canvas name="6" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="7" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="69d8a175e31fd46b141b4f142401142cf79d649dbfca8b5715643c53f64be086"/>
+    </canvas>
+    <canvas name="8" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="c46972e7aa48ef79b899a102749f46d3474c84ad99a34f47e4f79b3b9d68db74"/>
+    </canvas>
+    <canvas name="9" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="1a3792b751548391d8b5a72067e2b2ac1738725f97521f973bb3266166731fa3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="5" width="200" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="ace4d88aa5fca2f30ce1aba0361e59635ec9936e0d948d34100a6b20f6adcaa6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="53f6e366da478b2bf97da582637682cba6e16f6426f884b8d7dd78e0f2b8b420"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="ea7498c7f47b52286a540fda3522c46e3eaa4477bee49736508c58a0e8eb847a"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="bcd85aa903f39e6f5211f04e64ab12f27968cebec541f04b2df1d55f7b3ccd82"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="de90f4fa91c5d222eb9a524c87f50fb11b4f1dcf5fd126d9bcdb7aa24f687f33"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="7ce12372921280cca8a391b4aeb4473e77e15d22d5fc854d965d4b8b1cb64eb5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="ed173a097e57edeabd997764a1203fe48282c6b66b5b3c63b8959d1a68ab282c"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f561de600870aed73eefd738f90fc1043bed8280371cbb166f7dee0e66ffbd53"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3a0c130666d0a065906181c8bd7ba4cd7af1486cf095678d378ef485a4546848"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="443e54e4c9419660510be8ff8bf49b240de73248fbd94c3b75eacb478cf445cc"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="e9a9f905eaf9c7e697735d27789323e85fa1f1d8c8abb0892d7675da6e5de506"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="9b1981507d06d898fde691f11b21c3f9778b978b01de082e32a5d753432e68cf"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e14184568972a6e77906e675413433f8968c5075e9541f2d258de8ad38bcbabf"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="ddaf8bd5ce82b330d7edf018fd66ca865657a04d92f7d983afd279d03821bd84"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5b965163288d1c34396f6416910f627c94261153a4bb4ef8e75d7c2b249209a6"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b468ebfb3b67e05d740ff415fbfaf1a6756f09d8c19ca9ec4d77141d3efd3752"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="c1c4886943ef4862b15d434a478a125dfa092481b1b250f91ce8c73154815684"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1c99b9631d1c854e130f4b548591d393fcd4721a089799389c82f668f3da2393"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="39566a11077d123dcbd1d0032373d33c586b9a1e65d564da880520ac97ef671a"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="91fbe439bd6ffca9eaff288b2cda1c5be611ee89d34e4ca9a3946bc35ec66fd7"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="14c22bb33a2f2c1bc0f9e138aadf315c219d4abbcb5adb96835640caf32e51cf"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7377d913b3e0e22893bcf9019a884a4c298f4bee7ec9a8c0c7fc2e10fdc263e7"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="84a10b45ceda775f338d1d62ff555ebe7ac9dfb2e0d90ebf5e42aaaba0ffa37d"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="cf92e0ffc0a2e247486e0a5f56bd7c5c44d61bccd420ef0c4c91bac8d35fe293"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7afbb566b04355530205cbf6ee22a58875587d460f6147bfb708d5bb90b0551e"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="484249c5bc3dfa1b980be5f56a3e1d93bde25ca3dec81ef9bb9ad2ae1d761260"/>
+        </canvas>
+        <canvas name="15" width="160" height="49">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7bb927d4063b5272776e83cf201a25a418f2d4b9e5f9f43bd3bf373d46db0082"/>
+        </canvas>
+        <canvas name="16" width="60" height="49">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5a3f8187e830f852440585186c0e3c6ab10225f0828dcb2144202500b17d788b"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="c06e0a1d53536be3f89cca6c459c632b72cbd79542e11ad04f9f9199008e775c"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6c9d0e2e3f6778eeaa44d9b6d34213e75a83e6c2e4b984b03ae49104300fc092"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="47d401133797d76af401f7855fe44a3b0eeb388923bf0a2dcd9ca654f2279c28"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3cdf4b8968876423893686bb285c6d0c9729de34c4c661a726135e8c52133f59"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="092042886657e04f11bcf14ef2b0f1ca5d651bd00ab9e31a2610744317b09c44"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_inlink" value="attack1/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="1" height="1">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/1"/>
+        </canvas>
+        <canvas name="2" width="1" height="1">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/2"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="642855b4259104ce2ec98dd86be97d0a0d89d72f70999abbf9579c85affbd9cb"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="88c5b7ecac32cc860d00577f6105be5b15fd9f99f5d25a6b98b9cf029d1295c5"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="dbc0d33c40fae2a166034f2ae1f50076866dfef4987fc1118baf95539e88e2a2"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bfbd90318e054646f09a5432bf3b2c765026a4905790c24904079c4773ad2928"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8bafcbfd9edb6cc910b860acff509eed800ab8674b38dda99b16612211c07cbd"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="34abb4387224c37351708a0ce1f3a5815d798b538e58c752e4281f437c688cb8"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e74d8967bce61233d379d4eb6a17f8f2aa2c1154af9a94eb8997a39c83ae024d"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="befec05e861886328728153a33ea56c55a94a2027fa05723733e0920e35e7970"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0cf7c84ca3d414cb33d6ba874928f742d29e2c61aa3b3f500359adbbb168ec5a"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="174e922c141594c39b6bddafe2f37540e97a76fd04ada23fb2cdccdbaf3a9ba8"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="131" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="80572942c58ca7a183d698294afdd76f7ecd842b34c191be6cd02f821b12ed9b"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="75651698bb1a7372b7f7a180922219def3bc52bc55203e46ee357cb93ebb4e8c"/>
+        </canvas>
+        <canvas name="15" width="160" height="49">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b102caf9e5204ca94452ea072db696e6f957bfc0ec7b7343109b1a625f66390d"/>
+        </canvas>
+        <canvas name="16" width="60" height="49">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="39b8c41a36c92e6ba1040a5574908a6a52e5bcb5e4894afa8e414f3ea400d22e"/>
+        </canvas>
+        <int name="attackAfter" value="1440"/>
+      </imgdir>
+    </imgdir>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="86d5b7f06107a433030beb76025082080374cf85322cc2c3faf62f0d226b8402"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="cf7d28621dd3989207c3164fdc7964b5148af1ce8f75a880ef45efe1b5e50033"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="405951214f0a2f370941d42229a23ebb4ceb720fb99eb5f27acedb63a86dc5a7"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="aa48d2503799de6a57c495166c73807468794a007631f7463f83b0fff6da4388"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b7ca770a9097eb89987acee55d3d7e1e4717b5649467050fa5d68b352415718b"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="0e09dc6fa57eb7be950c839c37ebbb3b4ea54332b2eedf35688245e1c39bc440"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f43ed4a87893b2f41ee84926f4d7ea92fe403907c32a9985d6f1186e7a2debd9"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d75724403e970496e4ab4e2415da47785a3b19c5512e37658199ef5be15107be"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4bef2b6e975ea3d60ac5e267b62766c8f7b69110625e31e45da7af5989bb6def"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b04182cbe58f31aa5bd77c1f7eb2e317802b5628a7f4b35e1cbc0b511c7b7259"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="685279ece87a51e566920b5a6b07a177b648822071db1c5a0f0bb5c0574cf50d"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bbeb8cddd55bdfb84063941c2da093e548fd70dc3be0116120157d7169c47fbf"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0e58a86d405c0e81f5a60736d82467c33f7b495aac1f1300cd936ae21c43d4ea"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e589c7010946da5b996d44c8b50f56bf635b42fedab0fbd3617bbd2fc696da92"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="25904a1f9dd3d353b62aabf2b47d9b04d6735dd28ceab5ed2402f6227912a08d"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0b9ef739ffb6dc0b6f89295de0f803a644f4fda8edd1a27268d80ac94c014b7d"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-9" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9fc588141e33ba8b19abbedf133417a7d698923cf1bb0f9da15aab94529bb564"/>
+        </canvas>
+        <canvas name="12" width="297" height="89">
+          <vector name="origin" x="244" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bada5098ad663279b04f71dc98ac1ba223ff01e9a3a31d47971490faaf6d6b16"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d0922c563583f11ffb5ce844c70e219a1a26e4a80a2f7243320c4a557d544715"/>
+        </canvas>
+        <canvas name="14" width="1" height="1">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/14"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack2/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="611c4a8dbfab9d22ac8ff48e21fd7068528727bf09abc328af09466c1a582590"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3f4f0e69bdaa8e05ec683ef1a26e2cec9c381ef18125e6c3369e4f3336edae07"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="e6a4ed00509cfd9864dc2e1ccbbdd53eeb1f8013dbf21938e5d3cc47c5fe5230"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6efdbddb5a7fe5c392ffc88bd51618db78f6c631c282ebbca0e37ca2d4a75d6d"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f23473659433f05ef05f07664365d638e4508aa1e14e6b15540c90275c949da4"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f551b946051b5a564a273336dcaee1db2d6e6a3a9b1a90d022638b88eae475df"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="203e25bb1fd53b1a5e7d2cd80b3f8959bbba982fcf452bad93a0915ade08a653"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4fa6ae3fc1b006099a97c27a170a757c9ff161a6855d75b7ca67e32d9e33eca1"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="ecaba8472e3eb0a8fd18e358df6a3341c54626abf6aa95f2ebd66b913ed97589"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6577098e707bf33585d998f703eeb2d5c68d7bde9483ee3e399e388e9ac2a0a9"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="24cf809e09060234dc560c73f4b5be22e1c04052d07d7c60fc7d2bc302076a64"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0a1ba0ddae1eb1c189d0d1f4a5672d6018b79891706bd5def4ffe135ed1e89c6"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="65b514b10138bef0075d47585ee11cd2e633f21a7673c03e8568e095158c9016"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9ecddc089310016cdd8526ca2c4475c881176fd78a27b350b5e29e01c9389e93"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="c7cc7584fd2ad81d23d13f2367a5636c8fff3c74d10b9ddd936632d668af2946"/>
+        </canvas>
+        <canvas name="10" width="57" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6562d65d76730ec0f5a02700d0904269484c4d97617402b09b0011f60178235e"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d3030969d95ef8f505edbb401b97716a0cff5e70e3b8724a86d457bb8cdf4fb3"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="55fc186417168611c03cca71cce0900a7ada6bd808ace00858680a6009207d1a"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="641d5ae49645769d9bd9a4d338e9737473e91d7000b40f08aaa6d0f8c94cacbb"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="a4740c7c3d1c09c98b009ed045fa3e3680c1cbcff89f058f9b6ff70a0bd18142"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack5">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b16c000e92a26c2dea7b8e9d20ac3d359248873c4e5840e11a49da15a68d9d10"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="a053dcb8c8ccd9dba6ac60a12d68d03420615738ab86e181bb752a6dab961d1b"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="c38457d5b09126168e6ad1a5729bb5fbf8be4cab63276007d1d81f83ade87069"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f1e1600924557d89e7ad9367b9481af20a79b8b4188697a18a3bb5639c22dfeb"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="db7e3f6c18a368186b4d7ae1802337f9eabc352bec2989541e05274bd431bf30"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_inlink" value="attack4/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6a97cfc259437844155a80dedf1ae6c70a537f46a7b87880a792cd1a8158e9ad"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5681468acc1da43e17b6275f84ee07a11e4cbd50db1dea71c70c0362833bf041"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8f744d8e1b573d08ded2b9d4bf9115b2da99e9dfbe9459ef12553b77e14e1e70"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="124a7cff5f9b3e2cdd9f2c88ceea049d5f8404ad97e11fe28078214bbfeb1739"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1172cb339eb469aef3c2d1830f581e352b47c0256462f0aba2c104e781433e9e"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="2131e318abd89e9aeb577d1784fe7f4df0956b310ebe558a9695493326a90211"/>
+        </canvas>
+        <canvas name="7" width="57" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bb2495273f323718c161b84b590564c26037d905385b182378b57e6a3ff3d41e"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="db4e53724ecb0d6a42336494745ebcc4d9ca254098e4e8058818d23b6f2dd1a3"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="22621db1db697143c85f915a1af45b368729a2d59f12a6b7f20d4596688d4c78"/>
+        </canvas>
+        <canvas name="10" width="57" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1f783c6758d0201b88b495104b98d4142d0cf926d17f39f8799af47e8cec90bf"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9a5750d8e4107d9d925b59ba4c6448cb0ec671ebccb604af5c34a6357dff146a"/>
+        </canvas>
+        <canvas name="12" width="298" height="90">
+          <vector name="origin" x="244" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="80169ca1211efeb069d6b6054af8f417f6e1fffc25ba37e02f807f84ce2dc5ad"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="fadd8c8de8582e094bfdcb68d3408f51cceca443bb7a7671c72fa319ef471713"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f5931134c84763e2714eeea51af1f123897a978882305f584236dad7ab4cfb9f"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack6">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-767" y="-30"/>
+        <vector name="rb" x="751" y="13"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="191" height="183">
+          <vector name="origin" x="95" y="91"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b23a4d491f7813fb2f0c8c5fa271c7fbd71514d6f56deccb866d385356b9e8fb"/>
+        </canvas>
+        <canvas name="1" width="178" height="181">
+          <vector name="origin" x="89" y="90"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f0644280d8a073519c5b0e8c7ce14811c644efc33597b73b8a454b1ef39f2271"/>
+        </canvas>
+        <canvas name="2" width="186" height="187">
+          <vector name="origin" x="93" y="93"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="8a413ffb1efa0bf652dbed94868378cab7971850178ddcf4048689aed6022851"/>
+        </canvas>
+        <canvas name="3" width="183" height="190">
+          <vector name="origin" x="91" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6ee40481205f9562f733ec7bde2d841b0ef551f4375a0764c523f43a1cdf0da9"/>
+        </canvas>
+        <canvas name="4" width="125" height="118">
+          <vector name="origin" x="62" y="59"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="53f010a10ce309a7f5d21259a86a2764f876a41f4d71b296497f6f98544a7efd"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1920"/>
+    </imgdir>
+    <canvas name="0" width="196" height="193">
+      <vector name="origin" x="89" y="185"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="a79760470787833c345ed030e861d371bfc98fee59ecfaf5c4ea0693ee9655cb"/>
+    </canvas>
+    <canvas name="1" width="196" height="194">
+      <vector name="origin" x="89" y="208"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="a872a786293da41c92db4fd28fee9526a973d17504fcba08e522d5b9112b9e6f"/>
+    </canvas>
+    <canvas name="2" width="196" height="193">
+      <vector name="origin" x="89" y="212"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="8af3419110e62ebcf50e11ba92e0e75b00360dd0fcdc9e3a7a811f67f12b8b2b"/>
+    </canvas>
+    <canvas name="3" width="394" height="290">
+      <vector name="origin" x="211" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-175"/>
+      <vector name="rb" x="101" y="-28"/>
+      <string name="_hash" value="fae816367fb7d68fa46976a01b0b2a90c1a4b5087dc671632482ad5d8cc1b784"/>
+    </canvas>
+    <canvas name="4" width="385" height="280">
+      <vector name="origin" x="207" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="090ceb9e8278e32f36a6d4c58005cb7420f32177eb4f2a4e28700bdcf560af5c"/>
+    </canvas>
+    <canvas name="5" width="362" height="260">
+      <vector name="origin" x="195" y="264"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="7773304bbfd0645c946f3818588e9c2fad40903928e5d515a47e8f2158849673"/>
+    </canvas>
+    <canvas name="6" width="201" height="182">
+      <vector name="origin" x="95" y="222"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="ff951bbb84e527c5d3f2c14381c01fbda4f71e479514326ae04f94a73702e0fe"/>
+    </canvas>
+    <canvas name="7" width="199" height="183">
+      <vector name="origin" x="92" y="218"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="9c6d73dc138e9fdabeeb9421397491e8b6d75e809555001862a920c6e07c49a3"/>
+    </canvas>
+    <canvas name="8" width="190" height="176">
+      <vector name="origin" x="89" y="215"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="e79175d8bb0431e5af92097e0bbed53fc33ffe9718ada7fbbf1b1d6e21c371cd"/>
+    </canvas>
+    <canvas name="9" width="181" height="165">
+      <vector name="origin" x="87" y="213"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="d9a0fd8f01dadf112bade5f12c183fbb6dbe97717938a53add9da2083d4f5036"/>
+    </canvas>
+    <canvas name="10" width="1" height="1">
+      <vector name="origin" x="0" y="-1"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="394" height="290">
+      <vector name="origin" x="213" y="330"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="84e520166895fc4810530c4caab159231e5c1119905a78cd0aba5cf3866f741a"/>
+    </canvas>
+    <canvas name="12" width="304" height="217">
+      <vector name="origin" x="165" y="289"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="76f064d25d2a7bac2bacdebaaf884baf83ad8c0e6b7454d2e99c2130e4fe64a4"/>
+    </canvas>
+    <canvas name="13" width="278" height="193">
+      <vector name="origin" x="139" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="b09268b9631049d8e06b7f0a2d277ae613e630723591e98ff18e02a546f95de2"/>
+    </canvas>
+    <canvas name="14" width="276" height="193">
+      <vector name="origin" x="138" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="308d00825addf25b8c031da29cdcea3754077e6411fc83224ee8d4ef71c43409"/>
+    </canvas>
+    <canvas name="15" width="198" height="193">
+      <vector name="origin" x="91" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="e87b46b78957d44a624c9decc23a053fbf2ea2af5881c50a547543d63bc0de93"/>
+    </canvas>
+    <canvas name="16" width="1171" height="293">
+      <vector name="origin" x="580" y="247"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <string name="_hash" value="45b5e536f5213f312e54946008fb535a5cbbe43892aa8fdd810954f6005c70fc"/>
+    </canvas>
+    <canvas name="17" width="1189" height="283">
+      <vector name="origin" x="589" y="238"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1ae4b7dcb55cd2a0574e8bf712d2bfe3d4cae25368639e9a96281f01b94151e0"/>
+    </canvas>
+    <canvas name="18" width="1192" height="222">
+      <vector name="origin" x="591" y="182"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e15595dd07d247c539f19ed8557a028ae80d04159782cbc34255b7713a9724c2"/>
+    </canvas>
+    <canvas name="19" width="1199" height="221">
+      <vector name="origin" x="594" y="184"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="be936249e6c16c13180ea19b769daab53c724731e851583479dab3a6e08c4b6d"/>
+    </canvas>
+    <canvas name="20" width="1199" height="193">
+      <vector name="origin" x="595" y="156"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="-4"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b91e4107908aa9d9215856c9cd3ca3d42d7fdb6ba627865e17f2ac5ba2f3ec43"/>
+    </canvas>
+    <canvas name="21" width="1195" height="193">
+      <vector name="origin" x="592" y="156"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1c2e58f311b27eb7ffb65051f54ba7c9e59b6d1fe370e057752afee8e39ea03a"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack7">
+    <canvas name="12" width="196" height="392">
+      <vector name="origin" x="89" y="392"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/>
+    </canvas>
+    <canvas name="13" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="2" width="197" height="378">
+      <vector name="origin" x="90" y="380"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86893292f87ad179cf8e47634df1bdbcfa0d2e425ba7c7899ddee73317a94fa8"/>
+    </canvas>
+    <canvas name="15" width="196" height="393">
+      <vector name="origin" x="89" y="394"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/>
+    </canvas>
+    <canvas name="16" width="196" height="362">
+      <vector name="origin" x="89" y="362"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/>
+    </canvas>
+    <canvas name="17" width="196" height="389">
+      <vector name="origin" x="89" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/>
+    </canvas>
+    <canvas name="6" width="197" height="407">
+      <vector name="origin" x="90" y="407"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="eadebb118bef62fb27cca7c5d83c9981cfea514dc7364f4f3eef5ce23bfd8c6c"/>
+    </canvas>
+    <canvas name="7" width="196" height="412">
+      <vector name="origin" x="89" y="413"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="88ff94607cac27e1e7f91cfab14280d57726d3b88c18e62e641f6d9cb1d83e4f"/>
+    </canvas>
+    <canvas name="8" width="196" height="405">
+      <vector name="origin" x="89" y="407"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="7f87b481fab16131725a601b2d643cf86c8c0602dc21a4848a66c424a41a980b"/>
+    </canvas>
+    <canvas name="9" width="196" height="392">
+      <vector name="origin" x="89" y="393"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="d8cfbd754bee92b4b8b2c44f4219d8669079eff901edfcd6d7b8f4983d807528"/>
+    </canvas>
+    <canvas name="10" width="197" height="388">
+      <vector name="origin" x="90" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="b85da2f8c68b4183c71b3bb528f62ee9d0e1de070b7c2a9b514a9d6535519156"/>
+    </canvas>
+    <canvas name="11" width="196" height="412">
+      <vector name="origin" x="89" y="411"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="a6bdf2a3dee1a24bafac31bbfbf31e885766650cf02d46bd53ea9e7884945551"/>
+    </canvas>
+    <imgdir name="info">
+      <imgdir name="screenCenter">
+        <canvas name="0" width="1366" height="606">
+          <vector name="origin" x="678" y="355"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="961c56bb5d5d7dc7ad0f9d1672c952c63239ced1d00dac9a640f75c5a8a38db3"/>
+        </canvas>
+        <canvas name="1" width="1366" height="619">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="867aa6baaaafb5a67f6449347b80e1aedadf4826eac95adcf41a1e066e655cce"/>
+        </canvas>
+        <canvas name="2" width="1366" height="623">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="896019b3a7c82240f86eb00d90d3d41c00921d259e1334e39586cdd496be8da0"/>
+        </canvas>
+        <canvas name="3" width="1366" height="607">
+          <vector name="origin" x="678" y="348"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="2b9af8374df735f89f113e445eee7291ed2c92a409c1bdcedd311a1ba8fa69f1"/>
+        </canvas>
+        <canvas name="4" width="1366" height="623">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="a99f7e4272142dcf40e9796215118c2c80f7193d5ebe14837da17fd9c7aa3a9b"/>
+        </canvas>
+        <canvas name="5" width="1366" height="630">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="49ddf77b31c2831af083047a841e6fb3b10eb0edcfc5e00c0c433cebceeba14e"/>
+        </canvas>
+        <canvas name="6" width="1366" height="611">
+          <vector name="origin" x="678" y="359"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="e39edb718b12070548efe00dd6df6b54f6bc76635772eee6ab63c220523b3592"/>
+        </canvas>
+        <canvas name="7" width="1366" height="620">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="0f81bf6ef594a4d1b589443177195ed8c061ae6727faaf5077943ea4831254af"/>
+        </canvas>
+        <canvas name="8" width="1366" height="630">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="ca4565241d69c2df61ebbd52a7872290341fa1d64eb742a70656ef668a1733c0"/>
+        </canvas>
+        <canvas name="9" width="1366" height="616">
+          <vector name="origin" x="678" y="359"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="753176c9a79a0b4bfbeb07e3c6f015593e51ff776d46c1605e04623bfc7d4f54"/>
+        </canvas>
+        <canvas name="10" width="1366" height="624">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="a4ea2e9d7c2acc943aadae7b91e89b7755272bf0776278fa636b3d1a3f79400c"/>
+        </canvas>
+        <canvas name="11" width="1366" height="630">
+          <vector name="origin" x="678" y="363"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f95b69436294394856c442369930fa30939d076d5ca931717229bce5b2650bcc"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="1" width="176" height="192">
+          <vector name="origin" x="88" y="96"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="24297c65bd86f268e84f9da30bb28f28f6b3929df83c83ef4589743860586205"/>
+        </canvas>
+        <canvas name="2" width="165" height="192">
+          <vector name="origin" x="82" y="96"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="8ee5c4999ed66f77eec4a6891728d0caae27aab78b95d7c394b46b2dd7503c0e"/>
+        </canvas>
+        <canvas name="3" width="163" height="135">
+          <vector name="origin" x="81" y="67"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="710dd428dfead84cb3e570011283888350bc3cb4198c2276689f16c58a0159e8"/>
+        </canvas>
+        <canvas name="4" width="141" height="133">
+          <vector name="origin" x="70" y="66"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="2037b1d2981b15bc1694bd5f572014e17c6753082e8b6c109cfa4a4be7b752b7"/>
+        </canvas>
+        <canvas name="5" width="145" height="140">
+          <vector name="origin" x="72" y="70"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="65833d06e578de7367829fb27cdc203a3cec2d049cad8a50bbfa6bc4b11fa2c0"/>
+        </canvas>
+        <canvas name="6" width="149" height="152">
+          <vector name="origin" x="74" y="76"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="854a7c1bcea63d31cce503d0be743a3e307cf39768b30f4fa0330c0c627ecd51"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="range">
+        <vector name="lt" x="-680" y="-1147"/>
+        <vector name="rb" x="680" y="99"/>
+      </imgdir>
+      <int name="onlyFsm" value="1"/>
+    </imgdir>
+    <imgdir name="speak">
+      <int name="prop" value="100"/>
+      <string name="0" value="If you cannot stop it, should you not endure it?"/>
+    </imgdir>
+    <canvas name="0" width="196" height="392">
+      <vector name="origin" x="89" y="392"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/>
+    </canvas>
+    <canvas name="14" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="1" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="3" width="196" height="393">
+      <vector name="origin" x="89" y="394"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/>
+    </canvas>
+    <canvas name="4" width="196" height="362">
+      <vector name="origin" x="89" y="362"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/>
+    </canvas>
+    <canvas name="5" width="196" height="389">
+      <vector name="origin" x="89" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="20" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="8" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/>
+    </canvas>
+    <canvas name="9" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/>
+    </canvas>
+    <canvas name="10" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/>
+    </canvas>
+    <canvas name="11" width="196" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/>
+    </canvas>
+    <canvas name="12" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/>
+    </canvas>
+    <canvas name="13" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/>
+    </canvas>
+    <canvas name="14" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f2b1eb2b88b053721807e0d194e5b55f1b846b5a4b6e11939b92839ec267967e"/>
+    </canvas>
+    <canvas name="15" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="09afd8d8cf124fb4db9f0fec591e6a074ce56eacfae17b8135982d3dec438343"/>
+    </canvas>
+    <canvas name="16" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="2ad898a1542d67c7969aa86fc1c9882bd40dd32a60625b28a3b016346e1e2b38"/>
+    </canvas>
+    <canvas name="17" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="065bae5b5906dd8921a4e04933afa7f9535d191d86be631af646eac30f4cad82"/>
+    </canvas>
+    <canvas name="18" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c6c3f56700e80cf51e3339a72040262411ec5986573968da20513049bd4707bd"/>
+    </canvas>
+    <canvas name="19" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="3297db2c984ffaa1befe4f0177259104027a50eeae88aa5472a5060efbe3f255"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prop" value="100"/>
+      <string name="0" value="Tremble before this power!"/>
+    </imgdir>
+    <canvas name="7" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/>
+    </canvas>
+    <canvas name="4" width="196" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/>
+    </canvas>
+    <canvas name="5" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/>
+    </canvas>
+    <canvas name="6" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/0"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="8b1c227836bc8294007f8ff45ce54f480d7907c0853f29319dea0b4cf614cea1"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/2"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/3"/>
+    </canvas>
+    <canvas name="4" width="196" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/4"/>
+    </canvas>
+    <canvas name="5" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/5"/>
+    </canvas>
+    <canvas name="6" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1578c13f059d956d6aeb5ca636e1d72331eac87a8e1a01fbfdc0085f424d5bbe"/>
+    </canvas>
+    <canvas name="7" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="8c437997c9158a5e1ed3dc72ff559562816d8efc8f8a1c189f2c9eb0152b1a1a"/>
+    </canvas>
+    <canvas name="8" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="26bf7cb4e392126aad1038844de35edc4adb007a480996ecef1f9b5888f8f278"/>
+    </canvas>
+    <canvas name="9" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/16"/>
+    </canvas>
+    <canvas name="10" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/17"/>
+    </canvas>
+    <canvas name="11" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_inlink" value="skill1/18"/>
+    </canvas>
+    <canvas name="12" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="636d5a1e1597807ad66adb0d47e00ac24e7f97d8429234c736cdb9347601f604"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill3">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="90" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1d0aac14b0085e2ec724af30e7ceeb5ff32ef5c9e2de6922614e262e656e514b"/>
+    </canvas>
+    <canvas name="1" width="196" height="205">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0270f3a6f9ceb6a83bce4ef665f0e03882a29be3faa0d4033b535baf2dd3756c"/>
+    </canvas>
+    <canvas name="2" width="196" height="213">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0d0cf54e86e131e21d9f127146d0184889794fd198db889de8157c6c2efb5f3a"/>
+    </canvas>
+    <canvas name="3" width="196" height="215">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="982b9d39aa44f124d59dd5fac3014606b9cb5c3b59a98170605a9ac9e86f4bad"/>
+    </canvas>
+    <canvas name="4" width="197" height="218">
+      <vector name="origin" x="90" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c3e340e338054e1adece96d3ba11a501ee729046720b245c7020c22d7a222f4c"/>
+    </canvas>
+    <canvas name="5" width="198" height="220">
+      <vector name="origin" x="91" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="af7f589835fd13d6b275c4cc1fe972c93d02207c7756cb4e581e41439ffa64ae"/>
+    </canvas>
+    <canvas name="6" width="197" height="214">
+      <vector name="origin" x="90" y="206"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1fe9c11f660642b36f07af486afbd56c2a2bc46edd912b7adb9ea0d6c9b70cbb"/>
+    </canvas>
+    <canvas name="7" width="197" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="400852cbca5268b0c396c6d5461fa99fa8d138d57ff64b3e6050e63f8e201151"/>
+    </canvas>
+    <canvas name="8" width="204" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0a6937e946fd7494552cb09f1965afbd21e75b91d71fb16568211e09fde987c6"/>
+    </canvas>
+    <canvas name="9" width="204" height="202">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e0efca09df704285e1cc5a59ad460c7cf3def9cc752c6f28e875106da8e6632a"/>
+    </canvas>
+    <canvas name="10" width="198" height="202">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="55eb33f9d5a8cabbc0ac37018e219811d6cbda349e3a81ed955236858876c60c"/>
+    </canvas>
+    <canvas name="11" width="199" height="204">
+      <vector name="origin" x="89" y="196"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c15a1b7a495533fbcc44b93ba70bc0e492c7e7f7427e326317f66e610412f72a"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill4">
+    <canvas name="0" width="956" height="363">
+      <vector name="origin" x="459" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="da1c9306bf191db3b9ca6446a0c50fb859cb08dc059b3093da6af1a7af6a416d"/>
+    </canvas>
+    <canvas name="1" width="974" height="371">
+      <vector name="origin" x="469" y="325"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="03ad3382983f4613b235848951dddb871f5b1407dd6869f93391e6f9a961911a"/>
+    </canvas>
+    <canvas name="2" width="962" height="377">
+      <vector name="origin" x="462" y="331"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e70a370621d4030bb0a82b3ec6f5edc55fc0f9948bf8cf19d2e3823a55d74f4a"/>
+    </canvas>
+    <canvas name="3" width="958" height="362">
+      <vector name="origin" x="460" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="afdafc77cbc62d9f1755d099ab8d661be62fe32619c2906fa0030a50bb6e5e73"/>
+    </canvas>
+    <canvas name="4" width="956" height="363">
+      <vector name="origin" x="459" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="9c3662fd377e82c8264734f8d9417e444f49d2812d4cf843ac5f3d94699f9ea6"/>
+    </canvas>
+    <canvas name="5" width="974" height="371">
+      <vector name="origin" x="469" y="325"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1c72e326b61263c5b09541c12852aee52a546bc2009f11ef94a6c6cb2784833b"/>
+    </canvas>
+    <canvas name="6" width="962" height="365">
+      <vector name="origin" x="462" y="319"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="7f0b27d216229c86b8505e63c40d382e5bd5730c492928d14bd308eb6005e020"/>
+    </canvas>
+    <canvas name="7" width="958" height="362">
+      <vector name="origin" x="460" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="abd5ca7492609f9c54319b080f892aa0cb5e714c3a1c6a35274972524483ef67"/>
+    </canvas>
+    <canvas name="8" width="956" height="363">
+      <vector name="origin" x="459" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="2de73e35ee56d9fe4f7e02459e796f0e55a451916606ff2cb280919bc9aba71a"/>
+    </canvas>
+    <canvas name="9" width="974" height="371">
+      <vector name="origin" x="469" y="325"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="01044fc53aa723c1c5d5eeef7dc12a36609cdb04326a7e8c76d19f5b3fb8444d"/>
+    </canvas>
+    <canvas name="10" width="962" height="377">
+      <vector name="origin" x="462" y="331"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="9b4c61b524397e7a9e6657a6c4225553734ee5c48353393c6bcce9a6737f690f"/>
+    </canvas>
+    <canvas name="11" width="957" height="362">
+      <vector name="origin" x="459" y="316"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="61e8a3c6f6bf6d4cca92bcf2a55f2ad4914d8287b42cad7f35783e70c112aca8"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="sleep">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="b2430fa639b89aa5288be7e776c5b288d9782c2d48f8feb6f0c988bbe56c9087"/>
+    </canvas>
+    <canvas name="1" width="196" height="199">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="cbfce70bc4aa789b671fd5e8b399b3181a9a7217c9eaf53e739ca7d73db54e67"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="622c48789a75abee11372071b4c17ac4bca3d6c331e3f2002ffb55c7812c01a3"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a1a00c60f5904e342e63e90375ef286a2dfed26169087d264a6cbba68a48637d"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="f76ed95f4848e01520006f427c3fc0d838ac7cb082e5ab7e3b2df583b5d7a01d"/>
+    </canvas>
+    <canvas name="5" width="196" height="203">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="3c8bd39163f7777ab7c09af8b678d21fe615a785b3ca0082c8ab3b33b8e39f75"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="wakeup">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="bb3a8529be1dd4f044e38b659cdcdcc31ea98e9b395b1ffeb79f9560a5069745"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="1539eb0621a8ae8ba73be693b113e5f3c4c99140f0fd21745db0f083b7015367"/>
+    </canvas>
+    <canvas name="5" width="196" height="203">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="3c8bd39163f7777ab7c09af8b678d21fe615a785b3ca0082c8ab3b33b8e39f75"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a1a00c60f5904e342e63e90375ef286a2dfed26169087d264a6cbba68a48637d"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="622c48789a75abee11372071b4c17ac4bca3d6c331e3f2002ffb55c7812c01a3"/>
+    </canvas>
+    <canvas name="1" width="196" height="199">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="cbfce70bc4aa789b671fd5e8b399b3181a9a7217c9eaf53e739ca7d73db54e67"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill5">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="fe6d85f38fadf27cb19d34d1fef7ed74b51708b21c45700339375e7f327c4d78"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="7474900d3708017e1d79cfaa0ad65b50c15866d1ab8258b1a303c610e9e0f737"/>
+    </canvas>
+    <canvas name="2" width="394" height="290">
+      <vector name="origin" x="211" y="254"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="3" width="385" height="280">
+      <vector name="origin" x="207" y="249"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="4" width="362" height="260">
+      <vector name="origin" x="195" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="5" width="201" height="182">
+      <vector name="origin" x="95" y="199"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="6" width="199" height="183">
+      <vector name="origin" x="92" y="196"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="7" width="190" height="176">
+      <vector name="origin" x="89" y="193"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_inlink" value="attack6/8"/>
+    </canvas>
+    <canvas name="8" width="181" height="165">
+      <vector name="origin" x="87" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_inlink" value="attack6/9"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill6">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="b2430fa639b89aa5288be7e776c5b288d9782c2d48f8feb6f0c988bbe56c9087"/>
+    </canvas>
+    <canvas name="1" width="196" height="199">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="cbfce70bc4aa789b671fd5e8b399b3181a9a7217c9eaf53e739ca7d73db54e67"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="622c48789a75abee11372071b4c17ac4bca3d6c331e3f2002ffb55c7812c01a3"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a1a00c60f5904e342e63e90375ef286a2dfed26169087d264a6cbba68a48637d"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="f76ed95f4848e01520006f427c3fc0d838ac7cb082e5ab7e3b2df583b5d7a01d"/>
+    </canvas>
+    <canvas name="5" width="196" height="203">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="3c8bd39163f7777ab7c09af8b678d21fe615a785b3ca0082c8ab3b33b8e39f75"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skillAfter5">
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="fe6d85f38fadf27cb19d34d1fef7ed74b51708b21c45700339375e7f327c4d78"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="7474900d3708017e1d79cfaa0ad65b50c15866d1ab8258b1a303c610e9e0f737"/>
+    </canvas>
+    <canvas name="2" width="394" height="290">
+      <vector name="origin" x="211" y="254"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="3" width="385" height="280">
+      <vector name="origin" x="207" y="249"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="4" width="362" height="260">
+      <vector name="origin" x="195" y="239"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="5" width="201" height="182">
+      <vector name="origin" x="95" y="199"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="6" width="199" height="183">
+      <vector name="origin" x="92" y="196"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+    </canvas>
+    <canvas name="7" width="190" height="176">
+      <vector name="origin" x="89" y="193"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_inlink" value="attack6/8"/>
+    </canvas>
+    <canvas name="8" width="181" height="165">
+      <vector name="origin" x="87" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-91" y="-169"/>
+      <vector name="rb" x="106" y="-3"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_inlink" value="attack6/9"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack8">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-291" y="-103"/>
+        <vector name="rb" x="302" y="11"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="176" height="192">
+          <vector name="origin" x="88" y="96"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5b5bbf90f935698fa22ffc6c04334cad0af96e7dd4211f4a606d4d9f01e8526b"/>
+        </canvas>
+        <canvas name="1" width="165" height="192">
+          <vector name="origin" x="82" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f364f9d9613dbacb1f4ca3a01150f5587a4e7f51102e46b3cb327a5f415e5992"/>
+        </canvas>
+        <canvas name="2" width="163" height="135">
+          <vector name="origin" x="81" y="67"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="75f7941cc775149f4006ffef198de7efda1e50c809f2bac2dbb1bf28af282106"/>
+        </canvas>
+        <canvas name="3" width="141" height="133">
+          <vector name="origin" x="70" y="66"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f0d6a63a671be108aa176a9e1585dc7fcaf7f248cb2e85ffd823331564791147"/>
+        </canvas>
+        <canvas name="4" width="145" height="140">
+          <vector name="origin" x="72" y="70"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0f91d203de252aa01a9054313f809952e0194ff222870b26d548f37565acaa4d"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="74" y="73"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9f4f3d4b5d919ec75142aeeb50862ae7d41806fd7038b44a8323f00ba58716f8"/>
+          <string name="_outlink" value="Mob/9390624.img/attack2/info/hit/6"/>
+        </canvas>
+      </imgdir>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f9ff11c42be35e5e3fd109814f4e61b14dd109653833ad15bcd3335a56a891d5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="196" height="179">
+      <vector name="origin" x="89" y="171"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="029fc945fe7a87aea59c019b8a59e48364de0883dde4d4d6c540a9564507c8df"/>
+    </canvas>
+    <canvas name="2" width="192" height="164">
+      <vector name="origin" x="87" y="159"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="1220215ee1bfd503e711d2fa75cb24bbdef2174b20b30cfda11a4f2037da070c"/>
+    </canvas>
+    <canvas name="3" width="187" height="156">
+      <vector name="origin" x="86" y="157"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="8a7e19f2bffe98a8be6daa1e7043f1090cca13d46f8a3aa9ff25bb4f9938fc63"/>
+    </canvas>
+    <canvas name="4" width="175" height="151">
+      <vector name="origin" x="78" y="155"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="3b219a21f7c6625ddc68d067fffd2186ddad543e2fc7be9454c1002b9e49d860"/>
+    </canvas>
+    <canvas name="5" width="156" height="136">
+      <vector name="origin" x="69" y="156"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="086e3e5cf47d9b10c4c48aa15b38d0619c690f08e45e12c5e07d7c432decd957"/>
+    </canvas>
+    <canvas name="6" width="125" height="122">
+      <vector name="origin" x="48" y="151"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="315f1dd0e72160d042c46b73c891f65113b2b6734dbbc25c21beb6c96a1676a8"/>
+    </canvas>
+    <canvas name="7" width="65" height="47">
+      <vector name="origin" x="8" y="93"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="b828e2dc0153f7e04df420a0ddadbdbdfe8664baf63a1c4a5d8a16efdbe4df22"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/9300340.img.xml
+++ b/gms-server/wz/Mob.wz/9300340.img.xml
@@ -21,7 +21,7 @@
     <int name="fixedDamage" value="6"/>
     <imgdir name="speak">
       <int name="chatBalloon" value="0"/>
-      <string name="0" value="꺄오~ 6주년이다!"/>
+      <string name="0" value="Kyao! It is the 6th anniversary!"/>
     </imgdir>
   </imgdir>
   <imgdir name="move">
@@ -196,7 +196,7 @@
       <int name="delay" value="150"/>
     </canvas>
     <imgdir name="speak">
-      <string name="0" value="메이플 6주년 축하해요~♥"/>
+      <string name="0" value="Happy 6th anniversary, MapleStory!"/>
       <int name="prob" value="100"/>
     </imgdir>
   </imgdir>

--- a/gms-server/wz/Mob.wz/9450022.img.xml
+++ b/gms-server/wz/Mob.wz/9450022.img.xml
@@ -1,1 +1,2339 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="9450022.img"><imgdir name="info"><int name="level" value="150"/><int name="maxHP" value="1500000000"/><int name="maxMP" value="100000"/><int name="mpRecovery" value="10000"/><int name="hpRecovery" value="10000000"/><int name="speed" value="0"/><int name="PADamage" value="1350"/><int name="MADamage" value="1400"/><int name="PDRate" value="30"/><int name="MDRate" value="20"/><int name="acc" value="999"/><int name="eva" value="80"/><int name="pushed" value="199999"/><float name="fs" value="10.0"/><int name="exp" value="22000000"/><int name="summonType" value="1"/><int name="firstAttack" value="1"/><int name="boss" value="1"/><int name="bodyAttack" value="1"/><imgdir name="skill"><imgdir name="0"><int name="skill" value="128"/><int name="action" value="1"/><int name="level" value="2"/><int name="effectAfter" value="0"/></imgdir><imgdir name="1"><int name="skill" value="145"/><int name="action" value="2"/><int name="level" value="2"/><int name="effectAfter" value="0"/></imgdir></imgdir></imgdir><imgdir name="stand"><canvas name="6" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="aacfdac6db9941a92082d4ff149e479f91f9b7f9b17d384ad091f8446779d0bc"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="9720c408116d2ab09e8295717dc11971cbd4d77a353c168ebb28c04f746e232d"/></canvas><canvas name="10" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="cc792d53d48c07a6c8c037fbe59907615b6fc0e8107e7f22c903ad06b7d79ebf"/></canvas><canvas name="11" width="196" height="198"><vector name="origin" x="89" y="189"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="e692398e07ba283472e8fca4e7e5a26b1cd3d5578ab92a5c37ce89719d8608dc"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="4a6ef4330261092c4be1be264c84fc9267ad1b48ba59fd0169d306b570993dc9"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="4c12eb8473e722e09eec99743488c040d27f1fa9c00e7c6efafd77212894159a"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a8f58b13a489ca5850848829e359f05b8eed60ac4a1cce456a03680c644faaef"/></canvas><canvas name="5" width="196" height="198"><vector name="origin" x="89" y="189"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="210cd2abd8fb276b8e1e08abe2f19994edf8f3d0b2dc66721b81898279ac7a99"/></canvas><canvas name="7" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="69d8a175e31fd46b141b4f142401142cf79d649dbfca8b5715643c53f64be086"/></canvas><canvas name="8" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="c46972e7aa48ef79b899a102749f46d3474c84ad99a34f47e4f79b3b9d68db74"/></canvas><canvas name="9" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="1a3792b751548391d8b5a72067e2b2ac1738725f97521f973bb3266166731fa3"/></canvas><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="aacfdac6db9941a92082d4ff149e479f91f9b7f9b17d384ad091f8446779d0bc"/></canvas></imgdir><imgdir name="move"><canvas name="5" width="200" height="198"><vector name="origin" x="89" y="189"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="ace4d88aa5fca2f30ce1aba0361e59635ec9936e0d948d34100a6b20f6adcaa6"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="53f6e366da478b2bf97da582637682cba6e16f6426f884b8d7dd78e0f2b8b420"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="ea7498c7f47b52286a540fda3522c46e3eaa4477bee49736508c58a0e8eb847a"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="bcd85aa903f39e6f5211f04e64ab12f27968cebec541f04b2df1d55f7b3ccd82"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="de90f4fa91c5d222eb9a524c87f50fb11b4f1dcf5fd126d9bcdb7aa24f687f33"/></canvas><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="7ce12372921280cca8a391b4aeb4473e77e15d22d5fc854d965d4b8b1cb64eb5"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="196" height="199"><vector name="origin" x="89" y="191"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="f9ff11c42be35e5e3fd109814f4e61b14dd109653833ad15bcd3335a56a891d5"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="196" height="199"><vector name="origin" x="89" y="191"/><int name="z" value="0"/></canvas><canvas name="1" width="196" height="179"><vector name="origin" x="89" y="171"/><int name="z" value="0"/><string name="_hash" value="029fc945fe7a87aea59c019b8a59e48364de0883dde4d4d6c540a9564507c8df"/></canvas><canvas name="2" width="192" height="164"><vector name="origin" x="87" y="159"/><int name="z" value="0"/><string name="_hash" value="1220215ee1bfd503e711d2fa75cb24bbdef2174b20b30cfda11a4f2037da070c"/></canvas><canvas name="3" width="187" height="156"><vector name="origin" x="86" y="157"/><int name="z" value="0"/><string name="_hash" value="8a7e19f2bffe98a8be6daa1e7043f1090cca13d46f8a3aa9ff25bb4f9938fc63"/></canvas><canvas name="4" width="175" height="151"><vector name="origin" x="78" y="155"/><int name="z" value="0"/><string name="_hash" value="3b219a21f7c6625ddc68d067fffd2186ddad543e2fc7be9454c1002b9e49d860"/></canvas><canvas name="5" width="156" height="136"><vector name="origin" x="69" y="156"/><int name="z" value="0"/><string name="_hash" value="086e3e5cf47d9b10c4c48aa15b38d0619c690f08e45e12c5e07d7c432decd957"/></canvas><canvas name="6" width="125" height="122"><vector name="origin" x="48" y="151"/><int name="z" value="0"/><string name="_hash" value="315f1dd0e72160d042c46b73c891f65113b2b6734dbbc25c21beb6c96a1676a8"/></canvas><canvas name="7" width="65" height="47"><vector name="origin" x="8" y="93"/><int name="z" value="0"/><string name="_hash" value="b828e2dc0153f7e04df420a0ddadbdbdfe8664baf63a1c4a5d8a16efdbe4df22"/></canvas></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-280" y="-65"/><vector name="rb" x="-2" y="-34"/></imgdir><imgdir name="hit"><canvas name="0" width="199" height="194"><vector name="origin" x="99" y="97"/><int name="z" value="0"/><string name="_hash" value="ed173a097e57edeabd997764a1203fe48282c6b66b5b3c63b8959d1a68ab282c"/></canvas><canvas name="1" width="183" height="198"><vector name="origin" x="91" y="99"/><int name="z" value="0"/><string name="_hash" value="f561de600870aed73eefd738f90fc1043bed8280371cbb166f7dee0e66ffbd53"/></canvas><canvas name="2" width="201" height="206"><vector name="origin" x="100" y="103"/><int name="z" value="0"/><string name="_hash" value="3a0c130666d0a065906181c8bd7ba4cd7af1486cf095678d378ef485a4546848"/></canvas><canvas name="3" width="196" height="189"><vector name="origin" x="98" y="94"/><int name="z" value="0"/><string name="_hash" value="443e54e4c9419660510be8ff8bf49b240de73248fbd94c3b75eacb478cf445cc"/></canvas><canvas name="4" width="187" height="185"><vector name="origin" x="93" y="92"/><int name="z" value="0"/><string name="_hash" value="e9a9f905eaf9c7e697735d27789323e85fa1f1d8c8abb0892d7675da6e5de506"/></canvas><canvas name="5" width="193" height="191"><vector name="origin" x="96" y="95"/><int name="z" value="0"/><string name="_hash" value="9b1981507d06d898fde691f11b21c3f9778b978b01de082e32a5d753432e68cf"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="1" height="1"><vector name="origin" x="5" y="65"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="11" height="16"><vector name="origin" x="-25" y="79"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e14184568972a6e77906e675413433f8968c5075e9541f2d258de8ad38bcbabf"/></canvas><canvas name="2" width="19" height="24"><vector name="origin" x="-18" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="ddaf8bd5ce82b330d7edf018fd66ca865657a04d92f7d983afd279d03821bd84"/></canvas><canvas name="3" width="25" height="32"><vector name="origin" x="-14" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="5b965163288d1c34396f6416910f627c94261153a4bb4ef8e75d7c2b249209a6"/></canvas><canvas name="4" width="30" height="30"><vector name="origin" x="-12" y="95"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b468ebfb3b67e05d740ff415fbfaf1a6756f09d8c19ca9ec4d77141d3efd3752"/></canvas><canvas name="5" width="72" height="73"><vector name="origin" x="4" y="124"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c1c4886943ef4862b15d434a478a125dfa092481b1b250f91ce8c73154815684"/></canvas><canvas name="6" width="60" height="74"><vector name="origin" x="-4" y="130"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1c99b9631d1c854e130f4b548591d393fcd4721a089799389c82f668f3da2393"/></canvas><canvas name="7" width="64" height="71"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="39566a11077d123dcbd1d0032373d33c586b9a1e65d564da880520ac97ef671a"/></canvas><canvas name="8" width="53" height="72"><vector name="origin" x="-7" y="135"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="91fbe439bd6ffca9eaff288b2cda1c5be611ee89d34e4ca9a3946bc35ec66fd7"/></canvas><canvas name="9" width="60" height="74"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="14c22bb33a2f2c1bc0f9e138aadf315c219d4abbcb5adb96835640caf32e51cf"/></canvas><canvas name="10" width="64" height="71"><vector name="origin" x="-5" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7377d913b3e0e22893bcf9019a884a4c298f4bee7ec9a8c0c7fc2e10fdc263e7"/></canvas><canvas name="11" width="53" height="72"><vector name="origin" x="-7" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="84a10b45ceda775f338d1d62ff555ebe7ac9dfb2e0d90ebf5e42aaaba0ffa37d"/></canvas><canvas name="12" width="296" height="88"><vector name="origin" x="243" y="126"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="cf92e0ffc0a2e247486e0a5f56bd7c5c44d61bccd420ef0c4c91bac8d35fe293"/></canvas><canvas name="13" width="212" height="64"><vector name="origin" x="258" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7afbb566b04355530205cbf6ee22a58875587d460f6147bfb708d5bb90b0551e"/></canvas><canvas name="14" width="180" height="58"><vector name="origin" x="257" y="93"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="484249c5bc3dfa1b980be5f56a3e1d93bde25ca3dec81ef9bb9ad2ae1d761260"/></canvas><canvas name="15" width="160" height="49"><vector name="origin" x="247" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="7bb927d4063b5272776e83cf201a25a418f2d4b9e5f9f43bd3bf373d46db0082"/></canvas><canvas name="16" width="60" height="49"><vector name="origin" x="143" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="5a3f8187e830f852440585186c0e3c6ab10225f0828dcb2144202500b17d788b"/></canvas></imgdir><int name="attackAfter" value="1440"/></imgdir><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="12" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/></canvas><canvas name="13" width="196" height="209"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/></canvas><canvas name="14" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/></canvas><canvas name="15" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/></canvas><canvas name="16" width="196" height="208"><vector name="origin" x="89" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/></canvas><canvas name="17" width="196" height="208"><vector name="origin" x="89" y="198"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/></canvas></imgdir><imgdir name="attack2"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-280" y="-65"/><vector name="rb" x="-2" y="-34"/></imgdir><imgdir name="hit"><canvas name="0" width="199" height="194"><vector name="origin" x="99" y="97"/><int name="z" value="0"/><string name="_hash" value="c06e0a1d53536be3f89cca6c459c632b72cbd79542e11ad04f9f9199008e775c"/></canvas><canvas name="1" width="183" height="198"><vector name="origin" x="91" y="99"/><int name="z" value="0"/><string name="_hash" value="6c9d0e2e3f6778eeaa44d9b6d34213e75a83e6c2e4b984b03ae49104300fc092"/></canvas><canvas name="2" width="201" height="206"><vector name="origin" x="100" y="103"/><int name="z" value="0"/><string name="_hash" value="47d401133797d76af401f7855fe44a3b0eeb388923bf0a2dcd9ca654f2279c28"/></canvas><canvas name="3" width="196" height="189"><vector name="origin" x="98" y="94"/><int name="z" value="0"/><string name="_hash" value="3cdf4b8968876423893686bb285c6d0c9729de34c4c661a726135e8c52133f59"/></canvas><canvas name="4" width="187" height="185"><vector name="origin" x="93" y="92"/><int name="z" value="0"/><string name="_hash" value="092042886657e04f11bcf14ef2b0f1ca5d651bd00ab9e31a2610744317b09c44"/></canvas><canvas name="5" width="1" height="1"><vector name="origin" x="96" y="95"/><int name="z" value="0"/><string name="_inlink" value="attack1/info/hit/5"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="1" height="1"><vector name="origin" x="5" y="65"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="1" height="1"><vector name="origin" x="-25" y="79"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/1"/></canvas><canvas name="2" width="1" height="1"><vector name="origin" x="-18" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/2"/></canvas><canvas name="3" width="25" height="32"><vector name="origin" x="-14" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="642855b4259104ce2ec98dd86be97d0a0d89d72f70999abbf9579c85affbd9cb"/></canvas><canvas name="4" width="30" height="30"><vector name="origin" x="-12" y="95"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="88c5b7ecac32cc860d00577f6105be5b15fd9f99f5d25a6b98b9cf029d1295c5"/></canvas><canvas name="5" width="72" height="73"><vector name="origin" x="4" y="124"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="dbc0d33c40fae2a166034f2ae1f50076866dfef4987fc1118baf95539e88e2a2"/></canvas><canvas name="6" width="60" height="74"><vector name="origin" x="-4" y="130"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bfbd90318e054646f09a5432bf3b2c765026a4905790c24904079c4773ad2928"/></canvas><canvas name="7" width="64" height="71"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8bafcbfd9edb6cc910b860acff509eed800ab8674b38dda99b16612211c07cbd"/></canvas><canvas name="8" width="53" height="72"><vector name="origin" x="-7" y="135"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="34abb4387224c37351708a0ce1f3a5815d798b538e58c752e4281f437c688cb8"/></canvas><canvas name="9" width="60" height="74"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e74d8967bce61233d379d4eb6a17f8f2aa2c1154af9a94eb8997a39c83ae024d"/></canvas><canvas name="10" width="64" height="71"><vector name="origin" x="-5" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="befec05e861886328728153a33ea56c55a94a2027fa05723733e0920e35e7970"/></canvas><canvas name="11" width="53" height="72"><vector name="origin" x="-7" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0cf7c84ca3d414cb33d6ba874928f742d29e2c61aa3b3f500359adbbb168ec5a"/></canvas><canvas name="12" width="296" height="88"><vector name="origin" x="243" y="126"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="174e922c141594c39b6bddafe2f37540e97a76fd04ada23fb2cdccdbaf3a9ba8"/></canvas><canvas name="13" width="212" height="64"><vector name="origin" x="131" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="80572942c58ca7a183d698294afdd76f7ecd842b34c191be6cd02f821b12ed9b"/></canvas><canvas name="14" width="180" height="58"><vector name="origin" x="257" y="93"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="75651698bb1a7372b7f7a180922219def3bc52bc55203e46ee357cb93ebb4e8c"/></canvas><canvas name="15" width="160" height="49"><vector name="origin" x="247" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b102caf9e5204ca94452ea072db696e6f957bfc0ec7b7343109b1a625f66390d"/></canvas><canvas name="16" width="60" height="49"><vector name="origin" x="143" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="39b8c41a36c92e6ba1040a5574908a6a52e5bcb5e4894afa8e414f3ea400d22e"/></canvas><int name="attackAfter" value="1440"/></imgdir></imgdir><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="17" width="196" height="208"><vector name="origin" x="89" y="198"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/></canvas><canvas name="16" width="196" height="208"><vector name="origin" x="89" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/></canvas><canvas name="15" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/></canvas><canvas name="14" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/></canvas><canvas name="13" width="196" height="209"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/></canvas><canvas name="12" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas></imgdir><imgdir name="attack3"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-280" y="-65"/><vector name="rb" x="-2" y="-34"/></imgdir><imgdir name="hit"><canvas name="0" width="199" height="194"><vector name="origin" x="99" y="97"/><int name="z" value="0"/><string name="_hash" value="86d5b7f06107a433030beb76025082080374cf85322cc2c3faf62f0d226b8402"/></canvas><canvas name="1" width="183" height="198"><vector name="origin" x="91" y="99"/><int name="z" value="0"/><string name="_hash" value="cf7d28621dd3989207c3164fdc7964b5148af1ce8f75a880ef45efe1b5e50033"/></canvas><canvas name="2" width="201" height="206"><vector name="origin" x="100" y="103"/><int name="z" value="0"/><string name="_hash" value="405951214f0a2f370941d42229a23ebb4ceb720fb99eb5f27acedb63a86dc5a7"/></canvas><canvas name="3" width="196" height="189"><vector name="origin" x="98" y="94"/><int name="z" value="0"/><string name="_hash" value="aa48d2503799de6a57c495166c73807468794a007631f7463f83b0fff6da4388"/></canvas><canvas name="4" width="187" height="185"><vector name="origin" x="93" y="92"/><int name="z" value="0"/><string name="_hash" value="b7ca770a9097eb89987acee55d3d7e1e4717b5649467050fa5d68b352415718b"/></canvas><canvas name="5" width="193" height="191"><vector name="origin" x="96" y="95"/><int name="z" value="0"/><string name="_hash" value="0e09dc6fa57eb7be950c839c37ebbb3b4ea54332b2eedf35688245e1c39bc440"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="1" height="1"><vector name="origin" x="5" y="65"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="11" height="16"><vector name="origin" x="-25" y="79"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f43ed4a87893b2f41ee84926f4d7ea92fe403907c32a9985d6f1186e7a2debd9"/></canvas><canvas name="2" width="19" height="24"><vector name="origin" x="-18" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d75724403e970496e4ab4e2415da47785a3b19c5512e37658199ef5be15107be"/></canvas><canvas name="3" width="25" height="32"><vector name="origin" x="-14" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="4bef2b6e975ea3d60ac5e267b62766c8f7b69110625e31e45da7af5989bb6def"/></canvas><canvas name="4" width="30" height="30"><vector name="origin" x="-12" y="95"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="b04182cbe58f31aa5bd77c1f7eb2e317802b5628a7f4b35e1cbc0b511c7b7259"/></canvas><canvas name="5" width="72" height="73"><vector name="origin" x="4" y="124"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="685279ece87a51e566920b5a6b07a177b648822071db1c5a0f0bb5c0574cf50d"/></canvas><canvas name="6" width="60" height="74"><vector name="origin" x="-4" y="130"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bbeb8cddd55bdfb84063941c2da093e548fd70dc3be0116120157d7169c47fbf"/></canvas><canvas name="7" width="64" height="71"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0e58a86d405c0e81f5a60736d82467c33f7b495aac1f1300cd936ae21c43d4ea"/></canvas><canvas name="8" width="53" height="72"><vector name="origin" x="-7" y="135"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="e589c7010946da5b996d44c8b50f56bf635b42fedab0fbd3617bbd2fc696da92"/></canvas><canvas name="9" width="60" height="74"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="25904a1f9dd3d353b62aabf2b47d9b04d6735dd28ceab5ed2402f6227912a08d"/></canvas><canvas name="10" width="64" height="71"><vector name="origin" x="-5" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0b9ef739ffb6dc0b6f89295de0f803a644f4fda8edd1a27268d80ac94c014b7d"/></canvas><canvas name="11" width="53" height="72"><vector name="origin" x="-9" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9fc588141e33ba8b19abbedf133417a7d698923cf1bb0f9da15aab94529bb564"/></canvas><canvas name="12" width="297" height="89"><vector name="origin" x="244" y="126"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bada5098ad663279b04f71dc98ac1ba223ff01e9a3a31d47971490faaf6d6b16"/></canvas><canvas name="13" width="212" height="64"><vector name="origin" x="258" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d0922c563583f11ffb5ce844c70e219a1a26e4a80a2f7243320c4a557d544715"/></canvas><canvas name="14" width="1" height="1"><vector name="origin" x="257" y="93"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/14"/></canvas><canvas name="15" width="1" height="1"><vector name="origin" x="247" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/15"/></canvas><canvas name="16" width="1" height="1"><vector name="origin" x="143" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack2/info/effect/16"/></canvas></imgdir><int name="attackAfter" value="1440"/></imgdir><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="17" width="196" height="208"><vector name="origin" x="89" y="198"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/></canvas><canvas name="16" width="196" height="208"><vector name="origin" x="89" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/></canvas><canvas name="15" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/></canvas><canvas name="14" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/></canvas><canvas name="13" width="196" height="209"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/></canvas><canvas name="12" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas></imgdir><imgdir name="attack4"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-280" y="-65"/><vector name="rb" x="-2" y="-34"/></imgdir><imgdir name="hit"><canvas name="0" width="199" height="194"><vector name="origin" x="99" y="97"/><int name="z" value="0"/><string name="_hash" value="611c4a8dbfab9d22ac8ff48e21fd7068528727bf09abc328af09466c1a582590"/></canvas><canvas name="1" width="183" height="198"><vector name="origin" x="91" y="99"/><int name="z" value="0"/><string name="_hash" value="3f4f0e69bdaa8e05ec683ef1a26e2cec9c381ef18125e6c3369e4f3336edae07"/></canvas><canvas name="2" width="201" height="206"><vector name="origin" x="100" y="103"/><int name="z" value="0"/><string name="_hash" value="e6a4ed00509cfd9864dc2e1ccbbdd53eeb1f8013dbf21938e5d3cc47c5fe5230"/></canvas><canvas name="3" width="196" height="189"><vector name="origin" x="98" y="94"/><int name="z" value="0"/><string name="_hash" value="6efdbddb5a7fe5c392ffc88bd51618db78f6c631c282ebbca0e37ca2d4a75d6d"/></canvas><canvas name="4" width="187" height="185"><vector name="origin" x="93" y="92"/><int name="z" value="0"/><string name="_hash" value="f23473659433f05ef05f07664365d638e4508aa1e14e6b15540c90275c949da4"/></canvas><canvas name="5" width="193" height="191"><vector name="origin" x="96" y="95"/><int name="z" value="0"/><string name="_hash" value="f551b946051b5a564a273336dcaee1db2d6e6a3a9b1a90d022638b88eae475df"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="1" height="1"><vector name="origin" x="5" y="65"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="11" height="16"><vector name="origin" x="-25" y="79"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="203e25bb1fd53b1a5e7d2cd80b3f8959bbba982fcf452bad93a0915ade08a653"/></canvas><canvas name="2" width="19" height="24"><vector name="origin" x="-18" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="4fa6ae3fc1b006099a97c27a170a757c9ff161a6855d75b7ca67e32d9e33eca1"/></canvas><canvas name="3" width="25" height="32"><vector name="origin" x="-14" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="ecaba8472e3eb0a8fd18e358df6a3341c54626abf6aa95f2ebd66b913ed97589"/></canvas><canvas name="4" width="30" height="30"><vector name="origin" x="-12" y="95"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="6577098e707bf33585d998f703eeb2d5c68d7bde9483ee3e399e388e9ac2a0a9"/></canvas><canvas name="5" width="72" height="73"><vector name="origin" x="4" y="124"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="24cf809e09060234dc560c73f4b5be22e1c04052d07d7c60fc7d2bc302076a64"/></canvas><canvas name="6" width="60" height="74"><vector name="origin" x="-4" y="130"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="0a1ba0ddae1eb1c189d0d1f4a5672d6018b79891706bd5def4ffe135ed1e89c6"/></canvas><canvas name="7" width="64" height="71"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="65b514b10138bef0075d47585ee11cd2e633f21a7673c03e8568e095158c9016"/></canvas><canvas name="8" width="53" height="72"><vector name="origin" x="-7" y="135"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9ecddc089310016cdd8526ca2c4475c881176fd78a27b350b5e29e01c9389e93"/></canvas><canvas name="9" width="60" height="74"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="c7cc7584fd2ad81d23d13f2367a5636c8fff3c74d10b9ddd936632d668af2946"/></canvas><canvas name="10" width="57" height="71"><vector name="origin" x="-5" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="6562d65d76730ec0f5a02700d0904269484c4d97617402b09b0011f60178235e"/></canvas><canvas name="11" width="53" height="72"><vector name="origin" x="-7" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="d3030969d95ef8f505edbb401b97716a0cff5e70e3b8724a86d457bb8cdf4fb3"/></canvas><canvas name="12" width="296" height="88"><vector name="origin" x="243" y="126"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="55fc186417168611c03cca71cce0900a7ada6bd808ace00858680a6009207d1a"/></canvas><canvas name="13" width="212" height="64"><vector name="origin" x="258" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="641d5ae49645769d9bd9a4d338e9737473e91d7000b40f08aaa6d0f8c94cacbb"/></canvas><canvas name="14" width="180" height="58"><vector name="origin" x="257" y="93"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="a4740c7c3d1c09c98b009ed045fa3e3680c1cbcff89f058f9b6ff70a0bd18142"/></canvas><canvas name="15" width="1" height="1"><vector name="origin" x="247" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/15"/></canvas><canvas name="16" width="1" height="1"><vector name="origin" x="143" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/16"/></canvas></imgdir><int name="attackAfter" value="1440"/></imgdir><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="12" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/></canvas><canvas name="13" width="196" height="209"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/></canvas><canvas name="14" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/></canvas><canvas name="15" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/></canvas><canvas name="16" width="196" height="208"><vector name="origin" x="89" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/></canvas><canvas name="17" width="196" height="208"><vector name="origin" x="89" y="198"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas></imgdir><imgdir name="attack5"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-280" y="-65"/><vector name="rb" x="-2" y="-34"/></imgdir><imgdir name="hit"><canvas name="0" width="199" height="194"><vector name="origin" x="99" y="97"/><int name="z" value="0"/><string name="_hash" value="b16c000e92a26c2dea7b8e9d20ac3d359248873c4e5840e11a49da15a68d9d10"/></canvas><canvas name="1" width="183" height="198"><vector name="origin" x="91" y="99"/><int name="z" value="0"/><string name="_hash" value="a053dcb8c8ccd9dba6ac60a12d68d03420615738ab86e181bb752a6dab961d1b"/></canvas><canvas name="2" width="201" height="206"><vector name="origin" x="100" y="103"/><int name="z" value="0"/><string name="_hash" value="c38457d5b09126168e6ad1a5729bb5fbf8be4cab63276007d1d81f83ade87069"/></canvas><canvas name="3" width="196" height="189"><vector name="origin" x="98" y="94"/><int name="z" value="0"/><string name="_hash" value="f1e1600924557d89e7ad9367b9481af20a79b8b4188697a18a3bb5639c22dfeb"/></canvas><canvas name="4" width="187" height="185"><vector name="origin" x="93" y="92"/><int name="z" value="0"/><string name="_hash" value="db7e3f6c18a368186b4d7ae1802337f9eabc352bec2989541e05274bd431bf30"/></canvas><canvas name="5" width="1" height="1"><vector name="origin" x="96" y="95"/><int name="z" value="0"/><string name="_inlink" value="attack4/info/hit/5"/></canvas></imgdir><imgdir name="effect"><canvas name="0" width="1" height="1"><vector name="origin" x="5" y="65"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="1" width="11" height="16"><vector name="origin" x="-25" y="79"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="6a97cfc259437844155a80dedf1ae6c70a537f46a7b87880a792cd1a8158e9ad"/></canvas><canvas name="2" width="19" height="24"><vector name="origin" x="-18" y="85"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="5681468acc1da43e17b6275f84ee07a11e4cbd50db1dea71c70c0362833bf041"/></canvas><canvas name="3" width="25" height="32"><vector name="origin" x="-14" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="8f744d8e1b573d08ded2b9d4bf9115b2da99e9dfbe9459ef12553b77e14e1e70"/></canvas><canvas name="4" width="30" height="30"><vector name="origin" x="-12" y="95"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="124a7cff5f9b3e2cdd9f2c88ceea049d5f8404ad97e11fe28078214bbfeb1739"/></canvas><canvas name="5" width="72" height="73"><vector name="origin" x="4" y="124"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1172cb339eb469aef3c2d1830f581e352b47c0256462f0aba2c104e781433e9e"/></canvas><canvas name="6" width="60" height="74"><vector name="origin" x="-4" y="130"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="2131e318abd89e9aeb577d1784fe7f4df0956b310ebe558a9695493326a90211"/></canvas><canvas name="7" width="57" height="71"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="bb2495273f323718c161b84b590564c26037d905385b182378b57e6a3ff3d41e"/></canvas><canvas name="8" width="53" height="72"><vector name="origin" x="-7" y="135"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="db4e53724ecb0d6a42336494745ebcc4d9ca254098e4e8058818d23b6f2dd1a3"/></canvas><canvas name="9" width="60" height="74"><vector name="origin" x="-5" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="22621db1db697143c85f915a1af45b368729a2d59f12a6b7f20d4596688d4c78"/></canvas><canvas name="10" width="57" height="71"><vector name="origin" x="-5" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="1f783c6758d0201b88b495104b98d4142d0cf926d17f39f8799af47e8cec90bf"/></canvas><canvas name="11" width="53" height="72"><vector name="origin" x="-7" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="9a5750d8e4107d9d925b59ba4c6448cb0ec671ebccb604af5c34a6357dff146a"/></canvas><canvas name="12" width="298" height="90"><vector name="origin" x="244" y="127"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="80169ca1211efeb069d6b6054af8f417f6e1fffc25ba37e02f807f84ce2dc5ad"/></canvas><canvas name="13" width="212" height="64"><vector name="origin" x="258" y="96"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="fadd8c8de8582e094bfdcb68d3408f51cceca443bb7a7671c72fa319ef471713"/></canvas><canvas name="14" width="180" height="58"><vector name="origin" x="257" y="93"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_hash" value="f5931134c84763e2714eeea51af1f123897a978882305f584236dad7ab4cfb9f"/></canvas><canvas name="15" width="1" height="1"><vector name="origin" x="247" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/15"/></canvas><canvas name="16" width="1" height="1"><vector name="origin" x="143" y="92"/><int name="z" value="0"/><int name="delay" value="120"/><string name="_inlink" value="attack1/info/effect/16"/></canvas></imgdir><int name="attackAfter" value="1440"/></imgdir><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><int name="delay" value="120"/><string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/></canvas><canvas name="10" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/></canvas><canvas name="11" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/></canvas><canvas name="12" width="196" height="210"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/></canvas><canvas name="13" width="196" height="209"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/></canvas><canvas name="14" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/></canvas><canvas name="15" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/></canvas><canvas name="16" width="196" height="208"><vector name="origin" x="89" y="199"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/></canvas><canvas name="17" width="196" height="208"><vector name="origin" x="89" y="198"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/></canvas><canvas name="4" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/></canvas><canvas name="5" width="196" height="208"><vector name="origin" x="89" y="199"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/></canvas><canvas name="6" width="196" height="208"><vector name="origin" x="89" y="200"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/></canvas><canvas name="7" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/></canvas><canvas name="8" width="196" height="208"><vector name="origin" x="89" y="202"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/></canvas><canvas name="9" width="196" height="208"><vector name="origin" x="89" y="201"/><vector name="lt" x="-81" y="-144"/><vector name="rb" x="77" y="-18"/><vector name="head" x="-14" y="-109"/><int name="delay" value="120"/><string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/></canvas></imgdir><imgdir name="attack6"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-767" y="-30"/><vector name="rb" x="751" y="13"/></imgdir><imgdir name="hit"><canvas name="0" width="191" height="183"><vector name="origin" x="95" y="91"/><int name="z" value="0"/><string name="_hash" value="b23a4d491f7813fb2f0c8c5fa271c7fbd71514d6f56deccb866d385356b9e8fb"/></canvas><canvas name="1" width="178" height="181"><vector name="origin" x="89" y="90"/><int name="z" value="0"/><string name="_hash" value="f0644280d8a073519c5b0e8c7ce14811c644efc33597b73b8a454b1ef39f2271"/></canvas><canvas name="2" width="186" height="187"><vector name="origin" x="93" y="93"/><int name="z" value="0"/><string name="_hash" value="8a413ffb1efa0bf652dbed94868378cab7971850178ddcf4048689aed6022851"/></canvas><canvas name="3" width="183" height="190"><vector name="origin" x="91" y="95"/><int name="z" value="0"/><string name="_hash" value="6ee40481205f9562f733ec7bde2d841b0ef551f4375a0764c523f43a1cdf0da9"/></canvas><canvas name="4" width="125" height="118"><vector name="origin" x="62" y="59"/><int name="z" value="0"/><string name="_hash" value="53f010a10ce309a7f5d21259a86a2764f876a41f4d71b296497f6f98544a7efd"/></canvas></imgdir><int name="attackAfter" value="1920"/></imgdir><canvas name="0" width="196" height="193"><vector name="origin" x="89" y="185"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="a79760470787833c345ed030e861d371bfc98fee59ecfaf5c4ea0693ee9655cb"/></canvas><canvas name="1" width="196" height="194"><vector name="origin" x="89" y="208"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="a872a786293da41c92db4fd28fee9526a973d17504fcba08e522d5b9112b9e6f"/></canvas><canvas name="2" width="196" height="193"><vector name="origin" x="89" y="212"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="8af3419110e62ebcf50e11ba92e0e75b00360dd0fcdc9e3a7a811f67f12b8b2b"/></canvas><canvas name="3" width="394" height="290"><vector name="origin" x="211" y="279"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-81" y="-175"/><vector name="rb" x="101" y="-28"/><string name="_hash" value="fae816367fb7d68fa46976a01b0b2a90c1a4b5087dc671632482ad5d8cc1b784"/></canvas><canvas name="4" width="385" height="280"><vector name="origin" x="207" y="274"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="090ceb9e8278e32f36a6d4c58005cb7420f32177eb4f2a4e28700bdcf560af5c"/></canvas><canvas name="5" width="362" height="260"><vector name="origin" x="195" y="264"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="7773304bbfd0645c946f3818588e9c2fad40903928e5d515a47e8f2158849673"/></canvas><canvas name="6" width="201" height="182"><vector name="origin" x="95" y="222"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="ff951bbb84e527c5d3f2c14381c01fbda4f71e479514326ae04f94a73702e0fe"/></canvas><canvas name="7" width="199" height="183"><vector name="origin" x="92" y="218"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="9c6d73dc138e9fdabeeb9421397491e8b6d75e809555001862a920c6e07c49a3"/></canvas><canvas name="8" width="190" height="176"><vector name="origin" x="89" y="215"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="e79175d8bb0431e5af92097e0bbed53fc33ffe9718ada7fbbf1b1d6e21c371cd"/></canvas><canvas name="9" width="181" height="165"><vector name="origin" x="87" y="213"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-4" y="-172"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="91" y="-52"/><string name="_hash" value="d9a0fd8f01dadf112bade5f12c183fbb6dbe97717938a53add9da2083d4f5036"/></canvas><canvas name="10" width="1" height="1"><vector name="origin" x="0" y="-1"/><int name="z" value="0"/><int name="delay" value="120"/></canvas><canvas name="11" width="394" height="290"><vector name="origin" x="213" y="330"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-9" y="-205"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="84" y="-88"/><string name="_hash" value="84e520166895fc4810530c4caab159231e5c1119905a78cd0aba5cf3866f741a"/></canvas><canvas name="12" width="304" height="217"><vector name="origin" x="165" y="289"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-9" y="-205"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="84" y="-88"/><string name="_hash" value="76f064d25d2a7bac2bacdebaaf884baf83ad8c0e6b7454d2e99c2130e4fe64a4"/></canvas><canvas name="13" width="278" height="193"><vector name="origin" x="139" y="277"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-9" y="-205"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="84" y="-88"/><string name="_hash" value="b09268b9631049d8e06b7f0a2d277ae613e630723591e98ff18e02a546f95de2"/></canvas><canvas name="14" width="276" height="193"><vector name="origin" x="138" y="279"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-9" y="-205"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="84" y="-88"/><string name="_hash" value="308d00825addf25b8c031da29cdcea3754077e6411fc83224ee8d4ef71c43409"/></canvas><canvas name="15" width="198" height="193"><vector name="origin" x="91" y="281"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-9" y="-205"/><vector name="lt" x="-86" y="-210"/><vector name="rb" x="84" y="-88"/><string name="_hash" value="e87b46b78957d44a624c9decc23a053fbf2ea2af5881c50a547543d63bc0de93"/></canvas><canvas name="16" width="1171" height="293"><vector name="origin" x="580" y="247"/><int name="z" value="0"/><int name="delay" value="120"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="15"/><string name="_hash" value="45b5e536f5213f312e54946008fb535a5cbbe43892aa8fdd810954f6005c70fc"/></canvas><canvas name="17" width="1189" height="283"><vector name="origin" x="589" y="238"/><int name="z" value="0"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="15"/><int name="delay" value="120"/><string name="_hash" value="1ae4b7dcb55cd2a0574e8bf712d2bfe3d4cae25368639e9a96281f01b94151e0"/></canvas><canvas name="18" width="1192" height="222"><vector name="origin" x="591" y="182"/><int name="z" value="0"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="15"/><int name="delay" value="120"/><string name="_hash" value="e15595dd07d247c539f19ed8557a028ae80d04159782cbc34255b7713a9724c2"/></canvas><canvas name="19" width="1199" height="221"><vector name="origin" x="594" y="184"/><int name="z" value="0"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="15"/><int name="delay" value="120"/><string name="_hash" value="be936249e6c16c13180ea19b769daab53c724731e851583479dab3a6e08c4b6d"/></canvas><canvas name="20" width="1199" height="193"><vector name="origin" x="595" y="156"/><int name="z" value="0"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="-4"/><int name="delay" value="120"/><string name="_hash" value="b91e4107908aa9d9215856c9cd3ca3d42d7fdb6ba627865e17f2ac5ba2f3ec43"/></canvas><canvas name="21" width="1195" height="193"><vector name="origin" x="592" y="156"/><int name="z" value="0"/><vector name="head" x="-5" y="-80"/><vector name="lt" x="-116" y="-135"/><vector name="rb" x="128" y="15"/><int name="delay" value="120"/><string name="_hash" value="1c2e58f311b27eb7ffb65051f54ba7c9e59b6d1fe370e057752afee8e39ea03a"/></canvas></imgdir><imgdir name="skill1"><canvas name="20" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/></canvas><canvas name="8" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/></canvas><canvas name="9" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/></canvas><canvas name="10" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/></canvas><canvas name="11" width="196" height="203"><vector name="origin" x="89" y="195"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/></canvas><canvas name="12" width="196" height="198"><vector name="origin" x="89" y="189"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/></canvas><canvas name="13" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/></canvas><canvas name="14" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="f2b1eb2b88b053721807e0d194e5b55f1b846b5a4b6e11939b92839ec267967e"/></canvas><canvas name="15" width="196" height="198"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="09afd8d8cf124fb4db9f0fec591e6a074ce56eacfae17b8135982d3dec438343"/></canvas><canvas name="16" width="196" height="198"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="2ad898a1542d67c7969aa86fc1c9882bd40dd32a60625b28a3b016346e1e2b38"/></canvas><canvas name="17" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="065bae5b5906dd8921a4e04933afa7f9535d191d86be631af646eac30f4cad82"/></canvas><canvas name="18" width="196" height="198"><vector name="origin" x="89" y="189"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="c6c3f56700e80cf51e3339a72040262411ec5986573968da20513049bd4707bd"/></canvas><canvas name="19" width="196" height="198"><vector name="origin" x="89" y="190"/><int name="z" value="0"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="3297db2c984ffaa1befe4f0177259104027a50eeae88aa5472a5060efbe3f255"/></canvas><imgdir name="speak"><int name="prop" value="100"/><string name="0" value="?????"/></imgdir><canvas name="7" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/></canvas><canvas name="3" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/></canvas><canvas name="4" width="196" height="203"><vector name="origin" x="89" y="195"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/></canvas><canvas name="5" width="196" height="198"><vector name="origin" x="89" y="189"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/></canvas><canvas name="6" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/></canvas><canvas name="0" width="196" height="198"><vector name="origin" x="89" y="190"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/></canvas><canvas name="1" width="196" height="198"><vector name="origin" x="89" y="191"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/></canvas><canvas name="2" width="196" height="198"><vector name="origin" x="89" y="192"/><vector name="head" x="-8" y="-125"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/></canvas></imgdir><imgdir name="skill2"><canvas name="0" width="196" height="199"><vector name="origin" x="90" y="190"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="1d0aac14b0085e2ec724af30e7ceeb5ff32ef5c9e2de6922614e262e656e514b"/></canvas><canvas name="1" width="196" height="205"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="0270f3a6f9ceb6a83bce4ef665f0e03882a29be3faa0d4033b535baf2dd3756c"/></canvas><canvas name="2" width="196" height="213"><vector name="origin" x="89" y="192"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="0d0cf54e86e131e21d9f127146d0184889794fd198db889de8157c6c2efb5f3a"/></canvas><canvas name="3" width="196" height="215"><vector name="origin" x="89" y="191"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="982b9d39aa44f124d59dd5fac3014606b9cb5c3b59a98170605a9ac9e86f4bad"/></canvas><canvas name="4" width="197" height="218"><vector name="origin" x="90" y="192"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="c3e340e338054e1adece96d3ba11a501ee729046720b245c7020c22d7a222f4c"/></canvas><canvas name="5" width="198" height="220"><vector name="origin" x="91" y="192"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="af7f589835fd13d6b275c4cc1fe972c93d02207c7756cb4e581e41439ffa64ae"/></canvas><canvas name="6" width="197" height="214"><vector name="origin" x="90" y="206"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="1fe9c11f660642b36f07af486afbd56c2a2bc46edd912b7adb9ea0d6c9b70cbb"/></canvas><canvas name="7" width="197" height="210"><vector name="origin" x="89" y="202"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="400852cbca5268b0c396c6d5461fa99fa8d138d57ff64b3e6050e63f8e201151"/></canvas><canvas name="8" width="204" height="203"><vector name="origin" x="89" y="195"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="0a6937e946fd7494552cb09f1965afbd21e75b91d71fb16568211e09fde987c6"/></canvas><canvas name="9" width="204" height="202"><vector name="origin" x="89" y="194"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="e0efca09df704285e1cc5a59ad460c7cf3def9cc752c6f28e875106da8e6632a"/></canvas><canvas name="10" width="198" height="202"><vector name="origin" x="89" y="194"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="55eb33f9d5a8cabbc0ac37018e219811d6cbda349e3a81ed955236858876c60c"/></canvas><canvas name="11" width="199" height="204"><vector name="origin" x="89" y="196"/><int name="z" value="0"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="c15a1b7a495533fbcc44b93ba70bc0e492c7e7f7427e326317f66e610412f72a"/></canvas></imgdir><imgdir name="attack7"><canvas name="12" width="196" height="392"><vector name="origin" x="89" y="392"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/></canvas><canvas name="13" width="196" height="405"><vector name="origin" x="89" y="406"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/></canvas><canvas name="2" width="197" height="378"><vector name="origin" x="90" y="380"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="86893292f87ad179cf8e47634df1bdbcfa0d2e425ba7c7899ddee73317a94fa8"/></canvas><canvas name="15" width="196" height="393"><vector name="origin" x="89" y="394"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/></canvas><canvas name="16" width="196" height="362"><vector name="origin" x="89" y="362"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/></canvas><canvas name="17" width="196" height="389"><vector name="origin" x="89" y="388"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/></canvas><canvas name="6" width="197" height="407"><vector name="origin" x="90" y="407"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="eadebb118bef62fb27cca7c5d83c9981cfea514dc7364f4f3eef5ce23bfd8c6c"/></canvas><canvas name="7" width="196" height="412"><vector name="origin" x="89" y="413"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="88ff94607cac27e1e7f91cfab14280d57726d3b88c18e62e641f6d9cb1d83e4f"/></canvas><canvas name="8" width="196" height="405"><vector name="origin" x="89" y="407"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="7f87b481fab16131725a601b2d643cf86c8c0602dc21a4848a66c424a41a980b"/></canvas><canvas name="9" width="196" height="392"><vector name="origin" x="89" y="393"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="d8cfbd754bee92b4b8b2c44f4219d8669079eff901edfcd6d7b8f4983d807528"/></canvas><canvas name="10" width="197" height="388"><vector name="origin" x="90" y="388"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="b85da2f8c68b4183c71b3bb528f62ee9d0e1de070b7c2a9b514a9d6535519156"/></canvas><canvas name="11" width="196" height="412"><vector name="origin" x="89" y="411"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="a6bdf2a3dee1a24bafac31bbfbf31e885766650cf02d46bd53ea9e7884945551"/></canvas><imgdir name="info"><imgdir name="hit"><canvas name="1" width="176" height="192"><vector name="origin" x="88" y="96"/><int name="z" value="0"/><string name="_hash" value="24297c65bd86f268e84f9da30bb28f28f6b3929df83c83ef4589743860586205"/></canvas><canvas name="2" width="165" height="192"><vector name="origin" x="82" y="96"/><int name="z" value="0"/><string name="_hash" value="8ee5c4999ed66f77eec4a6891728d0caae27aab78b95d7c394b46b2dd7503c0e"/></canvas><canvas name="3" width="163" height="135"><vector name="origin" x="81" y="67"/><int name="z" value="0"/><string name="_hash" value="710dd428dfead84cb3e570011283888350bc3cb4198c2276689f16c58a0159e8"/></canvas><canvas name="4" width="141" height="133"><vector name="origin" x="70" y="66"/><int name="z" value="0"/><string name="_hash" value="2037b1d2981b15bc1694bd5f572014e17c6753082e8b6c109cfa4a4be7b752b7"/></canvas><canvas name="5" width="145" height="140"><vector name="origin" x="72" y="70"/><int name="z" value="0"/><string name="_hash" value="65833d06e578de7367829fb27cdc203a3cec2d049cad8a50bbfa6bc4b11fa2c0"/></canvas><canvas name="6" width="149" height="152"><vector name="origin" x="74" y="76"/><int name="z" value="0"/><string name="_hash" value="854a7c1bcea63d31cce503d0be743a3e307cf39768b30f4fa0330c0c627ecd51"/></canvas></imgdir><imgdir name="range"><vector name="lt" x="-680" y="-1147"/><vector name="rb" x="680" y="99"/></imgdir><int name="attackAfter" value="1920"/></imgdir><canvas name="0" width="196" height="392"><vector name="origin" x="89" y="392"/><vector name="head" x="-14" y="-109"/><vector name="lt" x="-88" y="-183"/><vector name="rb" x="108" y="8"/><string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/></canvas><canvas name="14" width="196" height="405"><vector name="origin" x="89" y="406"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/></canvas><canvas name="1" width="196" height="405"><vector name="origin" x="89" y="406"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/></canvas><canvas name="3" width="196" height="393"><vector name="origin" x="89" y="394"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/></canvas><canvas name="4" width="196" height="362"><vector name="origin" x="89" y="362"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/></canvas><canvas name="5" width="196" height="389"><vector name="origin" x="89" y="388"/><int name="z" value="0"/><vector name="head" x="-14" y="-208"/><vector name="lt" x="-88" y="-282"/><vector name="rb" x="108" y="-91"/><string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/></canvas></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9450022.img">
+  <imgdir name="info">
+    <int name="level" value="150"/>
+    <int name="maxHP" value="1500000000"/>
+    <int name="maxMP" value="100000"/>
+    <int name="mpRecovery" value="10000"/>
+    <int name="hpRecovery" value="10000000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="1350"/>
+    <int name="MADamage" value="1400"/>
+    <int name="PDRate" value="30"/>
+    <int name="MDRate" value="20"/>
+    <int name="acc" value="999"/>
+    <int name="eva" value="80"/>
+    <int name="pushed" value="199999"/>
+    <float name="fs" value="10.0"/>
+    <int name="exp" value="22000000"/>
+    <int name="summonType" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="128"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="145"/>
+        <int name="action" value="2"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="6" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="aacfdac6db9941a92082d4ff149e479f91f9b7f9b17d384ad091f8446779d0bc"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="9720c408116d2ab09e8295717dc11971cbd4d77a353c168ebb28c04f746e232d"/>
+    </canvas>
+    <canvas name="10" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="cc792d53d48c07a6c8c037fbe59907615b6fc0e8107e7f22c903ad06b7d79ebf"/>
+    </canvas>
+    <canvas name="11" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="e692398e07ba283472e8fca4e7e5a26b1cd3d5578ab92a5c37ce89719d8608dc"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="4a6ef4330261092c4be1be264c84fc9267ad1b48ba59fd0169d306b570993dc9"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="4c12eb8473e722e09eec99743488c040d27f1fa9c00e7c6efafd77212894159a"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a8f58b13a489ca5850848829e359f05b8eed60ac4a1cce456a03680c644faaef"/>
+    </canvas>
+    <canvas name="5" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="210cd2abd8fb276b8e1e08abe2f19994edf8f3d0b2dc66721b81898279ac7a99"/>
+    </canvas>
+    <canvas name="7" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="69d8a175e31fd46b141b4f142401142cf79d649dbfca8b5715643c53f64be086"/>
+    </canvas>
+    <canvas name="8" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="c46972e7aa48ef79b899a102749f46d3474c84ad99a34f47e4f79b3b9d68db74"/>
+    </canvas>
+    <canvas name="9" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="1a3792b751548391d8b5a72067e2b2ac1738725f97521f973bb3266166731fa3"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="aacfdac6db9941a92082d4ff149e479f91f9b7f9b17d384ad091f8446779d0bc"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="5" width="200" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="ace4d88aa5fca2f30ce1aba0361e59635ec9936e0d948d34100a6b20f6adcaa6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="53f6e366da478b2bf97da582637682cba6e16f6426f884b8d7dd78e0f2b8b420"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="ea7498c7f47b52286a540fda3522c46e3eaa4477bee49736508c58a0e8eb847a"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="bcd85aa903f39e6f5211f04e64ab12f27968cebec541f04b2df1d55f7b3ccd82"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="de90f4fa91c5d222eb9a524c87f50fb11b4f1dcf5fd126d9bcdb7aa24f687f33"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="7ce12372921280cca8a391b4aeb4473e77e15d22d5fc854d965d4b8b1cb64eb5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f9ff11c42be35e5e3fd109814f4e61b14dd109653833ad15bcd3335a56a891d5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="1" width="196" height="179">
+      <vector name="origin" x="89" y="171"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="029fc945fe7a87aea59c019b8a59e48364de0883dde4d4d6c540a9564507c8df"/>
+    </canvas>
+    <canvas name="2" width="192" height="164">
+      <vector name="origin" x="87" y="159"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="1220215ee1bfd503e711d2fa75cb24bbdef2174b20b30cfda11a4f2037da070c"/>
+    </canvas>
+    <canvas name="3" width="187" height="156">
+      <vector name="origin" x="86" y="157"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="8a7e19f2bffe98a8be6daa1e7043f1090cca13d46f8a3aa9ff25bb4f9938fc63"/>
+    </canvas>
+    <canvas name="4" width="175" height="151">
+      <vector name="origin" x="78" y="155"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="3b219a21f7c6625ddc68d067fffd2186ddad543e2fc7be9454c1002b9e49d860"/>
+    </canvas>
+    <canvas name="5" width="156" height="136">
+      <vector name="origin" x="69" y="156"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="086e3e5cf47d9b10c4c48aa15b38d0619c690f08e45e12c5e07d7c432decd957"/>
+    </canvas>
+    <canvas name="6" width="125" height="122">
+      <vector name="origin" x="48" y="151"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="315f1dd0e72160d042c46b73c891f65113b2b6734dbbc25c21beb6c96a1676a8"/>
+    </canvas>
+    <canvas name="7" width="65" height="47">
+      <vector name="origin" x="8" y="93"/>
+      <int name="z" value="0"/>
+      <string name="_hash" value="b828e2dc0153f7e04df420a0ddadbdbdfe8664baf63a1c4a5d8a16efdbe4df22"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="ed173a097e57edeabd997764a1203fe48282c6b66b5b3c63b8959d1a68ab282c"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f561de600870aed73eefd738f90fc1043bed8280371cbb166f7dee0e66ffbd53"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3a0c130666d0a065906181c8bd7ba4cd7af1486cf095678d378ef485a4546848"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="443e54e4c9419660510be8ff8bf49b240de73248fbd94c3b75eacb478cf445cc"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="e9a9f905eaf9c7e697735d27789323e85fa1f1d8c8abb0892d7675da6e5de506"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="9b1981507d06d898fde691f11b21c3f9778b978b01de082e32a5d753432e68cf"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e14184568972a6e77906e675413433f8968c5075e9541f2d258de8ad38bcbabf"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="ddaf8bd5ce82b330d7edf018fd66ca865657a04d92f7d983afd279d03821bd84"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5b965163288d1c34396f6416910f627c94261153a4bb4ef8e75d7c2b249209a6"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b468ebfb3b67e05d740ff415fbfaf1a6756f09d8c19ca9ec4d77141d3efd3752"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="c1c4886943ef4862b15d434a478a125dfa092481b1b250f91ce8c73154815684"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1c99b9631d1c854e130f4b548591d393fcd4721a089799389c82f668f3da2393"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="39566a11077d123dcbd1d0032373d33c586b9a1e65d564da880520ac97ef671a"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="91fbe439bd6ffca9eaff288b2cda1c5be611ee89d34e4ca9a3946bc35ec66fd7"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="14c22bb33a2f2c1bc0f9e138aadf315c219d4abbcb5adb96835640caf32e51cf"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7377d913b3e0e22893bcf9019a884a4c298f4bee7ec9a8c0c7fc2e10fdc263e7"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="84a10b45ceda775f338d1d62ff555ebe7ac9dfb2e0d90ebf5e42aaaba0ffa37d"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="cf92e0ffc0a2e247486e0a5f56bd7c5c44d61bccd420ef0c4c91bac8d35fe293"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7afbb566b04355530205cbf6ee22a58875587d460f6147bfb708d5bb90b0551e"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="484249c5bc3dfa1b980be5f56a3e1d93bde25ca3dec81ef9bb9ad2ae1d761260"/>
+        </canvas>
+        <canvas name="15" width="160" height="49">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="7bb927d4063b5272776e83cf201a25a418f2d4b9e5f9f43bd3bf373d46db0082"/>
+        </canvas>
+        <canvas name="16" width="60" height="49">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5a3f8187e830f852440585186c0e3c6ab10225f0828dcb2144202500b17d788b"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="c06e0a1d53536be3f89cca6c459c632b72cbd79542e11ad04f9f9199008e775c"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6c9d0e2e3f6778eeaa44d9b6d34213e75a83e6c2e4b984b03ae49104300fc092"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="47d401133797d76af401f7855fe44a3b0eeb388923bf0a2dcd9ca654f2279c28"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3cdf4b8968876423893686bb285c6d0c9729de34c4c661a726135e8c52133f59"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="092042886657e04f11bcf14ef2b0f1ca5d651bd00ab9e31a2610744317b09c44"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_inlink" value="attack1/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="1" height="1">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/1"/>
+        </canvas>
+        <canvas name="2" width="1" height="1">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/2"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="642855b4259104ce2ec98dd86be97d0a0d89d72f70999abbf9579c85affbd9cb"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="88c5b7ecac32cc860d00577f6105be5b15fd9f99f5d25a6b98b9cf029d1295c5"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="dbc0d33c40fae2a166034f2ae1f50076866dfef4987fc1118baf95539e88e2a2"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bfbd90318e054646f09a5432bf3b2c765026a4905790c24904079c4773ad2928"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8bafcbfd9edb6cc910b860acff509eed800ab8674b38dda99b16612211c07cbd"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="34abb4387224c37351708a0ce1f3a5815d798b538e58c752e4281f437c688cb8"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e74d8967bce61233d379d4eb6a17f8f2aa2c1154af9a94eb8997a39c83ae024d"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="befec05e861886328728153a33ea56c55a94a2027fa05723733e0920e35e7970"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0cf7c84ca3d414cb33d6ba874928f742d29e2c61aa3b3f500359adbbb168ec5a"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="174e922c141594c39b6bddafe2f37540e97a76fd04ada23fb2cdccdbaf3a9ba8"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="131" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="80572942c58ca7a183d698294afdd76f7ecd842b34c191be6cd02f821b12ed9b"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="75651698bb1a7372b7f7a180922219def3bc52bc55203e46ee357cb93ebb4e8c"/>
+        </canvas>
+        <canvas name="15" width="160" height="49">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b102caf9e5204ca94452ea072db696e6f957bfc0ec7b7343109b1a625f66390d"/>
+        </canvas>
+        <canvas name="16" width="60" height="49">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="39b8c41a36c92e6ba1040a5574908a6a52e5bcb5e4894afa8e414f3ea400d22e"/>
+        </canvas>
+        <int name="attackAfter" value="1440"/>
+      </imgdir>
+    </imgdir>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="86d5b7f06107a433030beb76025082080374cf85322cc2c3faf62f0d226b8402"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="cf7d28621dd3989207c3164fdc7964b5148af1ce8f75a880ef45efe1b5e50033"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="405951214f0a2f370941d42229a23ebb4ceb720fb99eb5f27acedb63a86dc5a7"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="aa48d2503799de6a57c495166c73807468794a007631f7463f83b0fff6da4388"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b7ca770a9097eb89987acee55d3d7e1e4717b5649467050fa5d68b352415718b"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="0e09dc6fa57eb7be950c839c37ebbb3b4ea54332b2eedf35688245e1c39bc440"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f43ed4a87893b2f41ee84926f4d7ea92fe403907c32a9985d6f1186e7a2debd9"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d75724403e970496e4ab4e2415da47785a3b19c5512e37658199ef5be15107be"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4bef2b6e975ea3d60ac5e267b62766c8f7b69110625e31e45da7af5989bb6def"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="b04182cbe58f31aa5bd77c1f7eb2e317802b5628a7f4b35e1cbc0b511c7b7259"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="685279ece87a51e566920b5a6b07a177b648822071db1c5a0f0bb5c0574cf50d"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bbeb8cddd55bdfb84063941c2da093e548fd70dc3be0116120157d7169c47fbf"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0e58a86d405c0e81f5a60736d82467c33f7b495aac1f1300cd936ae21c43d4ea"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="e589c7010946da5b996d44c8b50f56bf635b42fedab0fbd3617bbd2fc696da92"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="25904a1f9dd3d353b62aabf2b47d9b04d6735dd28ceab5ed2402f6227912a08d"/>
+        </canvas>
+        <canvas name="10" width="64" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0b9ef739ffb6dc0b6f89295de0f803a644f4fda8edd1a27268d80ac94c014b7d"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-9" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9fc588141e33ba8b19abbedf133417a7d698923cf1bb0f9da15aab94529bb564"/>
+        </canvas>
+        <canvas name="12" width="297" height="89">
+          <vector name="origin" x="244" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bada5098ad663279b04f71dc98ac1ba223ff01e9a3a31d47971490faaf6d6b16"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d0922c563583f11ffb5ce844c70e219a1a26e4a80a2f7243320c4a557d544715"/>
+        </canvas>
+        <canvas name="14" width="1" height="1">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/14"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack2/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="611c4a8dbfab9d22ac8ff48e21fd7068528727bf09abc328af09466c1a582590"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="3f4f0e69bdaa8e05ec683ef1a26e2cec9c381ef18125e6c3369e4f3336edae07"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="e6a4ed00509cfd9864dc2e1ccbbdd53eeb1f8013dbf21938e5d3cc47c5fe5230"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6efdbddb5a7fe5c392ffc88bd51618db78f6c631c282ebbca0e37ca2d4a75d6d"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f23473659433f05ef05f07664365d638e4508aa1e14e6b15540c90275c949da4"/>
+        </canvas>
+        <canvas name="5" width="193" height="191">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f551b946051b5a564a273336dcaee1db2d6e6a3a9b1a90d022638b88eae475df"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="203e25bb1fd53b1a5e7d2cd80b3f8959bbba982fcf452bad93a0915ade08a653"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="4fa6ae3fc1b006099a97c27a170a757c9ff161a6855d75b7ca67e32d9e33eca1"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="ecaba8472e3eb0a8fd18e358df6a3341c54626abf6aa95f2ebd66b913ed97589"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6577098e707bf33585d998f703eeb2d5c68d7bde9483ee3e399e388e9ac2a0a9"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="24cf809e09060234dc560c73f4b5be22e1c04052d07d7c60fc7d2bc302076a64"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="0a1ba0ddae1eb1c189d0d1f4a5672d6018b79891706bd5def4ffe135ed1e89c6"/>
+        </canvas>
+        <canvas name="7" width="64" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="65b514b10138bef0075d47585ee11cd2e633f21a7673c03e8568e095158c9016"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9ecddc089310016cdd8526ca2c4475c881176fd78a27b350b5e29e01c9389e93"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="c7cc7584fd2ad81d23d13f2367a5636c8fff3c74d10b9ddd936632d668af2946"/>
+        </canvas>
+        <canvas name="10" width="57" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6562d65d76730ec0f5a02700d0904269484c4d97617402b09b0011f60178235e"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="d3030969d95ef8f505edbb401b97716a0cff5e70e3b8724a86d457bb8cdf4fb3"/>
+        </canvas>
+        <canvas name="12" width="296" height="88">
+          <vector name="origin" x="243" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="55fc186417168611c03cca71cce0900a7ada6bd808ace00858680a6009207d1a"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="641d5ae49645769d9bd9a4d338e9737473e91d7000b40f08aaa6d0f8c94cacbb"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="a4740c7c3d1c09c98b009ed045fa3e3680c1cbcff89f058f9b6ff70a0bd18142"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack5">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-280" y="-65"/>
+        <vector name="rb" x="-2" y="-34"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="199" height="194">
+          <vector name="origin" x="99" y="97"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b16c000e92a26c2dea7b8e9d20ac3d359248873c4e5840e11a49da15a68d9d10"/>
+        </canvas>
+        <canvas name="1" width="183" height="198">
+          <vector name="origin" x="91" y="99"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="a053dcb8c8ccd9dba6ac60a12d68d03420615738ab86e181bb752a6dab961d1b"/>
+        </canvas>
+        <canvas name="2" width="201" height="206">
+          <vector name="origin" x="100" y="103"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="c38457d5b09126168e6ad1a5729bb5fbf8be4cab63276007d1d81f83ade87069"/>
+        </canvas>
+        <canvas name="3" width="196" height="189">
+          <vector name="origin" x="98" y="94"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f1e1600924557d89e7ad9367b9481af20a79b8b4188697a18a3bb5639c22dfeb"/>
+        </canvas>
+        <canvas name="4" width="187" height="185">
+          <vector name="origin" x="93" y="92"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="db7e3f6c18a368186b4d7ae1802337f9eabc352bec2989541e05274bd431bf30"/>
+        </canvas>
+        <canvas name="5" width="1" height="1">
+          <vector name="origin" x="96" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_inlink" value="attack4/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="effect">
+        <canvas name="0" width="1" height="1">
+          <vector name="origin" x="5" y="65"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="11" height="16">
+          <vector name="origin" x="-25" y="79"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="6a97cfc259437844155a80dedf1ae6c70a537f46a7b87880a792cd1a8158e9ad"/>
+        </canvas>
+        <canvas name="2" width="19" height="24">
+          <vector name="origin" x="-18" y="85"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="5681468acc1da43e17b6275f84ee07a11e4cbd50db1dea71c70c0362833bf041"/>
+        </canvas>
+        <canvas name="3" width="25" height="32">
+          <vector name="origin" x="-14" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="8f744d8e1b573d08ded2b9d4bf9115b2da99e9dfbe9459ef12553b77e14e1e70"/>
+        </canvas>
+        <canvas name="4" width="30" height="30">
+          <vector name="origin" x="-12" y="95"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="124a7cff5f9b3e2cdd9f2c88ceea049d5f8404ad97e11fe28078214bbfeb1739"/>
+        </canvas>
+        <canvas name="5" width="72" height="73">
+          <vector name="origin" x="4" y="124"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1172cb339eb469aef3c2d1830f581e352b47c0256462f0aba2c104e781433e9e"/>
+        </canvas>
+        <canvas name="6" width="60" height="74">
+          <vector name="origin" x="-4" y="130"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="2131e318abd89e9aeb577d1784fe7f4df0956b310ebe558a9695493326a90211"/>
+        </canvas>
+        <canvas name="7" width="57" height="71">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="bb2495273f323718c161b84b590564c26037d905385b182378b57e6a3ff3d41e"/>
+        </canvas>
+        <canvas name="8" width="53" height="72">
+          <vector name="origin" x="-7" y="135"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="db4e53724ecb0d6a42336494745ebcc4d9ca254098e4e8058818d23b6f2dd1a3"/>
+        </canvas>
+        <canvas name="9" width="60" height="74">
+          <vector name="origin" x="-5" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="22621db1db697143c85f915a1af45b368729a2d59f12a6b7f20d4596688d4c78"/>
+        </canvas>
+        <canvas name="10" width="57" height="71">
+          <vector name="origin" x="-5" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="1f783c6758d0201b88b495104b98d4142d0cf926d17f39f8799af47e8cec90bf"/>
+        </canvas>
+        <canvas name="11" width="53" height="72">
+          <vector name="origin" x="-7" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="9a5750d8e4107d9d925b59ba4c6448cb0ec671ebccb604af5c34a6357dff146a"/>
+        </canvas>
+        <canvas name="12" width="298" height="90">
+          <vector name="origin" x="244" y="127"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="80169ca1211efeb069d6b6054af8f417f6e1fffc25ba37e02f807f84ce2dc5ad"/>
+        </canvas>
+        <canvas name="13" width="212" height="64">
+          <vector name="origin" x="258" y="96"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="fadd8c8de8582e094bfdcb68d3408f51cceca443bb7a7671c72fa319ef471713"/>
+        </canvas>
+        <canvas name="14" width="180" height="58">
+          <vector name="origin" x="257" y="93"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_hash" value="f5931134c84763e2714eeea51af1f123897a978882305f584236dad7ab4cfb9f"/>
+        </canvas>
+        <canvas name="15" width="1" height="1">
+          <vector name="origin" x="247" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/15"/>
+        </canvas>
+        <canvas name="16" width="1" height="1">
+          <vector name="origin" x="143" y="92"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="_inlink" value="attack1/info/effect/16"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1440"/>
+    </imgdir>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="49d5c976208ee4c91c988390efdf95d168b0aa477379b9f89ce35f3e27d0e527"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="a441c5e39de9ea4b26cf49c1906272f461f3b2ea373924e8a3f2e6dcd48875c6"/>
+    </canvas>
+    <canvas name="10" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="63912b04541b28a36fadcfc01eba91d92db5eb07f747e3211083c47e766937b1"/>
+    </canvas>
+    <canvas name="11" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="55b270067bc514b1104abb5cf134732b3a0b5e6e98a87228a0d65a2722335e93"/>
+    </canvas>
+    <canvas name="12" width="196" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="524a213fa4f1ae12ce551da94ee76599d5c0c34c5ee68b08d2534295b2fdf416"/>
+    </canvas>
+    <canvas name="13" width="196" height="209">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c4e08ee2f75e3ae56f13afe56e47aaf360ae1460b8f34eace56dd43ed55552af"/>
+    </canvas>
+    <canvas name="14" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d3e393b4b73b071577a63e4f035bb8e8ec07e2d2bf3288f21617c66500802d8b"/>
+    </canvas>
+    <canvas name="15" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c36943bec25926113043c96c1d4027b8ca869c074bfbfb359a59e804a957c51e"/>
+    </canvas>
+    <canvas name="16" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="a9e32f9e377c7ac5e5dcad8ba6cf7424400d36920ea8a669c9e9c841a9380318"/>
+    </canvas>
+    <canvas name="17" width="196" height="208">
+      <vector name="origin" x="89" y="198"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <string name="_hash" value="85ecba6916c63381e5babeffe566c47484bf65b850bf6e74125ba345abed7876"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="758042c9754202d4015cb013f2153e3735ca2dc71c6b5272204381a35039a2cd"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b2632d5e425eb2656e5315850e8dbeb836730e35482740ecd8ae9b6f685e8eb6"/>
+    </canvas>
+    <canvas name="4" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="74f6f1eca8bc7c18a6b02aac682c86a5f2f49d4c8648c2126be2482b4dc1d04c"/>
+    </canvas>
+    <canvas name="5" width="196" height="208">
+      <vector name="origin" x="89" y="199"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6ad12ac88b72843228950165246bcb97624d724db8ee4a85095574b0225edd25"/>
+    </canvas>
+    <canvas name="6" width="196" height="208">
+      <vector name="origin" x="89" y="200"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ce6656a822130fb577fdbaf7a6a5222ef768018b88d949071d5cf8e5e772b527"/>
+    </canvas>
+    <canvas name="7" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4a1d9a49b19d48073f28e0aac773a247c170e382f347105c7c2c0160cc1e2616"/>
+    </canvas>
+    <canvas name="8" width="196" height="208">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="45724f49b388cbdc04aeca3649d11522d8dc9ec119a7a99436b1bf1f6e19d856"/>
+    </canvas>
+    <canvas name="9" width="196" height="208">
+      <vector name="origin" x="89" y="201"/>
+      <vector name="lt" x="-81" y="-144"/>
+      <vector name="rb" x="77" y="-18"/>
+      <vector name="head" x="-14" y="-109"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6a935b647565628ba12d8d8cf6b0f524f0e50c5c447569eec31237648ba3f70b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack6">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-767" y="-30"/>
+        <vector name="rb" x="751" y="13"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="191" height="183">
+          <vector name="origin" x="95" y="91"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="b23a4d491f7813fb2f0c8c5fa271c7fbd71514d6f56deccb866d385356b9e8fb"/>
+        </canvas>
+        <canvas name="1" width="178" height="181">
+          <vector name="origin" x="89" y="90"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="f0644280d8a073519c5b0e8c7ce14811c644efc33597b73b8a454b1ef39f2271"/>
+        </canvas>
+        <canvas name="2" width="186" height="187">
+          <vector name="origin" x="93" y="93"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="8a413ffb1efa0bf652dbed94868378cab7971850178ddcf4048689aed6022851"/>
+        </canvas>
+        <canvas name="3" width="183" height="190">
+          <vector name="origin" x="91" y="95"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="6ee40481205f9562f733ec7bde2d841b0ef551f4375a0764c523f43a1cdf0da9"/>
+        </canvas>
+        <canvas name="4" width="125" height="118">
+          <vector name="origin" x="62" y="59"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="53f010a10ce309a7f5d21259a86a2764f876a41f4d71b296497f6f98544a7efd"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1920"/>
+    </imgdir>
+    <canvas name="0" width="196" height="193">
+      <vector name="origin" x="89" y="185"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="a79760470787833c345ed030e861d371bfc98fee59ecfaf5c4ea0693ee9655cb"/>
+    </canvas>
+    <canvas name="1" width="196" height="194">
+      <vector name="origin" x="89" y="208"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="a872a786293da41c92db4fd28fee9526a973d17504fcba08e522d5b9112b9e6f"/>
+    </canvas>
+    <canvas name="2" width="196" height="193">
+      <vector name="origin" x="89" y="212"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="8af3419110e62ebcf50e11ba92e0e75b00360dd0fcdc9e3a7a811f67f12b8b2b"/>
+    </canvas>
+    <canvas name="3" width="394" height="290">
+      <vector name="origin" x="211" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-81" y="-175"/>
+      <vector name="rb" x="101" y="-28"/>
+      <string name="_hash" value="fae816367fb7d68fa46976a01b0b2a90c1a4b5087dc671632482ad5d8cc1b784"/>
+    </canvas>
+    <canvas name="4" width="385" height="280">
+      <vector name="origin" x="207" y="274"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="090ceb9e8278e32f36a6d4c58005cb7420f32177eb4f2a4e28700bdcf560af5c"/>
+    </canvas>
+    <canvas name="5" width="362" height="260">
+      <vector name="origin" x="195" y="264"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="7773304bbfd0645c946f3818588e9c2fad40903928e5d515a47e8f2158849673"/>
+    </canvas>
+    <canvas name="6" width="201" height="182">
+      <vector name="origin" x="95" y="222"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="ff951bbb84e527c5d3f2c14381c01fbda4f71e479514326ae04f94a73702e0fe"/>
+    </canvas>
+    <canvas name="7" width="199" height="183">
+      <vector name="origin" x="92" y="218"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="9c6d73dc138e9fdabeeb9421397491e8b6d75e809555001862a920c6e07c49a3"/>
+    </canvas>
+    <canvas name="8" width="190" height="176">
+      <vector name="origin" x="89" y="215"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="e79175d8bb0431e5af92097e0bbed53fc33ffe9718ada7fbbf1b1d6e21c371cd"/>
+    </canvas>
+    <canvas name="9" width="181" height="165">
+      <vector name="origin" x="87" y="213"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-4" y="-172"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="91" y="-52"/>
+      <string name="_hash" value="d9a0fd8f01dadf112bade5f12c183fbb6dbe97717938a53add9da2083d4f5036"/>
+    </canvas>
+    <canvas name="10" width="1" height="1">
+      <vector name="origin" x="0" y="-1"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="394" height="290">
+      <vector name="origin" x="213" y="330"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="84e520166895fc4810530c4caab159231e5c1119905a78cd0aba5cf3866f741a"/>
+    </canvas>
+    <canvas name="12" width="304" height="217">
+      <vector name="origin" x="165" y="289"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="76f064d25d2a7bac2bacdebaaf884baf83ad8c0e6b7454d2e99c2130e4fe64a4"/>
+    </canvas>
+    <canvas name="13" width="278" height="193">
+      <vector name="origin" x="139" y="277"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="b09268b9631049d8e06b7f0a2d277ae613e630723591e98ff18e02a546f95de2"/>
+    </canvas>
+    <canvas name="14" width="276" height="193">
+      <vector name="origin" x="138" y="279"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="308d00825addf25b8c031da29cdcea3754077e6411fc83224ee8d4ef71c43409"/>
+    </canvas>
+    <canvas name="15" width="198" height="193">
+      <vector name="origin" x="91" y="281"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-9" y="-205"/>
+      <vector name="lt" x="-86" y="-210"/>
+      <vector name="rb" x="84" y="-88"/>
+      <string name="_hash" value="e87b46b78957d44a624c9decc23a053fbf2ea2af5881c50a547543d63bc0de93"/>
+    </canvas>
+    <canvas name="16" width="1171" height="293">
+      <vector name="origin" x="580" y="247"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="120"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <string name="_hash" value="45b5e536f5213f312e54946008fb535a5cbbe43892aa8fdd810954f6005c70fc"/>
+    </canvas>
+    <canvas name="17" width="1189" height="283">
+      <vector name="origin" x="589" y="238"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1ae4b7dcb55cd2a0574e8bf712d2bfe3d4cae25368639e9a96281f01b94151e0"/>
+    </canvas>
+    <canvas name="18" width="1192" height="222">
+      <vector name="origin" x="591" y="182"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e15595dd07d247c539f19ed8557a028ae80d04159782cbc34255b7713a9724c2"/>
+    </canvas>
+    <canvas name="19" width="1199" height="221">
+      <vector name="origin" x="594" y="184"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="be936249e6c16c13180ea19b769daab53c724731e851583479dab3a6e08c4b6d"/>
+    </canvas>
+    <canvas name="20" width="1199" height="193">
+      <vector name="origin" x="595" y="156"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="-4"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b91e4107908aa9d9215856c9cd3ca3d42d7fdb6ba627865e17f2ac5ba2f3ec43"/>
+    </canvas>
+    <canvas name="21" width="1195" height="193">
+      <vector name="origin" x="592" y="156"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-5" y="-80"/>
+      <vector name="lt" x="-116" y="-135"/>
+      <vector name="rb" x="128" y="15"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1c2e58f311b27eb7ffb65051f54ba7c9e59b6d1fe370e057752afee8e39ea03a"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="20" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="8" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/>
+    </canvas>
+    <canvas name="9" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/>
+    </canvas>
+    <canvas name="10" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/>
+    </canvas>
+    <canvas name="11" width="196" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/>
+    </canvas>
+    <canvas name="12" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/>
+    </canvas>
+    <canvas name="13" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/>
+    </canvas>
+    <canvas name="14" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f2b1eb2b88b053721807e0d194e5b55f1b846b5a4b6e11939b92839ec267967e"/>
+    </canvas>
+    <canvas name="15" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="09afd8d8cf124fb4db9f0fec591e6a074ce56eacfae17b8135982d3dec438343"/>
+    </canvas>
+    <canvas name="16" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="2ad898a1542d67c7969aa86fc1c9882bd40dd32a60625b28a3b016346e1e2b38"/>
+    </canvas>
+    <canvas name="17" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="065bae5b5906dd8921a4e04933afa7f9535d191d86be631af646eac30f4cad82"/>
+    </canvas>
+    <canvas name="18" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c6c3f56700e80cf51e3339a72040262411ec5986573968da20513049bd4707bd"/>
+    </canvas>
+    <canvas name="19" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="3297db2c984ffaa1befe4f0177259104027a50eeae88aa5472a5060efbe3f255"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prop" value="100"/>
+      <string name="0" value="Tremble before this power!"/>
+    </imgdir>
+    <canvas name="7" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="3" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="f96ec13af373d98857d7a2ac6e20334e71a95bbca1991c45ae9bdc1c46614c10"/>
+    </canvas>
+    <canvas name="4" width="196" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c48215a404a59c48860c43cd4671a3d2e2bb7903567de5d1bd364d47183deb4c"/>
+    </canvas>
+    <canvas name="5" width="196" height="198">
+      <vector name="origin" x="89" y="189"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e591c999fe5f0159242bd4392da827ac567f5d2a369b900e57fa1f99851ab0f3"/>
+    </canvas>
+    <canvas name="6" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="bfed43c5a7170c7e9ca01dda837ae7a572b53eb31f2af99608318bc186b4d1d4"/>
+    </canvas>
+    <canvas name="0" width="196" height="198">
+      <vector name="origin" x="89" y="190"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="585142b19fdd94c363f9c31926e7ee60de021074f5831cf1f8861ed3968b049c"/>
+    </canvas>
+    <canvas name="1" width="196" height="198">
+      <vector name="origin" x="89" y="191"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="eb0a31758682ad10cd4f679e59b90da28b85c3b930bcbb40cd323455de9b4f43"/>
+    </canvas>
+    <canvas name="2" width="196" height="198">
+      <vector name="origin" x="89" y="192"/>
+      <vector name="head" x="-8" y="-125"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="54776ba034f509ac4815c9eb90a4ecfad10da6635b30645039a1a4e9cec8c7a7"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="196" height="199">
+      <vector name="origin" x="90" y="190"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1d0aac14b0085e2ec724af30e7ceeb5ff32ef5c9e2de6922614e262e656e514b"/>
+    </canvas>
+    <canvas name="1" width="196" height="205">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0270f3a6f9ceb6a83bce4ef665f0e03882a29be3faa0d4033b535baf2dd3756c"/>
+    </canvas>
+    <canvas name="2" width="196" height="213">
+      <vector name="origin" x="89" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0d0cf54e86e131e21d9f127146d0184889794fd198db889de8157c6c2efb5f3a"/>
+    </canvas>
+    <canvas name="3" width="196" height="215">
+      <vector name="origin" x="89" y="191"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="982b9d39aa44f124d59dd5fac3014606b9cb5c3b59a98170605a9ac9e86f4bad"/>
+    </canvas>
+    <canvas name="4" width="197" height="218">
+      <vector name="origin" x="90" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c3e340e338054e1adece96d3ba11a501ee729046720b245c7020c22d7a222f4c"/>
+    </canvas>
+    <canvas name="5" width="198" height="220">
+      <vector name="origin" x="91" y="192"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="af7f589835fd13d6b275c4cc1fe972c93d02207c7756cb4e581e41439ffa64ae"/>
+    </canvas>
+    <canvas name="6" width="197" height="214">
+      <vector name="origin" x="90" y="206"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="1fe9c11f660642b36f07af486afbd56c2a2bc46edd912b7adb9ea0d6c9b70cbb"/>
+    </canvas>
+    <canvas name="7" width="197" height="210">
+      <vector name="origin" x="89" y="202"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="400852cbca5268b0c396c6d5461fa99fa8d138d57ff64b3e6050e63f8e201151"/>
+    </canvas>
+    <canvas name="8" width="204" height="203">
+      <vector name="origin" x="89" y="195"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="0a6937e946fd7494552cb09f1965afbd21e75b91d71fb16568211e09fde987c6"/>
+    </canvas>
+    <canvas name="9" width="204" height="202">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="e0efca09df704285e1cc5a59ad460c7cf3def9cc752c6f28e875106da8e6632a"/>
+    </canvas>
+    <canvas name="10" width="198" height="202">
+      <vector name="origin" x="89" y="194"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="55eb33f9d5a8cabbc0ac37018e219811d6cbda349e3a81ed955236858876c60c"/>
+    </canvas>
+    <canvas name="11" width="199" height="204">
+      <vector name="origin" x="89" y="196"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="c15a1b7a495533fbcc44b93ba70bc0e492c7e7f7427e326317f66e610412f72a"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack7">
+    <canvas name="12" width="196" height="392">
+      <vector name="origin" x="89" y="392"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/>
+    </canvas>
+    <canvas name="13" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="2" width="197" height="378">
+      <vector name="origin" x="90" y="380"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86893292f87ad179cf8e47634df1bdbcfa0d2e425ba7c7899ddee73317a94fa8"/>
+    </canvas>
+    <canvas name="15" width="196" height="393">
+      <vector name="origin" x="89" y="394"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/>
+    </canvas>
+    <canvas name="16" width="196" height="362">
+      <vector name="origin" x="89" y="362"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/>
+    </canvas>
+    <canvas name="17" width="196" height="389">
+      <vector name="origin" x="89" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/>
+    </canvas>
+    <canvas name="6" width="197" height="407">
+      <vector name="origin" x="90" y="407"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="eadebb118bef62fb27cca7c5d83c9981cfea514dc7364f4f3eef5ce23bfd8c6c"/>
+    </canvas>
+    <canvas name="7" width="196" height="412">
+      <vector name="origin" x="89" y="413"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="88ff94607cac27e1e7f91cfab14280d57726d3b88c18e62e641f6d9cb1d83e4f"/>
+    </canvas>
+    <canvas name="8" width="196" height="405">
+      <vector name="origin" x="89" y="407"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="7f87b481fab16131725a601b2d643cf86c8c0602dc21a4848a66c424a41a980b"/>
+    </canvas>
+    <canvas name="9" width="196" height="392">
+      <vector name="origin" x="89" y="393"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="d8cfbd754bee92b4b8b2c44f4219d8669079eff901edfcd6d7b8f4983d807528"/>
+    </canvas>
+    <canvas name="10" width="197" height="388">
+      <vector name="origin" x="90" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="b85da2f8c68b4183c71b3bb528f62ee9d0e1de070b7c2a9b514a9d6535519156"/>
+    </canvas>
+    <canvas name="11" width="196" height="412">
+      <vector name="origin" x="89" y="411"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="a6bdf2a3dee1a24bafac31bbfbf31e885766650cf02d46bd53ea9e7884945551"/>
+    </canvas>
+    <imgdir name="info">
+      <imgdir name="hit">
+        <canvas name="1" width="176" height="192">
+          <vector name="origin" x="88" y="96"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="24297c65bd86f268e84f9da30bb28f28f6b3929df83c83ef4589743860586205"/>
+        </canvas>
+        <canvas name="2" width="165" height="192">
+          <vector name="origin" x="82" y="96"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="8ee5c4999ed66f77eec4a6891728d0caae27aab78b95d7c394b46b2dd7503c0e"/>
+        </canvas>
+        <canvas name="3" width="163" height="135">
+          <vector name="origin" x="81" y="67"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="710dd428dfead84cb3e570011283888350bc3cb4198c2276689f16c58a0159e8"/>
+        </canvas>
+        <canvas name="4" width="141" height="133">
+          <vector name="origin" x="70" y="66"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="2037b1d2981b15bc1694bd5f572014e17c6753082e8b6c109cfa4a4be7b752b7"/>
+        </canvas>
+        <canvas name="5" width="145" height="140">
+          <vector name="origin" x="72" y="70"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="65833d06e578de7367829fb27cdc203a3cec2d049cad8a50bbfa6bc4b11fa2c0"/>
+        </canvas>
+        <canvas name="6" width="149" height="152">
+          <vector name="origin" x="74" y="76"/>
+          <int name="z" value="0"/>
+          <string name="_hash" value="854a7c1bcea63d31cce503d0be743a3e307cf39768b30f4fa0330c0c627ecd51"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="range">
+        <vector name="lt" x="-680" y="-1147"/>
+        <vector name="rb" x="680" y="99"/>
+      </imgdir>
+      <int name="attackAfter" value="1920"/>
+    </imgdir>
+    <canvas name="0" width="196" height="392">
+      <vector name="origin" x="89" y="392"/>
+      <vector name="head" x="-14" y="-109"/>
+      <vector name="lt" x="-88" y="-183"/>
+      <vector name="rb" x="108" y="8"/>
+      <string name="_hash" value="32eaf30ba315696cc8ee1e369b454d950e14d488f3c04801f2c1427075a23fb2"/>
+    </canvas>
+    <canvas name="14" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="1" width="196" height="405">
+      <vector name="origin" x="89" y="406"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="86e482bb6738dd51a43ef1d11825be2bb7fff2de4e8fbf1659f3a30691b0f998"/>
+    </canvas>
+    <canvas name="3" width="196" height="393">
+      <vector name="origin" x="89" y="394"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="1e3385ff8a219ca0afdc2fe279fe330bd5daa42999c926ca06de6895badf7df9"/>
+    </canvas>
+    <canvas name="4" width="196" height="362">
+      <vector name="origin" x="89" y="362"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="9df867597e612756cf403e5e8e7ac8d3230b2b7617c4787fb752cba379d7839e"/>
+    </canvas>
+    <canvas name="5" width="196" height="389">
+      <vector name="origin" x="89" y="388"/>
+      <int name="z" value="0"/>
+      <vector name="head" x="-14" y="-208"/>
+      <vector name="lt" x="-88" y="-282"/>
+      <vector name="rb" x="108" y="-91"/>
+      <string name="_hash" value="3351899fcf8940b9c87a1fd907a57df9017d88fcee34de94bd3fff29c2093049"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/9700035.img.xml
+++ b/gms-server/wz/Mob.wz/9700035.img.xml
@@ -50,12 +50,12 @@
       <imgdir name="0">
         <int name="hp" value="700000"/>
         <int name="prob" value="100"/>
-        <string name="0" value="침입자 녀석들! 전부 수장 시켜 주마."/>
+        <string name="0" value="Intruders! I will sink every last one of you."/>
       </imgdir>
       <imgdir name="1">
         <int name="hp" value="350000"/>
         <int name="prob" value="100"/>
-        <string name="0" value="나를 우습게 보지마라! 나는 이 배의 일등항해사다!"/>
+        <string name="0" value="Do not underestimate me! I am the first mate of this ship!"/>
       </imgdir>
     </imgdir>
   </imgdir>
@@ -350,7 +350,7 @@
     </canvas>
     <imgdir name="speak">
       <int name="prob" value="100"/>
-      <string name="0" value="하...함장...니..임...  죄송합니..다. 크윽"/>
+      <string name="0" value="C-Captain... I am sorry... Ugh."/>
     </imgdir>
   </imgdir>
   <imgdir name="attack1">
@@ -1023,7 +1023,7 @@
     </canvas>
     <imgdir name="speak">
       <int name="prob" value="100"/>
-      <string name="0" value="모두 나와서 침입자들을 물리쳐라. 명령이다!"/>
+      <string name="0" value="All hands, repel the intruders. That is an order!"/>
     </imgdir>
   </imgdir>
   <imgdir name="skill2">

--- a/gms-server/wz/Mob.wz/9700037.img.xml
+++ b/gms-server/wz/Mob.wz/9700037.img.xml
@@ -57,17 +57,17 @@
       <imgdir name="0">
         <int name="hp" value="3900000"/>
         <int name="prob" value="100"/>
-        <string name="0" value="겁도 없이 잘도 기어 들어왔구나! 모두 죽어라!!"/>
+        <string name="0" value="You dared to crawl in here without fear! Die, all of you!"/>
       </imgdir>
       <imgdir name="1">
         <int name="hp" value="2000000"/>
         <int name="prob" value="100"/>
-        <string name="0" value="해군의 명예를 걸고 무찔러 주마."/>
+        <string name="0" value="On the honor of the navy, I will defeat you."/>
       </imgdir>
       <imgdir name="2">
         <int name="hp" value="800000"/>
         <int name="prob" value="100"/>
-        <string name="0" value="이정도론 어림없다. 이녀석들."/>
+        <string name="0" value="That will not be enough, you fools."/>
       </imgdir>
     </imgdir>
   </imgdir>
@@ -309,7 +309,7 @@
     </canvas>
     <imgdir name="speak">
       <int name="prob" value="100"/>
-      <string name="0" value="이런 애송들에게 내가 당하다니.. 으윽.."/>
+      <string name="0" value="To think I would fall to brats like you... Ugh..."/>
     </imgdir>
   </imgdir>
   <imgdir name="attack1">
@@ -1142,7 +1142,7 @@
     </canvas>
     <imgdir name="speak">
       <int name="prob" value="100"/>
-      <string name="0" value="나의 충성스런 부하들이여. 침입자들을 해치워라!"/>
+      <string name="0" value="My loyal crew, dispose of the intruders!"/>
     </imgdir>
   </imgdir>
   <imgdir name="skill2">
@@ -1281,7 +1281,7 @@
     </canvas>
     <imgdir name="speak">
       <int name="prob" value="50"/>
-      <string name="0" value="해군의 명예를 위하여!!"/>
+      <string name="0" value="For the honor of the navy!"/>
     </imgdir>
   </imgdir>
 </imgdir>

--- a/gms-server/wz/Mob.wz/9870021.img.xml
+++ b/gms-server/wz/Mob.wz/9870021.img.xml
@@ -1,1 +1,243 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="9870021.img"><imgdir name="die1"><canvas name="1" width="166" height="158"><vector name="origin" x="47" y="164"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="b26777da6c3034c9942e547982413ab692840a464cdd87ad7d7edbd0ebef7137"/></canvas><canvas name="2" width="171" height="155"><vector name="origin" x="50" y="159"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="b8965faf42dd7b2265ebc66aa9653d20c1954380a0f46cbaf4dc1db6ff189d9f"/></canvas><canvas name="3" width="144" height="156"><vector name="origin" x="22" y="154"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="1502de3498911657ca624ebb31873328547accf2096709fcd972f8c049c581e0"/></canvas><canvas name="4" width="144" height="149"><vector name="origin" x="20" y="147"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="2b6f88b0cb03c60280d3d06de4e247ff42fef30829482d780566c85cd9347d37"/></canvas><canvas name="5" width="144" height="147"><vector name="origin" x="19" y="143"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="b59c3fd08bc9f91743acefb1006d89663d75d394b5de89223ac4d549cf60d94b"/></canvas><canvas name="6" width="146" height="147"><vector name="origin" x="20" y="141"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="549e94cafe4e7117d27e54b22a636cc819f214e3719b274a6aeac8a188f0c539"/></canvas><canvas name="7" width="146" height="147"><vector name="origin" x="19" y="140"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="5a9ae39c7eceb5f1d8237c9be6c4b508130c535d79d8ee395db61e9e04dbe336"/></canvas><canvas name="8" width="143" height="26"><vector name="origin" x="21" y="34"/><int name="z" value="0"/><int name="delay" value="150"/><string name="_hash" value="654c14afdcbac94c5057376d590416bfae55ccb08fd0afa1f473052550e90331"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="我再次回到過去了嗎…"/><int name="delay" value="150"/></imgdir><canvas name="0" width="166" height="169"><vector name="origin" x="72" y="173"/><vector name="lt" x="-67" y="-165"/><vector name="rb" x="86" y="-8"/><vector name="head" x="4" y="-157"/><int name="delay" value="600"/><string name="_hash" value="27a3ca5e517757897fd06982f851139a189109dc0d30cc4bf4c13c99e93810a3"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="166" height="169"><vector name="origin" x="72" y="173"/><vector name="lt" x="-67" y="-165"/><vector name="rb" x="86" y="-8"/><vector name="head" x="4" y="-157"/><int name="delay" value="300"/><string name="_hash" value="27a3ca5e517757897fd06982f851139a189109dc0d30cc4bf4c13c99e93810a3"/></canvas></imgdir><imgdir name="move"><canvas name="0" width="146" height="146"><vector name="origin" x="70" y="148"/><vector name="lt" x="-71" y="-149"/><vector name="rb" x="76" y="-3"/><vector name="head" x="-4" y="-149"/><int name="delay" value="120"/><string name="_hash" value="7a884eb3f27f8be4f1ec9c2e374dac979db11a885f6f713ae319d9eaa69355c2"/></canvas><canvas name="1" width="144" height="147"><vector name="origin" x="69" y="149"/><vector name="lt" x="-71" y="-151"/><vector name="rb" x="74" y="-6"/><vector name="head" x="-4" y="-149"/><int name="delay" value="120"/><string name="_hash" value="24f9c88990290a82f0f24b0178db8b8fddbe0714b8c03904507a9cf8d81b3a2a"/></canvas><canvas name="2" width="144" height="145"><vector name="origin" x="70" y="150"/><vector name="lt" x="-71" y="-151"/><vector name="rb" x="74" y="-7"/><vector name="head" x="-5" y="-150"/><int name="delay" value="120"/><string name="_hash" value="bfffdf22371253aac17d4191f4c7e354573b239120a3f6971995be20bfc1fe79"/></canvas><canvas name="3" width="144" height="145"><vector name="origin" x="69" y="151"/><vector name="lt" x="-71" y="-152"/><vector name="rb" x="75" y="-7"/><vector name="head" x="-4" y="-151"/><int name="delay" value="120"/><string name="_hash" value="ae5e37c17237542c9063a8e314f506e999e5f2babff963ac449f0d428111575b"/></canvas><canvas name="4" width="144" height="146"><vector name="origin" x="68" y="150"/><vector name="lt" x="-71" y="-151"/><vector name="rb" x="76" y="-4"/><vector name="head" x="-3" y="-150"/><int name="delay" value="120"/><string name="_hash" value="6fdbb127966dd276d5c9bda2f88f77d84247db4e209cb815d84839bb5e8f4475"/></canvas><canvas name="5" width="146" height="147"><vector name="origin" x="69" y="149"/><vector name="lt" x="-70" y="-150"/><vector name="rb" x="77" y="-2"/><vector name="head" x="-2" y="-149"/><int name="delay" value="120"/><string name="_hash" value="4653e6c866b2b9963981aaa8598307bf90a0366ee6f6885038b22e6102f22f9b"/></canvas></imgdir><imgdir name="stand"><canvas name="0" width="146" height="145"><vector name="origin" x="70" y="148"/><vector name="lt" x="-71" y="-149"/><vector name="rb" x="76" y="-3"/><vector name="head" x="-4" y="-149"/><int name="delay" value="120"/><string name="_hash" value="183b2363968d901509b6096e827bbe753e17f7084cb1dea644ac4274faa7fb96"/></canvas><canvas name="1" width="145" height="144"><vector name="origin" x="70" y="149"/><vector name="lt" x="-71" y="-151"/><vector name="rb" x="74" y="-6"/><vector name="head" x="-4" y="-149"/><int name="delay" value="120"/><string name="_hash" value="b665edc222a07c0e984555d1aad9c50d8d1110ed9837fd9dbcbdeb91f8f0b064"/></canvas><canvas name="2" width="144" height="143"><vector name="origin" x="70" y="150"/><vector name="lt" x="-71" y="-151"/><vector name="rb" x="74" y="-7"/><vector name="head" x="-4" y="-150"/><int name="delay" value="120"/><string name="_hash" value="da18fdbfa1972cb4b243f964dd9723f4b0f6b9fb128c3efea899f7eb15318a5e"/></canvas><canvas name="3" width="145" height="145"><vector name="origin" x="70" y="151"/><vector name="lt" x="-71" y="-152"/><vector name="rb" x="75" y="-7"/><vector name="head" x="-4" y="-151"/><int name="delay" value="120"/><string name="_hash" value="e0f3a13bc0a0ab0b84bf934868c5e2859a5ecb4e0e1d47f87af7daa5c850cc57"/></canvas><canvas name="4" width="146" height="146"><vector name="origin" x="70" y="150"/><vector name="lt" x="-71" y="-151"/><vector name="rb" x="76" y="-4"/><vector name="head" x="-4" y="-150"/><int name="delay" value="120"/><string name="_hash" value="56e11d8d8eb97a38e8a48b33f826276e85884c76d4d05bff7ba433101cf9e1a5"/></canvas><canvas name="5" width="147" height="147"><vector name="origin" x="70" y="149"/><vector name="lt" x="-70" y="-150"/><vector name="rb" x="77" y="-2"/><vector name="head" x="-2" y="-149"/><int name="delay" value="120"/><string name="_hash" value="66de9c6269e1f78ac7d7b7c9a6cecb38ede6b53090b85d92bf3b1af318dde187"/></canvas><canvas name="6" width="146" height="145"><vector name="origin" x="70" y="148"/><vector name="lt" x="-71" y="-149"/><vector name="rb" x="76" y="-3"/><vector name="head" x="-4" y="-149"/><int name="delay" value="120"/><string name="_hash" value="233587ff2cd16883a78e4f19a4fa23b7145ba280ddf949efa7f5973279bf026b"/></canvas><canvas name="7" width="145" height="144"><vector name="origin" x="70" y="149"/><vector name="lt" x="-71" y="-151"/><vector name="rb" x="75" y="-5"/><vector name="head" x="-4" y="-149"/><int name="delay" value="120"/><string name="_inlink" value="stand/1"/></canvas><canvas name="8" width="144" height="143"><vector name="origin" x="70" y="150"/><vector name="lt" x="-70" y="-151"/><vector name="rb" x="74" y="-7"/><vector name="head" x="-4" y="-150"/><int name="delay" value="120"/><string name="_hash" value="4da2e35cfe01442d1a155582211fe0d041604f62ee283f0ad0877c8c730be144"/></canvas><canvas name="9" width="145" height="145"><vector name="origin" x="70" y="151"/><vector name="lt" x="-70" y="-152"/><vector name="rb" x="75" y="-6"/><vector name="head" x="-5" y="-152"/><int name="delay" value="120"/><string name="_hash" value="c00dbb6944442e8294c17c0f6fcf4b9abcfcfdff88de229273416064d6707885"/></canvas><canvas name="10" width="146" height="146"><vector name="origin" x="70" y="150"/><vector name="lt" x="-71" y="-150"/><vector name="rb" x="76" y="-5"/><vector name="head" x="-3" y="-150"/><int name="delay" value="120"/><string name="_hash" value="cd33cfe80f0124b2bfdd9971e7f97287857ed76fa4f2fd6f08540e674c14b81c"/></canvas><canvas name="11" width="147" height="147"><vector name="origin" x="70" y="149"/><vector name="lt" x="-70" y="-151"/><vector name="rb" x="77" y="-2"/><vector name="head" x="-3" y="-149"/><int name="delay" value="120"/><string name="_hash" value="4c951eb97ca6259343a056f5f02495cf6cbee1a452818f1a84bd8913c1fd5fe2"/></canvas></imgdir><imgdir name="info"><int name="bodyAttack" value="1"/><int name="level" value="41"/><int name="maxHP" value="20500"/><int name="maxMP" value="50"/><int name="speed" value="-15"/><int name="PADamage" value="125"/><int name="PDDamage" value="130"/><int name="MADamage" value="142"/><int name="MDDamage" value="160"/><int name="acc" value="145"/><int name="eva" value="22"/><int name="exp" value="2050"/><int name="undead" value="1"/><int name="pushed" value="0"/><float name="fs" value="10.0"/><int name="summonType" value="1"/><int name="mobType" value="5"/></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9870021.img">
+  <imgdir name="die1">
+    <canvas name="1" width="166" height="158">
+      <vector name="origin" x="47" y="164"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="b26777da6c3034c9942e547982413ab692840a464cdd87ad7d7edbd0ebef7137"/>
+    </canvas>
+    <canvas name="2" width="171" height="155">
+      <vector name="origin" x="50" y="159"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="b8965faf42dd7b2265ebc66aa9653d20c1954380a0f46cbaf4dc1db6ff189d9f"/>
+    </canvas>
+    <canvas name="3" width="144" height="156">
+      <vector name="origin" x="22" y="154"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="1502de3498911657ca624ebb31873328547accf2096709fcd972f8c049c581e0"/>
+    </canvas>
+    <canvas name="4" width="144" height="149">
+      <vector name="origin" x="20" y="147"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="2b6f88b0cb03c60280d3d06de4e247ff42fef30829482d780566c85cd9347d37"/>
+    </canvas>
+    <canvas name="5" width="144" height="147">
+      <vector name="origin" x="19" y="143"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="b59c3fd08bc9f91743acefb1006d89663d75d394b5de89223ac4d549cf60d94b"/>
+    </canvas>
+    <canvas name="6" width="146" height="147">
+      <vector name="origin" x="20" y="141"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="549e94cafe4e7117d27e54b22a636cc819f214e3719b274a6aeac8a188f0c539"/>
+    </canvas>
+    <canvas name="7" width="146" height="147">
+      <vector name="origin" x="19" y="140"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="5a9ae39c7eceb5f1d8237c9be6c4b508130c535d79d8ee395db61e9e04dbe336"/>
+    </canvas>
+    <canvas name="8" width="143" height="26">
+      <vector name="origin" x="21" y="34"/>
+      <int name="z" value="0"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="654c14afdcbac94c5057376d590416bfae55ccb08fd0afa1f473052550e90331"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Am I going back to the past again..."/>
+      <int name="delay" value="150"/>
+    </imgdir>
+    <canvas name="0" width="166" height="169">
+      <vector name="origin" x="72" y="173"/>
+      <vector name="lt" x="-67" y="-165"/>
+      <vector name="rb" x="86" y="-8"/>
+      <vector name="head" x="4" y="-157"/>
+      <int name="delay" value="600"/>
+      <string name="_hash" value="27a3ca5e517757897fd06982f851139a189109dc0d30cc4bf4c13c99e93810a3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="166" height="169">
+      <vector name="origin" x="72" y="173"/>
+      <vector name="lt" x="-67" y="-165"/>
+      <vector name="rb" x="86" y="-8"/>
+      <vector name="head" x="4" y="-157"/>
+      <int name="delay" value="300"/>
+      <string name="_hash" value="27a3ca5e517757897fd06982f851139a189109dc0d30cc4bf4c13c99e93810a3"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="146" height="146">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7a884eb3f27f8be4f1ec9c2e374dac979db11a885f6f713ae319d9eaa69355c2"/>
+    </canvas>
+    <canvas name="1" width="144" height="147">
+      <vector name="origin" x="69" y="149"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-6"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="24f9c88990290a82f0f24b0178db8b8fddbe0714b8c03904507a9cf8d81b3a2a"/>
+    </canvas>
+    <canvas name="2" width="144" height="145">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="-5" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bfffdf22371253aac17d4191f4c7e354573b239120a3f6971995be20bfc1fe79"/>
+    </canvas>
+    <canvas name="3" width="144" height="145">
+      <vector name="origin" x="69" y="151"/>
+      <vector name="lt" x="-71" y="-152"/>
+      <vector name="rb" x="75" y="-7"/>
+      <vector name="head" x="-4" y="-151"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ae5e37c17237542c9063a8e314f506e999e5f2babff963ac449f0d428111575b"/>
+    </canvas>
+    <canvas name="4" width="144" height="146">
+      <vector name="origin" x="68" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="76" y="-4"/>
+      <vector name="head" x="-3" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6fdbb127966dd276d5c9bda2f88f77d84247db4e209cb815d84839bb5e8f4475"/>
+    </canvas>
+    <canvas name="5" width="146" height="147">
+      <vector name="origin" x="69" y="149"/>
+      <vector name="lt" x="-70" y="-150"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="-2" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4653e6c866b2b9963981aaa8598307bf90a0366ee6f6885038b22e6102f22f9b"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="146" height="145">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="183b2363968d901509b6096e827bbe753e17f7084cb1dea644ac4274faa7fb96"/>
+    </canvas>
+    <canvas name="1" width="145" height="144">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-6"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="b665edc222a07c0e984555d1aad9c50d8d1110ed9837fd9dbcbdeb91f8f0b064"/>
+    </canvas>
+    <canvas name="2" width="144" height="143">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="-4" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="da18fdbfa1972cb4b243f964dd9723f4b0f6b9fb128c3efea899f7eb15318a5e"/>
+    </canvas>
+    <canvas name="3" width="145" height="145">
+      <vector name="origin" x="70" y="151"/>
+      <vector name="lt" x="-71" y="-152"/>
+      <vector name="rb" x="75" y="-7"/>
+      <vector name="head" x="-4" y="-151"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="e0f3a13bc0a0ab0b84bf934868c5e2859a5ecb4e0e1d47f87af7daa5c850cc57"/>
+    </canvas>
+    <canvas name="4" width="146" height="146">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="76" y="-4"/>
+      <vector name="head" x="-4" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="56e11d8d8eb97a38e8a48b33f826276e85884c76d4d05bff7ba433101cf9e1a5"/>
+    </canvas>
+    <canvas name="5" width="147" height="147">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-70" y="-150"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="-2" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="66de9c6269e1f78ac7d7b7c9a6cecb38ede6b53090b85d92bf3b1af318dde187"/>
+    </canvas>
+    <canvas name="6" width="146" height="145">
+      <vector name="origin" x="70" y="148"/>
+      <vector name="lt" x="-71" y="-149"/>
+      <vector name="rb" x="76" y="-3"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="233587ff2cd16883a78e4f19a4fa23b7145ba280ddf949efa7f5973279bf026b"/>
+    </canvas>
+    <canvas name="7" width="145" height="144">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-71" y="-151"/>
+      <vector name="rb" x="75" y="-5"/>
+      <vector name="head" x="-4" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_inlink" value="stand/1"/>
+    </canvas>
+    <canvas name="8" width="144" height="143">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-70" y="-151"/>
+      <vector name="rb" x="74" y="-7"/>
+      <vector name="head" x="-4" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4da2e35cfe01442d1a155582211fe0d041604f62ee283f0ad0877c8c730be144"/>
+    </canvas>
+    <canvas name="9" width="145" height="145">
+      <vector name="origin" x="70" y="151"/>
+      <vector name="lt" x="-70" y="-152"/>
+      <vector name="rb" x="75" y="-6"/>
+      <vector name="head" x="-5" y="-152"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c00dbb6944442e8294c17c0f6fcf4b9abcfcfdff88de229273416064d6707885"/>
+    </canvas>
+    <canvas name="10" width="146" height="146">
+      <vector name="origin" x="70" y="150"/>
+      <vector name="lt" x="-71" y="-150"/>
+      <vector name="rb" x="76" y="-5"/>
+      <vector name="head" x="-3" y="-150"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="cd33cfe80f0124b2bfdd9971e7f97287857ed76fa4f2fd6f08540e674c14b81c"/>
+    </canvas>
+    <canvas name="11" width="147" height="147">
+      <vector name="origin" x="70" y="149"/>
+      <vector name="lt" x="-70" y="-151"/>
+      <vector name="rb" x="77" y="-2"/>
+      <vector name="head" x="-3" y="-149"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="4c951eb97ca6259343a056f5f02495cf6cbee1a452818f1a84bd8913c1fd5fe2"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="41"/>
+    <int name="maxHP" value="20500"/>
+    <int name="maxMP" value="50"/>
+    <int name="speed" value="-15"/>
+    <int name="PADamage" value="125"/>
+    <int name="PDDamage" value="130"/>
+    <int name="MADamage" value="142"/>
+    <int name="MDDamage" value="160"/>
+    <int name="acc" value="145"/>
+    <int name="eva" value="22"/>
+    <int name="exp" value="2050"/>
+    <int name="undead" value="1"/>
+    <int name="pushed" value="0"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="mobType" value="5"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/9870040.img.xml
+++ b/gms-server/wz/Mob.wz/9870040.img.xml
@@ -1,1 +1,213 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="9870040.img"><imgdir name="stand"><canvas name="0" width="235" height="189"><vector name="origin" x="100" y="193"/><vector name="lt" x="-101" y="-179"/><vector name="rb" x="70" y="-5"/><vector name="head" x="-38" y="-211"/><int name="delay" value="120"/><string name="_hash" value="8a107e73ec7e11fcb01c001460a09f460cca4a0acd35f308e8eafdaeff9c5f04"/></canvas><canvas name="1" width="236" height="189"><vector name="origin" x="100" y="194"/><vector name="lt" x="-100" y="-179"/><vector name="rb" x="68" y="-5"/><vector name="head" x="-38" y="-211"/><int name="delay" value="120"/><string name="_hash" value="3423cee0d86daf8c9afae4733a912d1f93f3022b902852e4e7f4683b234bae9f"/></canvas><canvas name="2" width="238" height="190"><vector name="origin" x="100" y="196"/><vector name="lt" x="-99" y="-181"/><vector name="rb" x="63" y="-7"/><vector name="head" x="-38" y="-211"/><int name="delay" value="120"/><string name="_hash" value="3be8480d68cd8d0ed62d6e6340b60bd7c3fbc93bea017447e1f10aafce9e8b0f"/></canvas><canvas name="3" width="236" height="188"><vector name="origin" x="100" y="195"/><vector name="lt" x="-99" y="-182"/><vector name="rb" x="61" y="-7"/><vector name="head" x="-38" y="-211"/><int name="delay" value="120"/><string name="_hash" value="ad71d26de1e76ce0ec97641bee9cd92fbd9d57278b859822115361039d8bce63"/></canvas><canvas name="4" width="243" height="189"><vector name="origin" x="100" y="197"/><vector name="lt" x="-100" y="-183"/><vector name="rb" x="54" y="-8"/><vector name="head" x="-38" y="-211"/><int name="delay" value="120"/><string name="_hash" value="bc56e97fae2d7e35af7429aece3affe3d772961208e56c136c0f96b7acb9d133"/></canvas><canvas name="5" width="238" height="189"><vector name="origin" x="100" y="196"/><vector name="lt" x="-91" y="-162"/><vector name="rb" x="53" y="-7"/><vector name="head" x="-38" y="-211"/><int name="delay" value="120"/><string name="_hash" value="d6f4d38639881847fe802db199c1e618f1daf40f863843d4d78668199298d85e"/></canvas><canvas name="6" width="235" height="190"><vector name="origin" x="100" y="196"/><vector name="lt" x="-91" y="-162"/><vector name="rb" x="57" y="-6"/><vector name="head" x="-38" y="-211"/><int name="delay" value="120"/><string name="_hash" value="2acd20d4194bf5d25aac4e5b95b32ceb3abf1e3bf0b73f01872189f1b88fd1eb"/></canvas><canvas name="7" width="234" height="190"><vector name="origin" x="100" y="194"/><vector name="lt" x="-91" y="-162"/><vector name="rb" x="65" y="-4"/><vector name="head" x="-38" y="-211"/><int name="delay" value="120"/><string name="_hash" value="6b9942d14743f4151ec792754445ddbfe988b5376601c5fd987570d4de9f155f"/></canvas></imgdir><imgdir name="move"><canvas name="0" width="234" height="189"><vector name="origin" x="100" y="181"/><vector name="lt" x="-99" y="-162"/><vector name="rb" x="67" y="7"/><vector name="head" x="-38" y="-200"/><int name="delay" value="120"/><string name="_hash" value="c06e861c807754ad708b6b55640b1fd123dd77cb6c398b082957e6d128576b1c"/></canvas><canvas name="1" width="238" height="189"><vector name="origin" x="100" y="182"/><vector name="lt" x="-100" y="-162"/><vector name="rb" x="47" y="4"/><vector name="head" x="-38" y="-200"/><int name="delay" value="120"/><string name="_hash" value="9da781721d887b8d1092bc71b52b3e08b2cafa97f873939488f5f52e16ddadae"/></canvas><canvas name="2" width="233" height="188"><vector name="origin" x="100" y="187"/><vector name="lt" x="-100" y="-169"/><vector name="rb" x="45" y="-2"/><vector name="head" x="-38" y="-200"/><int name="delay" value="120"/><string name="_hash" value="1731a4f2972a30cc82a0665d1056841c17776c97d8e5c90b12f3d0851d3490c3"/></canvas><canvas name="3" width="228" height="184"><vector name="origin" x="100" y="189"/><vector name="lt" x="-99" y="-174"/><vector name="rb" x="39" y="-5"/><vector name="head" x="-38" y="-200"/><int name="delay" value="120"/><string name="_hash" value="39430d42783c17ba05f488f45484894d714f433cf82ee5e01365d3ca1af8eaf4"/></canvas><canvas name="4" width="223" height="187"><vector name="origin" x="100" y="189"/><vector name="lt" x="-100" y="-171"/><vector name="rb" x="49" y="-2"/><vector name="head" x="-38" y="-200"/><int name="delay" value="120"/><string name="_hash" value="fb8abe436d88ef793a421762ff6f01e59bddabf33d3e68e70c713637b51e73ab"/></canvas><canvas name="5" width="239" height="186"><vector name="origin" x="100" y="185"/><vector name="lt" x="-100" y="-173"/><vector name="rb" x="48" y="-2"/><vector name="head" x="-38" y="-200"/><int name="delay" value="120"/><string name="_hash" value="7f777db15697811e167f816b5cdc81ebb7245785237d5889dbebde8daa2f8cc5"/></canvas><canvas name="6" width="238" height="190"><vector name="origin" x="100" y="184"/><vector name="lt" x="-99" y="-170"/><vector name="rb" x="69" y="4"/><vector name="head" x="-38" y="-200"/><int name="delay" value="120"/><string name="_hash" value="7192773e89b450babd09450714fc4c2e48189c706354ae0d3327c74b1df3afa1"/></canvas><canvas name="7" width="239" height="182"><vector name="origin" x="100" y="181"/><vector name="lt" x="-100" y="-168"/><vector name="rb" x="68" y="-1"/><vector name="head" x="-38" y="-200"/><int name="delay" value="120"/><string name="_hash" value="77852d6b842889fb39e56fccf10bf905ac42795b9f54e700a2c683d035c33e98"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="264" height="184"><vector name="origin" x="96" y="219"/><vector name="lt" x="-75" y="-175"/><vector name="rb" x="56" y="-32"/><vector name="head" x="-26" y="-218"/><int name="delay" value="300"/><string name="_hash" value="1e4cb8ea951f5f8ae7f8202bd20f876ed07607d6d75199c54ba2198c305472f5"/></canvas></imgdir><imgdir name="die1"><canvas name="0" width="236" height="189"><vector name="origin" x="100" y="185"/><vector name="head" x="-26" y="-218"/><int name="delay" value="150"/><string name="_hash" value="f4fac2d31da7cb4e6ff236287e2210ab66df6e55e6979b937a97ebaeb65ab235"/></canvas><canvas name="1" width="264" height="184"><vector name="origin" x="96" y="219"/><vector name="head" x="-26" y="-218"/><int name="delay" value="150"/><string name="_hash" value="3ab7d8de5e9b87c3bcc4452a4cb65eece0bc208cb8e18f5a8aa236e2c5206578"/></canvas><canvas name="2" width="275" height="176"><vector name="origin" x="89" y="214"/><vector name="head" x="-26" y="-218"/><int name="delay" value="150"/><string name="_hash" value="5a27660c793791ec25f15128e1000ae51c427ab808a4cd5acb0c59286f1bfbd6"/></canvas><canvas name="3" width="281" height="162"><vector name="origin" x="90" y="195"/><vector name="head" x="-26" y="-218"/><int name="delay" value="150"/><string name="_hash" value="6849a8194c104c9dda266283676a28a293be262e49dee220b7f5abb268172d32"/></canvas><canvas name="4" width="264" height="162"><vector name="origin" x="63" y="190"/><vector name="head" x="-26" y="-218"/><int name="delay" value="150"/><string name="_hash" value="e6d2398db6a033bfc8248f3838aecaecaab5d7eadf7088007e39b3aa6ebd3463"/></canvas><canvas name="5" width="264" height="162"><vector name="origin" x="54" y="169"/><vector name="head" x="-26" y="-218"/><int name="delay" value="150"/><string name="_hash" value="83c27b29335bfe7dd095d4304ba0ae917a6c82e8d309723db36a57385cb25f6a"/></canvas><canvas name="6" width="267" height="162"><vector name="origin" x="53" y="145"/><vector name="head" x="-26" y="-218"/><int name="delay" value="150"/><string name="_hash" value="c2bac7d58283aa4693fa809b60774462100967b14e568686757e5c60546c5878"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="히잉, 또 혼나겠네..."/></imgdir></imgdir><imgdir name="info"><int name="bodyAttack" value="1"/><int name="level" value="97"/><int name="maxHP" value="490000"/><int name="maxMP" value="210"/><int name="speed" value="-70"/><int name="PADamage" value="445"/><int name="PDDamage" value="830"/><int name="MADamage" value="500"/><int name="MDDamage" value="550"/><int name="acc" value="203"/><int name="eva" value="37"/><int name="exp" value="49000"/><int name="undead" value="0"/><int name="pushed" value="4300"/><float name="fs" value="10.0"/><int name="summonType" value="1"/><string name="elemAttr" value="F2L2"/><int name="mobType" value="3"/></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9870040.img">
+  <imgdir name="stand">
+    <canvas name="0" width="235" height="189">
+      <vector name="origin" x="100" y="193"/>
+      <vector name="lt" x="-101" y="-179"/>
+      <vector name="rb" x="70" y="-5"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="8a107e73ec7e11fcb01c001460a09f460cca4a0acd35f308e8eafdaeff9c5f04"/>
+    </canvas>
+    <canvas name="1" width="236" height="189">
+      <vector name="origin" x="100" y="194"/>
+      <vector name="lt" x="-100" y="-179"/>
+      <vector name="rb" x="68" y="-5"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3423cee0d86daf8c9afae4733a912d1f93f3022b902852e4e7f4683b234bae9f"/>
+    </canvas>
+    <canvas name="2" width="238" height="190">
+      <vector name="origin" x="100" y="196"/>
+      <vector name="lt" x="-99" y="-181"/>
+      <vector name="rb" x="63" y="-7"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="3be8480d68cd8d0ed62d6e6340b60bd7c3fbc93bea017447e1f10aafce9e8b0f"/>
+    </canvas>
+    <canvas name="3" width="236" height="188">
+      <vector name="origin" x="100" y="195"/>
+      <vector name="lt" x="-99" y="-182"/>
+      <vector name="rb" x="61" y="-7"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="ad71d26de1e76ce0ec97641bee9cd92fbd9d57278b859822115361039d8bce63"/>
+    </canvas>
+    <canvas name="4" width="243" height="189">
+      <vector name="origin" x="100" y="197"/>
+      <vector name="lt" x="-100" y="-183"/>
+      <vector name="rb" x="54" y="-8"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="bc56e97fae2d7e35af7429aece3affe3d772961208e56c136c0f96b7acb9d133"/>
+    </canvas>
+    <canvas name="5" width="238" height="189">
+      <vector name="origin" x="100" y="196"/>
+      <vector name="lt" x="-91" y="-162"/>
+      <vector name="rb" x="53" y="-7"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="d6f4d38639881847fe802db199c1e618f1daf40f863843d4d78668199298d85e"/>
+    </canvas>
+    <canvas name="6" width="235" height="190">
+      <vector name="origin" x="100" y="196"/>
+      <vector name="lt" x="-91" y="-162"/>
+      <vector name="rb" x="57" y="-6"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="2acd20d4194bf5d25aac4e5b95b32ceb3abf1e3bf0b73f01872189f1b88fd1eb"/>
+    </canvas>
+    <canvas name="7" width="234" height="190">
+      <vector name="origin" x="100" y="194"/>
+      <vector name="lt" x="-91" y="-162"/>
+      <vector name="rb" x="65" y="-4"/>
+      <vector name="head" x="-38" y="-211"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="6b9942d14743f4151ec792754445ddbfe988b5376601c5fd987570d4de9f155f"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="234" height="189">
+      <vector name="origin" x="100" y="181"/>
+      <vector name="lt" x="-99" y="-162"/>
+      <vector name="rb" x="67" y="7"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="c06e861c807754ad708b6b55640b1fd123dd77cb6c398b082957e6d128576b1c"/>
+    </canvas>
+    <canvas name="1" width="238" height="189">
+      <vector name="origin" x="100" y="182"/>
+      <vector name="lt" x="-100" y="-162"/>
+      <vector name="rb" x="47" y="4"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="9da781721d887b8d1092bc71b52b3e08b2cafa97f873939488f5f52e16ddadae"/>
+    </canvas>
+    <canvas name="2" width="233" height="188">
+      <vector name="origin" x="100" y="187"/>
+      <vector name="lt" x="-100" y="-169"/>
+      <vector name="rb" x="45" y="-2"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="1731a4f2972a30cc82a0665d1056841c17776c97d8e5c90b12f3d0851d3490c3"/>
+    </canvas>
+    <canvas name="3" width="228" height="184">
+      <vector name="origin" x="100" y="189"/>
+      <vector name="lt" x="-99" y="-174"/>
+      <vector name="rb" x="39" y="-5"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="39430d42783c17ba05f488f45484894d714f433cf82ee5e01365d3ca1af8eaf4"/>
+    </canvas>
+    <canvas name="4" width="223" height="187">
+      <vector name="origin" x="100" y="189"/>
+      <vector name="lt" x="-100" y="-171"/>
+      <vector name="rb" x="49" y="-2"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="fb8abe436d88ef793a421762ff6f01e59bddabf33d3e68e70c713637b51e73ab"/>
+    </canvas>
+    <canvas name="5" width="239" height="186">
+      <vector name="origin" x="100" y="185"/>
+      <vector name="lt" x="-100" y="-173"/>
+      <vector name="rb" x="48" y="-2"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7f777db15697811e167f816b5cdc81ebb7245785237d5889dbebde8daa2f8cc5"/>
+    </canvas>
+    <canvas name="6" width="238" height="190">
+      <vector name="origin" x="100" y="184"/>
+      <vector name="lt" x="-99" y="-170"/>
+      <vector name="rb" x="69" y="4"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="7192773e89b450babd09450714fc4c2e48189c706354ae0d3327c74b1df3afa1"/>
+    </canvas>
+    <canvas name="7" width="239" height="182">
+      <vector name="origin" x="100" y="181"/>
+      <vector name="lt" x="-100" y="-168"/>
+      <vector name="rb" x="68" y="-1"/>
+      <vector name="head" x="-38" y="-200"/>
+      <int name="delay" value="120"/>
+      <string name="_hash" value="77852d6b842889fb39e56fccf10bf905ac42795b9f54e700a2c683d035c33e98"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="264" height="184">
+      <vector name="origin" x="96" y="219"/>
+      <vector name="lt" x="-75" y="-175"/>
+      <vector name="rb" x="56" y="-32"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="300"/>
+      <string name="_hash" value="1e4cb8ea951f5f8ae7f8202bd20f876ed07607d6d75199c54ba2198c305472f5"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="236" height="189">
+      <vector name="origin" x="100" y="185"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="f4fac2d31da7cb4e6ff236287e2210ab66df6e55e6979b937a97ebaeb65ab235"/>
+    </canvas>
+    <canvas name="1" width="264" height="184">
+      <vector name="origin" x="96" y="219"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="3ab7d8de5e9b87c3bcc4452a4cb65eece0bc208cb8e18f5a8aa236e2c5206578"/>
+    </canvas>
+    <canvas name="2" width="275" height="176">
+      <vector name="origin" x="89" y="214"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="5a27660c793791ec25f15128e1000ae51c427ab808a4cd5acb0c59286f1bfbd6"/>
+    </canvas>
+    <canvas name="3" width="281" height="162">
+      <vector name="origin" x="90" y="195"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="6849a8194c104c9dda266283676a28a293be262e49dee220b7f5abb268172d32"/>
+    </canvas>
+    <canvas name="4" width="264" height="162">
+      <vector name="origin" x="63" y="190"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="e6d2398db6a033bfc8248f3838aecaecaab5d7eadf7088007e39b3aa6ebd3463"/>
+    </canvas>
+    <canvas name="5" width="264" height="162">
+      <vector name="origin" x="54" y="169"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="83c27b29335bfe7dd095d4304ba0ae917a6c82e8d309723db36a57385cb25f6a"/>
+    </canvas>
+    <canvas name="6" width="267" height="162">
+      <vector name="origin" x="53" y="145"/>
+      <vector name="head" x="-26" y="-218"/>
+      <int name="delay" value="150"/>
+      <string name="_hash" value="c2bac7d58283aa4693fa809b60774462100967b14e568686757e5c60546c5878"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Aww, I am going to get scolded again..."/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="97"/>
+    <int name="maxHP" value="490000"/>
+    <int name="maxMP" value="210"/>
+    <int name="speed" value="-70"/>
+    <int name="PADamage" value="445"/>
+    <int name="PDDamage" value="830"/>
+    <int name="MADamage" value="500"/>
+    <int name="MDDamage" value="550"/>
+    <int name="acc" value="203"/>
+    <int name="eva" value="37"/>
+    <int name="exp" value="49000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="4300"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <string name="elemAttr" value="F2L2"/>
+    <int name="mobType" value="3"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz/Mob.wz/9900000.img.xml
+++ b/gms-server/wz/Mob.wz/9900000.img.xml
@@ -1,1 +1,2808 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?><imgdir name="9900000.img"><imgdir name="stand"><canvas name="0" width="161" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="76" y="-37"/><int name="delay" value="120"/></canvas><canvas name="1" width="161" height="113"><vector name="origin" x="85" y="148"/><vector name="head" x="1" y="-152"/><vector name="lt" x="-85" y="-148"/><vector name="rb" x="76" y="-35"/><int name="delay" value="120"/></canvas><canvas name="2" width="161" height="114"><vector name="origin" x="85" y="147"/><vector name="head" x="1" y="-151"/><vector name="lt" x="-85" y="-147"/><vector name="rb" x="76" y="-33"/><int name="delay" value="120"/></canvas><canvas name="3" width="161" height="115"><vector name="origin" x="85" y="146"/><vector name="head" x="1" y="-150"/><vector name="lt" x="-85" y="-146"/><vector name="rb" x="76" y="-31"/><int name="delay" value="120"/></canvas><canvas name="4" width="160" height="116"><vector name="origin" x="85" y="145"/><vector name="head" x="1" y="-149"/><vector name="lt" x="-85" y="-145"/><vector name="rb" x="75" y="-29"/><int name="delay" value="120"/></canvas><canvas name="5" width="160" height="115"><vector name="origin" x="85" y="146"/><vector name="head" x="1" y="-150"/><vector name="lt" x="-85" y="-146"/><vector name="rb" x="75" y="-31"/><int name="delay" value="120"/></canvas><canvas name="6" width="160" height="114"><vector name="origin" x="85" y="147"/><vector name="head" x="1" y="-151"/><vector name="lt" x="-85" y="-147"/><vector name="rb" x="75" y="-33"/><int name="delay" value="120"/></canvas><canvas name="7" width="160" height="114"><vector name="origin" x="85" y="148"/><vector name="head" x="1" y="-152"/><vector name="lt" x="-85" y="-148"/><vector name="rb" x="75" y="-34"/><int name="delay" value="120"/></canvas></imgdir><imgdir name="move"><canvas name="0" width="158" height="112"><vector name="origin" x="81" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-81" y="-149"/><vector name="rb" x="77" y="-37"/><int name="delay" value="90"/></canvas><canvas name="1" width="158" height="113"><vector name="origin" x="81" y="148"/><vector name="head" x="1" y="-152"/><vector name="lt" x="-81" y="-148"/><vector name="rb" x="77" y="-35"/><int name="delay" value="90"/></canvas><canvas name="2" width="158" height="114"><vector name="origin" x="81" y="147"/><vector name="head" x="1" y="-151"/><vector name="lt" x="-81" y="-147"/><vector name="rb" x="77" y="-33"/><int name="delay" value="90"/></canvas><canvas name="3" width="158" height="115"><vector name="origin" x="81" y="146"/><vector name="head" x="1" y="-150"/><vector name="lt" x="-81" y="-146"/><vector name="rb" x="77" y="-31"/><int name="delay" value="90"/></canvas><canvas name="4" width="157" height="116"><vector name="origin" x="81" y="145"/><vector name="head" x="1" y="-149"/><vector name="lt" x="-81" y="-145"/><vector name="rb" x="76" y="-29"/><int name="delay" value="90"/></canvas><canvas name="5" width="157" height="115"><vector name="origin" x="81" y="146"/><vector name="head" x="1" y="-150"/><vector name="lt" x="-81" y="-146"/><vector name="rb" x="76" y="-31"/><int name="delay" value="90"/></canvas><canvas name="6" width="157" height="114"><vector name="origin" x="81" y="147"/><vector name="head" x="1" y="-151"/><vector name="lt" x="-81" y="-147"/><vector name="rb" x="76" y="-33"/><int name="delay" value="90"/></canvas><canvas name="7" width="157" height="114"><vector name="origin" x="81" y="148"/><vector name="head" x="1" y="-152"/><vector name="lt" x="-81" y="-148"/><vector name="rb" x="76" y="-34"/><int name="delay" value="90"/></canvas></imgdir><imgdir name="attack1"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-404" y="-205"/><vector name="rb" x="50" y="46"/></imgdir><imgdir name="hit"><canvas name="0" width="139" height="154"><vector name="origin" x="66" y="70"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack1/info/hit/0"/></canvas><canvas name="1" width="149" height="140"><vector name="origin" x="72" y="74"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack1/info/hit/1"/></canvas><canvas name="2" width="162" height="154"><vector name="origin" x="82" y="84"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack1/info/hit/2"/></canvas><canvas name="3" width="159" height="132"><vector name="origin" x="76" y="69"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack1/info/hit/3"/></canvas><canvas name="4" width="155" height="132"><vector name="origin" x="70" y="74"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack1/info/hit/4"/></canvas><canvas name="5" width="154" height="132"><vector name="origin" x="71" y="73"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack1/info/hit/5"/></canvas></imgdir><int name="attackAfter" value="900"/><int name="delay" value="90"/></imgdir><canvas name="0" width="161" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="76" y="-37"/><int name="delay" value="90"/></canvas><canvas name="1" width="178" height="113"><vector name="origin" x="90" y="151"/><vector name="head" x="5" y="-155"/><vector name="lt" x="-90" y="-151"/><vector name="rb" x="88" y="-38"/><int name="delay" value="90"/></canvas><canvas name="2" width="158" height="154"><vector name="origin" x="61" y="197"/><vector name="head" x="12" y="-161"/><vector name="lt" x="-61" y="-197"/><vector name="rb" x="97" y="-43"/><int name="delay" value="90"/></canvas><canvas name="3" width="166" height="155"><vector name="origin" x="70" y="199"/><vector name="head" x="15" y="-163"/><vector name="lt" x="-70" y="-199"/><vector name="rb" x="96" y="-44"/><int name="delay" value="90"/></canvas><canvas name="4" width="166" height="156"><vector name="origin" x="70" y="202"/><vector name="head" x="18" y="-166"/><vector name="lt" x="-32" y="-175"/><vector name="rb" x="96" y="-46"/><int name="delay" value="90"/></canvas><canvas name="5" width="161" height="155"><vector name="origin" x="62" y="203"/><vector name="head" x="19" y="-167"/><vector name="lt" x="-62" y="-203"/><vector name="rb" x="99" y="-48"/><int name="delay" value="90"/></canvas><canvas name="6" width="155" height="154"><vector name="origin" x="57" y="204"/><vector name="head" x="20" y="-168"/><vector name="lt" x="-57" y="-204"/><vector name="rb" x="98" y="-50"/><int name="delay" value="90"/></canvas><canvas name="7" width="154" height="154"><vector name="origin" x="56" y="204"/><vector name="head" x="20" y="-168"/><vector name="lt" x="-56" y="-204"/><vector name="rb" x="98" y="-50"/><int name="delay" value="90"/></canvas><canvas name="8" width="220" height="180"><vector name="origin" x="158" y="186"/><vector name="head" x="-45" y="-126"/><vector name="lt" x="-158" y="-186"/><vector name="rb" x="62" y="-6"/><int name="delay" value="90"/></canvas><canvas name="9" width="311" height="205"><vector name="origin" x="263" y="176"/><vector name="head" x="-49" y="-124"/><vector name="lt" x="-158" y="-186"/><vector name="rb" x="62" y="-6"/><int name="delay" value="90"/></canvas><canvas name="10" width="396" height="177"><vector name="origin" x="349" y="143"/><vector name="head" x="-51" y="-123"/><vector name="lt" x="-144" y="-143"/><vector name="rb" x="47" y="0"/><int name="delay" value="90"/></canvas><canvas name="11" width="451" height="171"><vector name="origin" x="404" y="145"/><vector name="head" x="-51" y="-123"/><vector name="lt" x="-132" y="-145"/><vector name="rb" x="47" y="0"/><int name="delay" value="90"/></canvas><canvas name="12" width="449" height="160"><vector name="origin" x="403" y="144"/><vector name="head" x="-49" y="-125"/><vector name="lt" x="-137" y="-144"/><vector name="rb" x="47" y="0"/><int name="delay" value="90"/></canvas><canvas name="13" width="466" height="146"><vector name="origin" x="404" y="141"/><vector name="head" x="-38" y="-131"/><vector name="lt" x="-125" y="-141"/><vector name="rb" x="61" y="2"/><int name="delay" value="90"/></canvas><canvas name="14" width="468" height="130"><vector name="origin" x="393" y="142"/><vector name="head" x="-12" y="-146"/><vector name="lt" x="-97" y="-142"/><vector name="rb" x="75" y="-32"/><int name="delay" value="90"/></canvas><canvas name="15" width="162" height="114"><vector name="origin" x="86" y="148"/><vector name="head" x="1" y="-152"/><vector name="lt" x="-86" y="-148"/><vector name="rb" x="76" y="-34"/><int name="delay" value="90"/></canvas><canvas name="16" width="161" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="76" y="-37"/><int name="delay" value="90"/></canvas><canvas name="17" width="160" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="90"/></canvas></imgdir><imgdir name="attack2"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-192" y="-199"/><vector name="rb" x="137" y="22"/></imgdir><imgdir name="hit"><canvas name="0" width="143" height="192"><vector name="origin" x="67" y="95"/><string name="source" value="Mob/8850011.img/attack1/info/hit/0"/></canvas><canvas name="1" width="147" height="192"><vector name="origin" x="71" y="95"/><string name="source" value="Mob/8850011.img/attack1/info/hit/1"/></canvas><canvas name="2" width="136" height="135"><vector name="origin" x="71" y="66"/><string name="source" value="Mob/8850011.img/attack1/info/hit/2"/></canvas><canvas name="3" width="135" height="133"><vector name="origin" x="70" y="65"/><string name="source" value="Mob/8850011.img/attack1/info/hit/3"/></canvas><canvas name="4" width="140" height="140"><vector name="origin" x="72" y="67"/><string name="source" value="Mob/8850011.img/attack1/info/hit/4"/></canvas><canvas name="5" width="149" height="152"><vector name="origin" x="80" y="75"/><string name="source" value="Mob/8620009.img/attack2/info/hit/4"/></canvas><int name="attach" value="1"/></imgdir><int name="attackAfter" value="900"/><int name="delay" value="120"/><imgdir name="hit2"><canvas name="0" width="112" height="150"><vector name="origin" x="350" y="108"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-350" y="-108"/><vector name="rb" x="-238" y="42"/></canvas><canvas name="1" width="115" height="150"><vector name="origin" x="353" y="108"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-353" y="-108"/><vector name="rb" x="-238" y="42"/></canvas><canvas name="2" width="107" height="104"><vector name="origin" x="353" y="85"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-353" y="-85"/><vector name="rb" x="-246" y="19"/></canvas><canvas name="3" width="106" height="104"><vector name="origin" x="352" y="85"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-352" y="-85"/><vector name="rb" x="-246" y="19"/></canvas><canvas name="4" width="110" height="111"><vector name="origin" x="354" y="87"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-354" y="-87"/><vector name="rb" x="-244" y="24"/></canvas><canvas name="5" width="113" height="119"><vector name="origin" x="360" y="93"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-360" y="-93"/><vector name="rb" x="-247" y="26"/></canvas></imgdir></imgdir><canvas name="0" width="161" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="76" y="-37"/><int name="delay" value="120"/></canvas><canvas name="1" width="165" height="114"><vector name="origin" x="89" y="178"/><vector name="head" x="2" y="-181"/><vector name="lt" x="-89" y="-178"/><vector name="rb" x="76" y="-64"/><int name="delay" value="120"/></canvas><canvas name="2" width="189" height="228"><vector name="origin" x="113" y="297"/><vector name="head" x="2" y="-191"/><vector name="lt" x="-74" y="-219"/><vector name="rb" x="76" y="-72"/><int name="delay" value="120"/></canvas><canvas name="3" width="187" height="224"><vector name="origin" x="111" y="294"/><vector name="head" x="2" y="-194"/><vector name="lt" x="-64" y="-192"/><vector name="rb" x="76" y="-70"/><int name="delay" value="120"/></canvas><canvas name="4" width="179" height="217"><vector name="origin" x="104" y="287"/><vector name="head" x="2" y="-196"/><vector name="lt" x="-65" y="-231"/><vector name="rb" x="75" y="-71"/><int name="delay" value="120"/></canvas><canvas name="5" width="167" height="207"><vector name="origin" x="92" y="278"/><vector name="head" x="2" y="-197"/><vector name="lt" x="-68" y="-240"/><vector name="rb" x="75" y="-71"/><int name="delay" value="120"/></canvas><canvas name="6" width="152" height="199"><vector name="origin" x="77" y="272"/><vector name="head" x="2" y="-198"/><vector name="lt" x="-77" y="-224"/><vector name="rb" x="75" y="-73"/><int name="delay" value="120"/></canvas><canvas name="7" width="152" height="201"><vector name="origin" x="77" y="275"/><vector name="head" x="2" y="-199"/><vector name="lt" x="-77" y="-250"/><vector name="rb" x="75" y="-74"/><int name="delay" value="120"/></canvas><canvas name="8" width="344" height="283"><vector name="origin" x="205" y="254"/><vector name="head" x="2" y="-126"/><vector name="lt" x="-98" y="-128"/><vector name="rb" x="98" y="-2"/><int name="delay" value="120"/></canvas><canvas name="9" width="483" height="210"><vector name="origin" x="271" y="182"/><vector name="head" x="2" y="-117"/><vector name="lt" x="-100" y="-129"/><vector name="rb" x="110" y="-5"/><int name="delay" value="120"/></canvas><canvas name="10" width="561" height="211"><vector name="origin" x="310" y="184"/><vector name="head" x="2" y="-113"/><vector name="lt" x="-114" y="-127"/><vector name="rb" x="113" y="-1"/><int name="delay" value="120"/></canvas><canvas name="11" width="603" height="227"><vector name="origin" x="331" y="202"/><vector name="head" x="2" y="-111"/><vector name="lt" x="-97" y="-112"/><vector name="rb" x="81" y="1"/><int name="delay" value="120"/></canvas><canvas name="12" width="601" height="219"><vector name="origin" x="330" y="200"/><vector name="head" x="2" y="-110"/><vector name="lt" x="-80" y="-113"/><vector name="rb" x="62" y="0"/><int name="delay" value="120"/></canvas><canvas name="13" width="591" height="206"><vector name="origin" x="325" y="194"/><vector name="head" x="2" y="-111"/><vector name="lt" x="-79" y="-112"/><vector name="rb" x="64" y="11"/><int name="delay" value="120"/></canvas><canvas name="14" width="492" height="145"><vector name="origin" x="281" y="143"/><vector name="head" x="2" y="-126"/><vector name="lt" x="-65" y="-142"/><vector name="rb" x="62" y="1"/><int name="delay" value="120"/></canvas></imgdir><imgdir name="attack3"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-65" y="-125"/><vector name="rb" x="65" y="0"/><int name="start" value="-4"/><int name="areaCount" value="9"/><int name="attackCount" value="4"/></imgdir><imgdir name="areaWarning"><canvas name="0" width="124" height="130"><vector name="origin" x="57" y="117"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/0"/></canvas><canvas name="1" width="128" height="127"><vector name="origin" x="59" y="114"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/1"/></canvas><canvas name="2" width="132" height="124"><vector name="origin" x="62" y="111"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/2"/></canvas><canvas name="3" width="127" height="115"><vector name="origin" x="65" y="102"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/3"/></canvas><canvas name="4" width="132" height="138"><vector name="origin" x="69" y="109"/><int name="delay" value="150"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/4"/></canvas><canvas name="5" width="132" height="145"><vector name="origin" x="69" y="119"/><int name="delay" value="150"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/5"/></canvas><canvas name="6" width="131" height="139"><vector name="origin" x="65" y="126"/><int name="delay" value="150"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/6"/></canvas><canvas name="7" width="128" height="137"><vector name="origin" x="61" y="124"/><int name="delay" value="150"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/7"/></canvas><canvas name="8" width="130" height="134"><vector name="origin" x="60" y="121"/><int name="delay" value="150"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/8"/></canvas><canvas name="9" width="127" height="99"><vector name="origin" x="65" y="86"/><int name="delay" value="150"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/9"/></canvas><canvas name="10" width="141" height="118"><vector name="origin" x="69" y="100"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/10"/></canvas><canvas name="11" width="163" height="294"><vector name="origin" x="79" y="277"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/11"/></canvas><canvas name="12" width="168" height="302"><vector name="origin" x="85" y="286"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/12"/></canvas><canvas name="13" width="198" height="303"><vector name="origin" x="100" y="285"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/13"/></canvas><canvas name="14" width="218" height="287"><vector name="origin" x="110" y="267"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/14"/></canvas><canvas name="15" width="231" height="262"><vector name="origin" x="116" y="241"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/15"/></canvas><canvas name="16" width="237" height="61"><vector name="origin" x="119" y="41"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack3/info/areaWarning/16"/></canvas></imgdir><imgdir name="hit"><canvas name="0" width="128" height="167"><vector name="origin" x="58" y="89"/><int name="delay" value="60"/><string name="source" value="Mob/8870000.img/attack3/info/hit/0"/></canvas><canvas name="1" width="176" height="164"><vector name="origin" x="96" y="85"/><int name="delay" value="60"/><string name="source" value="Mob/8870000.img/attack3/info/hit/1"/></canvas><canvas name="2" width="177" height="162"><vector name="origin" x="97" y="83"/><int name="delay" value="60"/><string name="source" value="Mob/8870000.img/attack3/info/hit/2"/></canvas><canvas name="3" width="176" height="157"><vector name="origin" x="97" y="81"/><int name="delay" value="60"/><string name="source" value="Mob/8870000.img/attack3/info/hit/3"/></canvas><canvas name="4" width="172" height="146"><vector name="origin" x="93" y="80"/><int name="delay" value="60"/><string name="source" value="Mob/8870000.img/attack3/info/hit/4"/></canvas><canvas name="5" width="88" height="71"><vector name="origin" x="41" y="54"/><int name="delay" value="60"/><string name="source" value="Mob/8870000.img/attack3/info/hit/5"/></canvas><canvas name="6" width="13" height="16"><vector name="origin" x="7" y="4"/><int name="delay" value="60"/><string name="source" value="Mob/8870000.img/attack3/info/hit/6"/></canvas></imgdir><int name="attackAfter" value="1620"/></imgdir><canvas name="0" width="160" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="76" y="-37"/><int name="delay" value="90"/></canvas><canvas name="1" width="160" height="113"><vector name="origin" x="85" y="148"/><vector name="head" x="2" y="-152"/><vector name="lt" x="-85" y="-148"/><vector name="rb" x="75" y="-35"/><int name="delay" value="90"/></canvas><canvas name="2" width="168" height="114"><vector name="origin" x="92" y="147"/><vector name="head" x="2" y="-151"/><vector name="lt" x="-92" y="-147"/><vector name="rb" x="76" y="-33"/><int name="delay" value="90"/></canvas><canvas name="3" width="146" height="146"><vector name="origin" x="70" y="175"/><vector name="head" x="2" y="-150"/><vector name="lt" x="-70" y="-175"/><vector name="rb" x="76" y="-29"/><int name="delay" value="90"/></canvas><canvas name="4" width="147" height="183"><vector name="origin" x="71" y="207"/><vector name="head" x="2" y="-149"/><vector name="lt" x="-71" y="-207"/><vector name="rb" x="76" y="-24"/><int name="delay" value="90"/></canvas><canvas name="5" width="149" height="189"><vector name="origin" x="73" y="214"/><vector name="head" x="2" y="-150"/><vector name="lt" x="-64" y="-176"/><vector name="rb" x="76" y="-25"/><int name="delay" value="90"/></canvas><canvas name="6" width="148" height="189"><vector name="origin" x="73" y="215"/><vector name="head" x="2" y="-151"/><vector name="lt" x="-73" y="-185"/><vector name="rb" x="75" y="-26"/><int name="delay" value="120"/></canvas><canvas name="7" width="148" height="189"><vector name="origin" x="73" y="216"/><vector name="head" x="1" y="-152"/><vector name="lt" x="-73" y="-216"/><vector name="rb" x="75" y="-27"/><int name="delay" value="120"/></canvas><canvas name="8" width="150" height="189"><vector name="origin" x="75" y="219"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-75" y="-219"/><vector name="rb" x="75" y="-30"/><int name="delay" value="120"/></canvas><canvas name="9" width="151" height="191"><vector name="origin" x="76" y="219"/><vector name="head" x="1" y="-152"/><vector name="lt" x="-76" y="-219"/><vector name="rb" x="75" y="-28"/><int name="delay" value="120"/></canvas><canvas name="10" width="152" height="193"><vector name="origin" x="77" y="219"/><vector name="head" x="1" y="-151"/><vector name="lt" x="-77" y="-219"/><vector name="rb" x="75" y="-26"/><int name="delay" value="120"/></canvas><canvas name="11" width="171" height="220"><vector name="origin" x="96" y="243"/><vector name="head" x="1" y="-149"/><vector name="lt" x="-95" y="-210"/><vector name="rb" x="75" y="-23"/><int name="delay" value="120"/></canvas><canvas name="12" width="175" height="225"><vector name="origin" x="99" y="243"/><vector name="head" x="1" y="-145"/><vector name="lt" x="-80" y="-191"/><vector name="rb" x="76" y="-18"/><int name="delay" value="120"/></canvas><canvas name="13" width="175" height="226"><vector name="origin" x="100" y="243"/><vector name="head" x="1" y="-143"/><vector name="lt" x="-96" y="-200"/><vector name="rb" x="75" y="-17"/><int name="delay" value="120"/></canvas><canvas name="14" width="174" height="227"><vector name="origin" x="99" y="263"/><vector name="head" x="1" y="-159"/><vector name="lt" x="-95" y="-208"/><vector name="rb" x="75" y="-36"/><int name="delay" value="120"/></canvas><canvas name="15" width="174" height="231"><vector name="origin" x="99" y="279"/><vector name="head" x="1" y="-172"/><vector name="lt" x="-95" y="-225"/><vector name="rb" x="75" y="-48"/><int name="delay" value="120"/></canvas><canvas name="16" width="174" height="235"><vector name="origin" x="99" y="285"/><vector name="head" x="1" y="-175"/><vector name="lt" x="-99" y="-245"/><vector name="rb" x="75" y="-50"/><int name="delay" value="120"/></canvas><canvas name="17" width="174" height="232"><vector name="origin" x="99" y="283"/><vector name="head" x="1" y="-177"/><vector name="lt" x="-99" y="-283"/><vector name="rb" x="75" y="-51"/><int name="delay" value="120"/></canvas><canvas name="18" width="173" height="240"><vector name="origin" x="98" y="289"/><vector name="head" x="1" y="-176"/><vector name="lt" x="-82" y="-225"/><vector name="rb" x="75" y="-49"/><int name="delay" value="120"/></canvas><canvas name="19" width="165" height="238"><vector name="origin" x="90" y="288"/><vector name="head" x="2" y="-172"/><vector name="lt" x="-91" y="-194"/><vector name="rb" x="75" y="-50"/><int name="delay" value="120"/></canvas><canvas name="20" width="165" height="230"><vector name="origin" x="90" y="267"/><vector name="head" x="2" y="-160"/><vector name="lt" x="-80" y="-161"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="21" width="162" height="120"><vector name="origin" x="87" y="152"/><vector name="head" x="2" y="-152"/><vector name="lt" x="-87" y="-152"/><vector name="rb" x="75" y="-32"/><int name="delay" value="120"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="预告攻击"/></imgdir></imgdir><imgdir name="attack4"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-480" y="-617"/><vector name="rb" x="434" y="10"/></imgdir><imgdir name="hit"><canvas name="0" width="303" height="735"><vector name="origin" x="148" y="730"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack4/info/hit/0"/></canvas><canvas name="1" width="284" height="735"><vector name="origin" x="139" y="730"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack4/info/hit/1"/></canvas><canvas name="2" width="270" height="735"><vector name="origin" x="131" y="730"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack4/info/hit/2"/></canvas><canvas name="3" width="266" height="735"><vector name="origin" x="132" y="730"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack4/info/hit/3"/></canvas><canvas name="4" width="261" height="735"><vector name="origin" x="120" y="730"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack4/info/hit/4"/></canvas><canvas name="5" width="188" height="735"><vector name="origin" x="95" y="730"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack4/info/hit/5"/></canvas><canvas name="6" width="22" height="721"><vector name="origin" x="8" y="717"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack4/info/hit/6"/></canvas><int name="pos" value="3"/><int name="attach" value="1"/></imgdir><int name="attackAfter" value="1680"/></imgdir><canvas name="1" width="161" height="113"><vector name="origin" x="85" y="150"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-85" y="-150"/><vector name="rb" x="76" y="-37"/><int name="delay" value="120"/></canvas><canvas name="2" width="205" height="190"><vector name="origin" x="104" y="238"/><vector name="head" x="2" y="-166"/><vector name="lt" x="-104" y="-176"/><vector name="rb" x="101" y="-48"/><int name="delay" value="120"/></canvas><canvas name="3" width="311" height="243"><vector name="origin" x="154" y="297"/><vector name="head" x="2" y="-212"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="4" width="346" height="264"><vector name="origin" x="167" y="302"/><vector name="head" x="2" y="-214"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="5" width="367" height="265"><vector name="origin" x="178" y="304"/><vector name="head" x="2" y="-214"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="6" width="372" height="227"><vector name="origin" x="181" y="311"/><vector name="head" x="2" y="-214"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="7" width="371" height="211"><vector name="origin" x="182" y="308"/><vector name="head" x="2" y="-214"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="8" width="368" height="244"><vector name="origin" x="181" y="308"/><vector name="head" x="2" y="-214"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="9" width="365" height="220"><vector name="origin" x="179" y="305"/><vector name="head" x="2" y="-214"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="10" width="359" height="212"><vector name="origin" x="174" y="306"/><vector name="head" x="2" y="-214"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="11" width="357" height="214"><vector name="origin" x="173" y="306"/><vector name="head" x="2" y="-214"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="12" width="355" height="217"><vector name="origin" x="173" y="307"/><vector name="head" x="2" y="-214"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="13" width="352" height="614"><vector name="origin" x="171" y="726"/><vector name="head" x="2" y="-237"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="14" width="350" height="607"><vector name="origin" x="168" y="726"/><vector name="head" x="2" y="-237"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="15" width="359" height="607"><vector name="origin" x="173" y="726"/><vector name="head" x="2" y="-237"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="16" width="365" height="608"><vector name="origin" x="176" y="726"/><vector name="head" x="2" y="-237"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="17" width="367" height="609"><vector name="origin" x="178" y="726"/><vector name="head" x="2" y="-237"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="18" width="358" height="633"><vector name="origin" x="176" y="726"/><vector name="head" x="2" y="-237"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="19" width="333" height="678"><vector name="origin" x="170" y="726"/><vector name="head" x="4" y="-214"/><vector name="lt" x="-75" y="-223"/><vector name="rb" x="75" y="-54"/><int name="delay" value="120"/></canvas><canvas name="20" width="158" height="763"><vector name="origin" x="84" y="725"/><vector name="head" x="2" y="-200"/><vector name="lt" x="-84" y="-199"/><vector name="rb" x="74" y="-57"/><int name="delay" value="120"/></canvas></imgdir><imgdir name="attack5"><imgdir name="info"><imgdir name="range"><vector name="lt" x="-185" y="-150"/><vector name="rb" x="185" y="0"/><int name="start" value="-1"/><int name="areaCount" value="3"/><int name="attackCount" value="1"/><int name="reverse" value="1"/></imgdir><imgdir name="areaWarning"><canvas name="0" width="56" height="167"><vector name="origin" x="25" y="141"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/0"/></canvas><canvas name="1" width="57" height="164"><vector name="origin" x="26" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/1"/></canvas><canvas name="2" width="82" height="157"><vector name="origin" x="40" y="126"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/2"/></canvas><canvas name="3" width="82" height="141"><vector name="origin" x="40" y="117"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/3"/></canvas><canvas name="4" width="83" height="92"><vector name="origin" x="41" y="90"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/4"/></canvas><canvas name="5" width="83" height="92"><vector name="origin" x="41" y="90"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/4"/></canvas><canvas name="6" width="83" height="92"><vector name="origin" x="41" y="90"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/6"/></canvas><canvas name="7" width="95" height="97"><vector name="origin" x="46" y="90"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/7"/></canvas><canvas name="8" width="201" height="102"><vector name="origin" x="99" y="90"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/8"/></canvas><canvas name="9" width="269" height="105"><vector name="origin" x="133" y="90"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/9"/></canvas><canvas name="10" width="345" height="176"><vector name="origin" x="171" y="158"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/10"/></canvas><canvas name="11" width="369" height="185"><vector name="origin" x="183" y="166"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/11"/></canvas><canvas name="12" width="371" height="187"><vector name="origin" x="184" y="168"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/12"/></canvas><canvas name="13" width="373" height="189"><vector name="origin" x="185" y="170"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/13"/></canvas><canvas name="14" width="373" height="190"><vector name="origin" x="185" y="171"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/14"/></canvas><canvas name="15" width="382" height="188"><vector name="origin" x="190" y="169"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/15"/></canvas><canvas name="16" width="373" height="188"><vector name="origin" x="185" y="169"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/16"/></canvas><canvas name="17" width="373" height="190"><vector name="origin" x="185" y="171"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/17"/></canvas><canvas name="18" width="373" height="190"><vector name="origin" x="185" y="171"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/18"/></canvas><canvas name="19" width="382" height="188"><vector name="origin" x="190" y="169"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/19"/></canvas><canvas name="20" width="373" height="188"><vector name="origin" x="185" y="169"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/20"/></canvas><canvas name="21" width="373" height="190"><vector name="origin" x="185" y="171"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/21"/></canvas><canvas name="22" width="373" height="190"><vector name="origin" x="185" y="171"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/22"/></canvas><canvas name="23" width="382" height="188"><vector name="origin" x="190" y="169"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/23"/></canvas><canvas name="24" width="373" height="188"><vector name="origin" x="185" y="169"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/24"/></canvas><canvas name="25" width="373" height="190"><vector name="origin" x="185" y="171"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/25"/></canvas><canvas name="26" width="373" height="190"><vector name="origin" x="185" y="171"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/26"/></canvas><canvas name="27" width="382" height="188"><vector name="origin" x="190" y="169"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/15"/></canvas><canvas name="28" width="373" height="188"><vector name="origin" x="185" y="169"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/40"/></canvas><canvas name="29" width="371" height="189"><vector name="origin" x="184" y="170"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/41"/></canvas><canvas name="30" width="369" height="186"><vector name="origin" x="183" y="167"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/42"/></canvas><canvas name="31" width="345" height="176"><vector name="origin" x="171" y="158"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/43"/></canvas><canvas name="32" width="269" height="152"><vector name="origin" x="133" y="122"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/44"/></canvas><canvas name="33" width="95" height="162"><vector name="origin" x="46" y="131"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/45"/></canvas><canvas name="34" width="56" height="167"><vector name="origin" x="25" y="141"/><int name="z" value="0"/><int name="delay" value="120"/><string name="source" value="Mob/8870000.img/attack5/info/areaWarning/0"/></canvas></imgdir><imgdir name="hit"><canvas name="0" width="136" height="123"><vector name="origin" x="80" y="63"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack5/info/hit/0"/></canvas><canvas name="1" width="168" height="127"><vector name="origin" x="96" y="68"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack5/info/hit/1"/></canvas><canvas name="2" width="169" height="134"><vector name="origin" x="94" y="72"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack5/info/hit/2"/></canvas><canvas name="3" width="176" height="140"><vector name="origin" x="100" y="74"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack5/info/hit/3"/></canvas><canvas name="4" width="168" height="139"><vector name="origin" x="97" y="76"/><int name="delay" value="90"/><string name="source" value="Mob/8870000.img/attack5/info/hit/4"/></canvas><canvas name="5" width="110" height="105"><vector name="origin" x="48" y="85"/><int name="delay" value="90"/><string name="source" value="Mob/8600005.img/attack2/info/hit/5"/></canvas></imgdir><int name="attackAfter" value="2400"/></imgdir><canvas name="1" width="296" height="168"><vector name="origin" x="113" y="163"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="2" width="313" height="214"><vector name="origin" x="167" y="211"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="3" width="240" height="250"><vector name="origin" x="142" y="242"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="4" width="208" height="300"><vector name="origin" x="119" y="235"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="5" width="338" height="262"><vector name="origin" x="94" y="223"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="6" width="272" height="343"><vector name="origin" x="85" y="325"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="7" width="226" height="271"><vector name="origin" x="85" y="266"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="8" width="194" height="215"><vector name="origin" x="85" y="219"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="9" width="175" height="172"><vector name="origin" x="86" y="185"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="10" width="153" height="135"><vector name="origin" x="83" y="172"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="11" width="126" height="186"><vector name="origin" x="66" y="223"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="12" width="119" height="247"><vector name="origin" x="54" y="284"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="13" width="121" height="264"><vector name="origin" x="55" y="303"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="14" width="111" height="264"><vector name="origin" x="51" y="305"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="15" width="159" height="294"><vector name="origin" x="78" y="336"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="16" width="182" height="304"><vector name="origin" x="89" y="347"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="17" width="788" height="641"><vector name="origin" x="387" y="584"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="18" width="819" height="652"><vector name="origin" x="402" y="590"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="19" width="839" height="660"><vector name="origin" x="427" y="594"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="20" width="862" height="711"><vector name="origin" x="442" y="649"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="21" width="897" height="754"><vector name="origin" x="454" y="690"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="22" width="931" height="801"><vector name="origin" x="474" y="710"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="23" width="950" height="813"><vector name="origin" x="480" y="712"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="24" width="968" height="826"><vector name="origin" x="478" y="711"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="25" width="922" height="795"><vector name="origin" x="426" y="680"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="26" width="822" height="691"><vector name="origin" x="363" y="581"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="27" width="850" height="681"><vector name="origin" x="371" y="589"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="28" width="858" height="633"><vector name="origin" x="373" y="591"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="29" width="749" height="594"><vector name="origin" x="367" y="561"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="30" width="165" height="298"><vector name="origin" x="85" y="336"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="31" width="135" height="263"><vector name="origin" x="85" y="303"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="32" width="145" height="183"><vector name="origin" x="85" y="223"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="33" width="161" height="114"><vector name="origin" x="85" y="152"/><vector name="head" x="2" y="-154"/><vector name="lt" x="-86" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="危险!快躲到魔法阵里面!!!"/><int name="floatNotice" value="73"/></imgdir></imgdir><imgdir name="skill1"><canvas name="0" width="160" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="120"/></canvas><canvas name="1" width="165" height="113"><vector name="origin" x="90" y="148"/><vector name="head" x="1" y="-152"/><vector name="lt" x="-90" y="-148"/><vector name="rb" x="75" y="-35"/><int name="delay" value="120"/></canvas><canvas name="2" width="181" height="114"><vector name="origin" x="105" y="147"/><vector name="head" x="1" y="-152"/><vector name="lt" x="-105" y="-147"/><vector name="rb" x="76" y="-33"/><int name="delay" value="120"/></canvas><canvas name="3" width="191" height="200"><vector name="origin" x="115" y="231"/><vector name="head" x="1" y="-150"/><vector name="lt" x="-115" y="-231"/><vector name="rb" x="76" y="-31"/><int name="delay" value="120"/></canvas><canvas name="4" width="207" height="210"><vector name="origin" x="131" y="239"/><vector name="head" x="2" y="-149"/><vector name="lt" x="-86" y="-173"/><vector name="rb" x="76" y="-29"/><int name="delay" value="120"/></canvas><canvas name="5" width="211" height="210"><vector name="origin" x="135" y="241"/><vector name="head" x="2" y="-150"/><vector name="lt" x="-86" y="-173"/><vector name="rb" x="76" y="-29"/><int name="delay" value="120"/></canvas><canvas name="6" width="213" height="223"><vector name="origin" x="138" y="257"/><vector name="head" x="2" y="-152"/><vector name="lt" x="-86" y="-173"/><vector name="rb" x="76" y="-29"/><int name="delay" value="120"/></canvas><canvas name="7" width="217" height="224"><vector name="origin" x="142" y="262"/><vector name="head" x="2" y="-156"/><vector name="lt" x="-86" y="-173"/><vector name="rb" x="76" y="-29"/><int name="delay" value="120"/></canvas><canvas name="8" width="224" height="229"><vector name="origin" x="149" y="277"/><vector name="head" x="2" y="-164"/><vector name="lt" x="-86" y="-173"/><vector name="rb" x="76" y="-29"/><int name="delay" value="120"/></canvas><canvas name="9" width="222" height="222"><vector name="origin" x="145" y="284"/><vector name="head" x="2" y="-179"/><vector name="lt" x="-86" y="-173"/><vector name="rb" x="76" y="-29"/><int name="delay" value="210"/></canvas><canvas name="10" width="218" height="223"><vector name="origin" x="142" y="287"/><vector name="head" x="2" y="-182"/><vector name="lt" x="-86" y="-173"/><vector name="rb" x="76" y="-29"/><int name="delay" value="120"/></canvas><canvas name="11" width="216" height="221"><vector name="origin" x="139" y="286"/><vector name="head" x="2" y="-184"/><vector name="lt" x="-86" y="-173"/><vector name="rb" x="76" y="-29"/><int name="delay" value="120"/></canvas><canvas name="12" width="216" height="222"><vector name="origin" x="139" y="287"/><vector name="head" x="2" y="-185"/><vector name="lt" x="-99" y="-193"/><vector name="rb" x="77" y="-65"/><int name="delay" value="120"/></canvas><canvas name="13" width="213" height="220"><vector name="origin" x="137" y="285"/><vector name="head" x="2" y="-184"/><vector name="lt" x="-110" y="-223"/><vector name="rb" x="76" y="-64"/><int name="delay" value="120"/></canvas><canvas name="14" width="212" height="222"><vector name="origin" x="136" y="283"/><vector name="head" x="2" y="-182"/><vector name="lt" x="-100" y="-208"/><vector name="rb" x="76" y="-64"/><int name="delay" value="120"/></canvas><canvas name="15" width="209" height="229"><vector name="origin" x="134" y="282"/><vector name="head" x="2" y="-171"/><vector name="lt" x="-64" y="-176"/><vector name="rb" x="75" y="-53"/><int name="delay" value="120"/></canvas><canvas name="16" width="206" height="229"><vector name="origin" x="131" y="264"/><vector name="head" x="2" y="-151"/><vector name="lt" x="-97" y="-160"/><vector name="rb" x="75" y="-35"/><int name="delay" value="120"/></canvas><canvas name="17" width="188" height="228"><vector name="origin" x="113" y="263"/><vector name="head" x="2" y="-152"/><vector name="lt" x="-112" y="-160"/><vector name="rb" x="75" y="-35"/><int name="delay" value="120"/></canvas></imgdir><imgdir name="skill2"><canvas name="0" width="161" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="76" y="-37"/><int name="delay" value="120"/></canvas><canvas name="1" width="158" height="114"><vector name="origin" x="83" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-83" y="-149"/><vector name="rb" x="75" y="-35"/><int name="delay" value="120"/></canvas><canvas name="2" width="158" height="115"><vector name="origin" x="75" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-75" y="-149"/><vector name="rb" x="83" y="-34"/><int name="delay" value="120"/></canvas><canvas name="3" width="265" height="126"><vector name="origin" x="106" y="159"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-106" y="-159"/><vector name="rb" x="159" y="-33"/><int name="delay" value="120"/></canvas><canvas name="4" width="268" height="118"><vector name="origin" x="108" y="151"/><vector name="head" x="3" y="-154"/><vector name="lt" x="-64" y="-151"/><vector name="rb" x="80" y="-33"/><int name="delay" value="120"/></canvas><canvas name="5" width="272" height="132"><vector name="origin" x="110" y="166"/><vector name="head" x="4" y="-155"/><vector name="lt" x="-60" y="-160"/><vector name="rb" x="96" y="-34"/><int name="delay" value="120"/></canvas><canvas name="6" width="272" height="158"><vector name="origin" x="110" y="192"/><vector name="head" x="6" y="-157"/><vector name="lt" x="-65" y="-160"/><vector name="rb" x="95" y="-34"/><int name="delay" value="120"/></canvas><canvas name="7" width="272" height="192"><vector name="origin" x="110" y="215"/><vector name="head" x="13" y="-163"/><vector name="lt" x="-65" y="-192"/><vector name="rb" x="128" y="-32"/><int name="delay" value="120"/></canvas><canvas name="8" width="264" height="200"><vector name="origin" x="106" y="224"/><vector name="head" x="23" y="-172"/><vector name="lt" x="-106" y="-224"/><vector name="rb" x="158" y="-24"/><int name="delay" value="120"/></canvas><canvas name="9" width="264" height="210"><vector name="origin" x="105" y="227"/><vector name="head" x="27" y="-176"/><vector name="lt" x="-105" y="-227"/><vector name="rb" x="159" y="-17"/><int name="delay" value="120"/></canvas><canvas name="10" width="266" height="211"><vector name="origin" x="106" y="227"/><vector name="head" x="28" y="-177"/><vector name="lt" x="-106" y="-227"/><vector name="rb" x="160" y="-16"/><int name="delay" value="120"/></canvas><canvas name="11" width="266" height="210"><vector name="origin" x="106" y="226"/><vector name="head" x="29" y="-178"/><vector name="lt" x="-106" y="-226"/><vector name="rb" x="160" y="-16"/><int name="delay" value="120"/></canvas><canvas name="12" width="266" height="209"><vector name="origin" x="106" y="226"/><vector name="head" x="30" y="-179"/><vector name="lt" x="-106" y="-226"/><vector name="rb" x="160" y="-17"/><int name="delay" value="120"/></canvas><canvas name="13" width="264" height="210"><vector name="origin" x="105" y="228"/><vector name="head" x="31" y="-180"/><vector name="lt" x="-105" y="-228"/><vector name="rb" x="159" y="-18"/><int name="delay" value="120"/></canvas><canvas name="14" width="260" height="206"><vector name="origin" x="103" y="225"/><vector name="head" x="30" y="-179"/><vector name="lt" x="-103" y="-225"/><vector name="rb" x="157" y="-19"/><int name="delay" value="120"/></canvas><canvas name="15" width="254" height="194"><vector name="origin" x="103" y="218"/><vector name="head" x="27" y="-176"/><vector name="lt" x="-49" y="-208"/><vector name="rb" x="79" y="-48"/><int name="delay" value="120"/></canvas><canvas name="16" width="170" height="125"><vector name="origin" x="77" y="169"/><vector name="head" x="17" y="-167"/><vector name="lt" x="-77" y="-169"/><vector name="rb" x="93" y="-44"/><int name="delay" value="120"/></canvas><canvas name="17" width="158" height="115"><vector name="origin" x="78" y="156"/><vector name="head" x="9" y="-160"/><vector name="lt" x="-78" y="-156"/><vector name="rb" x="80" y="-42"/><int name="delay" value="120"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="攻击反射"/></imgdir></imgdir><imgdir name="skill3"><canvas name="0" width="162" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="77" y="-37"/><int name="delay" value="120"/></canvas><canvas name="1" width="230" height="113"><vector name="origin" x="143" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="87" y="-36"/><int name="delay" value="120"/></canvas><canvas name="2" width="245" height="114"><vector name="origin" x="153" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-89" y="-149"/><vector name="rb" x="92" y="-35"/><int name="delay" value="120"/></canvas><canvas name="3" width="254" height="115"><vector name="origin" x="158" y="149"/><vector name="head" x="3" y="-153"/><vector name="lt" x="-89" y="-149"/><vector name="rb" x="96" y="-34"/><int name="delay" value="120"/></canvas><canvas name="4" width="258" height="116"><vector name="origin" x="160" y="149"/><vector name="head" x="4" y="-153"/><vector name="lt" x="-89" y="-149"/><vector name="rb" x="98" y="-33"/><int name="delay" value="120"/></canvas><canvas name="5" width="261" height="115"><vector name="origin" x="161" y="149"/><vector name="head" x="5" y="-153"/><vector name="lt" x="-89" y="-149"/><vector name="rb" x="100" y="-34"/><int name="delay" value="120"/></canvas><canvas name="6" width="262" height="125"><vector name="origin" x="161" y="149"/><vector name="head" x="6" y="-153"/><vector name="lt" x="-91" y="-149"/><vector name="rb" x="101" y="-24"/><int name="delay" value="120"/></canvas><canvas name="7" width="262" height="129"><vector name="origin" x="161" y="149"/><vector name="head" x="7" y="-153"/><vector name="lt" x="-91" y="-149"/><vector name="rb" x="101" y="-20"/><int name="delay" value="120"/></canvas><canvas name="8" width="198" height="152"><vector name="origin" x="141" y="165"/><vector name="head" x="-2" y="-153"/><vector name="lt" x="-90" y="-165"/><vector name="rb" x="57" y="-13"/><int name="delay" value="180"/></canvas><canvas name="9" width="196" height="153"><vector name="origin" x="143" y="166"/><vector name="head" x="-4" y="-153"/><vector name="lt" x="-111" y="-166"/><vector name="rb" x="53" y="-13"/><int name="delay" value="150"/></canvas><canvas name="10" width="196" height="151"><vector name="origin" x="144" y="167"/><vector name="head" x="-5" y="-153"/><vector name="lt" x="-96" y="-167"/><vector name="rb" x="52" y="-16"/><int name="delay" value="150"/></canvas><canvas name="11" width="210" height="144"><vector name="origin" x="144" y="166"/><vector name="head" x="-2" y="-153"/><vector name="lt" x="-97" y="-166"/><vector name="rb" x="66" y="-22"/><int name="delay" value="120"/></canvas><canvas name="12" width="210" height="135"><vector name="origin" x="138" y="163"/><vector name="head" x="0" y="-153"/><vector name="lt" x="-87" y="-163"/><vector name="rb" x="72" y="-28"/><int name="delay" value="120"/></canvas><canvas name="13" width="207" height="115"><vector name="origin" x="133" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-80" y="-149"/><vector name="rb" x="74" y="-34"/><int name="delay" value="120"/></canvas><canvas name="14" width="177" height="114"><vector name="origin" x="102" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-80" y="-149"/><vector name="rb" x="75" y="-35"/><int name="delay" value="120"/></canvas><canvas name="15" width="173" height="114"><vector name="origin" x="97" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-80" y="-149"/><vector name="rb" x="76" y="-35"/><int name="delay" value="120"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="潜能无效化"/></imgdir></imgdir><imgdir name="skill4"><canvas name="0" width="162" height="112"><vector name="origin" x="84" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="77" y="-37"/><int name="delay" value="120"/></canvas><canvas name="1" width="190" height="113"><vector name="origin" x="81" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="108" y="-36"/><int name="delay" value="120"/></canvas><canvas name="2" width="182" height="114"><vector name="origin" x="79" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="102" y="-35"/><int name="delay" value="120"/></canvas><canvas name="3" width="178" height="121"><vector name="origin" x="78" y="151"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-78" y="-151"/><vector name="rb" x="100" y="-30"/><int name="delay" value="120"/></canvas><canvas name="4" width="179" height="120"><vector name="origin" x="77" y="153"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-77" y="-153"/><vector name="rb" x="102" y="-33"/><int name="delay" value="120"/></canvas><canvas name="5" width="180" height="115"><vector name="origin" x="76" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-76" y="-149"/><vector name="rb" x="104" y="-34"/><int name="delay" value="120"/></canvas><canvas name="6" width="180" height="114"><vector name="origin" x="75" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-75" y="-149"/><vector name="rb" x="105" y="-35"/><int name="delay" value="120"/></canvas><canvas name="7" width="180" height="114"><vector name="origin" x="75" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-75" y="-149"/><vector name="rb" x="105" y="-35"/><int name="delay" value="120"/></canvas><canvas name="8" width="289" height="144"><vector name="origin" x="238" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-238" y="-149"/><vector name="rb" x="51" y="-5"/><int name="delay" value="120"/></canvas><canvas name="9" width="346" height="141"><vector name="origin" x="303" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-303" y="-149"/><vector name="rb" x="43" y="-8"/><int name="delay" value="120"/></canvas><canvas name="10" width="382" height="142"><vector name="origin" x="343" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-343" y="-149"/><vector name="rb" x="39" y="-7"/><int name="delay" value="120"/></canvas><canvas name="11" width="442" height="142"><vector name="origin" x="375" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-375" y="-149"/><vector name="rb" x="67" y="-7"/><int name="delay" value="120"/></canvas><canvas name="12" width="456" height="143"><vector name="origin" x="383" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-383" y="-149"/><vector name="rb" x="73" y="-6"/><int name="delay" value="120"/></canvas><canvas name="13" width="460" height="143"><vector name="origin" x="385" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-385" y="-149"/><vector name="rb" x="75" y="-6"/><int name="delay" value="120"/></canvas><canvas name="14" width="404" height="143"><vector name="origin" x="328" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-328" y="-149"/><vector name="rb" x="76" y="-6"/><int name="delay" value="120"/></canvas><canvas name="15" width="406" height="142"><vector name="origin" x="329" y="149"/><vector name="head" x="1" y="-161"/><vector name="lt" x="-329" y="-149"/><vector name="rb" x="77" y="-7"/><int name="delay" value="120"/></canvas></imgdir><imgdir name="skill5"><canvas name="0" width="161" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="76" y="-37"/><int name="delay" value="120"/></canvas><canvas name="1" width="186" height="125"><vector name="origin" x="93" y="160"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-93" y="-160"/><vector name="rb" x="93" y="-35"/><int name="delay" value="120"/></canvas><canvas name="2" width="192" height="156"><vector name="origin" x="96" y="189"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-96" y="-189"/><vector name="rb" x="96" y="-33"/><int name="delay" value="120"/></canvas><canvas name="3" width="194" height="169"><vector name="origin" x="97" y="200"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-97" y="-200"/><vector name="rb" x="97" y="-31"/><int name="delay" value="120"/></canvas><canvas name="4" width="194" height="172"><vector name="origin" x="97" y="201"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-97" y="-201"/><vector name="rb" x="97" y="-29"/><int name="delay" value="120"/></canvas><canvas name="5" width="194" height="173"><vector name="origin" x="97" y="202"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-97" y="-202"/><vector name="rb" x="97" y="-29"/><int name="delay" value="120"/></canvas><canvas name="6" width="192" height="173"><vector name="origin" x="96" y="203"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-96" y="-203"/><vector name="rb" x="96" y="-30"/><int name="delay" value="120"/></canvas><canvas name="7" width="192" height="173"><vector name="origin" x="96" y="203"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-96" y="-203"/><vector name="rb" x="96" y="-30"/><int name="delay" value="120"/></canvas><canvas name="8" width="194" height="163"><vector name="origin" x="97" y="182"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-97" y="-182"/><vector name="rb" x="97" y="-19"/><int name="delay" value="180"/></canvas><canvas name="9" width="194" height="184"><vector name="origin" x="97" y="189"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-97" y="-189"/><vector name="rb" x="97" y="-5"/><int name="delay" value="150"/></canvas><canvas name="10" width="194" height="198"><vector name="origin" x="97" y="198"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-97" y="-198"/><vector name="rb" x="97" y="0"/><int name="delay" value="150"/></canvas><canvas name="11" width="192" height="196"><vector name="origin" x="95" y="198"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-95" y="-198"/><vector name="rb" x="97" y="-2"/><int name="delay" value="150"/></canvas><canvas name="12" width="186" height="193"><vector name="origin" x="93" y="198"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-93" y="-198"/><vector name="rb" x="93" y="-5"/><int name="delay" value="120"/></canvas><canvas name="13" width="160" height="132"><vector name="origin" x="85" y="171"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-171"/><vector name="rb" x="75" y="-39"/><int name="delay" value="120"/></canvas><canvas name="14" width="160" height="114"><vector name="origin" x="85" y="150"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-150"/><vector name="rb" x="75" y="-36"/><int name="delay" value="120"/></canvas><canvas name="15" width="160" height="114"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="75" y="-35"/><int name="delay" value="120"/></canvas></imgdir><imgdir name="skill6"><canvas name="0" width="162" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="77" y="-37"/><int name="delay" value="120"/></canvas><canvas name="1" width="230" height="113"><vector name="origin" x="143" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-143" y="-149"/><vector name="rb" x="87" y="-36"/><int name="delay" value="120"/></canvas><canvas name="2" width="245" height="114"><vector name="origin" x="153" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-153" y="-149"/><vector name="rb" x="92" y="-35"/><int name="delay" value="120"/></canvas><canvas name="3" width="254" height="115"><vector name="origin" x="158" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-158" y="-149"/><vector name="rb" x="96" y="-34"/><int name="delay" value="120"/></canvas><canvas name="4" width="258" height="116"><vector name="origin" x="160" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-160" y="-149"/><vector name="rb" x="98" y="-33"/><int name="delay" value="120"/></canvas><canvas name="5" width="261" height="115"><vector name="origin" x="161" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-161" y="-149"/><vector name="rb" x="100" y="-34"/><int name="delay" value="120"/></canvas><canvas name="6" width="262" height="125"><vector name="origin" x="161" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-161" y="-149"/><vector name="rb" x="101" y="-24"/><int name="delay" value="120"/></canvas><canvas name="7" width="262" height="129"><vector name="origin" x="161" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-161" y="-149"/><vector name="rb" x="101" y="-20"/><int name="delay" value="120"/></canvas><canvas name="8" width="198" height="152"><vector name="origin" x="141" y="165"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-141" y="-165"/><vector name="rb" x="57" y="-13"/><int name="delay" value="180"/></canvas><canvas name="9" width="196" height="153"><vector name="origin" x="143" y="166"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-143" y="-166"/><vector name="rb" x="53" y="-13"/><int name="delay" value="150"/></canvas><canvas name="10" width="196" height="151"><vector name="origin" x="144" y="167"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-144" y="-167"/><vector name="rb" x="52" y="-16"/><int name="delay" value="150"/></canvas><canvas name="11" width="210" height="144"><vector name="origin" x="144" y="166"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-144" y="-166"/><vector name="rb" x="66" y="-22"/><int name="delay" value="120"/></canvas><canvas name="12" width="210" height="135"><vector name="origin" x="138" y="163"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-138" y="-163"/><vector name="rb" x="72" y="-28"/><int name="delay" value="120"/></canvas><canvas name="13" width="207" height="115"><vector name="origin" x="133" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-133" y="-149"/><vector name="rb" x="74" y="-34"/><int name="delay" value="120"/></canvas><canvas name="14" width="177" height="114"><vector name="origin" x="102" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-102" y="-149"/><vector name="rb" x="75" y="-35"/><int name="delay" value="120"/></canvas><canvas name="15" width="173" height="114"><vector name="origin" x="97" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-97" y="-149"/><vector name="rb" x="76" y="-35"/><int name="delay" value="120"/></canvas><imgdir name="speak"><int name="prob" value="100"/><string name="0" value="增益解除"/></imgdir></imgdir><imgdir name="skill7"><canvas name="0" width="161" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="76" y="-37"/><int name="delay" value="120"/></canvas><canvas name="1" width="163" height="113"><vector name="origin" x="79" y="148"/><vector name="head" x="2" y="-153"/><vector name="lt" x="-79" y="-148"/><vector name="rb" x="84" y="-35"/><int name="delay" value="120"/></canvas><canvas name="2" width="166" height="139"><vector name="origin" x="84" y="172"/><vector name="head" x="2" y="-151"/><vector name="lt" x="-84" y="-172"/><vector name="rb" x="82" y="-33"/><int name="delay" value="120"/></canvas><canvas name="3" width="189" height="180"><vector name="origin" x="114" y="211"/><vector name="head" x="1" y="-161"/><vector name="lt" x="-114" y="-211"/><vector name="rb" x="75" y="-31"/><int name="delay" value="120"/></canvas><canvas name="4" width="182" height="184"><vector name="origin" x="119" y="233"/><vector name="head" x="2" y="-169"/><vector name="lt" x="-119" y="-233"/><vector name="rb" x="63" y="-49"/><int name="delay" value="120"/></canvas><canvas name="5" width="168" height="195"><vector name="origin" x="124" y="251"/><vector name="head" x="2" y="-176"/><vector name="lt" x="-124" y="-251"/><vector name="rb" x="44" y="-56"/><int name="delay" value="120"/></canvas><canvas name="6" width="179" height="212"><vector name="origin" x="135" y="272"/><vector name="head" x="2" y="-179"/><vector name="lt" x="-135" y="-272"/><vector name="rb" x="44" y="-60"/><int name="delay" value="120"/></canvas><canvas name="7" width="202" height="215"><vector name="origin" x="158" y="276"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-158" y="-276"/><vector name="rb" x="44" y="-61"/><int name="delay" value="120"/></canvas><canvas name="8" width="212" height="231"><vector name="origin" x="168" y="294"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-168" y="-294"/><vector name="rb" x="44" y="-63"/><int name="delay" value="120"/></canvas><canvas name="9" width="202" height="232"><vector name="origin" x="158" y="294"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-158" y="-294"/><vector name="rb" x="44" y="-62"/><int name="delay" value="120"/></canvas><canvas name="10" width="184" height="223"><vector name="origin" x="140" y="284"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-140" y="-284"/><vector name="rb" x="44" y="-61"/><int name="delay" value="120"/></canvas><canvas name="11" width="180" height="214"><vector name="origin" x="136" y="274"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-136" y="-274"/><vector name="rb" x="44" y="-60"/><int name="delay" value="120"/></canvas><canvas name="12" width="167" height="201"><vector name="origin" x="123" y="260"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-123" y="-260"/><vector name="rb" x="44" y="-59"/><int name="delay" value="120"/></canvas><canvas name="13" width="167" height="198"><vector name="origin" x="123" y="258"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-123" y="-258"/><vector name="rb" x="44" y="-60"/><int name="delay" value="120"/></canvas><canvas name="14" width="167" height="198"><vector name="origin" x="123" y="259"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-123" y="-259"/><vector name="rb" x="44" y="-61"/><int name="delay" value="120"/></canvas><canvas name="15" width="167" height="199"><vector name="origin" x="123" y="258"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-123" y="-258"/><vector name="rb" x="44" y="-59"/><int name="delay" value="120"/></canvas><canvas name="16" width="133" height="144"><vector name="origin" x="89" y="202"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-89" y="-202"/><vector name="rb" x="44" y="-58"/><int name="delay" value="120"/></canvas><canvas name="17" width="133" height="149"><vector name="origin" x="89" y="202"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-89" y="-202"/><vector name="rb" x="44" y="-53"/><int name="delay" value="120"/></canvas><canvas name="18" width="157" height="157"><vector name="origin" x="89" y="202"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-89" y="-202"/><vector name="rb" x="68" y="-45"/><int name="delay" value="120"/></canvas><canvas name="19" width="160" height="112"><vector name="origin" x="85" y="152"/><vector name="head" x="2" y="-180"/><vector name="lt" x="-85" y="-152"/><vector name="rb" x="75" y="-40"/><int name="delay" value="120"/></canvas></imgdir><imgdir name="skill8"><canvas name="0" width="161" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-154"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="76" y="-37"/><int name="delay" value="120"/><string name="source" value="Mob/8870200.img/attack2/0"/></canvas><canvas name="1" width="165" height="114"><vector name="origin" x="89" y="178"/><vector name="head" x="2" y="-181"/><vector name="lt" x="-89" y="-178"/><vector name="rb" x="76" y="-64"/><int name="delay" value="120"/></canvas><canvas name="2" width="189" height="228"><vector name="origin" x="113" y="297"/><vector name="head" x="2" y="-192"/><vector name="lt" x="-113" y="-297"/><vector name="rb" x="76" y="-69"/><int name="delay" value="120"/></canvas><canvas name="3" width="187" height="224"><vector name="origin" x="111" y="294"/><vector name="head" x="2" y="-194"/><vector name="lt" x="-111" y="-294"/><vector name="rb" x="76" y="-70"/><int name="delay" value="120"/></canvas><canvas name="4" width="179" height="217"><vector name="origin" x="104" y="287"/><vector name="head" x="2" y="-196"/><vector name="lt" x="-104" y="-287"/><vector name="rb" x="75" y="-70"/><int name="delay" value="120"/></canvas><canvas name="5" width="167" height="207"><vector name="origin" x="92" y="278"/><vector name="head" x="2" y="-198"/><vector name="lt" x="-92" y="-278"/><vector name="rb" x="75" y="-71"/><int name="delay" value="120"/></canvas><canvas name="6" width="160" height="201"><vector name="origin" x="85" y="274"/><vector name="head" x="-1" y="-152"/><vector name="lt" x="-85" y="-274"/><vector name="rb" x="75" y="-73"/><int name="delay" value="120"/></canvas><canvas name="7" width="161" height="203"><vector name="origin" x="86" y="277"/><vector name="head" x="2" y="-200"/><vector name="lt" x="-86" y="-277"/><vector name="rb" x="75" y="-74"/><int name="delay" value="120"/></canvas><canvas name="8" width="234" height="280"><vector name="origin" x="147" y="266"/><vector name="head" x="-1" y="-152"/><vector name="lt" x="-147" y="-266"/><vector name="rb" x="87" y="14"/><int name="delay" value="120"/></canvas><canvas name="9" width="274" height="225"><vector name="origin" x="167" y="210"/><vector name="head" x="-1" y="-152"/><vector name="lt" x="-167" y="-210"/><vector name="rb" x="107" y="15"/><int name="delay" value="180"/></canvas><canvas name="10" width="296" height="184"><vector name="origin" x="178" y="167"/><vector name="head" x="-1" y="-152"/><vector name="lt" x="-178" y="-167"/><vector name="rb" x="118" y="17"/><int name="delay" value="120"/></canvas><canvas name="11" width="294" height="169"><vector name="origin" x="177" y="151"/><vector name="head" x="0" y="-118"/><vector name="lt" x="-177" y="-151"/><vector name="rb" x="117" y="18"/><int name="delay" value="120"/></canvas><canvas name="12" width="292" height="149"><vector name="origin" x="176" y="132"/><vector name="head" x="2" y="-110"/><vector name="lt" x="-176" y="-132"/><vector name="rb" x="116" y="17"/><int name="delay" value="120"/></canvas><canvas name="13" width="259" height="125"><vector name="origin" x="151" y="113"/><vector name="head" x="2" y="-111"/><vector name="lt" x="-151" y="-113"/><vector name="rb" x="108" y="12"/><int name="delay" value="120"/></canvas><canvas name="14" width="145" height="132"><vector name="origin" x="70" y="140"/><vector name="head" x="2" y="-126"/><vector name="lt" x="-70" y="-140"/><vector name="rb" x="75" y="-8"/><int name="delay" value="120"/></canvas></imgdir><imgdir name="skill9"><canvas name="0" width="160" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="150"/></canvas><canvas name="1" width="160" height="113"><vector name="origin" x="85" y="148"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-148"/><vector name="rb" x="75" y="-35"/><int name="delay" value="150"/></canvas><canvas name="2" width="245" height="142"><vector name="origin" x="170" y="147"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-170" y="-147"/><vector name="rb" x="75" y="-5"/><int name="delay" value="150"/></canvas><canvas name="3" width="335" height="175"><vector name="origin" x="171" y="146"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-146"/><vector name="rb" x="164" y="29"/><int name="delay" value="150"/></canvas><canvas name="4" width="336" height="163"><vector name="origin" x="171" y="145"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-145"/><vector name="rb" x="165" y="18"/><int name="delay" value="150"/></canvas><canvas name="5" width="337" height="152"><vector name="origin" x="171" y="146"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-146"/><vector name="rb" x="166" y="6"/><int name="delay" value="150"/></canvas><canvas name="7" width="337" height="153"><vector name="origin" x="171" y="157"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-157"/><vector name="rb" x="166" y="-4"/><int name="delay" value="150"/></canvas><canvas name="6" width="337" height="146"><vector name="origin" x="171" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-149"/><vector name="rb" x="166" y="-3"/><int name="delay" value="150"/></canvas><canvas name="8" width="337" height="232"><vector name="origin" x="171" y="237"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-237"/><vector name="rb" x="166" y="-5"/><int name="delay" value="150"/></canvas><canvas name="9" width="371" height="234"><vector name="origin" x="205" y="238"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-205" y="-238"/><vector name="rb" x="166" y="-4"/><int name="delay" value="150"/></canvas><canvas name="10" width="404" height="267"><vector name="origin" x="207" y="245"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-207" y="-245"/><vector name="rb" x="197" y="22"/><int name="delay" value="150"/></canvas><canvas name="11" width="404" height="264"><vector name="origin" x="207" y="242"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-207" y="-242"/><vector name="rb" x="197" y="22"/><int name="delay" value="150"/></canvas><canvas name="12" width="403" height="262"><vector name="origin" x="206" y="239"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-206" y="-239"/><vector name="rb" x="197" y="23"/><int name="delay" value="150"/></canvas><canvas name="13" width="373" height="247"><vector name="origin" x="175" y="224"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-175" y="-224"/><vector name="rb" x="198" y="23"/><int name="delay" value="150"/></canvas><canvas name="14" width="347" height="179"><vector name="origin" x="153" y="160"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-153" y="-160"/><vector name="rb" x="194" y="19"/><int name="delay" value="150"/></canvas><canvas name="15" width="285" height="158"><vector name="origin" x="132" y="152"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-132" y="-152"/><vector name="rb" x="153" y="6"/><int name="delay" value="150"/></canvas><canvas name="16" width="198" height="145"><vector name="origin" x="85" y="150"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-150"/><vector name="rb" x="113" y="-5"/><int name="delay" value="150"/></canvas><canvas name="17" width="160" height="114"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="75" y="-35"/><int name="delay" value="150"/></canvas></imgdir><imgdir name="hit1"><canvas name="0" width="152" height="124"><vector name="origin" x="27" y="161"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-27" y="-161"/><vector name="rb" x="125" y="-37"/><int name="delay" value="300"/></canvas></imgdir><imgdir name="die1"><canvas name="1" width="152" height="115"><vector name="origin" x="22" y="152"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="2" width="151" height="112"><vector name="origin" x="20" y="149"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="3" width="161" height="112"><vector name="origin" x="29" y="149"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="4" width="195" height="118"><vector name="origin" x="47" y="154"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="5" width="205" height="163"><vector name="origin" x="47" y="161"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="6" width="204" height="176"><vector name="origin" x="51" y="174"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="7" width="226" height="167"><vector name="origin" x="67" y="165"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="8" width="220" height="168"><vector name="origin" x="51" y="166"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="9" width="228" height="166"><vector name="origin" x="52" y="164"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="10" width="226" height="168"><vector name="origin" x="67" y="166"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="11" width="220" height="163"><vector name="origin" x="51" y="161"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="12" width="228" height="169"><vector name="origin" x="52" y="167"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="13" width="228" height="171"><vector name="origin" x="67" y="166"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="14" width="229" height="353"><vector name="origin" x="55" y="345"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="15" width="240" height="357"><vector name="origin" x="58" y="348"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="16" width="236" height="355"><vector name="origin" x="71" y="346"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="17" width="231" height="362"><vector name="origin" x="56" y="353"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="18" width="240" height="360"><vector name="origin" x="58" y="351"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="19" width="181" height="348"><vector name="origin" x="36" y="339"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="20" width="153" height="354"><vector name="origin" x="34" y="346"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="21" width="95" height="353"><vector name="origin" x="-12" y="345"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas><canvas name="22" width="76" height="313"><vector name="origin" x="-23" y="310"/><vector name="head" x="1" y="-153"/><int name="delay" value="90"/></canvas></imgdir><imgdir name="sleep"><canvas name="0" width="337" height="153"><vector name="origin" x="171" y="183"/><int name="delay" value="300"/><string name="source" value="Mob/8870200.img/skill9/7"/></canvas><canvas name="1" width="337" height="153"><vector name="origin" x="171" y="184"/><int name="delay" value="300"/><string name="source" value="Mob/8870200.img/skill9/7"/></canvas><canvas name="2" width="337" height="153"><vector name="origin" x="171" y="185"/><int name="delay" value="300"/><string name="source" value="Mob/8870200.img/skill9/7"/></canvas><canvas name="3" width="337" height="153"><vector name="origin" x="171" y="184"/><int name="delay" value="300"/><string name="source" value="Mob/8870200.img/skill9/7"/></canvas></imgdir><imgdir name="wakeup"><canvas name="0" width="337" height="153"><vector name="origin" x="171" y="184"/><int name="delay" value="150"/><string name="source" value="Mob/8870200.img/skill9/7"/></canvas><canvas name="1" width="337" height="153"><vector name="origin" x="171" y="157"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-157"/><vector name="rb" x="166" y="-4"/><int name="delay" value="150"/><string name="source" value="Mob/8870200.img/skill9/7"/></canvas><canvas name="2" width="337" height="146"><vector name="origin" x="171" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-149"/><vector name="rb" x="166" y="-3"/><int name="delay" value="150"/><string name="source" value="Mob/8870200.img/skill9/6"/></canvas><canvas name="3" width="337" height="152"><vector name="origin" x="171" y="146"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-146"/><vector name="rb" x="166" y="6"/><int name="delay" value="150"/><string name="source" value="Mob/8870200.img/skill9/5"/></canvas><canvas name="4" width="336" height="163"><vector name="origin" x="171" y="145"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-145"/><vector name="rb" x="165" y="18"/><int name="delay" value="150"/><string name="source" value="Mob/8870200.img/skill9/4"/></canvas><canvas name="5" width="335" height="175"><vector name="origin" x="171" y="146"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-171" y="-146"/><vector name="rb" x="164" y="29"/><int name="delay" value="150"/><string name="source" value="Mob/8870200.img/skill9/3"/></canvas><canvas name="6" width="245" height="142"><vector name="origin" x="170" y="147"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-170" y="-147"/><vector name="rb" x="75" y="-5"/><int name="delay" value="150"/><string name="source" value="Mob/8870200.img/skill9/2"/></canvas><canvas name="7" width="160" height="113"><vector name="origin" x="85" y="148"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-148"/><vector name="rb" x="75" y="-35"/><int name="delay" value="150"/><string name="source" value="Mob/8870200.img/skill9/1"/></canvas><canvas name="8" width="160" height="112"><vector name="origin" x="85" y="149"/><vector name="head" x="1" y="-153"/><vector name="lt" x="-85" y="-149"/><vector name="rb" x="75" y="-37"/><int name="delay" value="150"/><string name="source" value="Mob/8870200.img/skill9/0"/></canvas></imgdir><imgdir name="info"><int name="bodyAttack" value="1"/><int name="level" value="180"/><int name="maxHP" value="2100000000"/><int name="maxMP" value="50000"/><int name="speed" value="-50"/><int name="PADamage" value="2100"/><int name="PDDamage" value="1930"/><int name="MADamage" value="2100"/><int name="MDDamage" value="1930"/><int name="acc" value="270"/><int name="eva" value="55"/><int name="exp" value="300000000"/><int name="hpRecovery" value="100000"/><int name="mpRecovery" value="1000"/><int name="undead" value="0"/><int name="pushed" value="140000"/><float name="fs" value="10.0"/><int name="summonType" value="12"/><int name="firstAttack" value="1"/><int name="boss" value="1"/><int name="publicReward" value="1"/><int name="explosiveReward" value="1"/><string name="buff" value="2022449"/><int name="hpTagColor" value="1"/><int name="hpTagBgcolor" value="5"/><string name="elemAttr" value="P2H2F2I2"/><int name="mobType" value="1"/><int name="rareItemDropLevel" value="3"/><imgdir name="skill"><imgdir name="0"><int name="skill" value="200"/><int name="action" value="1"/><int name="level" value="101"/><int name="effectAfter" value="0"/></imgdir><imgdir name="1"><int name="skill" value="145"/><int name="action" value="2"/><int name="level" value="2"/><int name="effectAfter" value="0"/></imgdir><imgdir name="2"><int name="skill" value="133"/><int name="action" value="3"/><int name="level" value="1"/><int name="effectAfter" value="0"/></imgdir></imgdir></imgdir></imgdir>
+<?xml version='1.0' encoding='utf-8'?>
+<imgdir name="9900000.img">
+  <imgdir name="stand">
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="161" height="113">
+      <vector name="origin" x="85" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-85" y="-148"/>
+      <vector name="rb" x="76" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="161" height="114">
+      <vector name="origin" x="85" y="147"/>
+      <vector name="head" x="1" y="-151"/>
+      <vector name="lt" x="-85" y="-147"/>
+      <vector name="rb" x="76" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="161" height="115">
+      <vector name="origin" x="85" y="146"/>
+      <vector name="head" x="1" y="-150"/>
+      <vector name="lt" x="-85" y="-146"/>
+      <vector name="rb" x="76" y="-31"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="160" height="116">
+      <vector name="origin" x="85" y="145"/>
+      <vector name="head" x="1" y="-149"/>
+      <vector name="lt" x="-85" y="-145"/>
+      <vector name="rb" x="75" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="160" height="115">
+      <vector name="origin" x="85" y="146"/>
+      <vector name="head" x="1" y="-150"/>
+      <vector name="lt" x="-85" y="-146"/>
+      <vector name="rb" x="75" y="-31"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="160" height="114">
+      <vector name="origin" x="85" y="147"/>
+      <vector name="head" x="1" y="-151"/>
+      <vector name="lt" x="-85" y="-147"/>
+      <vector name="rb" x="75" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="160" height="114">
+      <vector name="origin" x="85" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-85" y="-148"/>
+      <vector name="rb" x="75" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="158" height="112">
+      <vector name="origin" x="81" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-81" y="-149"/>
+      <vector name="rb" x="77" y="-37"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="158" height="113">
+      <vector name="origin" x="81" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-81" y="-148"/>
+      <vector name="rb" x="77" y="-35"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="158" height="114">
+      <vector name="origin" x="81" y="147"/>
+      <vector name="head" x="1" y="-151"/>
+      <vector name="lt" x="-81" y="-147"/>
+      <vector name="rb" x="77" y="-33"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="158" height="115">
+      <vector name="origin" x="81" y="146"/>
+      <vector name="head" x="1" y="-150"/>
+      <vector name="lt" x="-81" y="-146"/>
+      <vector name="rb" x="77" y="-31"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="157" height="116">
+      <vector name="origin" x="81" y="145"/>
+      <vector name="head" x="1" y="-149"/>
+      <vector name="lt" x="-81" y="-145"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="157" height="115">
+      <vector name="origin" x="81" y="146"/>
+      <vector name="head" x="1" y="-150"/>
+      <vector name="lt" x="-81" y="-146"/>
+      <vector name="rb" x="76" y="-31"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="157" height="114">
+      <vector name="origin" x="81" y="147"/>
+      <vector name="head" x="1" y="-151"/>
+      <vector name="lt" x="-81" y="-147"/>
+      <vector name="rb" x="76" y="-33"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="157" height="114">
+      <vector name="origin" x="81" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-81" y="-148"/>
+      <vector name="rb" x="76" y="-34"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-404" y="-205"/>
+        <vector name="rb" x="50" y="46"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="139" height="154">
+          <vector name="origin" x="66" y="70"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="149" height="140">
+          <vector name="origin" x="72" y="74"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="162" height="154">
+          <vector name="origin" x="82" y="84"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="159" height="132">
+          <vector name="origin" x="76" y="69"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="155" height="132">
+          <vector name="origin" x="70" y="74"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="154" height="132">
+          <vector name="origin" x="71" y="73"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack1/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="900"/>
+      <int name="delay" value="90"/>
+    </imgdir>
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="178" height="113">
+      <vector name="origin" x="90" y="151"/>
+      <vector name="head" x="5" y="-155"/>
+      <vector name="lt" x="-90" y="-151"/>
+      <vector name="rb" x="88" y="-38"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="158" height="154">
+      <vector name="origin" x="61" y="197"/>
+      <vector name="head" x="12" y="-161"/>
+      <vector name="lt" x="-61" y="-197"/>
+      <vector name="rb" x="97" y="-43"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="166" height="155">
+      <vector name="origin" x="70" y="199"/>
+      <vector name="head" x="15" y="-163"/>
+      <vector name="lt" x="-70" y="-199"/>
+      <vector name="rb" x="96" y="-44"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="166" height="156">
+      <vector name="origin" x="70" y="202"/>
+      <vector name="head" x="18" y="-166"/>
+      <vector name="lt" x="-32" y="-175"/>
+      <vector name="rb" x="96" y="-46"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="161" height="155">
+      <vector name="origin" x="62" y="203"/>
+      <vector name="head" x="19" y="-167"/>
+      <vector name="lt" x="-62" y="-203"/>
+      <vector name="rb" x="99" y="-48"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="155" height="154">
+      <vector name="origin" x="57" y="204"/>
+      <vector name="head" x="20" y="-168"/>
+      <vector name="lt" x="-57" y="-204"/>
+      <vector name="rb" x="98" y="-50"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="154" height="154">
+      <vector name="origin" x="56" y="204"/>
+      <vector name="head" x="20" y="-168"/>
+      <vector name="lt" x="-56" y="-204"/>
+      <vector name="rb" x="98" y="-50"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="220" height="180">
+      <vector name="origin" x="158" y="186"/>
+      <vector name="head" x="-45" y="-126"/>
+      <vector name="lt" x="-158" y="-186"/>
+      <vector name="rb" x="62" y="-6"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="9" width="311" height="205">
+      <vector name="origin" x="263" y="176"/>
+      <vector name="head" x="-49" y="-124"/>
+      <vector name="lt" x="-158" y="-186"/>
+      <vector name="rb" x="62" y="-6"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="10" width="396" height="177">
+      <vector name="origin" x="349" y="143"/>
+      <vector name="head" x="-51" y="-123"/>
+      <vector name="lt" x="-144" y="-143"/>
+      <vector name="rb" x="47" y="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="11" width="451" height="171">
+      <vector name="origin" x="404" y="145"/>
+      <vector name="head" x="-51" y="-123"/>
+      <vector name="lt" x="-132" y="-145"/>
+      <vector name="rb" x="47" y="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="449" height="160">
+      <vector name="origin" x="403" y="144"/>
+      <vector name="head" x="-49" y="-125"/>
+      <vector name="lt" x="-137" y="-144"/>
+      <vector name="rb" x="47" y="0"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="13" width="466" height="146">
+      <vector name="origin" x="404" y="141"/>
+      <vector name="head" x="-38" y="-131"/>
+      <vector name="lt" x="-125" y="-141"/>
+      <vector name="rb" x="61" y="2"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="14" width="468" height="130">
+      <vector name="origin" x="393" y="142"/>
+      <vector name="head" x="-12" y="-146"/>
+      <vector name="lt" x="-97" y="-142"/>
+      <vector name="rb" x="75" y="-32"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="15" width="162" height="114">
+      <vector name="origin" x="86" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-86" y="-148"/>
+      <vector name="rb" x="76" y="-34"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="16" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="17" width="160" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-192" y="-199"/>
+        <vector name="rb" x="137" y="22"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="143" height="192">
+          <vector name="origin" x="67" y="95"/>
+          <string name="source" value="Mob/8850011.img/attack1/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="147" height="192">
+          <vector name="origin" x="71" y="95"/>
+          <string name="source" value="Mob/8850011.img/attack1/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="136" height="135">
+          <vector name="origin" x="71" y="66"/>
+          <string name="source" value="Mob/8850011.img/attack1/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="135" height="133">
+          <vector name="origin" x="70" y="65"/>
+          <string name="source" value="Mob/8850011.img/attack1/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="140" height="140">
+          <vector name="origin" x="72" y="67"/>
+          <string name="source" value="Mob/8850011.img/attack1/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="149" height="152">
+          <vector name="origin" x="80" y="75"/>
+          <string name="source" value="Mob/8620009.img/attack2/info/hit/4"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="attackAfter" value="900"/>
+      <int name="delay" value="120"/>
+      <imgdir name="hit2">
+        <canvas name="0" width="112" height="150">
+          <vector name="origin" x="350" y="108"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-350" y="-108"/>
+          <vector name="rb" x="-238" y="42"/>
+        </canvas>
+        <canvas name="1" width="115" height="150">
+          <vector name="origin" x="353" y="108"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-353" y="-108"/>
+          <vector name="rb" x="-238" y="42"/>
+        </canvas>
+        <canvas name="2" width="107" height="104">
+          <vector name="origin" x="353" y="85"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-353" y="-85"/>
+          <vector name="rb" x="-246" y="19"/>
+        </canvas>
+        <canvas name="3" width="106" height="104">
+          <vector name="origin" x="352" y="85"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-352" y="-85"/>
+          <vector name="rb" x="-246" y="19"/>
+        </canvas>
+        <canvas name="4" width="110" height="111">
+          <vector name="origin" x="354" y="87"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-354" y="-87"/>
+          <vector name="rb" x="-244" y="24"/>
+        </canvas>
+        <canvas name="5" width="113" height="119">
+          <vector name="origin" x="360" y="93"/>
+          <vector name="head" x="1" y="-153"/>
+          <vector name="lt" x="-360" y="-93"/>
+          <vector name="rb" x="-247" y="26"/>
+        </canvas>
+      </imgdir>
+    </imgdir>
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="165" height="114">
+      <vector name="origin" x="89" y="178"/>
+      <vector name="head" x="2" y="-181"/>
+      <vector name="lt" x="-89" y="-178"/>
+      <vector name="rb" x="76" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="189" height="228">
+      <vector name="origin" x="113" y="297"/>
+      <vector name="head" x="2" y="-191"/>
+      <vector name="lt" x="-74" y="-219"/>
+      <vector name="rb" x="76" y="-72"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="187" height="224">
+      <vector name="origin" x="111" y="294"/>
+      <vector name="head" x="2" y="-194"/>
+      <vector name="lt" x="-64" y="-192"/>
+      <vector name="rb" x="76" y="-70"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="179" height="217">
+      <vector name="origin" x="104" y="287"/>
+      <vector name="head" x="2" y="-196"/>
+      <vector name="lt" x="-65" y="-231"/>
+      <vector name="rb" x="75" y="-71"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="167" height="207">
+      <vector name="origin" x="92" y="278"/>
+      <vector name="head" x="2" y="-197"/>
+      <vector name="lt" x="-68" y="-240"/>
+      <vector name="rb" x="75" y="-71"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="152" height="199">
+      <vector name="origin" x="77" y="272"/>
+      <vector name="head" x="2" y="-198"/>
+      <vector name="lt" x="-77" y="-224"/>
+      <vector name="rb" x="75" y="-73"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="152" height="201">
+      <vector name="origin" x="77" y="275"/>
+      <vector name="head" x="2" y="-199"/>
+      <vector name="lt" x="-77" y="-250"/>
+      <vector name="rb" x="75" y="-74"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="344" height="283">
+      <vector name="origin" x="205" y="254"/>
+      <vector name="head" x="2" y="-126"/>
+      <vector name="lt" x="-98" y="-128"/>
+      <vector name="rb" x="98" y="-2"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="483" height="210">
+      <vector name="origin" x="271" y="182"/>
+      <vector name="head" x="2" y="-117"/>
+      <vector name="lt" x="-100" y="-129"/>
+      <vector name="rb" x="110" y="-5"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="561" height="211">
+      <vector name="origin" x="310" y="184"/>
+      <vector name="head" x="2" y="-113"/>
+      <vector name="lt" x="-114" y="-127"/>
+      <vector name="rb" x="113" y="-1"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="603" height="227">
+      <vector name="origin" x="331" y="202"/>
+      <vector name="head" x="2" y="-111"/>
+      <vector name="lt" x="-97" y="-112"/>
+      <vector name="rb" x="81" y="1"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="601" height="219">
+      <vector name="origin" x="330" y="200"/>
+      <vector name="head" x="2" y="-110"/>
+      <vector name="lt" x="-80" y="-113"/>
+      <vector name="rb" x="62" y="0"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="591" height="206">
+      <vector name="origin" x="325" y="194"/>
+      <vector name="head" x="2" y="-111"/>
+      <vector name="lt" x="-79" y="-112"/>
+      <vector name="rb" x="64" y="11"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="492" height="145">
+      <vector name="origin" x="281" y="143"/>
+      <vector name="head" x="2" y="-126"/>
+      <vector name="lt" x="-65" y="-142"/>
+      <vector name="rb" x="62" y="1"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack3">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-65" y="-125"/>
+        <vector name="rb" x="65" y="0"/>
+        <int name="start" value="-4"/>
+        <int name="areaCount" value="9"/>
+        <int name="attackCount" value="4"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="124" height="130">
+          <vector name="origin" x="57" y="117"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/0"/>
+        </canvas>
+        <canvas name="1" width="128" height="127">
+          <vector name="origin" x="59" y="114"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/1"/>
+        </canvas>
+        <canvas name="2" width="132" height="124">
+          <vector name="origin" x="62" y="111"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/2"/>
+        </canvas>
+        <canvas name="3" width="127" height="115">
+          <vector name="origin" x="65" y="102"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/3"/>
+        </canvas>
+        <canvas name="4" width="132" height="138">
+          <vector name="origin" x="69" y="109"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/4"/>
+        </canvas>
+        <canvas name="5" width="132" height="145">
+          <vector name="origin" x="69" y="119"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/5"/>
+        </canvas>
+        <canvas name="6" width="131" height="139">
+          <vector name="origin" x="65" y="126"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/6"/>
+        </canvas>
+        <canvas name="7" width="128" height="137">
+          <vector name="origin" x="61" y="124"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/7"/>
+        </canvas>
+        <canvas name="8" width="130" height="134">
+          <vector name="origin" x="60" y="121"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/8"/>
+        </canvas>
+        <canvas name="9" width="127" height="99">
+          <vector name="origin" x="65" y="86"/>
+          <int name="delay" value="150"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/9"/>
+        </canvas>
+        <canvas name="10" width="141" height="118">
+          <vector name="origin" x="69" y="100"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/10"/>
+        </canvas>
+        <canvas name="11" width="163" height="294">
+          <vector name="origin" x="79" y="277"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/11"/>
+        </canvas>
+        <canvas name="12" width="168" height="302">
+          <vector name="origin" x="85" y="286"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/12"/>
+        </canvas>
+        <canvas name="13" width="198" height="303">
+          <vector name="origin" x="100" y="285"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/13"/>
+        </canvas>
+        <canvas name="14" width="218" height="287">
+          <vector name="origin" x="110" y="267"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/14"/>
+        </canvas>
+        <canvas name="15" width="231" height="262">
+          <vector name="origin" x="116" y="241"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/15"/>
+        </canvas>
+        <canvas name="16" width="237" height="61">
+          <vector name="origin" x="119" y="41"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/areaWarning/16"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="128" height="167">
+          <vector name="origin" x="58" y="89"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="176" height="164">
+          <vector name="origin" x="96" y="85"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="177" height="162">
+          <vector name="origin" x="97" y="83"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="176" height="157">
+          <vector name="origin" x="97" y="81"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="172" height="146">
+          <vector name="origin" x="93" y="80"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="88" height="71">
+          <vector name="origin" x="41" y="54"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/5"/>
+        </canvas>
+        <canvas name="6" width="13" height="16">
+          <vector name="origin" x="7" y="4"/>
+          <int name="delay" value="60"/>
+          <string name="source" value="Mob/8870000.img/attack3/info/hit/6"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="1620"/>
+    </imgdir>
+    <canvas name="0" width="160" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="160" height="113">
+      <vector name="origin" x="85" y="148"/>
+      <vector name="head" x="2" y="-152"/>
+      <vector name="lt" x="-85" y="-148"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="168" height="114">
+      <vector name="origin" x="92" y="147"/>
+      <vector name="head" x="2" y="-151"/>
+      <vector name="lt" x="-92" y="-147"/>
+      <vector name="rb" x="76" y="-33"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="146" height="146">
+      <vector name="origin" x="70" y="175"/>
+      <vector name="head" x="2" y="-150"/>
+      <vector name="lt" x="-70" y="-175"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="147" height="183">
+      <vector name="origin" x="71" y="207"/>
+      <vector name="head" x="2" y="-149"/>
+      <vector name="lt" x="-71" y="-207"/>
+      <vector name="rb" x="76" y="-24"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="149" height="189">
+      <vector name="origin" x="73" y="214"/>
+      <vector name="head" x="2" y="-150"/>
+      <vector name="lt" x="-64" y="-176"/>
+      <vector name="rb" x="76" y="-25"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="148" height="189">
+      <vector name="origin" x="73" y="215"/>
+      <vector name="head" x="2" y="-151"/>
+      <vector name="lt" x="-73" y="-185"/>
+      <vector name="rb" x="75" y="-26"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="148" height="189">
+      <vector name="origin" x="73" y="216"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-73" y="-216"/>
+      <vector name="rb" x="75" y="-27"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="150" height="189">
+      <vector name="origin" x="75" y="219"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-75" y="-219"/>
+      <vector name="rb" x="75" y="-30"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="151" height="191">
+      <vector name="origin" x="76" y="219"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-76" y="-219"/>
+      <vector name="rb" x="75" y="-28"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="152" height="193">
+      <vector name="origin" x="77" y="219"/>
+      <vector name="head" x="1" y="-151"/>
+      <vector name="lt" x="-77" y="-219"/>
+      <vector name="rb" x="75" y="-26"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="171" height="220">
+      <vector name="origin" x="96" y="243"/>
+      <vector name="head" x="1" y="-149"/>
+      <vector name="lt" x="-95" y="-210"/>
+      <vector name="rb" x="75" y="-23"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="175" height="225">
+      <vector name="origin" x="99" y="243"/>
+      <vector name="head" x="1" y="-145"/>
+      <vector name="lt" x="-80" y="-191"/>
+      <vector name="rb" x="76" y="-18"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="175" height="226">
+      <vector name="origin" x="100" y="243"/>
+      <vector name="head" x="1" y="-143"/>
+      <vector name="lt" x="-96" y="-200"/>
+      <vector name="rb" x="75" y="-17"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="174" height="227">
+      <vector name="origin" x="99" y="263"/>
+      <vector name="head" x="1" y="-159"/>
+      <vector name="lt" x="-95" y="-208"/>
+      <vector name="rb" x="75" y="-36"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="174" height="231">
+      <vector name="origin" x="99" y="279"/>
+      <vector name="head" x="1" y="-172"/>
+      <vector name="lt" x="-95" y="-225"/>
+      <vector name="rb" x="75" y="-48"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="174" height="235">
+      <vector name="origin" x="99" y="285"/>
+      <vector name="head" x="1" y="-175"/>
+      <vector name="lt" x="-99" y="-245"/>
+      <vector name="rb" x="75" y="-50"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="174" height="232">
+      <vector name="origin" x="99" y="283"/>
+      <vector name="head" x="1" y="-177"/>
+      <vector name="lt" x="-99" y="-283"/>
+      <vector name="rb" x="75" y="-51"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="173" height="240">
+      <vector name="origin" x="98" y="289"/>
+      <vector name="head" x="1" y="-176"/>
+      <vector name="lt" x="-82" y="-225"/>
+      <vector name="rb" x="75" y="-49"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="165" height="238">
+      <vector name="origin" x="90" y="288"/>
+      <vector name="head" x="2" y="-172"/>
+      <vector name="lt" x="-91" y="-194"/>
+      <vector name="rb" x="75" y="-50"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="165" height="230">
+      <vector name="origin" x="90" y="267"/>
+      <vector name="head" x="2" y="-160"/>
+      <vector name="lt" x="-80" y="-161"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="162" height="120">
+      <vector name="origin" x="87" y="152"/>
+      <vector name="head" x="2" y="-152"/>
+      <vector name="lt" x="-87" y="-152"/>
+      <vector name="rb" x="75" y="-32"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Attack warning"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="attack4">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-480" y="-617"/>
+        <vector name="rb" x="434" y="10"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="303" height="735">
+          <vector name="origin" x="148" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="284" height="735">
+          <vector name="origin" x="139" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="270" height="735">
+          <vector name="origin" x="131" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="266" height="735">
+          <vector name="origin" x="132" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="261" height="735">
+          <vector name="origin" x="120" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="188" height="735">
+          <vector name="origin" x="95" y="730"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/5"/>
+        </canvas>
+        <canvas name="6" width="22" height="721">
+          <vector name="origin" x="8" y="717"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack4/info/hit/6"/>
+        </canvas>
+        <int name="pos" value="3"/>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="attackAfter" value="1680"/>
+    </imgdir>
+    <canvas name="1" width="161" height="113">
+      <vector name="origin" x="85" y="150"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-85" y="-150"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="205" height="190">
+      <vector name="origin" x="104" y="238"/>
+      <vector name="head" x="2" y="-166"/>
+      <vector name="lt" x="-104" y="-176"/>
+      <vector name="rb" x="101" y="-48"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="311" height="243">
+      <vector name="origin" x="154" y="297"/>
+      <vector name="head" x="2" y="-212"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="346" height="264">
+      <vector name="origin" x="167" y="302"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="367" height="265">
+      <vector name="origin" x="178" y="304"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="372" height="227">
+      <vector name="origin" x="181" y="311"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="371" height="211">
+      <vector name="origin" x="182" y="308"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="368" height="244">
+      <vector name="origin" x="181" y="308"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="365" height="220">
+      <vector name="origin" x="179" y="305"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="359" height="212">
+      <vector name="origin" x="174" y="306"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="357" height="214">
+      <vector name="origin" x="173" y="306"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="355" height="217">
+      <vector name="origin" x="173" y="307"/>
+      <vector name="head" x="2" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="352" height="614">
+      <vector name="origin" x="171" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="350" height="607">
+      <vector name="origin" x="168" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="359" height="607">
+      <vector name="origin" x="173" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="365" height="608">
+      <vector name="origin" x="176" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="367" height="609">
+      <vector name="origin" x="178" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="358" height="633">
+      <vector name="origin" x="176" y="726"/>
+      <vector name="head" x="2" y="-237"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="333" height="678">
+      <vector name="origin" x="170" y="726"/>
+      <vector name="head" x="4" y="-214"/>
+      <vector name="lt" x="-75" y="-223"/>
+      <vector name="rb" x="75" y="-54"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="158" height="763">
+      <vector name="origin" x="84" y="725"/>
+      <vector name="head" x="2" y="-200"/>
+      <vector name="lt" x="-84" y="-199"/>
+      <vector name="rb" x="74" y="-57"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack5">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-185" y="-150"/>
+        <vector name="rb" x="185" y="0"/>
+        <int name="start" value="-1"/>
+        <int name="areaCount" value="3"/>
+        <int name="attackCount" value="1"/>
+        <int name="reverse" value="1"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="56" height="167">
+          <vector name="origin" x="25" y="141"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/0"/>
+        </canvas>
+        <canvas name="1" width="57" height="164">
+          <vector name="origin" x="26" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/1"/>
+        </canvas>
+        <canvas name="2" width="82" height="157">
+          <vector name="origin" x="40" y="126"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/2"/>
+        </canvas>
+        <canvas name="3" width="82" height="141">
+          <vector name="origin" x="40" y="117"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/3"/>
+        </canvas>
+        <canvas name="4" width="83" height="92">
+          <vector name="origin" x="41" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/4"/>
+        </canvas>
+        <canvas name="5" width="83" height="92">
+          <vector name="origin" x="41" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/4"/>
+        </canvas>
+        <canvas name="6" width="83" height="92">
+          <vector name="origin" x="41" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/6"/>
+        </canvas>
+        <canvas name="7" width="95" height="97">
+          <vector name="origin" x="46" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/7"/>
+        </canvas>
+        <canvas name="8" width="201" height="102">
+          <vector name="origin" x="99" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/8"/>
+        </canvas>
+        <canvas name="9" width="269" height="105">
+          <vector name="origin" x="133" y="90"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/9"/>
+        </canvas>
+        <canvas name="10" width="345" height="176">
+          <vector name="origin" x="171" y="158"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/10"/>
+        </canvas>
+        <canvas name="11" width="369" height="185">
+          <vector name="origin" x="183" y="166"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/11"/>
+        </canvas>
+        <canvas name="12" width="371" height="187">
+          <vector name="origin" x="184" y="168"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/12"/>
+        </canvas>
+        <canvas name="13" width="373" height="189">
+          <vector name="origin" x="185" y="170"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/13"/>
+        </canvas>
+        <canvas name="14" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/14"/>
+        </canvas>
+        <canvas name="15" width="382" height="188">
+          <vector name="origin" x="190" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/15"/>
+        </canvas>
+        <canvas name="16" width="373" height="188">
+          <vector name="origin" x="185" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/16"/>
+        </canvas>
+        <canvas name="17" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/17"/>
+        </canvas>
+        <canvas name="18" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/18"/>
+        </canvas>
+        <canvas name="19" width="382" height="188">
+          <vector name="origin" x="190" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/19"/>
+        </canvas>
+        <canvas name="20" width="373" height="188">
+          <vector name="origin" x="185" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/20"/>
+        </canvas>
+        <canvas name="21" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/21"/>
+        </canvas>
+        <canvas name="22" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/22"/>
+        </canvas>
+        <canvas name="23" width="382" height="188">
+          <vector name="origin" x="190" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/23"/>
+        </canvas>
+        <canvas name="24" width="373" height="188">
+          <vector name="origin" x="185" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/24"/>
+        </canvas>
+        <canvas name="25" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/25"/>
+        </canvas>
+        <canvas name="26" width="373" height="190">
+          <vector name="origin" x="185" y="171"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/26"/>
+        </canvas>
+        <canvas name="27" width="382" height="188">
+          <vector name="origin" x="190" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/15"/>
+        </canvas>
+        <canvas name="28" width="373" height="188">
+          <vector name="origin" x="185" y="169"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/40"/>
+        </canvas>
+        <canvas name="29" width="371" height="189">
+          <vector name="origin" x="184" y="170"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/41"/>
+        </canvas>
+        <canvas name="30" width="369" height="186">
+          <vector name="origin" x="183" y="167"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/42"/>
+        </canvas>
+        <canvas name="31" width="345" height="176">
+          <vector name="origin" x="171" y="158"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/43"/>
+        </canvas>
+        <canvas name="32" width="269" height="152">
+          <vector name="origin" x="133" y="122"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/44"/>
+        </canvas>
+        <canvas name="33" width="95" height="162">
+          <vector name="origin" x="46" y="131"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/45"/>
+        </canvas>
+        <canvas name="34" width="56" height="167">
+          <vector name="origin" x="25" y="141"/>
+          <int name="z" value="0"/>
+          <int name="delay" value="120"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/areaWarning/0"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="136" height="123">
+          <vector name="origin" x="80" y="63"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/hit/0"/>
+        </canvas>
+        <canvas name="1" width="168" height="127">
+          <vector name="origin" x="96" y="68"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/hit/1"/>
+        </canvas>
+        <canvas name="2" width="169" height="134">
+          <vector name="origin" x="94" y="72"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/hit/2"/>
+        </canvas>
+        <canvas name="3" width="176" height="140">
+          <vector name="origin" x="100" y="74"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/hit/3"/>
+        </canvas>
+        <canvas name="4" width="168" height="139">
+          <vector name="origin" x="97" y="76"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8870000.img/attack5/info/hit/4"/>
+        </canvas>
+        <canvas name="5" width="110" height="105">
+          <vector name="origin" x="48" y="85"/>
+          <int name="delay" value="90"/>
+          <string name="source" value="Mob/8600005.img/attack2/info/hit/5"/>
+        </canvas>
+      </imgdir>
+      <int name="attackAfter" value="2400"/>
+    </imgdir>
+    <canvas name="1" width="296" height="168">
+      <vector name="origin" x="113" y="163"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="313" height="214">
+      <vector name="origin" x="167" y="211"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="240" height="250">
+      <vector name="origin" x="142" y="242"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="208" height="300">
+      <vector name="origin" x="119" y="235"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="338" height="262">
+      <vector name="origin" x="94" y="223"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="272" height="343">
+      <vector name="origin" x="85" y="325"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="226" height="271">
+      <vector name="origin" x="85" y="266"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="194" height="215">
+      <vector name="origin" x="85" y="219"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="175" height="172">
+      <vector name="origin" x="86" y="185"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="153" height="135">
+      <vector name="origin" x="83" y="172"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="126" height="186">
+      <vector name="origin" x="66" y="223"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="119" height="247">
+      <vector name="origin" x="54" y="284"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="121" height="264">
+      <vector name="origin" x="55" y="303"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="111" height="264">
+      <vector name="origin" x="51" y="305"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="159" height="294">
+      <vector name="origin" x="78" y="336"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="182" height="304">
+      <vector name="origin" x="89" y="347"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="788" height="641">
+      <vector name="origin" x="387" y="584"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="819" height="652">
+      <vector name="origin" x="402" y="590"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="839" height="660">
+      <vector name="origin" x="427" y="594"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="862" height="711">
+      <vector name="origin" x="442" y="649"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="897" height="754">
+      <vector name="origin" x="454" y="690"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="931" height="801">
+      <vector name="origin" x="474" y="710"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="23" width="950" height="813">
+      <vector name="origin" x="480" y="712"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="24" width="968" height="826">
+      <vector name="origin" x="478" y="711"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="25" width="922" height="795">
+      <vector name="origin" x="426" y="680"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="26" width="822" height="691">
+      <vector name="origin" x="363" y="581"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="27" width="850" height="681">
+      <vector name="origin" x="371" y="589"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="28" width="858" height="633">
+      <vector name="origin" x="373" y="591"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="29" width="749" height="594">
+      <vector name="origin" x="367" y="561"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="30" width="165" height="298">
+      <vector name="origin" x="85" y="336"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="31" width="135" height="263">
+      <vector name="origin" x="85" y="303"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="32" width="145" height="183">
+      <vector name="origin" x="85" y="223"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="33" width="161" height="114">
+      <vector name="origin" x="85" y="152"/>
+      <vector name="head" x="2" y="-154"/>
+      <vector name="lt" x="-86" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Danger! Hide in the magic circle!!!"/>
+      <int name="floatNotice" value="73"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="160" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="165" height="113">
+      <vector name="origin" x="90" y="148"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-90" y="-148"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="181" height="114">
+      <vector name="origin" x="105" y="147"/>
+      <vector name="head" x="1" y="-152"/>
+      <vector name="lt" x="-105" y="-147"/>
+      <vector name="rb" x="76" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="191" height="200">
+      <vector name="origin" x="115" y="231"/>
+      <vector name="head" x="1" y="-150"/>
+      <vector name="lt" x="-115" y="-231"/>
+      <vector name="rb" x="76" y="-31"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="207" height="210">
+      <vector name="origin" x="131" y="239"/>
+      <vector name="head" x="2" y="-149"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="211" height="210">
+      <vector name="origin" x="135" y="241"/>
+      <vector name="head" x="2" y="-150"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="213" height="223">
+      <vector name="origin" x="138" y="257"/>
+      <vector name="head" x="2" y="-152"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="217" height="224">
+      <vector name="origin" x="142" y="262"/>
+      <vector name="head" x="2" y="-156"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="224" height="229">
+      <vector name="origin" x="149" y="277"/>
+      <vector name="head" x="2" y="-164"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="222" height="222">
+      <vector name="origin" x="145" y="284"/>
+      <vector name="head" x="2" y="-179"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="10" width="218" height="223">
+      <vector name="origin" x="142" y="287"/>
+      <vector name="head" x="2" y="-182"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="216" height="221">
+      <vector name="origin" x="139" y="286"/>
+      <vector name="head" x="2" y="-184"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="76" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="216" height="222">
+      <vector name="origin" x="139" y="287"/>
+      <vector name="head" x="2" y="-185"/>
+      <vector name="lt" x="-99" y="-193"/>
+      <vector name="rb" x="77" y="-65"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="213" height="220">
+      <vector name="origin" x="137" y="285"/>
+      <vector name="head" x="2" y="-184"/>
+      <vector name="lt" x="-110" y="-223"/>
+      <vector name="rb" x="76" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="212" height="222">
+      <vector name="origin" x="136" y="283"/>
+      <vector name="head" x="2" y="-182"/>
+      <vector name="lt" x="-100" y="-208"/>
+      <vector name="rb" x="76" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="209" height="229">
+      <vector name="origin" x="134" y="282"/>
+      <vector name="head" x="2" y="-171"/>
+      <vector name="lt" x="-64" y="-176"/>
+      <vector name="rb" x="75" y="-53"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="206" height="229">
+      <vector name="origin" x="131" y="264"/>
+      <vector name="head" x="2" y="-151"/>
+      <vector name="lt" x="-97" y="-160"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="188" height="228">
+      <vector name="origin" x="113" y="263"/>
+      <vector name="head" x="2" y="-152"/>
+      <vector name="lt" x="-112" y="-160"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="158" height="114">
+      <vector name="origin" x="83" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-83" y="-149"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="158" height="115">
+      <vector name="origin" x="75" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-75" y="-149"/>
+      <vector name="rb" x="83" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="265" height="126">
+      <vector name="origin" x="106" y="159"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-106" y="-159"/>
+      <vector name="rb" x="159" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="268" height="118">
+      <vector name="origin" x="108" y="151"/>
+      <vector name="head" x="3" y="-154"/>
+      <vector name="lt" x="-64" y="-151"/>
+      <vector name="rb" x="80" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="272" height="132">
+      <vector name="origin" x="110" y="166"/>
+      <vector name="head" x="4" y="-155"/>
+      <vector name="lt" x="-60" y="-160"/>
+      <vector name="rb" x="96" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="272" height="158">
+      <vector name="origin" x="110" y="192"/>
+      <vector name="head" x="6" y="-157"/>
+      <vector name="lt" x="-65" y="-160"/>
+      <vector name="rb" x="95" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="272" height="192">
+      <vector name="origin" x="110" y="215"/>
+      <vector name="head" x="13" y="-163"/>
+      <vector name="lt" x="-65" y="-192"/>
+      <vector name="rb" x="128" y="-32"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="264" height="200">
+      <vector name="origin" x="106" y="224"/>
+      <vector name="head" x="23" y="-172"/>
+      <vector name="lt" x="-106" y="-224"/>
+      <vector name="rb" x="158" y="-24"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="264" height="210">
+      <vector name="origin" x="105" y="227"/>
+      <vector name="head" x="27" y="-176"/>
+      <vector name="lt" x="-105" y="-227"/>
+      <vector name="rb" x="159" y="-17"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="266" height="211">
+      <vector name="origin" x="106" y="227"/>
+      <vector name="head" x="28" y="-177"/>
+      <vector name="lt" x="-106" y="-227"/>
+      <vector name="rb" x="160" y="-16"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="266" height="210">
+      <vector name="origin" x="106" y="226"/>
+      <vector name="head" x="29" y="-178"/>
+      <vector name="lt" x="-106" y="-226"/>
+      <vector name="rb" x="160" y="-16"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="266" height="209">
+      <vector name="origin" x="106" y="226"/>
+      <vector name="head" x="30" y="-179"/>
+      <vector name="lt" x="-106" y="-226"/>
+      <vector name="rb" x="160" y="-17"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="264" height="210">
+      <vector name="origin" x="105" y="228"/>
+      <vector name="head" x="31" y="-180"/>
+      <vector name="lt" x="-105" y="-228"/>
+      <vector name="rb" x="159" y="-18"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="260" height="206">
+      <vector name="origin" x="103" y="225"/>
+      <vector name="head" x="30" y="-179"/>
+      <vector name="lt" x="-103" y="-225"/>
+      <vector name="rb" x="157" y="-19"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="254" height="194">
+      <vector name="origin" x="103" y="218"/>
+      <vector name="head" x="27" y="-176"/>
+      <vector name="lt" x="-49" y="-208"/>
+      <vector name="rb" x="79" y="-48"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="170" height="125">
+      <vector name="origin" x="77" y="169"/>
+      <vector name="head" x="17" y="-167"/>
+      <vector name="lt" x="-77" y="-169"/>
+      <vector name="rb" x="93" y="-44"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="158" height="115">
+      <vector name="origin" x="78" y="156"/>
+      <vector name="head" x="9" y="-160"/>
+      <vector name="lt" x="-78" y="-156"/>
+      <vector name="rb" x="80" y="-42"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Damage reflection"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill3">
+    <canvas name="0" width="162" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="77" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="230" height="113">
+      <vector name="origin" x="143" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="87" y="-36"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="245" height="114">
+      <vector name="origin" x="153" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-89" y="-149"/>
+      <vector name="rb" x="92" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="254" height="115">
+      <vector name="origin" x="158" y="149"/>
+      <vector name="head" x="3" y="-153"/>
+      <vector name="lt" x="-89" y="-149"/>
+      <vector name="rb" x="96" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="258" height="116">
+      <vector name="origin" x="160" y="149"/>
+      <vector name="head" x="4" y="-153"/>
+      <vector name="lt" x="-89" y="-149"/>
+      <vector name="rb" x="98" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="261" height="115">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="5" y="-153"/>
+      <vector name="lt" x="-89" y="-149"/>
+      <vector name="rb" x="100" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="262" height="125">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="6" y="-153"/>
+      <vector name="lt" x="-91" y="-149"/>
+      <vector name="rb" x="101" y="-24"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="262" height="129">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="7" y="-153"/>
+      <vector name="lt" x="-91" y="-149"/>
+      <vector name="rb" x="101" y="-20"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="198" height="152">
+      <vector name="origin" x="141" y="165"/>
+      <vector name="head" x="-2" y="-153"/>
+      <vector name="lt" x="-90" y="-165"/>
+      <vector name="rb" x="57" y="-13"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="196" height="153">
+      <vector name="origin" x="143" y="166"/>
+      <vector name="head" x="-4" y="-153"/>
+      <vector name="lt" x="-111" y="-166"/>
+      <vector name="rb" x="53" y="-13"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="196" height="151">
+      <vector name="origin" x="144" y="167"/>
+      <vector name="head" x="-5" y="-153"/>
+      <vector name="lt" x="-96" y="-167"/>
+      <vector name="rb" x="52" y="-16"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="210" height="144">
+      <vector name="origin" x="144" y="166"/>
+      <vector name="head" x="-2" y="-153"/>
+      <vector name="lt" x="-97" y="-166"/>
+      <vector name="rb" x="66" y="-22"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="210" height="135">
+      <vector name="origin" x="138" y="163"/>
+      <vector name="head" x="0" y="-153"/>
+      <vector name="lt" x="-87" y="-163"/>
+      <vector name="rb" x="72" y="-28"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="207" height="115">
+      <vector name="origin" x="133" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-80" y="-149"/>
+      <vector name="rb" x="74" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="177" height="114">
+      <vector name="origin" x="102" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-80" y="-149"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="173" height="114">
+      <vector name="origin" x="97" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-80" y="-149"/>
+      <vector name="rb" x="76" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Potential nullification"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill4">
+    <canvas name="0" width="162" height="112">
+      <vector name="origin" x="84" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="77" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="190" height="113">
+      <vector name="origin" x="81" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="108" y="-36"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="182" height="114">
+      <vector name="origin" x="79" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="102" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="178" height="121">
+      <vector name="origin" x="78" y="151"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-78" y="-151"/>
+      <vector name="rb" x="100" y="-30"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="179" height="120">
+      <vector name="origin" x="77" y="153"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-77" y="-153"/>
+      <vector name="rb" x="102" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="180" height="115">
+      <vector name="origin" x="76" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-76" y="-149"/>
+      <vector name="rb" x="104" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="180" height="114">
+      <vector name="origin" x="75" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-75" y="-149"/>
+      <vector name="rb" x="105" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="180" height="114">
+      <vector name="origin" x="75" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-75" y="-149"/>
+      <vector name="rb" x="105" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="289" height="144">
+      <vector name="origin" x="238" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-238" y="-149"/>
+      <vector name="rb" x="51" y="-5"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="346" height="141">
+      <vector name="origin" x="303" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-303" y="-149"/>
+      <vector name="rb" x="43" y="-8"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="382" height="142">
+      <vector name="origin" x="343" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-343" y="-149"/>
+      <vector name="rb" x="39" y="-7"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="442" height="142">
+      <vector name="origin" x="375" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-375" y="-149"/>
+      <vector name="rb" x="67" y="-7"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="456" height="143">
+      <vector name="origin" x="383" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-383" y="-149"/>
+      <vector name="rb" x="73" y="-6"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="460" height="143">
+      <vector name="origin" x="385" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-385" y="-149"/>
+      <vector name="rb" x="75" y="-6"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="404" height="143">
+      <vector name="origin" x="328" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-328" y="-149"/>
+      <vector name="rb" x="76" y="-6"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="406" height="142">
+      <vector name="origin" x="329" y="149"/>
+      <vector name="head" x="1" y="-161"/>
+      <vector name="lt" x="-329" y="-149"/>
+      <vector name="rb" x="77" y="-7"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill5">
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="186" height="125">
+      <vector name="origin" x="93" y="160"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-93" y="-160"/>
+      <vector name="rb" x="93" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="192" height="156">
+      <vector name="origin" x="96" y="189"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-96" y="-189"/>
+      <vector name="rb" x="96" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="194" height="169">
+      <vector name="origin" x="97" y="200"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-200"/>
+      <vector name="rb" x="97" y="-31"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="194" height="172">
+      <vector name="origin" x="97" y="201"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-201"/>
+      <vector name="rb" x="97" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="194" height="173">
+      <vector name="origin" x="97" y="202"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-202"/>
+      <vector name="rb" x="97" y="-29"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="192" height="173">
+      <vector name="origin" x="96" y="203"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-96" y="-203"/>
+      <vector name="rb" x="96" y="-30"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="192" height="173">
+      <vector name="origin" x="96" y="203"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-96" y="-203"/>
+      <vector name="rb" x="96" y="-30"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="194" height="163">
+      <vector name="origin" x="97" y="182"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-182"/>
+      <vector name="rb" x="97" y="-19"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="194" height="184">
+      <vector name="origin" x="97" y="189"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-189"/>
+      <vector name="rb" x="97" y="-5"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="194" height="198">
+      <vector name="origin" x="97" y="198"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-198"/>
+      <vector name="rb" x="97" y="0"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="192" height="196">
+      <vector name="origin" x="95" y="198"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-95" y="-198"/>
+      <vector name="rb" x="97" y="-2"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="186" height="193">
+      <vector name="origin" x="93" y="198"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-93" y="-198"/>
+      <vector name="rb" x="93" y="-5"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="160" height="132">
+      <vector name="origin" x="85" y="171"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-171"/>
+      <vector name="rb" x="75" y="-39"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="160" height="114">
+      <vector name="origin" x="85" y="150"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-150"/>
+      <vector name="rb" x="75" y="-36"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="160" height="114">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill6">
+    <canvas name="0" width="162" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="77" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="230" height="113">
+      <vector name="origin" x="143" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-143" y="-149"/>
+      <vector name="rb" x="87" y="-36"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="245" height="114">
+      <vector name="origin" x="153" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-153" y="-149"/>
+      <vector name="rb" x="92" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="254" height="115">
+      <vector name="origin" x="158" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-158" y="-149"/>
+      <vector name="rb" x="96" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="258" height="116">
+      <vector name="origin" x="160" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-160" y="-149"/>
+      <vector name="rb" x="98" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="261" height="115">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-161" y="-149"/>
+      <vector name="rb" x="100" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="262" height="125">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-161" y="-149"/>
+      <vector name="rb" x="101" y="-24"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="262" height="129">
+      <vector name="origin" x="161" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-161" y="-149"/>
+      <vector name="rb" x="101" y="-20"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="198" height="152">
+      <vector name="origin" x="141" y="165"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-141" y="-165"/>
+      <vector name="rb" x="57" y="-13"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="196" height="153">
+      <vector name="origin" x="143" y="166"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-143" y="-166"/>
+      <vector name="rb" x="53" y="-13"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="196" height="151">
+      <vector name="origin" x="144" y="167"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-144" y="-167"/>
+      <vector name="rb" x="52" y="-16"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="210" height="144">
+      <vector name="origin" x="144" y="166"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-144" y="-166"/>
+      <vector name="rb" x="66" y="-22"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="210" height="135">
+      <vector name="origin" x="138" y="163"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-138" y="-163"/>
+      <vector name="rb" x="72" y="-28"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="207" height="115">
+      <vector name="origin" x="133" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-133" y="-149"/>
+      <vector name="rb" x="74" y="-34"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="177" height="114">
+      <vector name="origin" x="102" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-102" y="-149"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="173" height="114">
+      <vector name="origin" x="97" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-97" y="-149"/>
+      <vector name="rb" x="76" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <imgdir name="speak">
+      <int name="prob" value="100"/>
+      <string name="0" value="Buff cancel"/>
+    </imgdir>
+  </imgdir>
+  <imgdir name="skill7">
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="163" height="113">
+      <vector name="origin" x="79" y="148"/>
+      <vector name="head" x="2" y="-153"/>
+      <vector name="lt" x="-79" y="-148"/>
+      <vector name="rb" x="84" y="-35"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="166" height="139">
+      <vector name="origin" x="84" y="172"/>
+      <vector name="head" x="2" y="-151"/>
+      <vector name="lt" x="-84" y="-172"/>
+      <vector name="rb" x="82" y="-33"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="189" height="180">
+      <vector name="origin" x="114" y="211"/>
+      <vector name="head" x="1" y="-161"/>
+      <vector name="lt" x="-114" y="-211"/>
+      <vector name="rb" x="75" y="-31"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="182" height="184">
+      <vector name="origin" x="119" y="233"/>
+      <vector name="head" x="2" y="-169"/>
+      <vector name="lt" x="-119" y="-233"/>
+      <vector name="rb" x="63" y="-49"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="168" height="195">
+      <vector name="origin" x="124" y="251"/>
+      <vector name="head" x="2" y="-176"/>
+      <vector name="lt" x="-124" y="-251"/>
+      <vector name="rb" x="44" y="-56"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="179" height="212">
+      <vector name="origin" x="135" y="272"/>
+      <vector name="head" x="2" y="-179"/>
+      <vector name="lt" x="-135" y="-272"/>
+      <vector name="rb" x="44" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="202" height="215">
+      <vector name="origin" x="158" y="276"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-158" y="-276"/>
+      <vector name="rb" x="44" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="212" height="231">
+      <vector name="origin" x="168" y="294"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-168" y="-294"/>
+      <vector name="rb" x="44" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="202" height="232">
+      <vector name="origin" x="158" y="294"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-158" y="-294"/>
+      <vector name="rb" x="44" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="184" height="223">
+      <vector name="origin" x="140" y="284"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-140" y="-284"/>
+      <vector name="rb" x="44" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="180" height="214">
+      <vector name="origin" x="136" y="274"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-136" y="-274"/>
+      <vector name="rb" x="44" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="167" height="201">
+      <vector name="origin" x="123" y="260"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-123" y="-260"/>
+      <vector name="rb" x="44" y="-59"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="167" height="198">
+      <vector name="origin" x="123" y="258"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-123" y="-258"/>
+      <vector name="rb" x="44" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="167" height="198">
+      <vector name="origin" x="123" y="259"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-123" y="-259"/>
+      <vector name="rb" x="44" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="167" height="199">
+      <vector name="origin" x="123" y="258"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-123" y="-258"/>
+      <vector name="rb" x="44" y="-59"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="133" height="144">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-89" y="-202"/>
+      <vector name="rb" x="44" y="-58"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="133" height="149">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-89" y="-202"/>
+      <vector name="rb" x="44" y="-53"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="157" height="157">
+      <vector name="origin" x="89" y="202"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-89" y="-202"/>
+      <vector name="rb" x="68" y="-45"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="160" height="112">
+      <vector name="origin" x="85" y="152"/>
+      <vector name="head" x="2" y="-180"/>
+      <vector name="lt" x="-85" y="-152"/>
+      <vector name="rb" x="75" y="-40"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill8">
+    <canvas name="0" width="161" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-154"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="76" y="-37"/>
+      <int name="delay" value="120"/>
+      <string name="source" value="Mob/8870200.img/attack2/0"/>
+    </canvas>
+    <canvas name="1" width="165" height="114">
+      <vector name="origin" x="89" y="178"/>
+      <vector name="head" x="2" y="-181"/>
+      <vector name="lt" x="-89" y="-178"/>
+      <vector name="rb" x="76" y="-64"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="189" height="228">
+      <vector name="origin" x="113" y="297"/>
+      <vector name="head" x="2" y="-192"/>
+      <vector name="lt" x="-113" y="-297"/>
+      <vector name="rb" x="76" y="-69"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="187" height="224">
+      <vector name="origin" x="111" y="294"/>
+      <vector name="head" x="2" y="-194"/>
+      <vector name="lt" x="-111" y="-294"/>
+      <vector name="rb" x="76" y="-70"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="179" height="217">
+      <vector name="origin" x="104" y="287"/>
+      <vector name="head" x="2" y="-196"/>
+      <vector name="lt" x="-104" y="-287"/>
+      <vector name="rb" x="75" y="-70"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="167" height="207">
+      <vector name="origin" x="92" y="278"/>
+      <vector name="head" x="2" y="-198"/>
+      <vector name="lt" x="-92" y="-278"/>
+      <vector name="rb" x="75" y="-71"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="160" height="201">
+      <vector name="origin" x="85" y="274"/>
+      <vector name="head" x="-1" y="-152"/>
+      <vector name="lt" x="-85" y="-274"/>
+      <vector name="rb" x="75" y="-73"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="161" height="203">
+      <vector name="origin" x="86" y="277"/>
+      <vector name="head" x="2" y="-200"/>
+      <vector name="lt" x="-86" y="-277"/>
+      <vector name="rb" x="75" y="-74"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="234" height="280">
+      <vector name="origin" x="147" y="266"/>
+      <vector name="head" x="-1" y="-152"/>
+      <vector name="lt" x="-147" y="-266"/>
+      <vector name="rb" x="87" y="14"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="274" height="225">
+      <vector name="origin" x="167" y="210"/>
+      <vector name="head" x="-1" y="-152"/>
+      <vector name="lt" x="-167" y="-210"/>
+      <vector name="rb" x="107" y="15"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="296" height="184">
+      <vector name="origin" x="178" y="167"/>
+      <vector name="head" x="-1" y="-152"/>
+      <vector name="lt" x="-178" y="-167"/>
+      <vector name="rb" x="118" y="17"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="294" height="169">
+      <vector name="origin" x="177" y="151"/>
+      <vector name="head" x="0" y="-118"/>
+      <vector name="lt" x="-177" y="-151"/>
+      <vector name="rb" x="117" y="18"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="292" height="149">
+      <vector name="origin" x="176" y="132"/>
+      <vector name="head" x="2" y="-110"/>
+      <vector name="lt" x="-176" y="-132"/>
+      <vector name="rb" x="116" y="17"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="259" height="125">
+      <vector name="origin" x="151" y="113"/>
+      <vector name="head" x="2" y="-111"/>
+      <vector name="lt" x="-151" y="-113"/>
+      <vector name="rb" x="108" y="12"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="145" height="132">
+      <vector name="origin" x="70" y="140"/>
+      <vector name="head" x="2" y="-126"/>
+      <vector name="lt" x="-70" y="-140"/>
+      <vector name="rb" x="75" y="-8"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill9">
+    <canvas name="0" width="160" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="160" height="113">
+      <vector name="origin" x="85" y="148"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-148"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="245" height="142">
+      <vector name="origin" x="170" y="147"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-170" y="-147"/>
+      <vector name="rb" x="75" y="-5"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="335" height="175">
+      <vector name="origin" x="171" y="146"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-146"/>
+      <vector name="rb" x="164" y="29"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="336" height="163">
+      <vector name="origin" x="171" y="145"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-145"/>
+      <vector name="rb" x="165" y="18"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="337" height="152">
+      <vector name="origin" x="171" y="146"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-146"/>
+      <vector name="rb" x="166" y="6"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="337" height="153">
+      <vector name="origin" x="171" y="157"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-157"/>
+      <vector name="rb" x="166" y="-4"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="337" height="146">
+      <vector name="origin" x="171" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-149"/>
+      <vector name="rb" x="166" y="-3"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="337" height="232">
+      <vector name="origin" x="171" y="237"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-237"/>
+      <vector name="rb" x="166" y="-5"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="371" height="234">
+      <vector name="origin" x="205" y="238"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-205" y="-238"/>
+      <vector name="rb" x="166" y="-4"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="404" height="267">
+      <vector name="origin" x="207" y="245"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-207" y="-245"/>
+      <vector name="rb" x="197" y="22"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="404" height="264">
+      <vector name="origin" x="207" y="242"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-207" y="-242"/>
+      <vector name="rb" x="197" y="22"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="403" height="262">
+      <vector name="origin" x="206" y="239"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-206" y="-239"/>
+      <vector name="rb" x="197" y="23"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="373" height="247">
+      <vector name="origin" x="175" y="224"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-175" y="-224"/>
+      <vector name="rb" x="198" y="23"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="14" width="347" height="179">
+      <vector name="origin" x="153" y="160"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-153" y="-160"/>
+      <vector name="rb" x="194" y="19"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="15" width="285" height="158">
+      <vector name="origin" x="132" y="152"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-132" y="-152"/>
+      <vector name="rb" x="153" y="6"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="16" width="198" height="145">
+      <vector name="origin" x="85" y="150"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-150"/>
+      <vector name="rb" x="113" y="-5"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="17" width="160" height="114">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="152" height="124">
+      <vector name="origin" x="27" y="161"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-27" y="-161"/>
+      <vector name="rb" x="125" y="-37"/>
+      <int name="delay" value="300"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="1" width="152" height="115">
+      <vector name="origin" x="22" y="152"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="151" height="112">
+      <vector name="origin" x="20" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="161" height="112">
+      <vector name="origin" x="29" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="195" height="118">
+      <vector name="origin" x="47" y="154"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="205" height="163">
+      <vector name="origin" x="47" y="161"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="204" height="176">
+      <vector name="origin" x="51" y="174"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="226" height="167">
+      <vector name="origin" x="67" y="165"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="220" height="168">
+      <vector name="origin" x="51" y="166"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="9" width="228" height="166">
+      <vector name="origin" x="52" y="164"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="10" width="226" height="168">
+      <vector name="origin" x="67" y="166"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="11" width="220" height="163">
+      <vector name="origin" x="51" y="161"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="228" height="169">
+      <vector name="origin" x="52" y="167"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="13" width="228" height="171">
+      <vector name="origin" x="67" y="166"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="14" width="229" height="353">
+      <vector name="origin" x="55" y="345"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="15" width="240" height="357">
+      <vector name="origin" x="58" y="348"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="16" width="236" height="355">
+      <vector name="origin" x="71" y="346"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="17" width="231" height="362">
+      <vector name="origin" x="56" y="353"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="18" width="240" height="360">
+      <vector name="origin" x="58" y="351"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="19" width="181" height="348">
+      <vector name="origin" x="36" y="339"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="20" width="153" height="354">
+      <vector name="origin" x="34" y="346"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="21" width="95" height="353">
+      <vector name="origin" x="-12" y="345"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="22" width="76" height="313">
+      <vector name="origin" x="-23" y="310"/>
+      <vector name="head" x="1" y="-153"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="sleep">
+    <canvas name="0" width="337" height="153">
+      <vector name="origin" x="171" y="183"/>
+      <int name="delay" value="300"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+    <canvas name="1" width="337" height="153">
+      <vector name="origin" x="171" y="184"/>
+      <int name="delay" value="300"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+    <canvas name="2" width="337" height="153">
+      <vector name="origin" x="171" y="185"/>
+      <int name="delay" value="300"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+    <canvas name="3" width="337" height="153">
+      <vector name="origin" x="171" y="184"/>
+      <int name="delay" value="300"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="wakeup">
+    <canvas name="0" width="337" height="153">
+      <vector name="origin" x="171" y="184"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+    <canvas name="1" width="337" height="153">
+      <vector name="origin" x="171" y="157"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-157"/>
+      <vector name="rb" x="166" y="-4"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/7"/>
+    </canvas>
+    <canvas name="2" width="337" height="146">
+      <vector name="origin" x="171" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-149"/>
+      <vector name="rb" x="166" y="-3"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/6"/>
+    </canvas>
+    <canvas name="3" width="337" height="152">
+      <vector name="origin" x="171" y="146"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-146"/>
+      <vector name="rb" x="166" y="6"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/5"/>
+    </canvas>
+    <canvas name="4" width="336" height="163">
+      <vector name="origin" x="171" y="145"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-145"/>
+      <vector name="rb" x="165" y="18"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/4"/>
+    </canvas>
+    <canvas name="5" width="335" height="175">
+      <vector name="origin" x="171" y="146"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-171" y="-146"/>
+      <vector name="rb" x="164" y="29"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/3"/>
+    </canvas>
+    <canvas name="6" width="245" height="142">
+      <vector name="origin" x="170" y="147"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-170" y="-147"/>
+      <vector name="rb" x="75" y="-5"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/2"/>
+    </canvas>
+    <canvas name="7" width="160" height="113">
+      <vector name="origin" x="85" y="148"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-148"/>
+      <vector name="rb" x="75" y="-35"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/1"/>
+    </canvas>
+    <canvas name="8" width="160" height="112">
+      <vector name="origin" x="85" y="149"/>
+      <vector name="head" x="1" y="-153"/>
+      <vector name="lt" x="-85" y="-149"/>
+      <vector name="rb" x="75" y="-37"/>
+      <int name="delay" value="150"/>
+      <string name="source" value="Mob/8870200.img/skill9/0"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="180"/>
+    <int name="maxHP" value="2100000000"/>
+    <int name="maxMP" value="50000"/>
+    <int name="speed" value="-50"/>
+    <int name="PADamage" value="2100"/>
+    <int name="PDDamage" value="1930"/>
+    <int name="MADamage" value="2100"/>
+    <int name="MDDamage" value="1930"/>
+    <int name="acc" value="270"/>
+    <int name="eva" value="55"/>
+    <int name="exp" value="300000000"/>
+    <int name="hpRecovery" value="100000"/>
+    <int name="mpRecovery" value="1000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="140000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="12"/>
+    <int name="firstAttack" value="1"/>
+    <int name="boss" value="1"/>
+    <int name="publicReward" value="1"/>
+    <int name="explosiveReward" value="1"/>
+    <string name="buff" value="2022449"/>
+    <int name="hpTagColor" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <string name="elemAttr" value="P2H2F2I2"/>
+    <int name="mobType" value="1"/>
+    <int name="rareItemDropLevel" value="3"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="101"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="145"/>
+        <int name="action" value="2"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="133"/>
+        <int name="action" value="3"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+</imgdir>


### PR DESCRIPTION
## 改动内容
- 修复多个 Boss/Mob 对话中的乱码、韩文残留和 `XXXXX` 占位显示问题。
- 为缺失的中文 Mob WZ 补充对应文件，使中文目录可以独立提供本地化的 Boss/Mob 对话内容。
- 对部分英文 Mob WZ 的异常对话文本做英文原版修正，中文目录同步提供中文文本，保持功能性结构对称。
- 保留官方原有的 `speak/con` 条件节点，不再移除任务、宠物等条件彩蛋结构。
- 调整 WZ 资源读取逻辑，中文资源缺失时可按单文件回退到英文原版资源。
- 调整脚本加载逻辑，中文脚本存在时优先加载中文文件，缺失时按单个脚本文件回退到英文原版；事件脚本枚举会合并中英文目录并去重。
- 涉及范围主要为 Boss/Mob 对话、死亡对白、受击对白、技能对白，以及事件脚本列表枚举逻辑。

## 影响范围
- 影响服务端 WZ 读取逻辑、脚本加载逻辑和 Mob WZ 资源。
- 影响客户端显示的 Mob 对话文本，需要同步客户端资源包。
- 中英文 Mob WZ 均有对称改动：英文原版用于保证英文显示有效，中文目录用于中文显示。

## 验证情况
- 已执行 XML 解析检查。
- 已执行乱码检查，确认中文资源可按 UTF-8 正常读取。
- 已执行 Java 编译与测试验证。
- 已检查本次 PR 没有加入客户端压缩包、临时文件、备份文件、日志文件、构建产物或 Jar 包。
- 已完成本地游戏内测试，Boss 对话可正常显示中文。

## 客户端资源
客户端资源包将通过 Release 提供，并在 PR 评论中补充下载链接与 SHA256。