### PR TITLE
fix: 修复可疑男子中文脚本对话

### DIFF
--- a/gms-server/scripts-zh-CN/npc/1061016.js
+++ b/gms-server/scripts-zh-CN/npc/1061016.js
@@ -12,22 +12,22 @@ function action(mode, type, selection) {
     }
     status++;
     if (status == 0) {
-        cm.sendSimple("你好，#h0#。我可以交换你的巴尔洛克皮革。\r\n\r\n#r#L1#兑换物品#l#k");
+        cm.sendSimple("你好，#h0#。我可以帮你兑换蝙蝠怪的皮碎片。\r\n\r\n#r#L1#兑换物品#l#k");
     } else if (status == 1) {
-        var selStr = "Well, okay. These are what you can redeem...\r\n\r\n#b";
+        var selStr = "好吧，下面是你可以兑换的物品。\r\n\r\n#b";
         for (var i = 0; i < itemids.length; i++) {
             selStr += "#L" + i + "##i" + itemids[i] + "##z" + itemids[i] + "##l\r\n";
         }
         cm.sendSimple(selStr);
     } else if (status == 2) {
         if (!cm.canHold(itemids[selection], 1)) {
-            cm.sendOk("请腾出空间");
+            cm.sendOk("请先清出一些背包空间。");
         } else if (!cm.haveItemWithId(4001261)) {
-            cm.sendOk("你没有足够的皮革。");
+            cm.sendOk("你的蝙蝠怪的皮碎片数量不足。");
         } else {
             cm.gainItem(4001261, -1);
             cm.gainItem(itemids[selection], 1);
-            cm.sendOk("谢谢您的兑换。");
+            cm.sendOk("兑换完成，谢谢惠顾。");
         }
         cm.dispose();
     }


### PR DESCRIPTION
改动内容
- 修复 NPC“可疑男子”（1061016）的中文脚本文本，清理现有乱码与残留英文提示。
- 统一相关术语，将兑换提示中的道具名称统一为“蝙蝠怪的皮碎片”，与现有中文任务/WZ 文本保持一致。
- 本次仅修改 `scripts-zh-CN` 中文脚本目录，未改动英文原版脚本，也未改动任务流程或兑换逻辑。

影响范围
- 影响服务端中文 NPC 脚本显示。
- 不影响客户端资源文件，也不涉及服务端 Java/JAR 逻辑。

验证情况
- 已完成 JS 语法检查。
- 已完成中文乱码检查。
- 已确认分支相对 `master` 的变更仅包含本次修复文件。
- 已同步到测试环境服务端脚本目录，未发现额外客户端资源变更。

客户端资源
本次改动不需要客户端资源包。