### PR TITLE
fix: 汉化剩余探险家勋章任务面板文本

### DIFF
--- a/gms-server/scripts-zh-CN/map/onUserEnter/explorationPoint.js
+++ b/gms-server/scripts-zh-CN/map/onUserEnter/explorationPoint.js
@@ -30,13 +30,13 @@ function start(ms) {
     } else if (ms.getPlayer().getMapId() >= 105040300 && ms.getPlayer().getMapId() <= 105090900) {
         ms.explorerQuest(29014, "林中之城探险家");//Sleepywood Explorer
     } else if (ms.getPlayer().getMapId() >= 200000000 && ms.getPlayer().getMapId() <= 211041800) {
-        ms.explorerQuest(29006, "冰峰雪域山脉探险家");//El Nath Mts. Explorer
+        ms.explorerQuest(29006, "冰峰雪域探险家");//El Nath Mts. Explorer
     } else if (ms.getPlayer().getMapId() >= 220000000 && ms.getPlayer().getMapId() <= 222020000) {
         ms.explorerQuest(29007, "时间静止之湖探险家");//Ludus Lake Explorer
     } else if (ms.getPlayer().getMapId() >= 230000000 && ms.getPlayer().getMapId() <= 230040401) {
         ms.explorerQuest(29008, "海底探险家");//Undersea Explorer
     } else if (ms.getPlayer().getMapId() >= 250000000 && ms.getPlayer().getMapId() <= 251010500) {
-        ms.explorerQuest(29009, "武陵探险家");//Mu Lung Explorer
+        ms.explorerQuest(29009, "武陵道场探险家");//Mu Lung Explorer
     } else if (ms.getPlayer().getMapId() >= 260000000 && ms.getPlayer().getMapId() <= 261030000) {
         ms.explorerQuest(29010, "尼哈沙漠探险家");//Nihal Desert Explorer
     } else if (ms.getPlayer().getMapId() >= 240000000 && ms.getPlayer().getMapId() <= 240050000) {

--- a/gms-server/scripts-zh-CN/quest/29006.js
+++ b/gms-server/scripts-zh-CN/quest/29006.js
@@ -1,0 +1,23 @@
+var medalId = 1142113;
+var medalName = "冰峰雪域探险家勋章";
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("请探索冰峰雪域的主要区域。完成探索后，再来领取#b#t" + medalId + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (!qm.haveItem(medalId) && !qm.canHold(medalId)) {
+        qm.sendOk("请在装备栏中空出 1 个位置后再来领取#b" + medalName + "#k。");
+        qm.dispose();
+        return;
+    }
+
+    qm.forceCompleteQuest();
+    if (!qm.haveItem(medalId)) {
+        qm.gainItem(medalId, 1);
+    }
+    qm.sendOk("恭喜你完成冰峰雪域探索！\r\n获得勋章：#b#v" + medalId + "##t" + medalId + "##k");
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29008.js
+++ b/gms-server/scripts-zh-CN/quest/29008.js
@@ -1,0 +1,23 @@
+var medalId = 1142115;
+var medalName = "海底探险家勋章";
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("请探索水下世界的主要区域。完成探索后，再来领取#b#t" + medalId + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (!qm.haveItem(medalId) && !qm.canHold(medalId)) {
+        qm.sendOk("请在装备栏中空出 1 个位置后再来领取#b" + medalName + "#k。");
+        qm.dispose();
+        return;
+    }
+
+    qm.forceCompleteQuest();
+    if (!qm.haveItem(medalId)) {
+        qm.gainItem(medalId, 1);
+    }
+    qm.sendOk("恭喜你完成水下世界探索！\r\n获得勋章：#b#v" + medalId + "##t" + medalId + "##k");
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29009.js
+++ b/gms-server/scripts-zh-CN/quest/29009.js
@@ -1,0 +1,23 @@
+var medalId = 1142116;
+var medalName = "武陵道场探险家勋章";
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("请探索武陵和百草堂的主要区域。完成探索后，再来领取#b#t" + medalId + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (!qm.haveItem(medalId) && !qm.canHold(medalId)) {
+        qm.sendOk("请在装备栏中空出 1 个位置后再来领取#b" + medalName + "#k。");
+        qm.dispose();
+        return;
+    }
+
+    qm.forceCompleteQuest();
+    if (!qm.haveItem(medalId)) {
+        qm.gainItem(medalId, 1);
+    }
+    qm.sendOk("恭喜你完成武陵和百草堂探索！\r\n获得勋章：#b#v" + medalId + "##t" + medalId + "##k");
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29006.js
+++ b/gms-server/scripts/quest/29006.js
@@ -1,0 +1,23 @@
+var medalId = 1142113;
+var medalName = "El Nath Mts. Explorer Medal";
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Explore the main regions of El Nath Mts. Come back after completing the exploration to receive #b#t" + medalId + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (!qm.haveItem(medalId) && !qm.canHold(medalId)) {
+        qm.sendOk("Please make 1 free slot in your Equip inventory before receiving the #b" + medalName + "#k.");
+        qm.dispose();
+        return;
+    }
+
+    qm.forceCompleteQuest();
+    if (!qm.haveItem(medalId)) {
+        qm.gainItem(medalId, 1);
+    }
+    qm.sendOk("Congratulations on completing the El Nath Mts. exploration!\r\nMedal received: #b#v" + medalId + "##t" + medalId + "##k");
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29008.js
+++ b/gms-server/scripts/quest/29008.js
@@ -1,0 +1,23 @@
+var medalId = 1142115;
+var medalName = "Undersea Explorer Medal";
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Explore the main regions of Aqua Road. Come back after completing the exploration to receive #b#t" + medalId + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (!qm.haveItem(medalId) && !qm.canHold(medalId)) {
+        qm.sendOk("Please make 1 free slot in your Equip inventory before receiving the #b" + medalName + "#k.");
+        qm.dispose();
+        return;
+    }
+
+    qm.forceCompleteQuest();
+    if (!qm.haveItem(medalId)) {
+        qm.gainItem(medalId, 1);
+    }
+    qm.sendOk("Congratulations on completing the Aqua Road exploration!\r\nMedal received: #b#v" + medalId + "##t" + medalId + "##k");
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29009.js
+++ b/gms-server/scripts/quest/29009.js
@@ -1,0 +1,23 @@
+var medalId = 1142116;
+var medalName = "Mu Lung Explorer Medal";
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Explore the main regions of Mu Lung Garden. Come back after completing the exploration to receive #b#t" + medalId + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (!qm.haveItem(medalId) && !qm.canHold(medalId)) {
+        qm.sendOk("Please make 1 free slot in your Equip inventory before receiving the #b" + medalName + "#k.");
+        qm.dispose();
+        return;
+    }
+
+    qm.forceCompleteQuest();
+    if (!qm.haveItem(medalId)) {
+        qm.gainItem(medalId, 1);
+    }
+    qm.sendOk("Congratulations on completing the Mu Lung Garden exploration!\r\nMedal received: #b#v" + medalId + "##t" + medalId + "##k");
+    qm.dispose();
+}

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9421,9 +9421,9 @@
     <imgdir name="29007">
         <string name="name" value="挑战勋章-时间停止之湖探险家勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="You can earn the #b&lt;Ludus Lake Explorer&gt;#k title by exploring the Ludus Lake region."/>
