### PR TITLE
fix: 修正商城装备分类中的上衣标签

### DIFF
--- a/gms-server/wz-zh-CN/Etc.wz/Category.img.xml
+++ b/gms-server/wz-zh-CN/Etc.wz/Category.img.xml
@@ -33,7 +33,7 @@
     <imgdir name="6">
         <int name="Category" value="2"/>
         <int name="CategorySub" value="4"/>
-        <string name="Name" value="热销"/>
+        <string name="Name" value="上衣"/>
     </imgdir>
     <imgdir name="7">
         <int name="Category" value="2"/>


### PR DESCRIPTION
Closes #764

## 改动内容
- 修正商城“装备”分类下“上衣”标签显示错误的问题。
- 将 `Category=2`、`CategorySub=4` 的分类名称从错误的“热销”修正为“上衣”。
- 本次仅修改中文 WZ 分类文本，未涉及英文目录对称改动。
- 本次改动不涉及任务、NPC、道具逻辑或地图流程。

## 影响范围
- 影响服务端仓库中的中文 WZ 配置。
- 影响客户端商城中的分类显示文本。
- 需要同步客户端资源包。

## 验证情况
- XML 解析检查已通过。
- 中文文本乱码检查已通过。
- 本地游戏内测试已通过，商城“装备”分类中对应标签显示为“上衣”。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。