### PR TITLE
fix: 汉化遗物大会与连击称号活动任务文本

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -2736,67 +2736,67 @@
         <int name="medalCategory" value="3"/>
     </imgdir>
     <imgdir name="19005">
-        <string name="name" value="Top 10 in Artifact Hunt"/>
+        <string name="name" value="遗物大会Top10勋章"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="1" value="You can earn a title if you make the top 10 in Artifact Hunt."/>
-        <string name="2" value="You have earned a title for making the top 10 in Artifact Hunt."/>
+        <string name="1" value="在遗物大会中进入前10名，就能获得这个称号。"/>
+        <string name="2" value="你在遗物大会中取得了前10名，获得了这个称号。"/>
         <int name="medalCategory" value="3"/>
         <int name="viewMedalItem" value="1142124"/>
     </imgdir>
     <imgdir name="19006">
-        <string name="name" value="Mystical Artifact Discoverer"/>
+        <string name="name" value="神秘遗物发现者勋章"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="0" value="You can earn a title when you discover 8 Mystical Artifacts."/>
-        <string name="1" value="You can earn a title when you discover 8 Mystical Artifacts."/>
-        <string name="2" value="You have earned a title for discovering 8 Mystical Artifacts."/>
+        <string name="0" value="发现8件神秘遗物后，就能获得这个称号。"/>
+        <string name="1" value="发现8件神秘遗物后，就能获得这个称号。"/>
+        <string name="2" value="你发现了8件神秘遗物，获得了这个称号。"/>
         <int name="medalCategory" value="3"/>
         <int name="viewMedalItem" value="1142125"/>
     </imgdir>
     <imgdir name="19007">
-        <string name="name" value="Combo Maniac"/>
+        <string name="name" value="连击狂人勋章"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="3"/>
         <int name="viewMedalItem" value="1142134"/>
         <int name="autoAccept" value="1"/>
-        <string name="0" value="If you get a combo of 50 or more, you will receive the title Combo Maniac."/>
-        <string name="1" value="If you get a combo of 50 or more, you will receive the title Combo Maniac."/>
-        <string name="2" value="You got a combo of at least 50 and received the title Combo Maniac."/>
+        <string name="0" value="达成50连击以上时，就能获得#b&lt;连击狂人&gt;#k称号。"/>
+        <string name="1" value="达成50连击以上时，就能获得#b&lt;连击狂人&gt;#k称号。"/>
+        <string name="2" value="你达成了50连击以上，获得了#b&lt;连击狂人&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
     </imgdir>
     <imgdir name="19008">
-        <string name="name" value="Combo Master"/>
+        <string name="name" value="连击达人勋章"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="3"/>
         <int name="viewMedalItem" value="1142135"/>
         <int name="autoAccept" value="1"/>
-        <string name="0" value="If you get a combo of 200 or more, you will receive the title Combo Master."/>
-        <string name="1" value="If you get a combo of 200 or more, you will receive the title Combo Master."/>
-        <string name="2" value="You got a combo of at least 200 and received the title Combo Master."/>
+        <string name="0" value="达成200连击以上时，就能获得#b&lt;连击达人&gt;#k称号。"/>
+        <string name="1" value="达成200连击以上时，就能获得#b&lt;连击达人&gt;#k称号。"/>
+        <string name="2" value="你达成了200连击以上，获得了#b&lt;连击达人&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
     </imgdir>
     <imgdir name="19009">
-        <string name="name" value="Combo King"/>
+        <string name="name" value="连击王勋章"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="3"/>
         <int name="viewMedalItem" value="1142136"/>
         <int name="autoAccept" value="1"/>
-        <string name="0" value="If you get a combo of 500 or more, you will receive the title Combo King."/>
-        <string name="1" value="If you get a combo of 500 or more, you will receive the title Combo King."/>
-        <string name="2" value="You got a combo of at least 500 and received the title Combo King."/>
+        <string name="0" value="达成500连击以上时，就能获得#b&lt;连击王&gt;#k称号。"/>
+        <string name="1" value="达成500连击以上时，就能获得#b&lt;连击王&gt;#k称号。"/>
+        <string name="2" value="你达成了500连击以上，获得了#b&lt;连击王&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
     </imgdir>
     <imgdir name="19010">
-        <string name="name" value="류호 개척자"/>
+        <string name="name" value="里恩开拓者勋章"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="3"/>
         <int name="viewMedalItem" value="1142151"/>
-        <string name="0" value="신규 월드 #b&lt;류호&gt;#k을 맞아 메이플스토리에서 준비항 특별한 칭호 선물!\r\n각 마을에 위치한 #b#p9010010##k를 찾아가 보자."/>
-        <string name="1" value="#e#b류호 개척자 칭호에 도전#k#n\r\n* 획득 조건 : 이벤트 기간동안 #b레벨 50#k을 달성하여 아래의 칭호들을 차례로 획득\r\n#b● 이벤트 기간 : 2009년 9월 22일 ~ 10월 28일#k\r\n● 진행 상황\n#y10395# : #u10395#\n#y10396# : #u10396#\n#y10397# : #u10397#\n#y10398# : #u10398#\n#k"/>
-        <string name="2" value="#b&lt;류호 개척자&gt;#k의 칭호를 획득하였다."/>
+        <string name="0" value="为了迎接新世界#b&lt;里恩&gt;#k，冒险岛准备了特别称号奖励！\r\n去各个村庄寻找#b#p9010010##k吧。"/>
+        <string name="1" value="#e#b挑战里恩开拓者称号#k#n\r\n* 获得条件：在活动期间达到#b50级#k，并依次获得下列称号\r\n#b● 活动期间：2009年9月22日 ~ 10月28日#k\r\n● 进行情况\n#y10395# : #u10395#\n#y10396# : #u10396#\n#y10397# : #u10397#\n#y10398# : #u10398#\n#k"/>
+        <string name="2" value="你获得了#b&lt;里恩开拓者&gt;#k称号。"/>
     </imgdir>
     <imgdir name="2000">
         <string name="name" value="酋长的家修理"/>


### PR DESCRIPTION
## 改动内容
- 汉化遗物大会 / 连击称号活动系列任务文本。
- 涉及任务：19005 遗物大会Top10勋章、19006 神秘遗物发现者勋章、19007 连击狂人勋章、19008 连击达人勋章、19009 连击王勋章、19010 里恩开拓者勋章。
- 修复任务面板中任务名称、进行中说明和完成说明仍显示英文或韩文的问题。
- 本次只修改中文 Quest WZ 文本，不涉及中英文目录对称逻辑改动。

## 影响范围
- 影响服务端中文 WZ 资源和客户端任务面板显示文本。
- 因修改了 Quest.wz 的任务信息，需要同步客户端资源包。
- 不涉及服务端脚本、Java 逻辑、数据库或掉落配置。

## 验证情况
- 已执行 XML 解析检查。
- 已执行目标任务文本乱码检查。
- 已检查目标任务范围无原英文与韩文关键词残留。
- 已确认本次分支相对目标分支只包含本次修复文件。
- 已完成本地测试环境和客户端任务文本同步。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。