### PR TITLE
fix: 修复灵魂除灵发型称号任务入口与文本

### DIFF
--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -83,6 +83,7 @@ import org.gms.server.partyquest.MonsterCarnival;
 import org.gms.server.partyquest.MonsterCarnivalParty;
 import org.gms.server.partyquest.PartyQuest;
 import org.gms.server.quest.Quest;
+import org.gms.server.quest.medal.DynamicHairMedal;
 import org.gms.service.*;
 import org.gms.util.*;
 import org.gms.util.packets.WeddingPackets;
@@ -138,7 +139,6 @@ public class Character extends AbstractCharacterObject {
     @Setter
     @Getter
     private int gender;
-    @Setter
     @Getter
     private int hair;
     @Setter
@@ -549,6 +549,12 @@ public class Character extends AbstractCharacterObject {
 
     public Job getJobStyle(byte opt) {
         return Job.getJobStyleInternal(this.getJob().getId(), opt);
+    }
+
+    public void setHair(int hair) {
+        int oldHair = this.hair;
+        this.hair = hair;
+        DynamicHairMedal.onHairChanged(this, oldHair, hair);
     }
 
     public Job getJobStyle() {

--- a/gms-server/src/main/java/org/gms/server/quest/medal/DynamicHairMedal.java
+++ b/gms-server/src/main/java/org/gms/server/quest/medal/DynamicHairMedal.java
@@ -1,0 +1,33 @@
+package org.gms.server.quest.medal;
+
+import org.gms.client.Character;
+import org.gms.client.QuestStatus;
+import org.gms.server.quest.Quest;
+
+public final class DynamicHairMedal {
+    public static final int QUEST_ID = 29020;
+    public static final int REQUIRED_CHANGES = 50;
+
+    private DynamicHairMedal() {
+    }
+
+    public static void onHairChanged(Character player, int oldHair, int newHair) {
+        QuestStatus status = player.getQuestNoAdd(Quest.getInstance(QUEST_ID));
+        if (oldHair / 10 == newHair / 10 || status == null || status.getStatus() != QuestStatus.Status.STARTED) {
+            return;
+        }
+
+        int progress = getProgress(status);
+        if (progress < REQUIRED_CHANGES) {
+            player.setQuestProgress(QUEST_ID, 0, Integer.toString(Math.min(progress + 1, REQUIRED_CHANGES)));
+        }
+    }
+
+    private static int getProgress(QuestStatus status) {
+        try {
+            return Integer.parseInt(status.getProgress(0));
+        } catch (NumberFormatException nfe) {
+            return 0;
+        }
+    }
+}

--- a/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
@@ -35211,7 +35211,7 @@
     </imgdir>
     <imgdir name="29017">
         <imgdir name="0">
-            <int name="npc" value="1061011"/>
+            <int name="npc" value="9000040"/>
             <int name="lvmin" value="57"/>
             <imgdir name="quest">
                 <imgdir name="0">
@@ -35221,7 +35221,7 @@
             </imgdir>
         </imgdir>
         <imgdir name="1">
-            <int name="npc" value="1061011"/>
+            <int name="npc" value="9000040"/>
             <imgdir name="mbcard">
                 <imgdir name="0">
                     <int name="id" value="2383036"/>
@@ -35270,7 +35270,7 @@
     </imgdir>
     <imgdir name="29018">
         <imgdir name="0">
-            <int name="npc" value="1061011"/>
+            <int name="npc" value="9000040"/>
             <int name="lvmin" value="67"/>
             <imgdir name="quest">
                 <imgdir name="0">
@@ -35280,7 +35280,7 @@
             </imgdir>
         </imgdir>
         <imgdir name="1">
-            <int name="npc" value="1061011"/>
+            <int name="npc" value="9000040"/>
             <imgdir name="mbcard">
                 <imgdir name="0">
                     <int name="id" value="2384004"/>
@@ -35329,7 +35329,7 @@
     </imgdir>
     <imgdir name="29019">
         <imgdir name="0">
-            <int name="npc" value="1061011"/>
+            <int name="npc" value="9000040"/>
             <int name="lvmin" value="92"/>
             <imgdir name="quest">
                 <imgdir name="0">
@@ -35339,7 +35339,7 @@
             </imgdir>
         </imgdir>
         <imgdir name="1">
-            <int name="npc" value="1061011"/>
+            <int name="npc" value="9000040"/>
             <imgdir name="mbcard">
                 <imgdir name="0">
                     <int name="id" value="2386000"/>
@@ -35388,7 +35388,7 @@
     </imgdir>
     <imgdir name="29020">
         <imgdir name="0">
-            <int name="npc" value="9000066"/>
+            <int name="npc" value="9000040"/>
             <int name="lvmin" value="13"/>
             <imgdir name="item">
                 <imgdir name="0">
@@ -35397,7 +35397,7 @@
             </imgdir>
         </imgdir>
         <imgdir name="1">
-            <int name="npc" value="9000066"/>
+            <int name="npc" value="9000040"/>
             <int name="infoNumber" value="29020"/>
             <imgdir name="infoex">
                 <imgdir name="0">
@@ -76451,7 +76451,7 @@
     <imgdir name="29016">
         <imgdir name="0">
             <int name="lvmin" value="40"/>
-            <int name="npc" value="1061011"/>
+            <int name="npc" value="9000040"/>
         </imgdir>
         <imgdir name="1">
             <imgdir name="mbcard">
@@ -76498,7 +76498,7 @@
                     <int name="id" value="4230102"/>
                 </imgdir>
             </imgdir>
-            <int name="npc" value="1061011"/>
+            <int name="npc" value="9000040"/>
         </imgdir>
     </imgdir>
     <imgdir name="8050">

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9510,38 +9510,38 @@
         <string name="0" value="挑战自己，探索金银岛吧！\r\n新手探险家\n林中之城探险家\n必须共获得2个称号。"/>
     </imgdir>
     <imgdir name="29017">
-        <string name="name" value="Title - Soul Conjurer"/>
+        <string name="name" value="称号 - 阴阳师"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142138"/>
-        <string name="0" value="You can acquire the title of #b&lt;Soul Conjurer&gt;#k by eliminating undead monsters and sending them back to nirvana..."/>
-        <string name="1" value="#b#eTitle - Soul Conjurer#k#n\r\nEliminate undead monsters and send them back to where they came from.\n\n1 #t2383036#\n1 #t2384003#\n1 #t2383037# \n1 #t2383038# \n1 #t2388008# \n\n#o5150001# #a290171#\n#o6230602# #a290172#\n#o5130107# #a290173#\n#o5130108# #a290174#\n#o6300005# #a290175#"/>
-        <string name="2" value="You were able to eliminate the undead monsters and acquired the title of #b&lt;Soul Conjurer&gt;#k."/>
+        <string name="0" value="消灭亡灵怪物并将它们送往应去之处，即可获得#b&lt;阴阳师&gt;#k称号。"/>
+        <string name="1" value="#b#e称号 - 阴阳师#k#n\r\n消灭亡灵怪物，将它们送回应去之处。\n\n1 #t2383036#\n1 #t2384003#\n1 #t2383037# \n1 #t2383038# \n1 #t2388008# \n\n#o5150001# #a290171#\n#o6230602# #a290172#\n#o5130107# #a290173#\n#o5130108# #a290174#\n#o6300005# #a290175#"/>
+        <string name="2" value="你消灭了亡灵怪物，获得了#b&lt;阴阳师&gt;#k称号。"/>
         <int name="autoComplete" value="1"/>
         <string name="demandSummary" value="#t2383036# 1\r\n#t2384003# 1\r\n#t2383037# 1\r\n#t2383038# 1\r\n#t2388008# 1\r\n#t2384010# 1\r\n#o5150001# #a290171#\r\n#o6230602# #a290172#\r\n#o5130107# #a290173#\r\n#o5130108# #a290174#\r\n#o6300005# #a290175#\r\n#o6090000# #a290176#\r\n"/>
-        <string name="rewardSummary" value="#Wbasic#\r\n#i1142138:# #t1142138:# 1 \r\nGo on to &apos;Title - Soul Guardian&apos; quest\r\n"/>
+        <string name="rewardSummary" value="#Wbasic#\r\n#i1142138:# #t1142138:# 1 \r\n继续进行&lt;称号 - 退魔师&gt;任务\r\n"/>
     </imgdir>
     <imgdir name="29018">
-        <string name="name" value="Title - Soul Guardian"/>
+        <string name="name" value="称号 - 退魔师"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142139"/>
-        <string name="0" value="You can apparently acquire the title of #b&lt;Soul Guardian&gt;#k by eliminating undead monsters and sending them back to nirvana…"/>
-        <string name="1" value="#b#eTitle - Soul Guardian#k#n\r\nEliminate undead monsters and send them back to where they came from.\n\n1 #t2384004# \n1 #t2384014# \n1 #t2384018# \n1 #t2385000# \n1 #t2385020# \n\n#o6230400# #a290181#\n#o6230500# #a290182#\n#o6110301# #a290183#\n#o8140300# #a290184#\n#o7130300# #a290185#"/>
-        <string name="2" value="You were able to eliminate the undead monsters and acquired the title of #b&lt;Soul Guardian&gt;#k."/>
+        <string name="0" value="消灭亡灵怪物并将它们送往应去之处，即可获得#b&lt;退魔师&gt;#k称号。"/>
+        <string name="1" value="#b#e称号 - 退魔师#k#n\r\n消灭亡灵怪物，将它们送回应去之处。\n\n1 #t2384004# \n1 #t2384014# \n1 #t2384018# \n1 #t2385000# \n1 #t2385020# \n\n#o6230400# #a290181#\n#o6230500# #a290182#\n#o6110301# #a290183#\n#o8140300# #a290184#\n#o7130300# #a290185#"/>
+        <string name="2" value="你消灭了亡灵怪物，获得了#b&lt;退魔师&gt;#k称号。"/>
         <int name="autoComplete" value="1"/>
         <string name="demandSummary" value="#t2384004# 1\r\n#t2384014# 1\r\n#t2384018# 1\r\n#t2384019# 1\r\n#t2385000# 1\r\n#t2385012# 1\r\n#t2385020# 1\r\n#o6230400# #a290181#\r\n#o6230500# #a290182#\r\n#o6110301# #a290183#\r\n#o8140200# #a290184#\r\n#o8140300# #a290185#\r\n#o7130010# #a290186#\r\n#o7130300# #a290187#\r\n"/>
-        <string name="rewardSummary" value="#Wbasic#\r\n#i1142139:# #t1142139:# 1 \r\nGo on to &apos;Title - Saint Exorcist&apos; quest\r\n"/>
+        <string name="rewardSummary" value="#Wbasic#\r\n#i1142139:# #t1142139:# 1 \r\n继续进行&lt;称号 - 神圣驱魔&gt;任务\r\n"/>
     </imgdir>
     <imgdir name="29019">
-        <string name="name" value="Title - Saint Exorcist"/>
+        <string name="name" value="称号 - 神圣驱魔"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142140"/>
-        <string name="0" value="You can apparently acquire the title of #b&lt;Saint Exorcist&gt;#k by eliminating undead monsters and sending them back to nirvana…"/>
-        <string name="2" value="You were able to eliminate the undead monsters and acquired the title of #b&lt;Saint Exorcist&gt;#k."/>
+        <string name="0" value="消灭亡灵怪物并将它们送往应去之处，即可获得#b&lt;神圣驱魔&gt;#k称号。"/>
+        <string name="2" value="你消灭了亡灵怪物，获得了#b&lt;神圣驱魔&gt;#k称号。"/>
         <int name="autoComplete" value="1"/>
-        <string name="1" value="#b#eTitle - Saint Exorcist#k#n\r\nEliminate undead monsters and send them back to where they came from.\n\n1 #t2386000# \n1 #t2386004# \n1 #t2386010# \n1 #t2387002# \n1 #t2387003# \n\n#o8140600# #a290191#\n#o8142000# #a290192#\n#o8143000# #a290193#\n#o8190003# #a290194#\n#o8190004# #a290194#\r\n"/>
+        <string name="1" value="#b#e称号 - 神圣驱魔#k#n\r\n消灭亡灵怪物，将它们送回应去之处。\n\n1 #t2386000# \n1 #t2386004# \n1 #t2386010# \n1 #t2387002# \n1 #t2387003# \n\n#o8140600# #a290191#\n#o8142000# #a290192#\n#o8143000# #a290193#\n#o8190003# #a290194#\n#o8190004# #a290194#\r\n"/>
         <string name="demandSummary" value="#t2386000# 1\r\n#t2386004# 1\r\n#t2386010# 1\r\n#t2387001# 1\r\n#t2387002# 1\r\n#t2387003# 1\r\n#o8140600# #a290191#\r\n#o8142000# #a290192#\r\n#o8143000# #a290193#\r\n#o8170000# #a290194#\r\n#o8190003# #a290195#\r\n#o8190004# #a290196#\r\n"/>
         <string name="rewardSummary" value="#Wbasic#\r\n#i1142140:# #t1142140:# 1 \r\n"/>
     </imgdir>

--- a/gms-server/wz/Quest.wz/Check.img.xml
+++ b/gms-server/wz/Quest.wz/Check.img.xml
@@ -35241,11 +35241,11 @@
   </imgdir>
   <imgdir name="29016">
     <imgdir name="0">
-      <int name="npc" value="1061011"/>
+      <int name="npc" value="9000040"/>
       <int name="lvmin" value="40"/>
     </imgdir>
     <imgdir name="1">
-      <int name="npc" value="1061011"/>
+      <int name="npc" value="9000040"/>
       <imgdir name="mbcard">
         <imgdir name="0">
           <int name="id" value="2382040"/>
@@ -35294,7 +35294,7 @@
   </imgdir>
   <imgdir name="29017">
     <imgdir name="0">
-      <int name="npc" value="1061011"/>
+      <int name="npc" value="9000040"/>
       <int name="lvmin" value="57"/>
       <imgdir name="quest">
         <imgdir name="0">
@@ -35304,7 +35304,7 @@
       </imgdir>
     </imgdir>
     <imgdir name="1">
-      <int name="npc" value="1061011"/>
+      <int name="npc" value="9000040"/>
       <imgdir name="mbcard">
         <imgdir name="0">
           <int name="id" value="2383036"/>
@@ -35353,7 +35353,7 @@
   </imgdir>
   <imgdir name="29018">
     <imgdir name="0">
-      <int name="npc" value="1061011"/>
+      <int name="npc" value="9000040"/>
       <int name="lvmin" value="67"/>
       <imgdir name="quest">
         <imgdir name="0">
@@ -35363,7 +35363,7 @@
       </imgdir>
     </imgdir>
     <imgdir name="1">
-      <int name="npc" value="1061011"/>
+      <int name="npc" value="9000040"/>
       <imgdir name="mbcard">
         <imgdir name="0">
           <int name="id" value="2384004"/>
@@ -35412,7 +35412,7 @@
   </imgdir>
   <imgdir name="29019">
     <imgdir name="0">
-      <int name="npc" value="1061011"/>
+      <int name="npc" value="9000040"/>
       <int name="lvmin" value="92"/>
       <imgdir name="quest">
         <imgdir name="0">
@@ -35422,7 +35422,7 @@
       </imgdir>
     </imgdir>
     <imgdir name="1">
-      <int name="npc" value="1061011"/>
+      <int name="npc" value="9000040"/>
       <imgdir name="mbcard">
         <imgdir name="0">
           <int name="id" value="2386000"/>
@@ -35471,7 +35471,7 @@
   </imgdir>
   <imgdir name="29020">
     <imgdir name="0">
-      <int name="npc" value="9000066"/>
+      <int name="npc" value="9000040"/>
       <int name="lvmin" value="13"/>
       <imgdir name="item">
         <imgdir name="0">
@@ -35480,7 +35480,7 @@
       </imgdir>
     </imgdir>
     <imgdir name="1">
-      <int name="npc" value="9000066"/>
+      <int name="npc" value="9000040"/>
       <int name="infoNumber" value="29020"/>
       <imgdir name="infoex">
         <imgdir name="0">


### PR DESCRIPTION
## 改动内容
- 汉化 29017-29020 灵魂、除灵、发型称号系列任务的任务名、任务说明、进度说明、完成文本与奖励摘要。
- 修复 29020 发型变换达人称号的进度逻辑，仅在基础发型发生变化时累计次数，染发不计入进度。
- 调整 29016-29020 称号任务的开始与完成 NPC 绑定为德烈，使任务出现在德烈默认 NPC 任务列表中，与正在进行中的任务入口并列。
- 对称更新英文与中文 Quest Check 配置，保持任务结构一致；中文 QuestInfo 仅更新中文显示文本。

## 影响范围
- 影响服务端任务逻辑、任务 WZ 配置，以及客户端任务资源显示。
- 由于修改了 Quest.wz 相关 XML，客户端需要同步客户端资源包。

## 验证情况
- XML 解析检查通过。
- 乱码检查通过。
- diff 格式检查通过。
- 本地测试环境同步并重启后，WZ 加载、频道端口和登录端口启动正常。
- 本地游戏内测试通过，德烈处任务入口显示位置符合预期。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。