### PR TITLE
fix: 修复特殊挑战勋章任务重复显示与流程

### DIFF
--- a/gms-server/scripts-zh-CN/quest/29500.js
+++ b/gms-server/scripts-zh-CN/quest/29500.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.MAPLE_IDOL_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("人气达到 #b" + Medal.MAPLE_IDOL_REQUIRED_FAME + "#k 后，再来领取#b#t" + Medal.MAPLE_IDOL_MEDAL_ID + "##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.MAPLE_IDOL_MEDAL_ID)) {
+        return;
+    }
     var player = qm.getPlayer();
     if (player.getFame() < Medal.MAPLE_IDOL_REQUIRED_FAME) {
         qm.sendOk("领取这枚勋章需要人气达到 #b" + Medal.MAPLE_IDOL_REQUIRED_FAME + "#k。\r\n当前人气：#r" + player.getFame() + "#k");

--- a/gms-server/scripts-zh-CN/quest/29500.js
+++ b/gms-server/scripts-zh-CN/quest/29500.js
@@ -27,5 +27,6 @@ function awardMedal(medalId) {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("你的名字已经在冒险岛世界里传开了。人气不是偶然的掌声，而是大家记住你冒险足迹的证明。\r\n\r\n请收下#b#t" + medalId + "##k。从今天起，你就是名副其实的冒险岛偶像明星。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29500.js
+++ b/gms-server/scripts-zh-CN/quest/29500.js
@@ -1,0 +1,31 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("人气达到 #b" + Medal.MAPLE_IDOL_REQUIRED_FAME + "#k 后，再来领取#b#t" + Medal.MAPLE_IDOL_MEDAL_ID + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var player = qm.getPlayer();
+    if (player.getFame() < Medal.MAPLE_IDOL_REQUIRED_FAME) {
+        qm.sendOk("领取这枚勋章需要人气达到 #b" + Medal.MAPLE_IDOL_REQUIRED_FAME + "#k。\r\n当前人气：#r" + player.getFame() + "#k");
+        qm.dispose();
+        return;
+    }
+    awardMedal(Medal.MAPLE_IDOL_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29501.js
+++ b/gms-server/scripts-zh-CN/quest/29501.js
@@ -27,5 +27,6 @@ function awardMedal(medalId) {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("暗黑龙王的咆哮，终于在你的面前沉寂了。能够从那场战斗中归来并带回胜利的人，绝不会是普通冒险家。\r\n\r\n请收下#b#t" + medalId + "##k。暗黑龙王杀手的荣耀，属于你。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29501.js
+++ b/gms-server/scripts-zh-CN/quest/29501.js
@@ -1,0 +1,31 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("击败暗黑龙王 #b" + Medal.HORNTAIL_REQUIRED_KILLS + "#k 次后，再来领取#b#t" + Medal.HORNTAIL_SLAYER_MEDAL_ID + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var kills = Medal.getProgress(qm.getPlayer(), Medal.HORNTAIL_SLAYER_QUEST_ID, Medal.PROGRESS_KILLS);
+    if (kills < Medal.HORNTAIL_REQUIRED_KILLS) {
+        qm.sendOk("请先击败暗黑龙王，再回来报告。\r\n进度：#r" + kills + "#k / " + Medal.HORNTAIL_REQUIRED_KILLS);
+        qm.dispose();
+        return;
+    }
+    awardMedal(Medal.HORNTAIL_SLAYER_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29501.js
+++ b/gms-server/scripts-zh-CN/quest/29501.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.HORNTAIL_SLAYER_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("击败暗黑龙王 #b" + Medal.HORNTAIL_REQUIRED_KILLS + "#k 次后，再来领取#b#t" + Medal.HORNTAIL_SLAYER_MEDAL_ID + "##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.HORNTAIL_SLAYER_MEDAL_ID)) {
+        return;
+    }
     var kills = Medal.getProgress(qm.getPlayer(), Medal.HORNTAIL_SLAYER_QUEST_ID, Medal.PROGRESS_KILLS);
     if (kills < Medal.HORNTAIL_REQUIRED_KILLS) {
         qm.sendOk("请先击败暗黑龙王，再回来报告。\r\n进度：#r" + kills + "#k / " + Medal.HORNTAIL_REQUIRED_KILLS);

--- a/gms-server/scripts-zh-CN/quest/29502.js
+++ b/gms-server/scripts-zh-CN/quest/29502.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.PINK_BEAN_SLAYER_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("击败品克缤 #b" + Medal.PINK_BEAN_REQUIRED_KILLS + "#k 次后，再来领取#b#t" + Medal.PINK_BEAN_SLAYER_MEDAL_ID + "##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.PINK_BEAN_SLAYER_MEDAL_ID)) {
+        return;
+    }
     var kills = Medal.getProgress(qm.getPlayer(), Medal.PINK_BEAN_SLAYER_QUEST_ID, Medal.PROGRESS_KILLS);
     if (kills < Medal.PINK_BEAN_REQUIRED_KILLS) {
         qm.sendOk("请先击败品克缤，再回来报告。\r\n进度：#r" + kills + "#k / " + Medal.PINK_BEAN_REQUIRED_KILLS);

--- a/gms-server/scripts-zh-CN/quest/29502.js
+++ b/gms-server/scripts-zh-CN/quest/29502.js
@@ -27,5 +27,6 @@ function awardMedal(medalId) {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("品克缤那不可思议的力量，也没能动摇你的决心。冒险岛世界会记住你战胜传说的这一刻。\r\n\r\n请收下#b#t" + medalId + "##k。它将证明你曾直面品克缤，并取得胜利。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29502.js
+++ b/gms-server/scripts-zh-CN/quest/29502.js
@@ -1,0 +1,31 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("击败品克缤 #b" + Medal.PINK_BEAN_REQUIRED_KILLS + "#k 次后，再来领取#b#t" + Medal.PINK_BEAN_SLAYER_MEDAL_ID + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var kills = Medal.getProgress(qm.getPlayer(), Medal.PINK_BEAN_SLAYER_QUEST_ID, Medal.PROGRESS_KILLS);
+    if (kills < Medal.PINK_BEAN_REQUIRED_KILLS) {
+        qm.sendOk("请先击败品克缤，再回来报告。\r\n进度：#r" + kills + "#k / " + Medal.PINK_BEAN_REQUIRED_KILLS);
+        qm.dispose();
+        return;
+    }
+    awardMedal(Medal.PINK_BEAN_SLAYER_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29503.js
+++ b/gms-server/scripts-zh-CN/quest/29503.js
@@ -1,0 +1,31 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("贡献 #b" + Medal.DONATION_REQUIRED_MESO + "#k 金币用于公共设施建设后，再来领取#b#t" + Medal.DONATION_KING_MEDAL_ID + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (qm.getPlayer().getMeso() < Medal.DONATION_REQUIRED_MESO) {
+        qm.sendOk("完成这次公益贡献需要 #b" + Medal.DONATION_REQUIRED_MESO + "#k 金币。");
+        qm.dispose();
+        return;
+    }
+    if (!qm.haveItem(Medal.DONATION_KING_MEDAL_ID) && !qm.canHold(Medal.DONATION_KING_MEDAL_ID)) {
+        qm.sendOk("请在装备栏空出 1 个位置。");
+        qm.dispose();
+        return;
+    }
+    qm.gainMeso(-Medal.DONATION_REQUIRED_MESO);
+    awardMedal(Medal.DONATION_KING_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        qm.gainItem(medalId, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29503.js
+++ b/gms-server/scripts-zh-CN/quest/29503.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.DONATION_KING_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("贡献 #b" + Medal.DONATION_REQUIRED_MESO + "#k 金币用于公共设施建设后，再来领取#b#t" + Medal.DONATION_KING_MEDAL_ID + "##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.DONATION_KING_MEDAL_ID)) {
+        return;
+    }
     if (qm.getPlayer().getMeso() < Medal.DONATION_REQUIRED_MESO) {
         qm.sendOk("完成这次公益贡献需要 #b" + Medal.DONATION_REQUIRED_MESO + "#k 金币。");
         qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/29503.js
+++ b/gms-server/scripts-zh-CN/quest/29503.js
@@ -27,5 +27,6 @@ function awardMedal(medalId) {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("真正温暖人心的力量，不只来自武器，也来自愿意帮助他人的善意。你的贡献会让后来者走得更安心。\r\n\r\n请收下#b#t" + medalId + "##k。这份称号，献给你藏在强大背后的爱心。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29505.js
+++ b/gms-server/scripts-zh-CN/quest/29505.js
@@ -1,0 +1,31 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("在怪物嘉年华2中获胜 #b" + Medal.CARNIVAL_REQUIRED_WINS + "#k 次后，再来领取#b#t" + Medal.CARNIVAL_VICTORY_MEDAL_ID + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var wins = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_VICTORY_QUEST_ID, Medal.PROGRESS_WINS);
+    if (wins < Medal.CARNIVAL_REQUIRED_WINS) {
+        qm.sendOk("请继续在怪物嘉年华2中取得胜利。\r\n胜场：#r" + wins + "#k / " + Medal.CARNIVAL_REQUIRED_WINS);
+        qm.dispose();
+        return;
+    }
+    awardMedal(Medal.CARNIVAL_VICTORY_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29505.js
+++ b/gms-server/scripts-zh-CN/quest/29505.js
@@ -27,5 +27,6 @@ function awardMedal(medalId) {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("一场胜利也许是运气，一百场胜利就是宣言。你在怪物嘉年华2中的战绩，已经没人能够忽视。\r\n\r\n请收下#b#t" + medalId + "##k。百战百胜者的名号，配得上你的实力。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29505.js
+++ b/gms-server/scripts-zh-CN/quest/29505.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CARNIVAL_VICTORY_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("在怪物嘉年华2中获胜 #b" + Medal.CARNIVAL_REQUIRED_WINS + "#k 次后，再来领取#b#t" + Medal.CARNIVAL_VICTORY_MEDAL_ID + "##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CARNIVAL_VICTORY_MEDAL_ID)) {
+        return;
+    }
     var wins = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_VICTORY_QUEST_ID, Medal.PROGRESS_WINS);
     if (wins < Medal.CARNIVAL_REQUIRED_WINS) {
         qm.sendOk("请继续在怪物嘉年华2中取得胜利。\r\n胜场：#r" + wins + "#k / " + Medal.CARNIVAL_REQUIRED_WINS);

--- a/gms-server/scripts-zh-CN/quest/29506.js
+++ b/gms-server/scripts-zh-CN/quest/29506.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CARNIVAL_GENIUS_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("参加至少 #b" + Medal.CARNIVAL_GENIUS_MIN_MATCHES + "#k 场怪物嘉年华2，并保持 #b" + Medal.CARNIVAL_GENIUS_WIN_RATE + "%#k 以上胜率。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CARNIVAL_GENIUS_MEDAL_ID)) {
+        return;
+    }
     var wins = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_GENIUS_QUEST_ID, Medal.PROGRESS_WINS);
     var losses = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_GENIUS_QUEST_ID, Medal.PROGRESS_LOSSES);
     var matches = wins + losses;

--- a/gms-server/scripts-zh-CN/quest/29506.js
+++ b/gms-server/scripts-zh-CN/quest/29506.js
@@ -1,0 +1,34 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("参加至少 #b" + Medal.CARNIVAL_GENIUS_MIN_MATCHES + "#k 场怪物嘉年华2，并保持 #b" + Medal.CARNIVAL_GENIUS_WIN_RATE + "%#k 以上胜率。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var wins = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_GENIUS_QUEST_ID, Medal.PROGRESS_WINS);
+    var losses = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_GENIUS_QUEST_ID, Medal.PROGRESS_LOSSES);
+    var matches = wins + losses;
+    if (!Medal.hasCarnivalGeniusMedalProgress(qm.getPlayer())) {
+        var rate = matches == 0 ? 0 : Math.floor(wins * 100 / matches);
+        qm.sendOk("请继续提升怪物嘉年华2战绩。\r\n场次：#r" + matches + "#k / " + Medal.CARNIVAL_GENIUS_MIN_MATCHES + "\r\n胜率：#r" + rate + "%#k / " + Medal.CARNIVAL_GENIUS_WIN_RATE + "%");
+        qm.dispose();
+        return;
+    }
+    awardMedal(Medal.CARNIVAL_GENIUS_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29506.js
+++ b/gms-server/scripts-zh-CN/quest/29506.js
@@ -30,5 +30,6 @@ function awardMedal(medalId) {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("你并不是只会取胜，而是用判断、节奏和胆识持续赢下去。真正的嘉年华天才，就该有这样的战绩。\r\n\r\n请收下#b#t" + medalId + "##k。你的胜率，比任何夸耀都更有说服力。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29507.js
+++ b/gms-server/scripts-zh-CN/quest/29507.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.PET_OWNER_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("将宠物亲密度提升到 #b" + Medal.PET_REQUIRED_TAMENESS + "#k 后，再来领取#b#t" + Medal.PET_OWNER_MEDAL_ID + "##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.PET_OWNER_MEDAL_ID)) {
+        return;
+    }
     var tameness = Medal.getMaxPetTameness(qm.getPlayer());
     if (tameness < Medal.PET_REQUIRED_TAMENESS) {
         qm.sendOk("你的宠物亲密度还不够。\r\n最高亲密度：#r" + tameness + "#k / " + Medal.PET_REQUIRED_TAMENESS);

--- a/gms-server/scripts-zh-CN/quest/29507.js
+++ b/gms-server/scripts-zh-CN/quest/29507.js
@@ -1,0 +1,31 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("将宠物亲密度提升到 #b" + Medal.PET_REQUIRED_TAMENESS + "#k 后，再来领取#b#t" + Medal.PET_OWNER_MEDAL_ID + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var tameness = Medal.getMaxPetTameness(qm.getPlayer());
+    if (tameness < Medal.PET_REQUIRED_TAMENESS) {
+        qm.sendOk("你的宠物亲密度还不够。\r\n最高亲密度：#r" + tameness + "#k / " + Medal.PET_REQUIRED_TAMENESS);
+        qm.dispose();
+        return;
+    }
+    awardMedal(Medal.PET_OWNER_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29507.js
+++ b/gms-server/scripts-zh-CN/quest/29507.js
@@ -27,5 +27,6 @@ function awardMedal(medalId) {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("宠物跟随你，并不是因为命令，而是因为信任。能把这份羁绊培养到如此深厚，本身就是了不起的冒险。\r\n\r\n请收下#b#t" + medalId + "##k。愿所有人都看见你是一位真正可爱的宠物主人。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29509.js
+++ b/gms-server/scripts-zh-CN/quest/29509.js
@@ -1,0 +1,30 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("完成林中之城的三个危险迷宫任务后，再来领取#b#t" + Medal.CHALLENGER_MEDAL_ID + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (!qm.isQuestCompleted(2111) || !qm.isQuestCompleted(2112) || !qm.isQuestCompleted(2113)) {
+        qm.sendOk("请先完成#b#y2111##k、#b#y2112##k、#b#y2113##k 后再来报告。");
+        qm.dispose();
+        return;
+    }
+    awardMedal(Medal.CHALLENGER_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29509.js
+++ b/gms-server/scripts-zh-CN/quest/29509.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CHALLENGER_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("完成林中之城的三个危险迷宫任务后，再来领取#b#t" + Medal.CHALLENGER_MEDAL_ID + "##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CHALLENGER_MEDAL_ID)) {
+        return;
+    }
     if (!qm.isQuestCompleted(2111) || !qm.isQuestCompleted(2112) || !qm.isQuestCompleted(2113)) {
         qm.sendOk("请先完成#b#y2111##k、#b#y2112##k、#b#y2113##k 后再来报告。");
         qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/29509.js
+++ b/gms-server/scripts-zh-CN/quest/29509.js
@@ -26,5 +26,6 @@ function awardMedal(medalId) {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("危险的道路、幽暗的迷宫、数不清的怪物，都没能让你停下脚步。你一次次迎向挑战，直到把道路亲手打开。\r\n\r\n请收下#b#t" + medalId + "##k。坚强的挑战者这个称号，现在属于你。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29512.js
+++ b/gms-server/scripts-zh-CN/quest/29512.js
@@ -1,0 +1,31 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("收集 #b" + Medal.MONSTER_BOOK_REQUIRED_CARDS + "#k 张怪物卡后，再来领取#b#t" + Medal.MONSTER_EXPERT_MEDAL_ID + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var cards = Medal.getMonsterBookCards(qm.getPlayer());
+    if (cards < Medal.MONSTER_BOOK_REQUIRED_CARDS) {
+        qm.sendOk("请继续收集怪物卡。\r\n已收集：#r" + cards + "#k / " + Medal.MONSTER_BOOK_REQUIRED_CARDS);
+        qm.dispose();
+        return;
+    }
+    awardMedal(Medal.MONSTER_EXPERT_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts-zh-CN/quest/29512.js
+++ b/gms-server/scripts-zh-CN/quest/29512.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.MONSTER_EXPERT_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("收集 #b" + Medal.MONSTER_BOOK_REQUIRED_CARDS + "#k 张怪物卡后，再来领取#b#t" + Medal.MONSTER_EXPERT_MEDAL_ID + "##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.MONSTER_EXPERT_MEDAL_ID)) {
+        return;
+    }
     var cards = Medal.getMonsterBookCards(qm.getPlayer());
     if (cards < Medal.MONSTER_BOOK_REQUIRED_CARDS) {
         qm.sendOk("请继续收集怪物卡。\r\n已收集：#r" + cards + "#k / " + Medal.MONSTER_BOOK_REQUIRED_CARDS);

--- a/gms-server/scripts-zh-CN/quest/29512.js
+++ b/gms-server/scripts-zh-CN/quest/29512.js
@@ -27,5 +27,6 @@ function awardMedal(medalId) {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("你了解怪物，不只是靠战斗，更靠观察它们的习性、踪迹与秘密。知识同样是一把锋利的武器。\r\n\r\n请收下#b#t" + medalId + "##k。从现在起，你可以自豪地被称为怪物博士。");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29500.js
+++ b/gms-server/scripts/quest/29500.js
@@ -1,0 +1,33 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Reach #b" + Medal.MAPLE_IDOL_REQUIRED_FAME + "#k fame, then return to receive the #b#t" + Medal.MAPLE_IDOL_MEDAL_ID + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var player = qm.getPlayer();
+    if (player.getFame() < Medal.MAPLE_IDOL_REQUIRED_FAME) {
+        qm.sendOk("You need #b" + Medal.MAPLE_IDOL_REQUIRED_FAME + "#k fame to receive this medal.\r\nCurrent fame: #r" + player.getFame() + "#k");
+        qm.dispose();
+        return;
+    }
+
+    awardMedal(Medal.MAPLE_IDOL_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29500.js
+++ b/gms-server/scripts/quest/29500.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.MAPLE_IDOL_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("Reach #b" + Medal.MAPLE_IDOL_REQUIRED_FAME + "#k fame, then return to receive the #b#t" + Medal.MAPLE_IDOL_MEDAL_ID + "##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.MAPLE_IDOL_MEDAL_ID)) {
+        return;
+    }
     var player = qm.getPlayer();
     if (player.getFame() < Medal.MAPLE_IDOL_REQUIRED_FAME) {
         qm.sendOk("You need #b" + Medal.MAPLE_IDOL_REQUIRED_FAME + "#k fame to receive this medal.\r\nCurrent fame: #r" + player.getFame() + "#k");

--- a/gms-server/scripts/quest/29500.js
+++ b/gms-server/scripts/quest/29500.js
@@ -29,5 +29,6 @@ function awardMedal(medalId) {
 
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("Your name is already being carried across Maple World. That kind of fame is not luck; it is proof that people remember your adventures.\r\n\r\nPlease accept the #b#t" + medalId + "##k. From today on, you stand among the true Maple Idol Stars.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29501.js
+++ b/gms-server/scripts/quest/29501.js
@@ -1,0 +1,33 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Defeat Horntail #b" + Medal.HORNTAIL_REQUIRED_KILLS + "#k time, then return to receive the #b#t" + Medal.HORNTAIL_SLAYER_MEDAL_ID + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var kills = Medal.getProgress(qm.getPlayer(), Medal.HORNTAIL_SLAYER_QUEST_ID, Medal.PROGRESS_KILLS);
+    if (kills < Medal.HORNTAIL_REQUIRED_KILLS) {
+        qm.sendOk("Defeat Horntail and come back to report.\r\nProgress: #r" + kills + "#k / " + Medal.HORNTAIL_REQUIRED_KILLS);
+        qm.dispose();
+        return;
+    }
+
+    awardMedal(Medal.HORNTAIL_SLAYER_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29501.js
+++ b/gms-server/scripts/quest/29501.js
@@ -29,5 +29,6 @@ function awardMedal(medalId) {
 
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("The roar of Horntail has finally gone silent before you. Few adventurers can return from that battle and speak of victory.\r\n\r\nPlease accept the #b#t" + medalId + "##k. The title of Horntail Slayer belongs to you.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29501.js
+++ b/gms-server/scripts/quest/29501.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.HORNTAIL_SLAYER_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("Defeat Horntail #b" + Medal.HORNTAIL_REQUIRED_KILLS + "#k time, then return to receive the #b#t" + Medal.HORNTAIL_SLAYER_MEDAL_ID + "##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.HORNTAIL_SLAYER_MEDAL_ID)) {
+        return;
+    }
     var kills = Medal.getProgress(qm.getPlayer(), Medal.HORNTAIL_SLAYER_QUEST_ID, Medal.PROGRESS_KILLS);
     if (kills < Medal.HORNTAIL_REQUIRED_KILLS) {
         qm.sendOk("Defeat Horntail and come back to report.\r\nProgress: #r" + kills + "#k / " + Medal.HORNTAIL_REQUIRED_KILLS);

--- a/gms-server/scripts/quest/29502.js
+++ b/gms-server/scripts/quest/29502.js
@@ -1,0 +1,33 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Defeat Pink Bean #b" + Medal.PINK_BEAN_REQUIRED_KILLS + "#k time, then return to receive the #b#t" + Medal.PINK_BEAN_SLAYER_MEDAL_ID + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var kills = Medal.getProgress(qm.getPlayer(), Medal.PINK_BEAN_SLAYER_QUEST_ID, Medal.PROGRESS_KILLS);
+    if (kills < Medal.PINK_BEAN_REQUIRED_KILLS) {
+        qm.sendOk("Defeat Pink Bean and come back to report.\r\nProgress: #r" + kills + "#k / " + Medal.PINK_BEAN_REQUIRED_KILLS);
+        qm.dispose();
+        return;
+    }
+
+    awardMedal(Medal.PINK_BEAN_SLAYER_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29502.js
+++ b/gms-server/scripts/quest/29502.js
@@ -29,5 +29,6 @@ function awardMedal(medalId) {
 
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("Even the strange power of Pink Bean could not stop your resolve. Maple World will remember the day you overcame that legend.\r\n\r\nPlease accept the #b#t" + medalId + "##k. Wear it as proof that you stood against Pink Bean and won.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29502.js
+++ b/gms-server/scripts/quest/29502.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.PINK_BEAN_SLAYER_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("Defeat Pink Bean #b" + Medal.PINK_BEAN_REQUIRED_KILLS + "#k time, then return to receive the #b#t" + Medal.PINK_BEAN_SLAYER_MEDAL_ID + "##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.PINK_BEAN_SLAYER_MEDAL_ID)) {
+        return;
+    }
     var kills = Medal.getProgress(qm.getPlayer(), Medal.PINK_BEAN_SLAYER_QUEST_ID, Medal.PROGRESS_KILLS);
     if (kills < Medal.PINK_BEAN_REQUIRED_KILLS) {
         qm.sendOk("Defeat Pink Bean and come back to report.\r\nProgress: #r" + kills + "#k / " + Medal.PINK_BEAN_REQUIRED_KILLS);

--- a/gms-server/scripts/quest/29503.js
+++ b/gms-server/scripts/quest/29503.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.DONATION_KING_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("Contribute #b" + Medal.DONATION_REQUIRED_MESO + "#k mesos to support public facilities, then return to receive the #b#t" + Medal.DONATION_KING_MEDAL_ID + "##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.DONATION_KING_MEDAL_ID)) {
+        return;
+    }
     if (qm.getPlayer().getMeso() < Medal.DONATION_REQUIRED_MESO) {
         qm.sendOk("You need #b" + Medal.DONATION_REQUIRED_MESO + "#k mesos to complete this contribution.");
         qm.dispose();

--- a/gms-server/scripts/quest/29503.js
+++ b/gms-server/scripts/quest/29503.js
@@ -29,5 +29,6 @@ function awardMedal(medalId) {
 
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("A warm heart can build more than stone walls and bright streets. Your contribution will help many travelers who come after you.\r\n\r\nPlease accept the #b#t" + medalId + "##k. This title honors the kindness behind your strength.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29503.js
+++ b/gms-server/scripts/quest/29503.js
@@ -1,0 +1,33 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Contribute #b" + Medal.DONATION_REQUIRED_MESO + "#k mesos to support public facilities, then return to receive the #b#t" + Medal.DONATION_KING_MEDAL_ID + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (qm.getPlayer().getMeso() < Medal.DONATION_REQUIRED_MESO) {
+        qm.sendOk("You need #b" + Medal.DONATION_REQUIRED_MESO + "#k mesos to complete this contribution.");
+        qm.dispose();
+        return;
+    }
+    if (!qm.haveItem(Medal.DONATION_KING_MEDAL_ID) && !qm.canHold(Medal.DONATION_KING_MEDAL_ID)) {
+        qm.sendOk("Please make room in your equip inventory.");
+        qm.dispose();
+        return;
+    }
+
+    qm.gainMeso(-Medal.DONATION_REQUIRED_MESO);
+    awardMedal(Medal.DONATION_KING_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29505.js
+++ b/gms-server/scripts/quest/29505.js
@@ -29,5 +29,6 @@ function awardMedal(medalId) {
 
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("One victory can be luck, but one hundred victories are a declaration. Your record in Monster Carnival 2 has become impossible to ignore.\r\n\r\nPlease accept the #b#t" + medalId + "##k. You have earned the name of Absolute Victory Carnivalian.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29505.js
+++ b/gms-server/scripts/quest/29505.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CARNIVAL_VICTORY_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("Win Monster Carnival 2 #b" + Medal.CARNIVAL_REQUIRED_WINS + "#k times, then return to receive the #b#t" + Medal.CARNIVAL_VICTORY_MEDAL_ID + "##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CARNIVAL_VICTORY_MEDAL_ID)) {
+        return;
+    }
     var wins = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_VICTORY_QUEST_ID, Medal.PROGRESS_WINS);
     if (wins < Medal.CARNIVAL_REQUIRED_WINS) {
         qm.sendOk("Keep winning in Monster Carnival 2.\r\nWins: #r" + wins + "#k / " + Medal.CARNIVAL_REQUIRED_WINS);

--- a/gms-server/scripts/quest/29505.js
+++ b/gms-server/scripts/quest/29505.js
@@ -1,0 +1,33 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Win Monster Carnival 2 #b" + Medal.CARNIVAL_REQUIRED_WINS + "#k times, then return to receive the #b#t" + Medal.CARNIVAL_VICTORY_MEDAL_ID + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var wins = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_VICTORY_QUEST_ID, Medal.PROGRESS_WINS);
+    if (wins < Medal.CARNIVAL_REQUIRED_WINS) {
+        qm.sendOk("Keep winning in Monster Carnival 2.\r\nWins: #r" + wins + "#k / " + Medal.CARNIVAL_REQUIRED_WINS);
+        qm.dispose();
+        return;
+    }
+
+    awardMedal(Medal.CARNIVAL_VICTORY_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29506.js
+++ b/gms-server/scripts/quest/29506.js
@@ -1,0 +1,36 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Play at least #b" + Medal.CARNIVAL_GENIUS_MIN_MATCHES + "#k Monster Carnival 2 matches and keep a win rate of #b" + Medal.CARNIVAL_GENIUS_WIN_RATE + "%#k or higher.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var wins = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_GENIUS_QUEST_ID, Medal.PROGRESS_WINS);
+    var losses = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_GENIUS_QUEST_ID, Medal.PROGRESS_LOSSES);
+    var matches = wins + losses;
+    if (!Medal.hasCarnivalGeniusMedalProgress(qm.getPlayer())) {
+        var rate = matches == 0 ? 0 : Math.floor(wins * 100 / matches);
+        qm.sendOk("Keep improving your Monster Carnival 2 record.\r\nMatches: #r" + matches + "#k / " + Medal.CARNIVAL_GENIUS_MIN_MATCHES + "\r\nWin rate: #r" + rate + "%#k / " + Medal.CARNIVAL_GENIUS_WIN_RATE + "%");
+        qm.dispose();
+        return;
+    }
+
+    awardMedal(Medal.CARNIVAL_GENIUS_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29506.js
+++ b/gms-server/scripts/quest/29506.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CARNIVAL_GENIUS_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("Play at least #b" + Medal.CARNIVAL_GENIUS_MIN_MATCHES + "#k Monster Carnival 2 matches and keep a win rate of #b" + Medal.CARNIVAL_GENIUS_WIN_RATE + "%#k or higher.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CARNIVAL_GENIUS_MEDAL_ID)) {
+        return;
+    }
     var wins = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_GENIUS_QUEST_ID, Medal.PROGRESS_WINS);
     var losses = Medal.getProgress(qm.getPlayer(), Medal.CARNIVAL_GENIUS_QUEST_ID, Medal.PROGRESS_LOSSES);
     var matches = wins + losses;

--- a/gms-server/scripts/quest/29506.js
+++ b/gms-server/scripts/quest/29506.js
@@ -32,5 +32,6 @@ function awardMedal(medalId) {
 
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("You did not simply win; you kept winning with discipline, judgment, and nerve. That is the mark of a true Carnival genius.\r\n\r\nPlease accept the #b#t" + medalId + "##k. Your record speaks louder than any boast.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29507.js
+++ b/gms-server/scripts/quest/29507.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.PET_OWNER_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("Raise a pet's closeness to #b" + Medal.PET_REQUIRED_TAMENESS + "#k, then return to receive the #b#t" + Medal.PET_OWNER_MEDAL_ID + "##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.PET_OWNER_MEDAL_ID)) {
+        return;
+    }
     var tameness = Medal.getMaxPetTameness(qm.getPlayer());
     if (tameness < Medal.PET_REQUIRED_TAMENESS) {
         qm.sendOk("Your pet is not close enough yet.\r\nBest closeness: #r" + tameness + "#k / " + Medal.PET_REQUIRED_TAMENESS);

--- a/gms-server/scripts/quest/29507.js
+++ b/gms-server/scripts/quest/29507.js
@@ -1,0 +1,33 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Raise a pet's closeness to #b" + Medal.PET_REQUIRED_TAMENESS + "#k, then return to receive the #b#t" + Medal.PET_OWNER_MEDAL_ID + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var tameness = Medal.getMaxPetTameness(qm.getPlayer());
+    if (tameness < Medal.PET_REQUIRED_TAMENESS) {
+        qm.sendOk("Your pet is not close enough yet.\r\nBest closeness: #r" + tameness + "#k / " + Medal.PET_REQUIRED_TAMENESS);
+        qm.dispose();
+        return;
+    }
+
+    awardMedal(Medal.PET_OWNER_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29507.js
+++ b/gms-server/scripts/quest/29507.js
@@ -29,5 +29,6 @@ function awardMedal(medalId) {
 
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("Your pet follows you not because of orders, but because of trust. That bond is more precious than any trophy.\r\n\r\nPlease accept the #b#t" + medalId + "##k. May everyone see what a wonderful pet owner you are.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29509.js
+++ b/gms-server/scripts/quest/29509.js
@@ -1,0 +1,32 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Complete the three Dangerous Dungeon quests in Sleepywood, then return to receive the #b#t" + Medal.CHALLENGER_MEDAL_ID + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (!qm.isQuestCompleted(2111) || !qm.isQuestCompleted(2112) || !qm.isQuestCompleted(2113)) {
+        qm.sendOk("Complete #b#y2111##k, #b#y2112##k, and #b#y2113##k before reporting back.");
+        qm.dispose();
+        return;
+    }
+
+    awardMedal(Medal.CHALLENGER_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29509.js
+++ b/gms-server/scripts/quest/29509.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CHALLENGER_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("Complete the three Dangerous Dungeon quests in Sleepywood, then return to receive the #b#t" + Medal.CHALLENGER_MEDAL_ID + "##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.CHALLENGER_MEDAL_ID)) {
+        return;
+    }
     if (!qm.isQuestCompleted(2111) || !qm.isQuestCompleted(2112) || !qm.isQuestCompleted(2113)) {
         qm.sendOk("Complete #b#y2111##k, #b#y2112##k, and #b#y2113##k before reporting back.");
         qm.dispose();

--- a/gms-server/scripts/quest/29509.js
+++ b/gms-server/scripts/quest/29509.js
@@ -28,5 +28,6 @@ function awardMedal(medalId) {
 
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("Dangerous roads, dark dungeons, and endless monsters could not make you turn back. You kept challenging the impossible until the path opened.\r\n\r\nPlease accept the #b#t" + medalId + "##k. The title of Persevering Challenger is now yours.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29512.js
+++ b/gms-server/scripts/quest/29512.js
@@ -1,12 +1,34 @@
 var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
 
+function finishIfAlreadyAwarded(medalId) {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
 function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.MONSTER_EXPERT_MEDAL_ID)) {
+        return;
+    }
     qm.forceStartQuest();
     qm.sendOk("Collect #b" + Medal.MONSTER_BOOK_REQUIRED_CARDS + "#k monster cards, then return to receive the #b#t" + Medal.MONSTER_EXPERT_MEDAL_ID + "##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded(Medal.MONSTER_EXPERT_MEDAL_ID)) {
+        return;
+    }
     var cards = Medal.getMonsterBookCards(qm.getPlayer());
     if (cards < Medal.MONSTER_BOOK_REQUIRED_CARDS) {
         qm.sendOk("Collect more monster cards.\r\nCards: #r" + cards + "#k / " + Medal.MONSTER_BOOK_REQUIRED_CARDS);

--- a/gms-server/scripts/quest/29512.js
+++ b/gms-server/scripts/quest/29512.js
@@ -1,0 +1,33 @@
+var Medal = Java.type('org.gms.server.quest.medal.SpecialChallengeMedal');
+
+function start(mode, type, selection) {
+    qm.forceStartQuest();
+    qm.sendOk("Collect #b" + Medal.MONSTER_BOOK_REQUIRED_CARDS + "#k monster cards, then return to receive the #b#t" + Medal.MONSTER_EXPERT_MEDAL_ID + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    var cards = Medal.getMonsterBookCards(qm.getPlayer());
+    if (cards < Medal.MONSTER_BOOK_REQUIRED_CARDS) {
+        qm.sendOk("Collect more monster cards.\r\nCards: #r" + cards + "#k / " + Medal.MONSTER_BOOK_REQUIRED_CARDS);
+        qm.dispose();
+        return;
+    }
+
+    awardMedal(Medal.MONSTER_EXPERT_MEDAL_ID);
+}
+
+function awardMedal(medalId) {
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29512.js
+++ b/gms-server/scripts/quest/29512.js
@@ -29,5 +29,6 @@ function awardMedal(medalId) {
 
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
+    qm.sendOk("You studied monsters not only by fighting them, but by learning their habits, traces, and secrets. That knowledge is a weapon of its own.\r\n\r\nPlease accept the #b#t" + medalId + "##k. From now on, you may proudly be called a Monster Expert.");
     qm.dispose();
 }

--- a/gms-server/src/main/java/org/gms/server/life/Monster.java
+++ b/gms-server/src/main/java/org/gms/server/life/Monster.java
@@ -63,6 +63,7 @@ import org.gms.server.maps.AbstractAnimatedMapObject;
 import org.gms.server.maps.MapObjectType;
 import org.gms.server.maps.MapleMap;
 import org.gms.server.maps.Summon;
+import org.gms.server.quest.medal.SpecialChallengeMedal;
 import org.gms.server.quest.medal.VeteranHunterMedal;
 
 import java.awt.*;
@@ -773,6 +774,7 @@ public class Monster extends AbstractLoadedLife {
             attacker.increaseEquipExp(_personalExp);
             attacker.raiseQuestMobCount(getId());
             VeteranHunterMedal.onMonsterKilled(attacker, this);
+            SpecialChallengeMedal.onMonsterKilled(attacker, this);
         }
     }
 

--- a/gms-server/src/main/java/org/gms/server/life/Monster.java
+++ b/gms-server/src/main/java/org/gms/server/life/Monster.java
@@ -774,6 +774,7 @@ public class Monster extends AbstractLoadedLife {
             attacker.increaseEquipExp(_personalExp);
             attacker.raiseQuestMobCount(getId());
             VeteranHunterMedal.onMonsterKilled(attacker, this);
+            // 特级挑战勋章复用怪物死亡事件，在角色已接任务时写入个人击杀进度。
             SpecialChallengeMedal.onMonsterKilled(attacker, this);
         }
     }

--- a/gms-server/src/main/java/org/gms/server/partyquest/MonsterCarnival.java
+++ b/gms-server/src/main/java/org/gms/server/partyquest/MonsterCarnival.java
@@ -261,6 +261,7 @@ public class MonsterCarnival {
                 for (PartyCharacter mpc : leader1.getParty().getMembers()) {
                     Character mc = mpc.getPlayer();
                     if (mc != null) {
+                        // 怪物嘉年华结算时同步记录特级挑战勋章的个人胜负场进度。
                         SpecialChallengeMedal.onMonsterCarnivalFinished(mc, cpq1, true);
                         mc.gainFestivalPoints(this.redTotalCP);
                         mc.setMonsterCarnival(null);
@@ -276,6 +277,7 @@ public class MonsterCarnival {
                 for (PartyCharacter mpc : leader2.getParty().getMembers()) {
                     Character mc = mpc.getPlayer();
                     if (mc != null) {
+                        // 怪物嘉年华结算时同步记录特级挑战勋章的个人胜负场进度。
                         SpecialChallengeMedal.onMonsterCarnivalFinished(mc, cpq1, false);
                         mc.gainFestivalPoints(this.blueTotalCP);
                         mc.setMonsterCarnival(null);
@@ -292,6 +294,7 @@ public class MonsterCarnival {
                 for (PartyCharacter mpc : leader2.getParty().getMembers()) {
                     Character mc = mpc.getPlayer();
                     if (mc != null) {
+                        // 怪物嘉年华结算时同步记录特级挑战勋章的个人胜负场进度。
                         SpecialChallengeMedal.onMonsterCarnivalFinished(mc, cpq1, true);
                         mc.gainFestivalPoints(this.blueTotalCP);
                         mc.setMonsterCarnival(null);
@@ -307,6 +310,7 @@ public class MonsterCarnival {
                 for (PartyCharacter mpc : leader1.getParty().getMembers()) {
                     Character mc = mpc.getPlayer();
                     if (mc != null) {
+                        // 怪物嘉年华结算时同步记录特级挑战勋章的个人胜负场进度。
                         SpecialChallengeMedal.onMonsterCarnivalFinished(mc, cpq1, false);
                         mc.gainFestivalPoints(this.redTotalCP);
                         mc.setMonsterCarnival(null);

--- a/gms-server/src/main/java/org/gms/server/partyquest/MonsterCarnival.java
+++ b/gms-server/src/main/java/org/gms/server/partyquest/MonsterCarnival.java
@@ -10,6 +10,7 @@ import org.gms.net.server.world.PartyCharacter;
 import org.gms.server.TimerManager;
 import org.gms.server.maps.MapleMap;
 import org.gms.server.maps.Reactor;
+import org.gms.server.quest.medal.SpecialChallengeMedal;
 import org.gms.util.PacketCreator;
 
 import java.util.concurrent.ScheduledFuture;
@@ -260,6 +261,7 @@ public class MonsterCarnival {
                 for (PartyCharacter mpc : leader1.getParty().getMembers()) {
                     Character mc = mpc.getPlayer();
                     if (mc != null) {
+                        SpecialChallengeMedal.onMonsterCarnivalFinished(mc, cpq1, true);
                         mc.gainFestivalPoints(this.redTotalCP);
                         mc.setMonsterCarnival(null);
                         if (cpq1) {
@@ -274,6 +276,7 @@ public class MonsterCarnival {
                 for (PartyCharacter mpc : leader2.getParty().getMembers()) {
                     Character mc = mpc.getPlayer();
                     if (mc != null) {
+                        SpecialChallengeMedal.onMonsterCarnivalFinished(mc, cpq1, false);
                         mc.gainFestivalPoints(this.blueTotalCP);
                         mc.setMonsterCarnival(null);
                         if (cpq1) {
@@ -289,6 +292,7 @@ public class MonsterCarnival {
                 for (PartyCharacter mpc : leader2.getParty().getMembers()) {
                     Character mc = mpc.getPlayer();
                     if (mc != null) {
+                        SpecialChallengeMedal.onMonsterCarnivalFinished(mc, cpq1, true);
                         mc.gainFestivalPoints(this.blueTotalCP);
                         mc.setMonsterCarnival(null);
                         if (cpq1) {
@@ -303,6 +307,7 @@ public class MonsterCarnival {
                 for (PartyCharacter mpc : leader1.getParty().getMembers()) {
                     Character mc = mpc.getPlayer();
                     if (mc != null) {
+                        SpecialChallengeMedal.onMonsterCarnivalFinished(mc, cpq1, false);
                         mc.gainFestivalPoints(this.redTotalCP);
                         mc.setMonsterCarnival(null);
                         if (cpq1) {

--- a/gms-server/src/main/java/org/gms/server/quest/medal/SpecialChallengeMedal.java
+++ b/gms-server/src/main/java/org/gms/server/quest/medal/SpecialChallengeMedal.java
@@ -1,0 +1,122 @@
+package org.gms.server.quest.medal;
+
+import org.gms.client.Character;
+import org.gms.client.QuestStatus;
+import org.gms.client.inventory.Pet;
+import org.gms.constants.game.DelayedQuestUpdate;
+import org.gms.server.life.Monster;
+import org.gms.server.quest.Quest;
+
+public final class SpecialChallengeMedal {
+    public static final int MAPLE_IDOL_QUEST_ID = 29500;
+    public static final int HORNTAIL_SLAYER_QUEST_ID = 29501;
+    public static final int PINK_BEAN_SLAYER_QUEST_ID = 29502;
+    public static final int DONATION_KING_QUEST_ID = 29503;
+    public static final int CARNIVAL_VICTORY_QUEST_ID = 29505;
+    public static final int CARNIVAL_GENIUS_QUEST_ID = 29506;
+    public static final int PET_OWNER_QUEST_ID = 29507;
+    public static final int CHALLENGER_QUEST_ID = 29509;
+    public static final int MONSTER_EXPERT_QUEST_ID = 29512;
+
+    public static final int MAPLE_IDOL_MEDAL_ID = 1142006;
+    public static final int HORNTAIL_SLAYER_MEDAL_ID = 1142007;
+    public static final int PINK_BEAN_SLAYER_MEDAL_ID = 1142008;
+    public static final int DONATION_KING_MEDAL_ID = 1142014;
+    public static final int CARNIVAL_VICTORY_MEDAL_ID = 1142077;
+    public static final int CARNIVAL_GENIUS_MEDAL_ID = 1142078;
+    public static final int PET_OWNER_MEDAL_ID = 1142082;
+    public static final int CHALLENGER_MEDAL_ID = 1142084;
+    public static final int MONSTER_EXPERT_MEDAL_ID = 1142083;
+
+    public static final int MAPLE_IDOL_REQUIRED_FAME = 1000;
+    public static final int HORNTAIL_REQUIRED_KILLS = 1;
+    public static final int PINK_BEAN_REQUIRED_KILLS = 1;
+    public static final int DONATION_REQUIRED_MESO = 10000000;
+    public static final int CARNIVAL_REQUIRED_WINS = 100;
+    public static final int CARNIVAL_GENIUS_MIN_MATCHES = 50;
+    public static final int CARNIVAL_GENIUS_WIN_RATE = 70;
+    public static final int PET_REQUIRED_TAMENESS = 1400;
+    public static final int MONSTER_BOOK_REQUIRED_CARDS = 30;
+
+    public static final int HORNTAIL_MOB_ID = 8810018;
+    public static final int PINK_BEAN_MOB_ID = 8820001;
+
+    public static final int PROGRESS_KILLS = 0;
+    public static final int PROGRESS_WINS = 1;
+    public static final int PROGRESS_LOSSES = 2;
+
+    private SpecialChallengeMedal() {
+    }
+
+    public static int getProgress(Character player, int questId, int progressId) {
+        QuestStatus status = player.getQuest(Quest.getInstance(questId));
+        try {
+            return Integer.parseInt(status.getProgress(progressId));
+        } catch (NumberFormatException ignored) {
+            return 0;
+        }
+    }
+
+    public static int getMaxPetTameness(Character player) {
+        int tameness = 0;
+        for (Pet pet : player.getPets()) {
+            if (pet != null && pet.getTameness() > tameness) {
+                tameness = pet.getTameness();
+            }
+        }
+        return tameness;
+    }
+
+    public static int getMonsterBookCards(Character player) {
+        return player.getMonsterBook().getTotalCards();
+    }
+
+    public static boolean hasCarnivalVictoryMedalProgress(Character player) {
+        return getProgress(player, CARNIVAL_VICTORY_QUEST_ID, PROGRESS_WINS) >= CARNIVAL_REQUIRED_WINS;
+    }
+
+    public static boolean hasCarnivalGeniusMedalProgress(Character player) {
+        int wins = getProgress(player, CARNIVAL_GENIUS_QUEST_ID, PROGRESS_WINS);
+        int losses = getProgress(player, CARNIVAL_GENIUS_QUEST_ID, PROGRESS_LOSSES);
+        int matches = wins + losses;
+        return matches >= CARNIVAL_GENIUS_MIN_MATCHES && wins * 100 >= matches * CARNIVAL_GENIUS_WIN_RATE;
+    }
+
+    public static void onMonsterKilled(Character player, Monster monster) {
+        int mobId = monster.getId();
+        if (mobId == HORNTAIL_MOB_ID) {
+            addStartedQuestProgress(player, HORNTAIL_SLAYER_QUEST_ID, PROGRESS_KILLS, HORNTAIL_REQUIRED_KILLS);
+        } else if (mobId == PINK_BEAN_MOB_ID) {
+            addStartedQuestProgress(player, PINK_BEAN_SLAYER_QUEST_ID, PROGRESS_KILLS, PINK_BEAN_REQUIRED_KILLS);
+        }
+    }
+
+    public static void onMonsterCarnivalFinished(Character player, boolean cpq1, boolean won) {
+        if (cpq1) {
+            return;
+        }
+
+        if (won) {
+            addStartedQuestProgress(player, CARNIVAL_VICTORY_QUEST_ID, PROGRESS_WINS, CARNIVAL_REQUIRED_WINS);
+        }
+
+        int progressId = won ? PROGRESS_WINS : PROGRESS_LOSSES;
+        addStartedQuestProgress(player, CARNIVAL_GENIUS_QUEST_ID, progressId, Integer.MAX_VALUE);
+    }
+
+    private static void addStartedQuestProgress(Character player, int questId, int progressId, int cap) {
+        Quest quest = Quest.getInstance(questId);
+        QuestStatus status = player.getQuest(quest);
+        if (status.getStatus() != QuestStatus.Status.STARTED) {
+            return;
+        }
+
+        int progress = getProgress(player, questId, progressId);
+        if (progress >= cap) {
+            return;
+        }
+
+        status.setProgress(progressId, Integer.toString(Math.min(progress + 1, cap)));
+        player.announceUpdateQuest(DelayedQuestUpdate.UPDATE, status, false);
+    }
+}

--- a/gms-server/src/main/java/org/gms/server/quest/medal/SpecialChallengeMedal.java
+++ b/gms-server/src/main/java/org/gms/server/quest/medal/SpecialChallengeMedal.java
@@ -7,7 +7,14 @@ import org.gms.constants.game.DelayedQuestUpdate;
 import org.gms.server.life.Monster;
 import org.gms.server.quest.Quest;
 
+/**
+ * 特级挑战勋章的轻量化实现。
+ *
+ * <p>这些勋章原始数据里有“全服第一”“定期重置”“捐献排行”等机制，本服目前没有对应系统。
+ * 这里统一改成可控的个人条件：脚本负责领奖判断，击杀和嘉年华结算负责写入任务进度。</p>
+ */
 public final class SpecialChallengeMedal {
+    // 任务 ID：脚本和事件回调用这些 ID 读写对应任务状态。
     public static final int MAPLE_IDOL_QUEST_ID = 29500;
     public static final int HORNTAIL_SLAYER_QUEST_ID = 29501;
     public static final int PINK_BEAN_SLAYER_QUEST_ID = 29502;
@@ -18,6 +25,7 @@ public final class SpecialChallengeMedal {
     public static final int CHALLENGER_QUEST_ID = 29509;
     public static final int MONSTER_EXPERT_QUEST_ID = 29512;
 
+    // 勋章道具 ID：脚本发奖时直接引用，避免脚本里散落魔法数字。
     public static final int MAPLE_IDOL_MEDAL_ID = 1142006;
     public static final int HORNTAIL_SLAYER_MEDAL_ID = 1142007;
     public static final int PINK_BEAN_SLAYER_MEDAL_ID = 1142008;
@@ -28,6 +36,7 @@ public final class SpecialChallengeMedal {
     public static final int CHALLENGER_MEDAL_ID = 1142084;
     public static final int MONSTER_EXPERT_MEDAL_ID = 1142083;
 
+    // 领取阈值：集中在 Java 中，便于后续调整数值，不需要逐个改脚本。
     public static final int MAPLE_IDOL_REQUIRED_FAME = 1000;
     public static final int HORNTAIL_REQUIRED_KILLS = 1;
     public static final int PINK_BEAN_REQUIRED_KILLS = 1;
@@ -38,9 +47,11 @@ public final class SpecialChallengeMedal {
     public static final int PET_REQUIRED_TAMENESS = 1400;
     public static final int MONSTER_BOOK_REQUIRED_CARDS = 30;
 
+    // 击杀追踪只认最终 Boss 本体 ID，避免召唤物或阶段怪误计数。
     public static final int HORNTAIL_MOB_ID = 8810018;
     public static final int PINK_BEAN_MOB_ID = 8820001;
 
+    // 任务进度槽位：复用 QuestStatus progress，不新增数据库字段。
     public static final int PROGRESS_KILLS = 0;
     public static final int PROGRESS_WINS = 1;
     public static final int PROGRESS_LOSSES = 2;
@@ -48,6 +59,11 @@ public final class SpecialChallengeMedal {
     private SpecialChallengeMedal() {
     }
 
+    /**
+     * 读取指定任务的进度槽位。
+     *
+     * <p>未开始任务或旧数据为空时，QuestStatus 可能返回空值；解析失败统一当作 0，避免脚本领取时报错。</p>
+     */
     public static int getProgress(Character player, int questId, int progressId) {
         QuestStatus status = player.getQuest(Quest.getInstance(questId));
         try {
@@ -57,6 +73,11 @@ public final class SpecialChallengeMedal {
         }
     }
 
+    /**
+     * 获取角色当前所有出战宠物中的最高亲密度。
+     *
+     * <p>这样不再依赖 WZ 里固定的宠物 ID 列表，新宠物也能正常参与勋章判断。</p>
+     */
     public static int getMaxPetTameness(Character player) {
         int tameness = 0;
         for (Pet pet : player.getPets()) {
@@ -67,14 +88,17 @@ public final class SpecialChallengeMedal {
         return tameness;
     }
 
+    // 怪物博士只需要总卡片数，实际领取判断放在任务脚本中执行。
     public static int getMonsterBookCards(Character player) {
         return player.getMonsterBook().getTotalCards();
     }
 
+    // 29505：嘉年华百战百胜者，只看怪物嘉年华2胜场是否达到固定阈值。
     public static boolean hasCarnivalVictoryMedalProgress(Character player) {
         return getProgress(player, CARNIVAL_VICTORY_QUEST_ID, PROGRESS_WINS) >= CARNIVAL_REQUIRED_WINS;
     }
 
+    // 29506：嘉年华天才，需要先满足最低场次，再检查胜率。
     public static boolean hasCarnivalGeniusMedalProgress(Character player) {
         int wins = getProgress(player, CARNIVAL_GENIUS_QUEST_ID, PROGRESS_WINS);
         int losses = getProgress(player, CARNIVAL_GENIUS_QUEST_ID, PROGRESS_LOSSES);
@@ -82,6 +106,11 @@ public final class SpecialChallengeMedal {
         return matches >= CARNIVAL_GENIUS_MIN_MATCHES && wins * 100 >= matches * CARNIVAL_GENIUS_WIN_RATE;
     }
 
+    /**
+     * 怪物死亡时记录相关 Boss 勋章进度。
+     *
+     * <p>只给已经接取中的任务加进度；没有接任务时击杀不会被补记，保持任务流程可控。</p>
+     */
     public static void onMonsterKilled(Character player, Monster monster) {
         int mobId = monster.getId();
         if (mobId == HORNTAIL_MOB_ID) {
@@ -91,6 +120,11 @@ public final class SpecialChallengeMedal {
         }
     }
 
+    /**
+     * 怪物嘉年华结算时记录 29505 / 29506 进度。
+     *
+     * <p>本次需求只确认怪物嘉年华2，因此 cpq1 直接跳过。29505 只累计胜场，29506 同时累计胜负场用于算胜率。</p>
+     */
     public static void onMonsterCarnivalFinished(Character player, boolean cpq1, boolean won) {
         if (cpq1) {
             return;
@@ -104,6 +138,11 @@ public final class SpecialChallengeMedal {
         addStartedQuestProgress(player, CARNIVAL_GENIUS_QUEST_ID, progressId, Integer.MAX_VALUE);
     }
 
+    /**
+     * 给已接取任务增加一个指定进度槽位。
+     *
+     * <p>这里集中处理“必须已接任务”“达到上限后不再增加”“通知客户端刷新任务面板”三个细节。</p>
+     */
     private static void addStartedQuestProgress(Character player, int questId, int progressId, int cap) {
         Quest quest = Quest.getInstance(questId);
         QuestStatus status = player.getQuest(quest);

--- a/gms-server/src/main/java/org/gms/server/quest/medal/SpecialChallengeMedal.java
+++ b/gms-server/src/main/java/org/gms/server/quest/medal/SpecialChallengeMedal.java
@@ -7,12 +7,6 @@ import org.gms.constants.game.DelayedQuestUpdate;
 import org.gms.server.life.Monster;
 import org.gms.server.quest.Quest;
 
-/**
- * 特级挑战勋章的轻量化实现。
- *
- * <p>这些勋章原始数据里有“全服第一”“定期重置”“捐献排行”等机制，本服目前没有对应系统。
- * 这里统一改成可控的个人条件：脚本负责领奖判断，击杀和嘉年华结算负责写入任务进度。</p>
- */
 public final class SpecialChallengeMedal {
     // 任务 ID：脚本和事件回调用这些 ID 读写对应任务状态。
     public static final int MAPLE_IDOL_QUEST_ID = 29500;

--- a/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
@@ -35565,12 +35565,6 @@
             <int name="npc" value="9000040"/>
             <int name="interval" value="0"/>
             <string name="startscript" value="q29500s"/>
-            <imgdir name="item">
-                <imgdir name="0">
-                    <int name="id" value="1142003"/>
-                    <int name="count" value="1"/>
-                </imgdir>
-            </imgdir>
         </imgdir>
     </imgdir>
     <imgdir name="29501">
@@ -35647,135 +35641,11 @@
         <imgdir name="0">
             <int name="npc" value="9000040"/>
             <int name="lvmin" value="10"/>
+            <string name="startscript" value="q29507s"/>
         </imgdir>
         <imgdir name="1">
             <int name="npc" value="9000040"/>
-            <int name="pettamenessmin" value="1400"/>
-            <imgdir name="pet">
-                <imgdir name="0">
-                    <int name="id" value="5000000"/>
-                </imgdir>
-                <imgdir name="1">
-                    <int name="id" value="5000001"/>
-                </imgdir>
-                <imgdir name="2">
-                    <int name="id" value="5000002"/>
-                </imgdir>
-                <imgdir name="3">
-                    <int name="id" value="5000003"/>
-                </imgdir>
-                <imgdir name="4">
-                    <int name="id" value="5000004"/>
-                </imgdir>
-                <imgdir name="5">
-                    <int name="id" value="5000005"/>
-                </imgdir>
-                <imgdir name="6">
-                    <int name="id" value="5000006"/>
-                </imgdir>
-                <imgdir name="7">
-                    <int name="id" value="5000007"/>
-                </imgdir>
-                <imgdir name="8">
-                    <int name="id" value="5000008"/>
-                </imgdir>
-                <imgdir name="9">
-                    <int name="id" value="5000009"/>
-                </imgdir>
-                <imgdir name="10">
-                    <int name="id" value="5000010"/>
-                </imgdir>
-                <imgdir name="11">
-                    <int name="id" value="5000011"/>
-                </imgdir>
-                <imgdir name="12">
-                    <int name="id" value="5000012"/>
-                </imgdir>
-                <imgdir name="13">
-                    <int name="id" value="5000013"/>
-                </imgdir>
-                <imgdir name="14">
-                    <int name="id" value="5000014"/>
-                </imgdir>
-                <imgdir name="15">
-                    <int name="id" value="5000015"/>
-                </imgdir>
-                <imgdir name="16">
-                    <int name="id" value="5000017"/>
-                </imgdir>
-                <imgdir name="17">
-                    <int name="id" value="5000018"/>
-                </imgdir>
-                <imgdir name="18">
-                    <int name="id" value="5000020"/>
-                </imgdir>
-                <imgdir name="19">
-                    <int name="id" value="5000021"/>
-                </imgdir>
-                <imgdir name="20">
-                    <int name="id" value="5000022"/>
-                </imgdir>
-                <imgdir name="21">
-                    <int name="id" value="5000023"/>
-                </imgdir>
-                <imgdir name="22">
-                    <int name="id" value="5000024"/>
-                </imgdir>
-                <imgdir name="23">
-                    <int name="id" value="5000026"/>
-                </imgdir>
-                <imgdir name="24">
-                    <int name="id" value="5000040"/>
-                </imgdir>
-                <imgdir name="25">
-                    <int name="id" value="5000041"/>
-                </imgdir>
-                <imgdir name="26">
-                    <int name="id" value="5000042"/>
-                </imgdir>
-                <imgdir name="27">
-                    <int name="id" value="5000043"/>
-                </imgdir>
-                <imgdir name="28">
-                    <int name="id" value="5000046"/>
-                </imgdir>
-                <imgdir name="29">
-                    <int name="id" value="5000100"/>
-                </imgdir>
-                <imgdir name="30">
-                    <int name="id" value="5000101"/>
-                </imgdir>
-                <imgdir name="31">
-                    <int name="id" value="5000102"/>
-                </imgdir>
-                <imgdir name="32">
-                    <int name="id" value="5000060"/>
-                </imgdir>
-                <imgdir name="33">
-                    <int name="id" value="5000048"/>
-                </imgdir>
-                <imgdir name="34">
-                    <int name="id" value="5000049"/>
-                </imgdir>
-                <imgdir name="35">
-                    <int name="id" value="5000050"/>
-                </imgdir>
-                <imgdir name="36">
-                    <int name="id" value="5000051"/>
-                </imgdir>
-                <imgdir name="37">
-                    <int name="id" value="5000052"/>
-                </imgdir>
-                <imgdir name="38">
-                    <int name="id" value="5000053"/>
-                </imgdir>
-                <imgdir name="39">
-                    <int name="id" value="5000055"/>
-                </imgdir>
-                <imgdir name="40">
-                    <int name="id" value="5000066"/>
-                </imgdir>
-            </imgdir>
+            <string name="endscript" value="q29507e"/>
         </imgdir>
     </imgdir>
     <imgdir name="29508">
@@ -35802,37 +35672,11 @@
         <imgdir name="0">
             <int name="npc" value="9000040"/>
             <int name="lvmin" value="10"/>
-            <imgdir name="quest">
-                <imgdir name="0">
-                    <int name="id" value="2105"/>
-                    <int name="state" value="2"/>
-                </imgdir>
-                <imgdir name="1">
-                    <int name="id" value="2106"/>
-                    <int name="state" value="2"/>
-                </imgdir>
-                <imgdir name="2">
-                    <int name="id" value="2107"/>
-                    <int name="state" value="2"/>
-                </imgdir>
-            </imgdir>
+            <string name="startscript" value="q29509s"/>
         </imgdir>
         <imgdir name="1">
             <int name="npc" value="9000040"/>
-            <imgdir name="quest">
-                <imgdir name="0">
-                    <int name="id" value="2111"/>
-                    <int name="state" value="2"/>
-                </imgdir>
-                <imgdir name="1">
-                    <int name="id" value="2112"/>
-                    <int name="state" value="2"/>
-                </imgdir>
-                <imgdir name="2">
-                    <int name="id" value="2113"/>
-                    <int name="state" value="2"/>
-                </imgdir>
-            </imgdir>
+            <string name="endscript" value="q29509e"/>
         </imgdir>
     </imgdir>
     <imgdir name="29510">
@@ -35858,10 +35702,11 @@
         <imgdir name="0">
             <int name="npc" value="9000040"/>
             <int name="lvmin" value="10"/>
+            <string name="startscript" value="q29512s"/>
         </imgdir>
         <imgdir name="1">
             <int name="npc" value="9000040"/>
-            <int name="mbmin" value="30"/>
+            <string name="endscript" value="q29512e"/>
         </imgdir>
     </imgdir>
     <imgdir name="29900">

--- a/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
@@ -35563,6 +35563,11 @@
         </imgdir>
         <imgdir name="0">
             <int name="npc" value="9000040"/>
+            <imgdir name="item">
+                <imgdir name="0">
+                    <int name="id" value="1142006"/>
+                </imgdir>
+            </imgdir>
             <int name="interval" value="0"/>
             <string name="startscript" value="q29500s"/>
         </imgdir>
@@ -35574,6 +35579,11 @@
         </imgdir>
         <imgdir name="0">
             <int name="npc" value="9000040"/>
+            <imgdir name="item">
+                <imgdir name="0">
+                    <int name="id" value="1142007"/>
+                </imgdir>
+            </imgdir>
             <int name="interval" value="0"/>
             <string name="startscript" value="q29501s"/>
             <imgdir name="quest">
@@ -35591,6 +35601,11 @@
         </imgdir>
         <imgdir name="0">
             <int name="npc" value="9000040"/>
+            <imgdir name="item">
+                <imgdir name="0">
+                    <int name="id" value="1142008"/>
+                </imgdir>
+            </imgdir>
             <int name="interval" value="0"/>
             <string name="startscript" value="q29502s"/>
             <imgdir name="quest">
@@ -35609,6 +35624,11 @@
         <imgdir name="0">
             <int name="npc" value="9000040"/>
             <int name="lvmin" value="30"/>
+            <imgdir name="item">
+                <imgdir name="0">
+                    <int name="id" value="1142014"/>
+                </imgdir>
+            </imgdir>
             <int name="interval" value="0"/>
             <string name="startscript" value="q29503s"/>
         </imgdir>
@@ -35618,6 +35638,11 @@
             <int name="npc" value="2042005"/>
             <string name="startscript" value="q29505s"/>
             <int name="lvmin" value="51"/>
+            <imgdir name="item">
+                <imgdir name="0">
+                    <int name="id" value="1142077"/>
+                </imgdir>
+            </imgdir>
             <int name="interval" value="0"/>
         </imgdir>
         <imgdir name="1">
@@ -35630,6 +35655,11 @@
             <int name="npc" value="2042005"/>
             <string name="startscript" value="q29506s"/>
             <int name="lvmin" value="51"/>
+            <imgdir name="item">
+                <imgdir name="0">
+                    <int name="id" value="1142078"/>
+                </imgdir>
+            </imgdir>
             <int name="interval" value="0"/>
         </imgdir>
         <imgdir name="1">
@@ -35641,6 +35671,11 @@
         <imgdir name="0">
             <int name="npc" value="9000040"/>
             <int name="lvmin" value="10"/>
+            <imgdir name="item">
+                <imgdir name="0">
+                    <int name="id" value="1142082"/>
+                </imgdir>
+            </imgdir>
             <string name="startscript" value="q29507s"/>
         </imgdir>
         <imgdir name="1">
@@ -35672,6 +35707,11 @@
         <imgdir name="0">
             <int name="npc" value="9000040"/>
             <int name="lvmin" value="10"/>
+            <imgdir name="item">
+                <imgdir name="0">
+                    <int name="id" value="1142084"/>
+                </imgdir>
+            </imgdir>
             <string name="startscript" value="q29509s"/>
         </imgdir>
         <imgdir name="1">
@@ -35702,6 +35742,11 @@
         <imgdir name="0">
             <int name="npc" value="9000040"/>
             <int name="lvmin" value="10"/>
+            <imgdir name="item">
+                <imgdir name="0">
+                    <int name="id" value="1142083"/>
+                </imgdir>
+            </imgdir>
             <string name="startscript" value="q29512s"/>
         </imgdir>
         <imgdir name="1">

--- a/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
@@ -35568,7 +35568,6 @@
                     <int name="id" value="1142006"/>
                 </imgdir>
             </imgdir>
-            <int name="interval" value="0"/>
             <string name="startscript" value="q29500s"/>
         </imgdir>
     </imgdir>
@@ -35584,7 +35583,6 @@
                     <int name="id" value="1142007"/>
                 </imgdir>
             </imgdir>
-            <int name="interval" value="0"/>
             <string name="startscript" value="q29501s"/>
             <imgdir name="quest">
                 <imgdir name="0">
@@ -35606,7 +35604,6 @@
                     <int name="id" value="1142008"/>
                 </imgdir>
             </imgdir>
-            <int name="interval" value="0"/>
             <string name="startscript" value="q29502s"/>
             <imgdir name="quest">
                 <imgdir name="0">
@@ -35629,7 +35626,6 @@
                     <int name="id" value="1142014"/>
                 </imgdir>
             </imgdir>
-            <int name="interval" value="0"/>
             <string name="startscript" value="q29503s"/>
         </imgdir>
     </imgdir>
@@ -35643,7 +35639,6 @@
                     <int name="id" value="1142077"/>
                 </imgdir>
             </imgdir>
-            <int name="interval" value="0"/>
         </imgdir>
         <imgdir name="1">
             <int name="npc" value="2042005"/>
@@ -35660,7 +35655,6 @@
                     <int name="id" value="1142078"/>
                 </imgdir>
             </imgdir>
-            <int name="interval" value="0"/>
         </imgdir>
         <imgdir name="1">
             <string name="endscript" value="q29506e"/>

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9610,36 +9610,35 @@
     </imgdir>
     <imgdir name="29500">
         <string name="name" value="挑战勋章-冒险岛偶像明星勋章(特级)"/>
-        <string name="0" value="#b#e挑战勋章-冒险岛偶像明星勋章#n(特级)\n#k最受大家追捧的冒险家是谁呢？勋章老人将授予其#e#b冒险岛偶像明星勋章(特级)#k#n。"/>
-        <string name="1" value="#b#e挑战勋章-冒险岛偶像明星勋章#n(特级)\n\n#k - 人气度: #b#jpop##k"/>
-        <string name="2" value="#b#e挑战勋章-冒险岛偶像明星勋章#n(特级)\n\n#k - 人气度: #b#jpop##k \n\n只有世界人气度最高的人才有资格获得&apos;#b冒险岛偶像明星勋章(特级)#k&apos;的荣誉。勋章老人提醒大家只有制定好相应策略，该荣誉每月仅有一次机会挑战。"/>
+        <string name="0" value="#b#e挑战勋章-冒险岛偶像明星勋章#n(特级)\n#k人气达到 #b1000#k 后，即可领取#e#b冒险岛偶像明星勋章(特级)#k#n。"/>
+        <string name="1" value="#b#e挑战勋章-冒险岛偶像明星勋章#n(特级)\n\n#k - 需要人气度: #b1000#k\n - 当前人气度: #b#jpop##k"/>
+        <string name="2" value="#b#e挑战勋章-冒险岛偶像明星勋章#n(特级)\n\n#k达到指定人气度后获得&apos;#b冒险岛偶像明星勋章(特级)#k&apos;。"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142006"/>
     </imgdir>
     <imgdir name="29501">
         <string name="name" value="挑战勋章-暗黑龙王杀手勋章(特级)"/>
-        <string name="0" value="#b#e挑战勋章-暗黑龙王杀手勋章#n(特级)\n#k只有打猎暗黑龙王数量最多的冒险家才有资格获得#e#b暗黑龙王杀手勋章(特级)#k#n！勋章老人表示对于打猎了暗黑龙王却未向自己报告的一律不予承认。"/>
-        <string name="1" value="#b#e挑战勋章-暗黑龙王杀手勋章#n(特级)\n#k\n - 勋章老人所知的暗黑龙王打猎记录: #r#jmon##k 次\n\n勋章老人表示这个荣誉只授予那些在狩猎暗黑龙王后向自己报告次数最多的勇士。不过……请注意！一旦放弃挑战，下一次挑战时将从零开始计数！！！"/>
-        <string name="2" value="#b#e挑战勋章-暗黑龙王杀手勋章#n(特级)\n#k\n - 勋章老人所知的暗黑龙王打猎记录: #r#jmon##k 次\n\n向捕获暗黑龙王数量最多的一位勇士颁发&apos;#b暗黑龙王杀手勋章(特级)#k&apos;。"/>
+        <string name="0" value="#b#e挑战勋章-暗黑龙王杀手勋章#n(特级)\n#k击败暗黑龙王 #b1#k 次后，即可领取#e#b暗黑龙王杀手勋章(特级)#k#n。"/>
+        <string name="1" value="#b#e挑战勋章-暗黑龙王杀手勋章#n(特级)\n\n#k - 暗黑龙王击败记录: #r#jmon##k / 1 次"/>
+        <string name="2" value="#b#e挑战勋章-暗黑龙王杀手勋章#n(特级)\n\n#k完成个人击败暗黑龙王挑战后获得&apos;#b暗黑龙王杀手勋章(特级)#k&apos;。"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142007"/>
     </imgdir>
     <imgdir name="29502">
         <string name="name" value="挑战勋章-品克缤杀手勋章(特级)"/>
-        <string name="0" value="#b#e挑战勋章-品克缤杀手勋章#n(特级)\n#k只有打猎品克缤的数量最多的勇士才有资格获得#e#b品克缤杀手勋章(特级)#k#n！勋章老人表示对于打猎了品克缤却未向自己报告的一律不予承认。"/>
-        <string name="1" value="#b#e挑战勋章-品克缤杀手勋章#n(特级)\n#k\n - 勋章老人所知的品克缤打猎记录: #r#jmon##k 次\n\n只有将自己打猎品克缤的情况向勋章老人报告次数最多的勇士才有资格获得本荣誉。不过……请注意！一旦放弃挑战，下次挑战时将从零开始计数！！！"/>
-        <string name="2" value="#b#e挑战勋章-品克缤杀手勋章#n(特级)\n#k\n - 勋章老人所知的品克缤打猎记录: #r#jmon##k 次\n\n只有捕获品克缤数量最多的一位勇士才有资格获得&apos;#b品克缤杀手勋章(特级)#k&apos;。"/>
+        <string name="0" value="#b#e挑战勋章-品克缤杀手勋章#n(特级)\n#k击败品克缤 #b1#k 次后，即可领取#e#b品克缤杀手勋章(特级)#k#n。"/>
+        <string name="1" value="#b#e挑战勋章-品克缤杀手勋章#n(特级)\n\n#k - 品克缤击败记录: #r#jmon##k / 1 次"/>
+        <string name="2" value="#b#e挑战勋章-品克缤杀手勋章#n(特级)\n\n#k完成个人击败品克缤挑战后获得&apos;#b品克缤杀手勋章(特级)#k&apos;。"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142008"/>
     </imgdir>
     <imgdir name="29503">
         <string name="name" value="挑战勋章-爱心使者"/>
-        <string name="0" value="#b#e挑战勋章-爱心使者#n(特级称号)\n#k挑战只有1人可以拥有的财力和名誉的象征——#e#b爱心使者#k#n称号吧！听说现在正在选拔代表各个村庄的爱心使者。去见见名誉之神官#b#p9000040##k吧。"/>
-        <string name="1" value="#b#e挑战勋章-爱心使者#n(特级称号)\n#k\n - 剩余时间：#Qminlimit#分#Qseclimit#秒\n - 捐献数额：#b#jmoney##k金币\n\n每月初所有村庄的捐献记录初始化。达利尔叮嘱说并不单纯由捐献的金额决定称号的主人，让我发挥自己的智慧。"/>
-        <string name="2" value="#b#e挑战勋章-爱心使者#n(特级称号)\n#k\n - 剩余时间：#Qminlimit#分#Qseclimit#秒\n - 捐献村庄：#b#jm##k\n - 捐献数额：#b#jmoney##k金币\n\n达利尔叮嘱说并不单纯由捐献的金额决定称号的主人，让我发挥自己的智慧。"/>
-        <int name="timeLimit2" value="3600"/>
+        <string name="0" value="#b#e挑战勋章-爱心使者#n(特级称号)\n#k贡献 #b10000000#k 金币用于公共设施建设后，即可领取#e#b爱心使者#k#n称号。"/>
+        <string name="1" value="#b#e挑战勋章-爱心使者#n(特级称号)\n\n#k - 需要贡献金币: #b10000000#k"/>
+        <string name="2" value="#b#e挑战勋章-爱心使者#n(特级称号)\n\n#k完成固定金币贡献后获得&apos;#b爱心使者#k&apos;称号。"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142014"/>
@@ -9647,28 +9646,28 @@
     <imgdir name="29505">
         <string name="name" value="嘉年华百战百胜者"/>
         <int name="area" value="10"/>
-        <string name="0" value="如果你认为自己在怪物嘉年华2中拥有最多胜场，就去找休彼德蔓领取#b#t1142077##k吧！"/>
-        <string name="1" value="如果你认为自己在怪物嘉年华2中拥有最多胜场，就去找休彼德蔓领取#b#t1142077##k吧！"/>
-        <string name="2" value="已因在怪物嘉年华2中拥有最多胜场而获得#b#t1142077##k。"/>
+        <string name="0" value="在怪物嘉年华2中取得 #b100#k 场胜利后，可向休彼德蔓领取#b#t1142077##k。"/>
+        <string name="1" value="怪物嘉年华2胜场达到 #b100#k 场后，可向休彼德蔓领取#b#t1142077##k。"/>
+        <string name="2" value="已因在怪物嘉年华2中取得 #b100#k 场胜利而获得#b#t1142077##k。"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142077"/>
     </imgdir>
     <imgdir name="29506">
         <string name="name" value="嘉年华天才"/>
         <int name="area" value="10"/>
-        <string name="0" value="如果你认为自己在怪物嘉年华2中拥有最高胜率，就去找休彼德蔓领取#b#t1142078##k吧！"/>
-        <string name="1" value="如果你认为自己在怪物嘉年华2中拥有最高胜率，就去找休彼德蔓领取#b#t1142078##k吧！"/>
-        <string name="2" value="已因在怪物嘉年华2中拥有最高胜率而获得#b#t1142078##k。"/>
+        <string name="0" value="参加至少 #b50#k 场怪物嘉年华2，并保持 #b70%#k 以上胜率后，可向休彼德蔓领取#b#t1142078##k。"/>
+        <string name="1" value="怪物嘉年华2场次达到 #b50#k 场且胜率不低于 #b70%#k 后，可向休彼德蔓领取#b#t1142078##k。"/>
+        <string name="2" value="已因在怪物嘉年华2中保持优秀胜率而获得#b#t1142078##k。"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142078"/>
     </imgdir>
     <imgdir name="29507">
         <string name="name" value="挑战勋章-可爱宠物主人勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="#b#eTitle Challenge - Wonderful Pet Owner#n\n#kIf you have a pet, see if you can acquire #r1400 Closeness points#k with your pet! Dalair, on behalf of the God of Honor, is looking for passionate and caring pet owners. He says anyone who reaches #r1400 Closeness points#k with a pet will receive the #e#bWonderful Pet Owner#k#n title."/>
-        <string name="1" value="#b#eTitle Challenge - Wonderful Pet Owner#n#k\n\nAcquire #r1400#k Closeness points with your pet."/>
-        <string name="2" value="#b#eTitle Challenge - Wonderful Pet Owner#n#k\n\nYou have received the #bWonderful Pet Owner#k title and the associated medal."/>
-        <string name="demandSummary" value="Acquire 1400 Closeness points with your pet."/>
+        <string name="0" value="#b#e挑战勋章-可爱宠物主人勋章#n\n#k将任意宠物亲密度提升到 #r1400#k 后，即可领取#b可爱宠物主人#k称号。"/>
+        <string name="1" value="#b#e挑战勋章-可爱宠物主人勋章#n#k\n\n将任意宠物亲密度提升到 #r1400#k。"/>
+        <string name="2" value="#b#e挑战勋章-可爱宠物主人勋章#n#k\n\n你已获得#b可爱宠物主人#k称号和对应勋章。"/>
+        <string name="demandSummary" value="任意宠物亲密度达到 1400。"/>
         <string name="rewardSummary" value="#Wbasic# #v1142082:##t1142082:# 1"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142082"/>
@@ -9694,9 +9693,9 @@
     <imgdir name="29509">
         <string name="name" value="坚强的挑战者"/>
         <int name="area" value="51"/>
-        <string name="0" value="#b#eTitle Challenge - Persevering Challenger#n\nComplete the #k#bDangerous Dungeon!#k quest. Dalair, on behalf of the God of Honor, is looking for explorers who never cease to face challenges. He says anyone who defeats a lot of monsters in the dungeons in Sleepywood will receive the #bPersevering Challenger#k#n title."/>
-        <string name="1" value="#b#eTitle Challenge - Persevering Challenger#n#k\nComplete 3 types of #bDangerous Dungeon!#k quests in Sleepywood."/>
-        <string name="2" value="#b#eTitle Challenge - Persevering Challenger#n#k\n\nYou have acquired the #bPersevering Challenger#k title and the associated medal."/>
+        <string name="0" value="#b#e挑战勋章-坚强的挑战者#n\n#k完成林中之城的 3 个#b危险的迷宫#k任务后，即可领取#b坚强的挑战者#k称号。"/>
+        <string name="1" value="#b#e挑战勋章-坚强的挑战者#n#k\n完成林中之城的 3 个#b危险的迷宫#k任务。"/>
+        <string name="2" value="#b#e挑战勋章-坚强的挑战者#n#k\n\n你已获得#b坚强的挑战者#k称号和对应勋章。"/>
         <string name="demandSummary" value="- #y2111# (#u2111#) - #y2112# (#u2112#) - #y2113# (#u2113#)"/>
         <string name="rewardSummary" value="#Wbasic# #v1142084:##t1142084:# 1"/>
         <int name="medalCategory" value="2"/>
@@ -9712,10 +9711,10 @@
     <imgdir name="29512">
         <string name="name" value="挑战勋章-怪物博士勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="#b#eTitle Challenge - Monster Expert#n\nCollect #k#b30 Monster Cards#k. Dalair, on behalf of the God of Honor, is looking for explorers who know everything there is to know about the monsters in Maple World. He says anyone who collects more than 30 Monster Cards will receive the #bMonster Expert#k#n title."/>
-        <string name="1" value="Collect the Monster Cards, which will help you understand the tendencies, habitats, and dropped items of various monsters. Some cards have special powers that will help you in your adventures."/>
-        <string name="2" value="#b#eTitle Challenge - Monster Expert#n#k\n\nYou have received the #bMonster Expert#k title and the associated medal."/>
-        <string name="demandSummary" value="Acquire at least 30 Monster Cards."/>
+        <string name="0" value="#b#e挑战勋章-怪物博士勋章#n\n#k收集 #b30#k 张怪物卡后，即可领取#b怪物博士#k称号。"/>
+        <string name="1" value="收集怪物卡可以了解怪物的习性、栖息地和掉落物。收集 #b30#k 张怪物卡后即可完成挑战。"/>
+        <string name="2" value="#b#e挑战勋章-怪物博士勋章#n#k\n\n你已获得#b怪物博士#k称号和对应勋章。"/>
+        <string name="demandSummary" value="至少收集 30 张怪物卡。"/>
         <string name="rewardSummary" value="#Wbasic# #v1142083:##t1142083:# 1"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142083"/>

--- a/gms-server/wz/Quest.wz/Check.img.xml
+++ b/gms-server/wz/Quest.wz/Check.img.xml
@@ -35646,6 +35646,11 @@
     </imgdir>
     <imgdir name="0">
       <int name="npc" value="9000040"/>
+      <imgdir name="item">
+        <imgdir name="0">
+          <int name="id" value="1142006"/>
+        </imgdir>
+      </imgdir>
       <int name="interval" value="0"/>
       <string name="startscript" value="q29500s"/>
     </imgdir>
@@ -35657,6 +35662,11 @@
     </imgdir>
     <imgdir name="0">
       <int name="npc" value="9000040"/>
+      <imgdir name="item">
+        <imgdir name="0">
+          <int name="id" value="1142007"/>
+        </imgdir>
+      </imgdir>
       <int name="interval" value="0"/>
       <string name="startscript" value="q29501s"/>
       <imgdir name="quest">
@@ -35674,6 +35684,11 @@
     </imgdir>
     <imgdir name="0">
       <int name="npc" value="9000040"/>
+      <imgdir name="item">
+        <imgdir name="0">
+          <int name="id" value="1142008"/>
+        </imgdir>
+      </imgdir>
       <int name="interval" value="0"/>
       <string name="startscript" value="q29502s"/>
       <imgdir name="quest">
@@ -35692,6 +35707,11 @@
     <imgdir name="0">
       <int name="npc" value="9000040"/>
       <int name="lvmin" value="30"/>
+      <imgdir name="item">
+        <imgdir name="0">
+          <int name="id" value="1142014"/>
+        </imgdir>
+      </imgdir>
       <int name="interval" value="0"/>
       <string name="startscript" value="q29503s"/>
     </imgdir>
@@ -35701,6 +35721,11 @@
       <int name="npc" value="2042005"/>
       <string name="startscript" value="q29505s"/>
       <int name="lvmin" value="51"/>
+      <imgdir name="item">
+        <imgdir name="0">
+          <int name="id" value="1142077"/>
+        </imgdir>
+      </imgdir>
       <int name="interval" value="0"/>
     </imgdir>
     <imgdir name="1">
@@ -35713,6 +35738,11 @@
       <int name="npc" value="2042005"/>
       <string name="startscript" value="q29506s"/>
       <int name="lvmin" value="51"/>
+      <imgdir name="item">
+        <imgdir name="0">
+          <int name="id" value="1142078"/>
+        </imgdir>
+      </imgdir>
       <int name="interval" value="0"/>
     </imgdir>
     <imgdir name="1">
@@ -35724,6 +35754,11 @@
     <imgdir name="0">
       <int name="npc" value="9000040"/>
       <int name="lvmin" value="10"/>
+      <imgdir name="item">
+        <imgdir name="0">
+          <int name="id" value="1142082"/>
+        </imgdir>
+      </imgdir>
       <string name="startscript" value="q29507s"/>
     </imgdir>
     <imgdir name="1">
@@ -35755,6 +35790,11 @@
     <imgdir name="0">
       <int name="npc" value="9000040"/>
       <int name="lvmin" value="10"/>
+      <imgdir name="item">
+        <imgdir name="0">
+          <int name="id" value="1142084"/>
+        </imgdir>
+      </imgdir>
       <string name="startscript" value="q29509s"/>
     </imgdir>
     <imgdir name="1">
@@ -35785,6 +35825,11 @@
     <imgdir name="0">
       <int name="npc" value="9000040"/>
       <int name="lvmin" value="10"/>
+      <imgdir name="item">
+        <imgdir name="0">
+          <int name="id" value="1142083"/>
+        </imgdir>
+      </imgdir>
       <string name="startscript" value="q29512s"/>
     </imgdir>
     <imgdir name="1">

--- a/gms-server/wz/Quest.wz/Check.img.xml
+++ b/gms-server/wz/Quest.wz/Check.img.xml
@@ -35648,12 +35648,6 @@
       <int name="npc" value="9000040"/>
       <int name="interval" value="0"/>
       <string name="startscript" value="q29500s"/>
-      <imgdir name="item">
-        <imgdir name="0">
-          <int name="id" value="1142003"/>
-          <int name="count" value="1"/>
-        </imgdir>
-      </imgdir>
     </imgdir>
   </imgdir>
   <imgdir name="29501">
@@ -35730,135 +35724,11 @@
     <imgdir name="0">
       <int name="npc" value="9000040"/>
       <int name="lvmin" value="10"/>
+      <string name="startscript" value="q29507s"/>
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="9000040"/>
-      <int name="pettamenessmin" value="1400"/>
-      <imgdir name="pet">
-        <imgdir name="0">
-          <int name="id" value="5000000"/>
-        </imgdir>
-        <imgdir name="1">
-          <int name="id" value="5000001"/>
-        </imgdir>
-        <imgdir name="2">
-          <int name="id" value="5000002"/>
-        </imgdir>
-        <imgdir name="3">
-          <int name="id" value="5000003"/>
-        </imgdir>
-        <imgdir name="4">
-          <int name="id" value="5000004"/>
-        </imgdir>
-        <imgdir name="5">
-          <int name="id" value="5000005"/>
-        </imgdir>
-        <imgdir name="6">
-          <int name="id" value="5000006"/>
-        </imgdir>
-        <imgdir name="7">
-          <int name="id" value="5000007"/>
-        </imgdir>
-        <imgdir name="8">
-          <int name="id" value="5000008"/>
-        </imgdir>
-        <imgdir name="9">
-          <int name="id" value="5000009"/>
-        </imgdir>
-        <imgdir name="10">
-          <int name="id" value="5000010"/>
-        </imgdir>
-        <imgdir name="11">
-          <int name="id" value="5000011"/>
-        </imgdir>
-        <imgdir name="12">
-          <int name="id" value="5000012"/>
-        </imgdir>
-        <imgdir name="13">
-          <int name="id" value="5000013"/>
-        </imgdir>
-        <imgdir name="14">
-          <int name="id" value="5000014"/>
-        </imgdir>
-        <imgdir name="15">
-          <int name="id" value="5000015"/>
-        </imgdir>
-        <imgdir name="16">
-          <int name="id" value="5000017"/>
-        </imgdir>
-        <imgdir name="17">
-          <int name="id" value="5000018"/>
-        </imgdir>
-        <imgdir name="18">
-          <int name="id" value="5000020"/>
-        </imgdir>
-        <imgdir name="19">
-          <int name="id" value="5000021"/>
-        </imgdir>
-        <imgdir name="20">
-          <int name="id" value="5000022"/>
-        </imgdir>
-        <imgdir name="21">
-          <int name="id" value="5000023"/>
-        </imgdir>
-        <imgdir name="22">
-          <int name="id" value="5000024"/>
-        </imgdir>
-        <imgdir name="23">
-          <int name="id" value="5000026"/>
-        </imgdir>
-        <imgdir name="24">
-          <int name="id" value="5000040"/>
-        </imgdir>
-        <imgdir name="25">
-          <int name="id" value="5000041"/>
-        </imgdir>
-        <imgdir name="26">
-          <int name="id" value="5000042"/>
-        </imgdir>
-        <imgdir name="27">
-          <int name="id" value="5000043"/>
-        </imgdir>
-        <imgdir name="28">
-          <int name="id" value="5000046"/>
-        </imgdir>
-        <imgdir name="29">
-          <int name="id" value="5000100"/>
-        </imgdir>
-        <imgdir name="30">
-          <int name="id" value="5000101"/>
-        </imgdir>
-        <imgdir name="31">
-          <int name="id" value="5000102"/>
-        </imgdir>
-        <imgdir name="32">
-          <int name="id" value="5000060"/>
-        </imgdir>
-        <imgdir name="33">
-          <int name="id" value="5000048"/>
-        </imgdir>
-        <imgdir name="34">
-          <int name="id" value="5000049"/>
-        </imgdir>
-        <imgdir name="35">
-          <int name="id" value="5000050"/>
-        </imgdir>
-        <imgdir name="36">
-          <int name="id" value="5000051"/>
-        </imgdir>
-        <imgdir name="37">
-          <int name="id" value="5000052"/>
-        </imgdir>
-        <imgdir name="38">
-          <int name="id" value="5000053"/>
-        </imgdir>
-        <imgdir name="39">
-          <int name="id" value="5000055"/>
-        </imgdir>
-        <imgdir name="40">
-          <int name="id" value="5000066"/>
-        </imgdir>
-      </imgdir>
+      <string name="endscript" value="q29507e"/>
     </imgdir>
   </imgdir>
   <imgdir name="29508">
@@ -35885,37 +35755,11 @@
     <imgdir name="0">
       <int name="npc" value="9000040"/>
       <int name="lvmin" value="10"/>
-      <imgdir name="quest">
-        <imgdir name="0">
-          <int name="id" value="2105"/>
-          <int name="state" value="2"/>
-        </imgdir>
-        <imgdir name="1">
-          <int name="id" value="2106"/>
-          <int name="state" value="2"/>
-        </imgdir>
-        <imgdir name="2">
-          <int name="id" value="2107"/>
-          <int name="state" value="2"/>
-        </imgdir>
-      </imgdir>
+      <string name="startscript" value="q29509s"/>
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="9000040"/>
-      <imgdir name="quest">
-        <imgdir name="0">
-          <int name="id" value="2111"/>
-          <int name="state" value="2"/>
-        </imgdir>
-        <imgdir name="1">
-          <int name="id" value="2112"/>
-          <int name="state" value="2"/>
-        </imgdir>
-        <imgdir name="2">
-          <int name="id" value="2113"/>
-          <int name="state" value="2"/>
-        </imgdir>
-      </imgdir>
+      <string name="endscript" value="q29509e"/>
     </imgdir>
   </imgdir>
   <imgdir name="29510">
@@ -35941,10 +35785,11 @@
     <imgdir name="0">
       <int name="npc" value="9000040"/>
       <int name="lvmin" value="10"/>
+      <string name="startscript" value="q29512s"/>
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="9000040"/>
-      <int name="mbmin" value="30"/>
+      <string name="endscript" value="q29512e"/>
     </imgdir>
   </imgdir>
   <imgdir name="29900">

--- a/gms-server/wz/Quest.wz/Check.img.xml
+++ b/gms-server/wz/Quest.wz/Check.img.xml
@@ -35651,7 +35651,6 @@
           <int name="id" value="1142006"/>
         </imgdir>
       </imgdir>
-      <int name="interval" value="0"/>
       <string name="startscript" value="q29500s"/>
     </imgdir>
   </imgdir>
@@ -35667,7 +35666,6 @@
           <int name="id" value="1142007"/>
         </imgdir>
       </imgdir>
-      <int name="interval" value="0"/>
       <string name="startscript" value="q29501s"/>
       <imgdir name="quest">
         <imgdir name="0">
@@ -35689,7 +35687,6 @@
           <int name="id" value="1142008"/>
         </imgdir>
       </imgdir>
-      <int name="interval" value="0"/>
       <string name="startscript" value="q29502s"/>
       <imgdir name="quest">
         <imgdir name="0">
@@ -35712,7 +35709,6 @@
           <int name="id" value="1142014"/>
         </imgdir>
       </imgdir>
-      <int name="interval" value="0"/>
       <string name="startscript" value="q29503s"/>
     </imgdir>
   </imgdir>
@@ -35726,7 +35722,6 @@
           <int name="id" value="1142077"/>
         </imgdir>
       </imgdir>
-      <int name="interval" value="0"/>
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="2042005"/>
@@ -35743,7 +35738,6 @@
           <int name="id" value="1142078"/>
         </imgdir>
       </imgdir>
-      <int name="interval" value="0"/>
     </imgdir>
     <imgdir name="1">
       <string name="endscript" value="q29506e"/>

--- a/gms-server/wz/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz/Quest.wz/QuestInfo.img.xml
@@ -10618,7 +10618,6 @@ Able to proceed to &apos;For the peace of Victoria Island...&apos; as next quest
     <string name="0" value="#b#eTitle Challenge - Donation King#n(Special Title)\n#kA symbol of wealth and honor that is given to one person: try out for the #e#bDonation King#k#n title!  I heard they are choosing Donation Kings to represent each town.  I should go see the Monk of Honor, #b#p9000040##k."/>
     <string name="1" value="#b#eTitle Challenge - Donation King#n(Special Title)\n#k\n - Time Left : #Qminlimit#Minutes #Qseclimit#Seconds\n - Donated Amount : #b#jmoney##k Mesos\n\n At the beginning of each month, the donation record of every town is reset.   Dalair said simply donating a large amount of money will not win me this award, but he said I must demonstrate wisdom. "/>
     <string name="2" value="#b#eTitle Challenge - Donation King#n(Special Title)\n#k\n - Time Left : #Qminlimit#Minutes #Qseclimit#Seconds\n - Donated Town : #b#jm##k\n - Donated Amount : #b#jmoney##k Mesos\n\nAt the beginning of each month, the donation record of every town is reset.   Dalair said simply donating a large amount of money will not win me this award, but said I must demonstrate wisdom. "/>
-    <int name="timeLimit2" value="3600"/>
     <int name="area" value="51"/>
     <int name="medalCategory" value="2"/>
     <int name="viewMedalItem" value="1142014"/>


### PR DESCRIPTION
## 改动内容
- 为 29500 冒险岛偶像明星、29501 暗黑龙王杀手、29502 品克缤杀手、29503 爱心使者、29505 嘉年华百战百胜者、29506 嘉年华天才、29507 可爱宠物主人、29509 坚强的挑战者、29512 怪物博士补充可执行的勋章任务脚本。
- 将 29500 调整为达到指定人气即可领取，将 29501 和 29502 调整为个人击杀进度，不再依赖全服唯一排行。
- 将 29503 调整为固定金币贡献流程，避免依赖不存在的捐献排行系统。
- 为怪物嘉年华 2 胜场和胜率类勋章补充个人进度记录，并在怪物击杀与嘉年华结算处接入进度更新。
- 为 29507、29509、29512 补充脚本化完成判断，避免固定宠物 ID、旧任务条件或怪物卡条件导致流程不可控。
- 为上述勋章任务增加完成后的 NPC 对话反馈，不同勋章使用不同完成文本，避免点击完成后直接关闭窗口。
- 为上述勋章任务补充已完成、已持有勋章时的防重复接取与防重复领奖保护，并移除 29500、29501、29502、29503、29505、29506 的 repeatable 任务标记，避免完成后仍在 NPC 处显示为可接任务。
- 同步调整英文与中文脚本目录，并对 Quest.wz 的 Check、QuestInfo、Say 相关数据做中英文目录对称或中文文本修正。
- 涉及 NPC：达利尔、休彼德蔓；涉及道具：1142006、1142007、1142008、1142014、1142077、1142078、1142082、1142083、1142084；涉及任务：2111、2112、2113 以及 29500、29501、29502、29503、29505、29506、29507、29509、29512。

## 影响范围
- 影响服务端任务脚本、任务进度逻辑、怪物击杀回调、怪物嘉年华结算回调。
- 影响 Quest.wz 中任务条件、任务说明和 NPC 对话文本。
- 因为包含 Quest.wz 的客户端显示文本和任务条件变更，需要同步客户端资源包。

## 验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查。
- 已执行中文乱码检查。
- 已执行 Maven compile 验证，未打包 Jar。
- 已同步到本地测试环境并重启验证，确认 WZ 加载、频道端口和登录端口正常。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。