-        <string name="1" value="#b#eTitle - Ludus Lake Explorer#k#n\r\nExplore the 10 main regions of Ludus Lake.\r\n#b● Status : #R27012# / 10 Completed."/>
-        <string name="2" value="You have earned the #b&lt;Ludus Lake Explorer&gt;#k title for exploring various places in Ludus Lake."/>
+        <string name="0" value="探索时间停止之湖的主要区域，就能获得#b&lt;时间停止之湖探险家&gt;#k称号。"/>
+        <string name="1" value="#b#e勋章 - 时间停止之湖探险家#k#n\r\n探索时间停止之湖的10个主要区域。\r\n#b● 状态：#R27012# / 10 完成#k"/>
+        <string name="2" value="你已完成时间停止之湖各地的探索，获得了#b&lt;时间停止之湖探险家&gt;#k称号。"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142114"/>
     </imgdir>
@@ -9450,9 +9450,9 @@
     <imgdir name="29010">
         <string name="name" value="尼哈沙漠探险家勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="You can earn the #b&lt;Nihal Desert Explorer&gt;#k title by exploring the Nihal Desert."/>
-        <string name="1" value="#b#eTitle - Nihal Desert Explorer#k#n\r\nExplore the 10 main regions of Nihal Desert.\r\n#b● Status : #R27015# / 10 Completed."/>
-        <string name="2" value="You have completed exploring Nihal Desert and earned the #b&lt;Nihal Desert Explorer&gt;#k title."/>
+        <string name="0" value="探索尼哈沙漠的主要区域，就能获得#b&lt;尼哈沙漠探险家&gt;#k称号。"/>
+        <string name="1" value="#b#e勋章 - 尼哈沙漠探险家#k#n\r\n探索尼哈沙漠的10个主要区域。\r\n#b● 状态：#R27015# / 10 完成#k"/>
+        <string name="2" value="你已完成尼哈沙漠各地的探索，获得了#b&lt;尼哈沙漠探险家&gt;#k称号。"/>
         <string name="rewardSummary" value=" "/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142117"/>
