### PR TITLE
fix: 修复终极职业勋章任务

### DIFF
--- a/gms-server/scripts-zh-CN/quest/29910.js
+++ b/gms-server/scripts-zh-CN/quest/29910.js
@@ -1,0 +1,56 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+	Author : 		kevintjuh93
+	Description: 		Quest - Gallant Warrior
+	Quest ID : 		29910
+*/
+
+var status = -1;
+
+function start(mode, type, selection) {
+    if (qm.forceStartQuest()) {
+        qm.showInfoText("您已经获得了<战武神>头衔。您可以从达赖尔获得勋章。");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    status++;
+    if (mode != 1) {
+        qm.dispose();
+    } else {
+        if (status == 0) {
+            qm.sendNext("恭喜你获得了 #b<战武神>#k 头衔。祝您在未来的冒险中一切顺利！继续加油吧，勇士。\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142009:# #t1142009# 1");
+        } else if (status == 1) {
+            if (qm.canHold(1142009)) {
+                qm.gainItem(1142009);
+                qm.forceCompleteQuest();
+                qm.dispose();
+            } else {
+                qm.sendNext("请给背包留出空位");//NOT GMS LIKE
+            }
+        } else if (status == 2) {
+            qm.dispose();
+        }
+    }
+}

--- a/gms-server/scripts-zh-CN/quest/29911.js
+++ b/gms-server/scripts-zh-CN/quest/29911.js
@@ -1,0 +1,56 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+	Author : 		kevintjuh93
+	Description: 		Quest - Wiseman
+	Quest ID : 		29911
+*/
+
+var status = -1;
+
+function start(mode, type, selection) {
+    if (qm.forceStartQuest()) {
+        qm.showInfoText("您已经获得了<圣贤者>头衔。您可以从达赖尔获得勋章。");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    status++;
+    if (mode != 1) {
+        qm.dispose();
+    } else {
+        if (status == 0) {
+            qm.sendNext("恭喜你获得了 #b<圣贤者>#k 头衔。祝您在未来的冒险中一切顺利！继续加油吧，勇士。\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142010:# #t1142010# 1");
+        } else if (status == 1) {
+            if (qm.canHold(1142010)) {
+                qm.gainItem(1142010);
+                qm.forceCompleteQuest();
+                qm.dispose();
+            } else {
+                qm.sendNext("请给背包留出空位");//NOT GMS LIKE
+            }
+        } else if (status == 2) {
+            qm.dispose();
+        }
+    }
+}

--- a/gms-server/scripts-zh-CN/quest/29912.js
+++ b/gms-server/scripts-zh-CN/quest/29912.js
@@ -1,0 +1,56 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+	Author : 		kevintjuh93
+	Description: 		Quest - Lord Sniper
+	Quest ID : 		29912
+*/
+
+var status = -1;
+
+function start(mode, type, selection) {
+    if (qm.forceStartQuest()) {
+        qm.showInfoText("您已经获得了<狙击王>头衔。您可以从达赖尔获得勋章。");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    status++;
+    if (mode != 1) {
+        qm.dispose();
+    } else {
+        if (status == 0) {
+            qm.sendNext("恭喜你获得了 #b<狙击王>#k 头衔。祝您在未来的冒险中一切顺利！继续加油吧，勇士。\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142011:# #t1142011# 1");
+        } else if (status == 1) {
+            if (qm.canHold(1142011)) {
+                qm.gainItem(1142011);
+                qm.forceCompleteQuest();
+                qm.dispose();
+            } else {
+                qm.sendNext("请给背包留出空位");//NOT GMS LIKE
+            }
+        } else if (status == 2) {
+            qm.dispose();
+        }
+    }
+}

--- a/gms-server/scripts-zh-CN/quest/29913.js
+++ b/gms-server/scripts-zh-CN/quest/29913.js
@@ -1,0 +1,56 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+	Author : 		kevintjuh93
+	Description: 		Quest - Legendary Thief
+	Quest ID : 		29913
+*/
+
+var status = -1;
+
+function start(mode, type, selection) {
+    if (qm.forceStartQuest()) {
+        qm.showInfoText("您已经获得了<影飞侠>头衔。您可以从达赖尔获得勋章。");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    status++;
+    if (mode != 1) {
+        qm.dispose();
+    } else {
+        if (status == 0) {
+            qm.sendNext("恭喜你获得了 #b<影飞侠>#k 头衔。祝您在未来的冒险中一切顺利！继续加油吧，勇士。\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142012:# #t1142012# 1");
+        } else if (status == 1) {
+            if (qm.canHold(1142012)) {
+                qm.gainItem(1142012);
+                qm.forceCompleteQuest();
+                qm.dispose();
+            } else {
+                qm.sendNext("请给背包留出空位");//NOT GMS LIKE
+            }
+        } else if (status == 2) {
+            qm.dispose();
+        }
+    }
+}

--- a/gms-server/scripts-zh-CN/quest/29914.js
+++ b/gms-server/scripts-zh-CN/quest/29914.js
@@ -1,0 +1,56 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+	Author : 		kevintjuh93
+	Description: 		Quest - King Pirate
+	Quest ID : 		29914
+*/
+
+var status = -1;
+
+function start(mode, type, selection) {
+    if (qm.forceStartQuest()) {
+        qm.showInfoText("您已经获得了<海盗王>头衔。您可以从达赖尔获得勋章。");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    status++;
+    if (mode != 1) {
+        qm.dispose();
+    } else {
+        if (status == 0) {
+            qm.sendNext("恭喜你获得了 #b<海盗王>#k 头衔。祝您在未来的冒险中一切顺利！继续加油吧，勇士。\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142013:# #t1142013# 1");
+        } else if (status == 1) {
+            if (qm.canHold(1142013)) {
+                qm.gainItem(1142013);
+                qm.forceCompleteQuest();
+                qm.dispose();
+            } else {
+                qm.sendNext("请给背包留出空位");//NOT GMS LIKE
+            }
+        } else if (status == 2) {
+            qm.dispose();
+        }
+    }
+}

--- a/gms-server/scripts/quest/29910.js
+++ b/gms-server/scripts/quest/29910.js
@@ -1,0 +1,56 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+	Author : 		kevintjuh93
+	Description: 		Quest - Gallant Warrior
+	Quest ID : 		29910
+*/
+
+var status = -1;
+
+function start(mode, type, selection) {
+    if (qm.forceStartQuest()) {
+        qm.showInfoText("You have earned the <Gallant Warrior> title. You can receive a Medal from NPC Dalair.");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    status++;
+    if (mode != 1) {
+        qm.dispose();
+    } else {
+        if (status == 0) {
+            qm.sendNext("Congratulations on earning your honorable #b<Gallant Warrior>#k title. I wish you the best of luck in your future endeavors! Keep up the good work.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142009:# #t1142009# 1");
+        } else if (status == 1) {
+            if (qm.canHold(1142009)) {
+                qm.gainItem(1142009);
+                qm.forceCompleteQuest();
+                qm.dispose();
+            } else {
+                qm.sendNext("Please make room in your inventory");//NOT GMS LIKE
+            }
+        } else if (status == 2) {
+            qm.dispose();
+        }
+    }
+}

--- a/gms-server/scripts/quest/29911.js
+++ b/gms-server/scripts/quest/29911.js
@@ -1,0 +1,56 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+	Author : 		kevintjuh93
+	Description: 		Quest - Wiseman
+	Quest ID : 		29911
+*/
+
+var status = -1;
+
+function start(mode, type, selection) {
+    if (qm.forceStartQuest()) {
+        qm.showInfoText("You have earned the <Wiseman> title. You can receive a Medal from NPC Dalair.");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    status++;
+    if (mode != 1) {
+        qm.dispose();
+    } else {
+        if (status == 0) {
+            qm.sendNext("Congratulations on earning your honorable #b<Wiseman>#k title. I wish you the best of luck in your future endeavors! Keep up the good work.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142010:# #t1142010# 1");
+        } else if (status == 1) {
+            if (qm.canHold(1142010)) {
+                qm.gainItem(1142010);
+                qm.forceCompleteQuest();
+                qm.dispose();
+            } else {
+                qm.sendNext("Please make room in your inventory");//NOT GMS LIKE
+            }
+        } else if (status == 2) {
+            qm.dispose();
+        }
+    }
+}

--- a/gms-server/scripts/quest/29912.js
+++ b/gms-server/scripts/quest/29912.js
@@ -1,0 +1,56 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+	Author : 		kevintjuh93
+	Description: 		Quest - Lord Sniper
+	Quest ID : 		29912
+*/
+
+var status = -1;
+
+function start(mode, type, selection) {
+    if (qm.forceStartQuest()) {
+        qm.showInfoText("You have earned the <Lord Sniper> title. You can receive a Medal from NPC Dalair.");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    status++;
+    if (mode != 1) {
+        qm.dispose();
+    } else {
+        if (status == 0) {
+            qm.sendNext("Congratulations on earning your honorable #b<Lord Sniper>#k title. I wish you the best of luck in your future endeavors! Keep up the good work.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142011:# #t1142011# 1");
+        } else if (status == 1) {
+            if (qm.canHold(1142011)) {
+                qm.gainItem(1142011);
+                qm.forceCompleteQuest();
+                qm.dispose();
+            } else {
+                qm.sendNext("Please make room in your inventory");//NOT GMS LIKE
+            }
+        } else if (status == 2) {
+            qm.dispose();
+        }
+    }
+}

--- a/gms-server/scripts/quest/29913.js
+++ b/gms-server/scripts/quest/29913.js
@@ -1,0 +1,56 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+	Author : 		kevintjuh93
+	Description: 		Quest - Legendary Thief
+	Quest ID : 		29913
+*/
+
+var status = -1;
+
+function start(mode, type, selection) {
+    if (qm.forceStartQuest()) {
+        qm.showInfoText("You have earned the <Legendary Thief> title. You can receive a Medal from NPC Dalair.");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    status++;
+    if (mode != 1) {
+        qm.dispose();
+    } else {
+        if (status == 0) {
+            qm.sendNext("Congratulations on earning your honorable #b<Legendary Thief>#k title. I wish you the best of luck in your future endeavors! Keep up the good work.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142012:# #t1142012# 1");
+        } else if (status == 1) {
+            if (qm.canHold(1142012)) {
+                qm.gainItem(1142012);
+                qm.forceCompleteQuest();
+                qm.dispose();
+            } else {
+                qm.sendNext("Please make room in your inventory");//NOT GMS LIKE
+            }
+        } else if (status == 2) {
+            qm.dispose();
+        }
+    }
+}

--- a/gms-server/scripts/quest/29914.js
+++ b/gms-server/scripts/quest/29914.js
@@ -1,0 +1,56 @@
+/*
+	This file is part of the OdinMS Maple Story Server
+    Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+		       Matthias Butz <matze@odinms.de>
+		       Jan Christian Meyer <vimes@odinms.de>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+	Author : 		kevintjuh93
+	Description: 		Quest - King Pirate
+	Quest ID : 		29914
+*/
+
+var status = -1;
+
+function start(mode, type, selection) {
+    if (qm.forceStartQuest()) {
+        qm.showInfoText("You have earned the <King Pirate> title. You can receive a Medal from NPC Dalair.");
+    }
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    status++;
+    if (mode != 1) {
+        qm.dispose();
+    } else {
+        if (status == 0) {
+            qm.sendNext("Congratulations on earning your honorable #b<King Pirate>#k title. I wish you the best of luck in your future endeavors! Keep up the good work.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142013:# #t1142013# 1");
+        } else if (status == 1) {
+            if (qm.canHold(1142013)) {
+                qm.gainItem(1142013);
+                qm.forceCompleteQuest();
+                qm.dispose();
+            } else {
+                qm.sendNext("Please make room in your inventory");//NOT GMS LIKE
+            }
+        } else if (status == 2) {
+            qm.dispose();
+        }
+    }
+}

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <imgdir name="QuestInfo.img">
     <imgdir name="1000">
         <string name="name" value="借来莎丽的镜子"/>
@@ -9557,42 +9557,42 @@
         <string name="rewardSummary" value="#Wbasic#\r\n#i1142122:# #t1142122:# 1 \r\n"/>
     </imgdir>
     <imgdir name="29300">
-        <string name="name" value="Title Challenge - Ultimate Warrior"/>
-        <string name="0" value="#b#eTitle Challenge - Ultimate Warrior#n\n#kThe Monk of Honor, Dalair, said he will give those who reach the highest level in their job each a different title.  Warriors will get the title, #e#bGallant Warrior#k#n, Magicians, #e#bWiseman#k#n, Archers, #e#bLord Sniper#k#n, Thieves, #e#bLegendary Thief#k#n and Pirates, #e#bKing Pirate#k#n.  If I&apos;m qualified enough to be selected by the God of Honor, I should go see Dalair and take the test. "/>
-        <string name="1" value="#b#eTitle Challenge - Ultimate Warrior#n\n#k\n - Level : #b#jlevel##k / 200"/>
-        <string name="2" value="#b#eTitle Challenge - Ultimate Warrior#n\n#k\n - Level : #b#jlevel##k / 200\n\nThe Monk of Honor, Dalair, presented me with the Ultimate Warrior title &apos;#bGallant Warrior#k&apos; after I reached level 200. "/>
+        <string name="name" value="称号挑战 - 终极战士"/>
+        <string name="0" value="#b#e称号挑战 - 终极战士#n\n#k荣誉修士德烈说，会给达到职业巅峰的人授予不同的称号。战士可以获得#e#b战武神#k#n，魔法师可以获得#e#b圣贤者#k#n，弓箭手可以获得#e#b狙击王#k#n，飞侠可以获得#e#b影飞侠#k#n，海盗可以获得#e#b海盗王#k#n。如果我有资格接受荣誉之神的考验，就去见德烈吧。"/>
+        <string name="1" value="#b#e称号挑战 - 终极战士#n\n#k\n - 等级：#b#jlevel##k / 200"/>
+        <string name="2" value="#b#e称号挑战 - 终极战士#n\n#k\n - 等级：#b#jlevel##k / 200\n\n达到200级后，荣誉修士德烈授予了我终极战士称号“#b战武神#k”。"/>
         <int name="area" value="10"/>
         <int name="viewMedalItem" value="1142009"/>
     </imgdir>
     <imgdir name="29301">
-        <string name="name" value="Title Challenge - Ultimate Magician"/>
-        <string name="0" value="#b#eTitle Challenge - Ultimate Magician#n\n#kThe Monk of Honor, Dalair, said those who reach the highest level in their job will each receive their own unique title.  Warriors will get the title, #e#bGallant Warrior#k#n, Magicians, #e#bWiseman#k#n, Archers, #e#bLord Sniper#k#n, Thieves, #e#bLegendary Thief#k#n and Pirates, #e#bKing Pirate#k#n.  If I&apos;m qualified enough to be selected by the God of Honor, I should go see Dalair and take the test. "/>
-        <string name="1" value="#b#eTitle Challenge - Ultimate Magician#n\n#k\n - Level : #b#jlevel##k / 200"/>
-        <string name="2" value="#b#eTitle Challenge - Ultimate Magician#n\n#k\n - Level : #b#jlevel##k / 200\n\nThe Monk of Honor, Dalair, presented me with the Ultimate Magician title &apos;#bWiseman#k&apos; after I reached level 200."/>
+        <string name="name" value="称号挑战 - 终极魔法师"/>
+        <string name="0" value="#b#e称号挑战 - 终极魔法师#n\n#k荣誉修士德烈说，会给达到职业巅峰的人授予不同的称号。战士可以获得#e#b战武神#k#n，魔法师可以获得#e#b圣贤者#k#n，弓箭手可以获得#e#b狙击王#k#n，飞侠可以获得#e#b影飞侠#k#n，海盗可以获得#e#b海盗王#k#n。如果我有资格接受荣誉之神的考验，就去见德烈吧。"/>
+        <string name="1" value="#b#e称号挑战 - 终极魔法师#n\n#k\n - 等级：#b#jlevel##k / 200"/>
+        <string name="2" value="#b#e称号挑战 - 终极魔法师#n\n#k\n - 等级：#b#jlevel##k / 200\n\n达到200级后，荣誉修士德烈授予了我终极魔法师称号“#b圣贤者#k”。"/>
         <int name="area" value="10"/>
         <int name="viewMedalItem" value="1142010"/>
     </imgdir>
     <imgdir name="29302">
-        <string name="name" value="Title Challenge - Ultimate Archer"/>
-        <string name="0" value="#b#eTitle Challenge - Ultimate Archer#n\n#kThe Monk of Honor, Dalair, said he will give those who reach the highest level in their job each a different title.  Warriors will get the title, #e#bGallant Warrior#k#n, Magicians, #e#bWiseman#k#n, Archers, #e#bLord Sniper#k#n, Thieves, #e#bLegendary Thief#k#n and Pirates, #e#bKing Pirate#k#n.  If I&apos;m qualified enough to be selected by the God of Honor, I should go see Dalair and take the test. "/>
-        <string name="1" value="#b#eTitle Challenge - Ultimate Archer#n\n#k\n - Level : #b#jlevel##k / 200"/>
-        <string name="2" value="#b#eTitle Challenge - Ultimate Archer#n\n#k\n - Level : #b#jlevel##k / 200\n\nThe Monk of Honor, Dalair, presented me with the Ultimate Archer title &apos;#bLord Sniper#k&apos; after I reached level 200."/>
+        <string name="name" value="称号挑战 - 终极弓箭手"/>
+        <string name="0" value="#b#e称号挑战 - 终极弓箭手#n\n#k荣誉修士德烈说，会给达到职业巅峰的人授予不同的称号。战士可以获得#e#b战武神#k#n，魔法师可以获得#e#b圣贤者#k#n，弓箭手可以获得#e#b狙击王#k#n，飞侠可以获得#e#b影飞侠#k#n，海盗可以获得#e#b海盗王#k#n。如果我有资格接受荣誉之神的考验，就去见德烈吧。"/>
+        <string name="1" value="#b#e称号挑战 - 终极弓箭手#n\n#k\n - 等级：#b#jlevel##k / 200"/>
+        <string name="2" value="#b#e称号挑战 - 终极弓箭手#n\n#k\n - 等级：#b#jlevel##k / 200\n\n达到200级后，荣誉修士德烈授予了我终极弓箭手称号“#b狙击王#k”。"/>
         <int name="area" value="10"/>
         <int name="viewMedalItem" value="1142011"/>
     </imgdir>
     <imgdir name="29303">
-        <string name="name" value="Title Challenge - Ultimate Thief"/>
-        <string name="0" value="#b#eTitle Challenge - Ultimate Thief#n\n#kThe Monk of Honor, Dalair, said he will give those who reach the highest level in their job each a different title.  Warriors will get the title, #e#bGallant Warrior#k#n, Magicians, #e#bWiseman#k#n, Archers, #e#bLord Sniper#k#n, Thieves, #e#bLegendary Thief#k#n and Pirates, #e#bKing Pirate#k#n.  If I&apos;m qualified enough to be selected by the God of Honor, I should go see Dalair and take the test. "/>
-        <string name="1" value="#b#eTitle Challenge - Ultimate Thief#n\n#k\n - Level : #b#jlevel##k / 200"/>
-        <string name="2" value="#b#eTitle Challenge - Ultimate Thief#n\n#k\n - Level : #b#jlevel##k / 200\n\nThe Monk of Honor, Dalair, presented me with the Ultimate Thief title &apos;#bLegendary Thief#k&apos; after I reached level 200."/>
+        <string name="name" value="称号挑战 - 终极飞侠"/>
+        <string name="0" value="#b#e称号挑战 - 终极飞侠#n\n#k荣誉修士德烈说，会给达到职业巅峰的人授予不同的称号。战士可以获得#e#b战武神#k#n，魔法师可以获得#e#b圣贤者#k#n，弓箭手可以获得#e#b狙击王#k#n，飞侠可以获得#e#b影飞侠#k#n，海盗可以获得#e#b海盗王#k#n。如果我有资格接受荣誉之神的考验，就去见德烈吧。"/>
+        <string name="1" value="#b#e称号挑战 - 终极飞侠#n\n#k\n - 等级：#b#jlevel##k / 200"/>
+        <string name="2" value="#b#e称号挑战 - 终极飞侠#n\n#k\n - 等级：#b#jlevel##k / 200\n\n达到200级后，荣誉修士德烈授予了我终极飞侠称号“#b影飞侠#k”。"/>
         <int name="area" value="10"/>
         <int name="viewMedalItem" value="1142012"/>
     </imgdir>
     <imgdir name="29304">
-        <string name="name" value="Title Challenge - Ultimate Pirate"/>
-        <string name="0" value="#b#eTitle Challenge - Ultimate Pirate#n\n#kThe Monk of Honor, Dalair, said he will give those who reach the highest level in their job each a different title.  Warriors will get the title, #e#bGallant Warrior#k#n, Magicians, #e#bWiseman#k#n, Archers, #e#bLord Sniper#k#n, Thieves, #e#bLegendary Thief#k#n and Pirates, #e#bKing Pirate#k#n.  If I&apos;m qualified enough to be selected by the God of Honor, I should go see Dalair and take the test. "/>
-        <string name="1" value="#b#eTitle Challenge - Ultimate Pirate#n\n#k\n - Level : #b#jlevel##k / 200"/>
-        <string name="2" value="#b#eTitle Challenge - Ultimate Pirate#n\n#k\n - Level : #b#jlevel##k / 200\n\nThe Monk of Honor, Dalair, presented me with the Ultimate Pirate title &apos;#bKing Pirate#k&apos; after I reached level 200."/>
+        <string name="name" value="称号挑战 - 终极海盗"/>
+        <string name="0" value="#b#e称号挑战 - 终极海盗#n\n#k荣誉修士德烈说，会给达到职业巅峰的人授予不同的称号。战士可以获得#e#b战武神#k#n，魔法师可以获得#e#b圣贤者#k#n，弓箭手可以获得#e#b狙击王#k#n，飞侠可以获得#e#b影飞侠#k#n，海盗可以获得#e#b海盗王#k#n。如果我有资格接受荣誉之神的考验，就去见德烈吧。"/>
+        <string name="1" value="#b#e称号挑战 - 终极海盗#n\n#k\n - 等级：#b#jlevel##k / 200"/>
+        <string name="2" value="#b#e称号挑战 - 终极海盗#n\n#k\n - 等级：#b#jlevel##k / 200\n\n达到200级后，荣誉修士德烈授予了我终极海盗称号“#b海盗王#k”。"/>
         <int name="area" value="10"/>
         <int name="viewMedalItem" value="1142013"/>
     </imgdir>
@@ -9831,53 +9831,53 @@
         <int name="viewMedalItem" value="1142069"/>
     </imgdir>
     <imgdir name="29910">
-        <string name="name" value="Gallant Warrior"/>
+        <string name="name" value="战武神"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142009"/>
-        <string name="0" value="#b#eTitle - Gallant Warrior#n#\r\n#kChallenge yourself to the  #b&lt;Gallant Warrior&gt;#k title, given only to powerful Warriors over Lv. 200.\r\n●Requirement(s) : Complete #b&lt;#y29300#&gt;#k "/>
+        <string name="0" value="#b#e称号 - 战武神#n#\r\n#k挑战只有达到200级以上的强大战士才能获得的#b&lt;战武神&gt;#k称号。\r\n●条件：完成#b&lt;#y29300#&gt;#k"/>
         <string name="1" value=".."/>
-        <string name="2" value="You have accomplished something incredible. You&apos;ve reached Lv. 200! You have earned the #b&lt;Gallant Warrior&gt;#k title."/>
+        <string name="2" value="你达成了了不起的成就，成功达到200级！获得了#b&lt;战武神&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
     </imgdir>
     <imgdir name="29911">
-        <string name="name" value="Wiseman"/>
+        <string name="name" value="圣贤者"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142010"/>
-        <string name="0" value="#b#eTitle - Wiseman#n#\r\n#kChallenge yourself to the #b&lt;Wiseman&gt;#k title, given only to powerful Magicians over Lv. 200.\r\n●Requirement(s) : Complete #b&lt;#y29301#&gt;#k"/>
+        <string name="0" value="#b#e称号 - 圣贤者#n#\r\n#k挑战只有达到200级以上的强大魔法师才能获得的#b&lt;圣贤者&gt;#k称号。\r\n●条件：完成#b&lt;#y29301#&gt;#k"/>
         <string name="1" value=".."/>
-        <string name="2" value="You have accomplished something incredible. You&apos;ve reached Lv. 200! You have earned the #b&lt;Wiseman&gt;#k title."/>
+        <string name="2" value="你达成了了不起的成就，成功达到200级！获得了#b&lt;圣贤者&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
         <int name="autoComplete" value="1"/>
     </imgdir>
     <imgdir name="29912">
-        <string name="name" value="Lord Sniper"/>
+        <string name="name" value="狙击王"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142011"/>
-        <string name="0" value="#b#eTitle - Lord Sniper#n#\r\n#kChallenge yourself to the #b&lt;Lord Sniper&gt;#k title, given only to powerful Bowmen over Lv. 200.\r\n●Requirement(s) : Complete #b&lt;#y29302#&gt;#k"/>
+        <string name="0" value="#b#e称号 - 狙击王#n#\r\n#k挑战只有达到200级以上的强大弓箭手才能获得的#b&lt;狙击王&gt;#k称号。\r\n●条件：完成#b&lt;#y29302#&gt;#k"/>
         <string name="1" value=".."/>
-        <string name="2" value="You have accomplished something incredible. You&apos;ve reached Lv. 200! You have earned the #b&lt;Lord Sniper&gt;#k title."/>
+        <string name="2" value="你达成了了不起的成就，成功达到200级！获得了#b&lt;狙击王&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
     </imgdir>
     <imgdir name="29913">
-        <string name="name" value="Legendary Thief"/>
+        <string name="name" value="影飞侠"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142012"/>
-        <string name="0" value="#b#eTitle - Legendary Thief#n#\r\n#kChallenge yourself to the #b&lt;Legendary Thief&gt;#k title, given only to the powerful Thieves over Lv. 200.\r\n●Requirement(s) : Complete #b&lt;#y29303#&gt;#k"/>
+        <string name="0" value="#b#e称号 - 影飞侠#n#\r\n#k挑战只有达到200级以上的强大飞侠才能获得的#b&lt;影飞侠&gt;#k称号。\r\n●条件：完成#b&lt;#y29303#&gt;#k"/>
         <string name="1" value=".."/>
-        <string name="2" value="You have accomplished something incredible. You&apos;ve reached Lv. 200! You have earned the #b&lt;Legendary Thief&gt;#k title."/>
+        <string name="2" value="你达成了了不起的成就，成功达到200级！获得了#b&lt;影飞侠&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
     </imgdir>
     <imgdir name="29914">
-        <string name="name" value="King Pirate"/>
+        <string name="name" value="海盗王"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142013"/>
-        <string name="0" value="#b#eTitle - King Pirate#n#\r\n#kChallenge yourself to the #b&lt;King Pirate&gt;#k title, given only to powerful Pirates over Lv. 200. \r\n●Requirement(s) : Complete #b&lt;#y29304#&gt;#k"/>
+        <string name="0" value="#b#e称号 - 海盗王#n#\r\n#k挑战只有达到200级以上的强大海盗才能获得的#b&lt;海盗王&gt;#k称号。\r\n●条件：完成#b&lt;#y29304#&gt;#k"/>
         <string name="1" value=".."/>
-        <string name="2" value="You have accomplished something incredible. You&apos;ve reached Lv. 200! You have earned the #b&lt;King Pirate&gt;#k title."/>
+        <string name="2" value="你达成了了不起的成就，成功达到200级！获得了#b&lt;海盗王&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
     </imgdir>

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9849,7 +9849,6 @@
         <string name="2" value="你达成了了不起的成就，成功达到200级！获得了#b&lt;圣贤者&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <int name="autoComplete" value="1"/>
     </imgdir>
     <imgdir name="29912">
         <string name="name" value="狙击王"/>

--- a/gms-server/wz/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz/Quest.wz/QuestInfo.img.xml
@@ -10834,7 +10834,6 @@ Able to proceed to &apos;For the peace of Victoria Island...&apos; as next quest
     <string name="2" value="You have accomplished something incredible. You&apos;ve reached Lv. 200! You have earned the #b&lt;Wiseman&gt;#k title."/>
     <int name="autoStart" value="1"/>
     <int name="autoAccept" value="1"/>
-    <int name="autoComplete" value="1"/>
   </imgdir>
   <imgdir name="29912">
     <string name="name" value="Lord Sniper"/>


### PR DESCRIPTION
改动内容
- 补齐职业代表勋章任务 29910、29911、29912、29913、29914 的任务脚本，分别发放战士、魔法师、弓箭手、飞侠、海盗对应的 200 级职业勋章。
- 修正任务 29911 单独带有 `autoComplete=1` 的配置不一致问题，使五个职业任务的完成行为保持一致。
- 调整终极职业挑战相关任务文本，覆盖任务 29300-29304 与 29910-29914 的称号说明与完成提示。
- 同步中英文目录下的任务脚本与任务配置，确保服务端英文原版目录和中文目录的功能逻辑一致。

影响范围
- 本次改动同时影响服务端和客户端。
- 服务端新增了 29910-29914 的任务脚本，并调整了任务配置。
- 客户端任务面板与相关任务文本显示会受到影响，需要同步客户端资源包。

验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查。
- 已执行中文乱码检查。
- 已完成本地游戏内测试与测试环境同步验证。

客户端资源
客户端资源包将通过 Release 提供，并在 PR 评论中补充下载链接与 SHA256。