### PR TITLE
fix: 汉化活动荣誉与周年勋章任务文本

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -2708,31 +2708,31 @@
         <string name="sortkey" value="71"/>
     </imgdir>
     <imgdir name="19000">
-        <string name="name" value="Honorable Mesoranger"/>
+        <string name="name" value="荣誉冒险家勋章"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="2" value="Due to your impressive performance and results in the event, you have received the #b&lt;Honorable Mesoranger&gt;#k title from the Maple Admin."/>
+        <string name="2" value="你在活动中的表现和成绩十分出色，获得了冒险岛运营员授予的#b&lt;荣誉冒险家&gt;#k称号。"/>
         <int name="medalCategory" value="3"/>
         <int name="viewMedalItem" value="1142076"/>
     </imgdir>
     <imgdir name="19001">
-        <string name="name" value="Maple Nut"/>
+        <string name="name" value="热爱冒险岛勋章"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="2" value="Actively participating in the event celebrating MapleStory&apos;s 6th anniversary gave you the title of #b&lt;Maple Nut&gt;#k."/>
+        <string name="2" value="你积极参与冒险岛6周年庆典活动，获得了#b&lt;热爱冒险岛&gt;#k称号。"/>
         <int name="medalCategory" value="3"/>
         <int name="viewMedalItem" value="1142101"/>
     </imgdir>
     <imgdir name="19002">
-        <string name="name" value="The 2nd Honorable Mesoranger"/>
+        <string name="name" value="荣誉冒险人2期勋章"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142123"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="1" value="Due to your impressive performance and results in the event, you have received the #b&lt;Honorable Mesoranger&gt;#k title from the Maple Admin."/>
-        <string name="2" value="Due to your impressive performance and results in the event, you have received the #b&lt;Honorable Mesoranger&gt;#k title from the Maple Admin."/>
+        <string name="1" value="你在活动中的表现和成绩十分出色，获得了冒险岛运营员授予的#b&lt;荣誉冒险人2期&gt;#k称号。"/>
+        <string name="2" value="你在活动中的表现和成绩十分出色，获得了冒险岛运营员授予的#b&lt;荣誉冒险人2期&gt;#k称号。"/>
         <int name="medalCategory" value="3"/>
     </imgdir>
     <imgdir name="19005">


### PR DESCRIPTION
## 改动内容
- 汉化活动荣誉/周年称号系列勋章任务文本。
- 涉及任务：19000 荣誉冒险家勋章、19001 热爱冒险岛勋章、19002 荣誉冒险人2期勋章。
- 修复任务面板中任务名称、进行中说明和完成说明仍显示英文的问题。
- 本次只修改中文 WZ 文本，不涉及中英文目录对称逻辑改动。

## 影响范围
- 影响服务端中文 WZ 资源和客户端任务面板显示文本。
- 因修改了 Quest.wz 的任务信息，需要同步客户端资源包。
- 不涉及服务端脚本、Java 逻辑、数据库或掉落配置。

## 验证情况
- 已执行 XML 解析检查。
- 已执行目标任务文本乱码检查。
- 已检查目标任务范围无原英文关键词残留。
- 已确认本次分支相对目标分支只包含本次修复文件。

## 客户端资源
客户端资源包将通过 Release 提供，并在 PR 评论中补充下载链接与 SHA256。