@@ -9460,9 +9460,9 @@
     <imgdir name="29011">
         <string name="name" value="米纳尔森林探险家勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="You can earn the #b&lt;Minar Forest Explorer&gt;#k by exploring the Minar Forest."/>
-        <string name="1" value="#b#eTitle - Minar Forest Explorer#k#n\r\nExplore the 10 main regions of Minar Forest.\r\n#b● Status : #R27016# / 10 Completed."/>
-        <string name="2" value="You have earned the #b&lt;Minar Forest Explorer&gt;#k title for exploring the dangerous region of Minar Forest. "/>
+        <string name="0" value="探索米纳尔森林的主要区域，就能获得#b&lt;米纳尔森林探险家&gt;#k称号。"/>
+        <string name="1" value="#b#e勋章 - 米纳尔森林探险家#k#n\r\n探索米纳尔森林的10个主要区域。\r\n#b● 状态：#R27016# / 10 完成#k"/>
+        <string name="2" value="你已完成米纳尔森林各地的探索，获得了#b&lt;米纳尔森林探险家&gt;#k称号。"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142118"/>
     </imgdir>
@@ -9471,11 +9471,11 @@
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="1" value="#b#eTitle - Ossyria Explorer#n#k\r\n● Requirement(s)\nCan acquire after earning a total of 6 titles: El Nath Mts. Explorer, Ludus Lake Explorer, Undersea Explorer, Mu Lung Explorer, Nihal Desert Explorer, and Minar Forest Explorer\r\n#b● Status\n#y29006# : #u29006#\n#y29007# : #u29007#\n#y29008# : #u29008#\n#y29009# : #u29009#\n#y29010# : #u29010#\n#y29011# : #u29011#"/>
-        <string name="2" value="You have finally acquired the #b&lt;Ossyria Explorer&gt;#k title upon earning all of the explorer titles in Ossyria."/>
+        <string name="1" value="#b#e勋章 - 神秘岛探险家#n#k\r\n● 获得条件\n获得以下6个称号：冰峰雪域探险家、时间停止之湖探险家、海底探险家、武陵道场探险家、尼哈沙漠探险家、米纳尔森林探险家\r\n#b● 状态\n#y29006# : #u29006#\n#y29007# : #u29007#\n#y29008# : #u29008#\n#y29009# : #u29009#\n#y29010# : #u29010#\n#y29011# : #u29011#"/>
+        <string name="2" value="你已获得神秘岛地区的所有探险家称号，终于获得了#b&lt;神秘岛探险家&gt;#k称号。"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142119"/>
-        <string name="0" value="Let&apos;s explore the continent of Ossyria!\r\nEl Nath Mts. Explorer\nLudus Lake Explorer\nUndersea Explorer\nMu Lung Explorer\nNihal Desert Explorer\nMinar Forest Explorer\r\nYou must earn a total of 6 titles."/>
+        <string name="0" value="去探索神秘岛大陆吧！\r\n冰峰雪域探险家\n时间停止之湖探险家\n海底探险家\n武陵道场探险家\n尼哈沙漠探险家\n米纳尔森林探险家\r\n必须共获得6个称号。"/>
     </imgdir>
     <imgdir name="29013">
         <string name="name" value="冒险岛探险家勋章"/>
@@ -9483,18 +9483,18 @@
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
         <string name="rewardSummary" value=" "/>
-        <string name="1" value="#b#eTitle - Maple Explorer#n#k\r\n● Requirement(s)\nCan acquire after earning the Victoria Explorer and Ossyria Explorer titles.#b\r\n● Status\n#y29015# : #u29015#\n#y29012# : #u29012#"/>
-        <string name="2" value="You have finally acquired the #b&lt;Maple Explorer&gt;#k title upon earning both the Victoria and Ossyria Explorer titles."/>
+        <string name="1" value="#b#e勋章 - 冒险岛探险家#n#k\r\n● 获得条件\n获得金银岛探险家和神秘岛探险家称号。#b\r\n● 状态\n#y29015# : #u29015#\n#y29012# : #u29012#"/>
+        <string name="2" value="你已获得金银岛探险家和神秘岛探险家称号，终于获得了#b&lt;冒险岛探险家&gt;#k称号。"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142120"/>
-        <string name="0" value="To be acknowledged as the ultimate explorer in Maple World, let&apos;s earn the #b&lt;Maple Explorer&gt;#k title.r\nVictoria Explorer\nOssyria Explorer\r\nYou must earn a total of 2 titles."/>
+        <string name="0" value="想被认可为冒险岛世界终极探险家，就去获得#b&lt;冒险岛探险家&gt;#k称号吧。\r\n金银岛探险家\n神秘岛探险家\r\n必须共获得2个称号。"/>
     </imgdir>
     <imgdir name="29014">
         <string name="name" value="林中之城探险家"/>
         <int name="area" value="51"/>
-        <string name="0" value="You can earn the #b&lt;Sleepywood Explorer&gt;#k title by exploring Sleepywood."/>
-        <string name="1" value="#b#eTitle - Sleepywood Explorer#k#n\r\nExplore the 10 main regions of Sleepywood.\r\n#b● Status : #R27019# / 10 Completed."/>
-        <string name="2" value="You have earned the #b&lt;Sleepywood Explorer&gt;#k title for exploring various places in Sleepywood."/>
+        <string name="0" value="探索林中之城的主要区域，就能获得#b&lt;林中之城探险家&gt;#k称号。"/>
+        <string name="1" value="#b#e勋章 - 林中之城探险家#k#n\r\n探索林中之城的10个主要区域。\r\n#b● 状态：#R27019# / 10 完成#k"/>
+        <string name="2" value="你已完成林中之城各地的探索，获得了#b&lt;林中之城探险家&gt;#k称号。"/>
         <int name="viewMedalItem" value="1142128"/>
         <int name="medalCategory" value="1"/>
     </imgdir>
@@ -9503,11 +9503,11 @@
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="1" value="#b#eTitle - Victoria Explorer#n#k\r\n● Requirement(s)\nCan acquire after earning the Beginner Explorer and Sleepywood Explorer titles.\r\n#b● Status\n#y29005# : #u29005#\n#y29014# : #u29014#\r\n#k"/>
-        <string name="2" value="You have finally acquired the #b&lt;Victoria Explorer&gt;#k title for exploring various places on Victoria Island."/>
+        <string name="1" value="#b#e勋章 - 金银岛探险家#n#k\r\n● 获得条件\n获得新手探险家和林中之城探险家称号。\r\n#b● 状态\n#y29005# : #u29005#\n#y29014# : #u29014#\r\n#k"/>
+        <string name="2" value="你已完成金银岛各地的探索，终于获得了#b&lt;金银岛探险家&gt;#k称号。"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142112"/>
-        <string name="0" value="Challenge yourself and explore Victoria Island!\r\nBeginner Explorer\nSleepywood Explorer\nYou must earn a total of two titles."/>
+        <string name="0" value="挑战自己，探索金银岛吧！\r\n新手探险家\n林中之城探险家\n必须共获得2个称号。"/>
     </imgdir>
     <imgdir name="29017">
         <string name="name" value="Title - Soul Conjurer"/>

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9411,9 +9411,10 @@
     <imgdir name="29006">
         <string name="name" value="冰峰雪域探险家勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="You can earn the #b&lt;El Nath Mts. Explorer&gt;#k title by exploring the El Nath Mts."/>
-        <string name="1" value="#b#eTitle - El Nath Mts. Explorer#k#n\r\nExplore the 10 main regions of El Nath Mts.\r\n#b● Status : #R27011# / 10 Completed."/>
-        <string name="2" value="You have earned the #b&lt;El Nath Mts. Explorer&gt;#k title for exploring various places in El Nath Mts."/>
+        <string name="0" value="探索冰峰雪域的主要区域，就能获得#b&lt;冰峰雪域探险家&gt;#k称号。"/>
+        <string name="1" value="#b#e勋章 - 冰峰雪域探险家#k#n\r\n探索冰峰雪域的10个主要区域。\r\n#b● 状态：#R27011# / 10 完成#k"/>
+        <string name="2" value="你已完成冰峰雪域各地的探索，获得了#b&lt;冰峰雪域探险家&gt;#k称号。"/>
+        <string name="rewardSummary" value="#Wbasic# #v1142113:##t1142113:# 1"/>
         <int name="viewMedalItem" value="1142113"/>
         <int name="medalCategory" value="1"/>
     </imgdir>
@@ -9429,18 +9430,20 @@
     <imgdir name="29008">
         <string name="name" value="海底探险家勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="Let&apos;s earn the #b&lt;Undersea Explorer&gt;#k title by exploring the deep waters of Aqua Road."/>
-        <string name="1" value="#b#eTitle - Undersea Explorer#k#n\r\nExplore the 10 main regions of Aqua Road.\r\n#b● Status : #R27013# / 10 Completed."/>
-        <string name="2" value="You have earned the #b&lt;Undersea Explorer&gt;#k title for exploring various places in Aqua Road."/>
+        <string name="0" value="探索水下世界的深海区域，就能获得#b&lt;海底探险家&gt;#k称号。"/>
+        <string name="1" value="#b#e勋章 - 海底探险家#k#n\r\n探索水下世界的10个主要区域。\r\n#b● 状态：#R27013# / 10 完成#k"/>
+        <string name="2" value="你已完成水下世界各地的探索，获得了#b&lt;海底探险家&gt;#k称号。"/>
+        <string name="rewardSummary" value="#Wbasic# #v1142115:##t1142115:# 1"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142115"/>
     </imgdir>
     <imgdir name="29009">
-        <string name="name" value="武陵道院探险家勋章"/>
+        <string name="name" value="武陵道场探险家勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="You can earn the #b&lt;Mu Lung Explorer&gt;#k title by exploring the Mu Lung Garden."/>
-        <string name="1" value="#b#eTitle -Mu Lung Explorer#k#n\r\nExplore the 10 main regions of Mu Lung Garden.\r\n#b● Status : #R27014# / 10 Completed."/>
-        <string name="2" value="You have earned the #b&lt;Mu Lung Explorer&gt;#k title for exploring various places in Mu Lung Garden."/>
+        <string name="0" value="探索武陵和百草堂的主要区域，就能获得#b&lt;武陵道场探险家&gt;#k称号。"/>
+        <string name="1" value="#b#e勋章 - 武陵道场探险家#k#n\r\n探索武陵和百草堂的10个主要区域。\r\n#b● 状态：#R27014# / 10 完成#k"/>
+        <string name="2" value="你已完成武陵和百草堂各地的探索，获得了#b&lt;武陵道场探险家&gt;#k称号。"/>
+        <string name="rewardSummary" value="#Wbasic# #v1142116:##t1142116:# 1"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142116"/>
     </imgdir>


### PR DESCRIPTION
﻿改动内容
- 修复探险家区域勋章的任务面板文本，补全时间停止之湖、尼哈沙漠、米纳尔森林、神秘岛、冒险岛、林中之城、金银岛探险家勋章的中文描述。
- 补充冰峰雪域、海底、武陵道场探险家勋章的领取脚本，并调整探险进度触发文本。
- 涉及 NPC 为勋章相关 NPC，涉及任务包括 29006、29007、29008、29009、29010、29011、29012、29013、29014、29015。
- 领取脚本存在中英文目录对称改动；任务面板文本只修改中文 WZ 目录。

影响范围
- 影响服务端脚本与客户端任务面板显示。
- 因修改了 Quest.wz/QuestInfo 相关中文资源，需要同步客户端资源包。

验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查。
- 已执行本次新增内容乱码检查。
- 已执行本地游戏内测试通过。

客户端资源
客户端资源包将通过 Release 提供，并在 PR 评论中补充下载链接与 SHA256。
