### PR TITLE
fix: 统一冒险家勋章任务中文文本

### DIFF
--- a/gms-server/scripts-zh-CN/quest/29900.js
+++ b/gms-server/scripts-zh-CN/quest/29900.js
@@ -28,7 +28,7 @@
 var status = -1;
 
 function start(mode, type, selection) {
-		if (qm.forceStartQuest()) qm.showInfoText("您已经获得了<初学者冒险家>头衔. 您可以从达赖尔获得勋章.");
+		if (qm.forceStartQuest()) qm.showInfoText("您已经获得了<新手冒险家>头衔. 您可以从达赖尔获得勋章.");
 		qm.dispose();
 }
 
@@ -39,7 +39,7 @@ function end(mode, type, selection) {
         qm.dispose();
     } else {
         if (status == 0) {
-            qm.sendNext("恭喜你获得了 #b<初学者冒险家>#k 头衔. 祝您在未来的工作中一切顺利！ 继续加油吧勇士.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142107:# #t1142107# 1");
+            qm.sendNext("恭喜你获得了 #b<新手冒险家>#k 头衔. 祝您在未来的工作中一切顺利！ 继续加油吧勇士.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142107:# #t1142107# 1");
         } else if (status == 1) {
             if (qm.canHold(1142107)) {
                 qm.gainItem(1142107);

--- a/gms-server/scripts-zh-CN/quest/29900.js
+++ b/gms-server/scripts-zh-CN/quest/29900.js
@@ -28,7 +28,7 @@
 var status = -1;
 
 function start(mode, type, selection) {
-		if (qm.forceStartQuest()) qm.showInfoText("您已经获得了<新手冒险家>头衔. 您可以从达赖尔获得勋章.");
+		if (qm.forceStartQuest()) qm.showInfoText("您已经获得了<新手冒险家>头衔. 您可以从德烈处获得勋章.");
 		qm.dispose();
 }
 

--- a/gms-server/scripts-zh-CN/quest/29901.js
+++ b/gms-server/scripts-zh-CN/quest/29901.js
@@ -29,7 +29,7 @@ var status = -1;
 
 function start(mode, type, selection) {
     if (qm.forceStartQuest()) {
-        qm.showInfoText("您已经获得了<少年冒险家>头衔. 您可以从达赖尔获得勋章.");
+        qm.showInfoText("您已经获得了<中级冒险家>头衔. 您可以从达赖尔获得勋章.");
     }
     qm.dispose();
 }
@@ -41,14 +41,14 @@ function end(mode, type, selection) {
         qm.dispose();
     } else {
         if (status == 0) {
-            qm.sendNext("恭喜你获得了 #b<少年冒险家>#k 头衔. 祝您在未来的工作中一切顺利！ 继续加油吧勇士.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142108:# #t1142108# 1");
+            qm.sendNext("恭喜你获得了 #b<中级冒险家>#k 头衔. 祝您在未来的工作中一切顺利！ 继续加油吧勇士.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142108:# #t1142108# 1");
         } else if (status == 1) {
             if (qm.canHold(1142108)) {
                 qm.gainItem(1142108);
                 qm.forceCompleteQuest();
                 qm.dispose();
             } else {
-                qm.sendNext("Please make room in your inventory");//NOT GMS LIKE
+                qm.sendNext("请给背包留出空位");//NOT GMS LIKE
             }
         } else if (status == 2) {
             qm.dispose();

--- a/gms-server/scripts-zh-CN/quest/29901.js
+++ b/gms-server/scripts-zh-CN/quest/29901.js
@@ -29,7 +29,7 @@ var status = -1;
 
 function start(mode, type, selection) {
     if (qm.forceStartQuest()) {
-        qm.showInfoText("您已经获得了<中级冒险家>头衔. 您可以从达赖尔获得勋章.");
+        qm.showInfoText("您已经获得了<中级冒险家>头衔. 您可以从德烈处获得勋章.");
     }
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29902.js
+++ b/gms-server/scripts-zh-CN/quest/29902.js
@@ -29,7 +29,7 @@ var status = -1;
 
 function start(mode, type, selection) {
     if (qm.forceStartQuest()) {
-        qm.showInfoText("您已经获得了<老兵冒险家>头衔. 您可以从达赖尔获得勋章.");
+        qm.showInfoText("您已经获得了<高级冒险家>头衔. 您可以从达赖尔获得勋章.");
     }
     qm.dispose();
 }
@@ -41,7 +41,7 @@ function end(mode, type, selection) {
         qm.dispose();
     } else {
         if (status == 0) {
-            qm.sendNext("恭喜你获得了 #b<老兵冒险家>#k 头衔. 祝您在未来的工作中一切顺利！ 继续加油吧勇士.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142109:# #t1142109# 1");
+            qm.sendNext("恭喜你获得了 #b<高级冒险家>#k 头衔. 祝您在未来的工作中一切顺利！ 继续加油吧勇士.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142109:# #t1142109# 1");
         } else if (status == 1) {
             if (qm.canHold(1142109)) {
                 qm.gainItem(1142109);

--- a/gms-server/scripts-zh-CN/quest/29902.js
+++ b/gms-server/scripts-zh-CN/quest/29902.js
@@ -29,7 +29,7 @@ var status = -1;
 
 function start(mode, type, selection) {
     if (qm.forceStartQuest()) {
-        qm.showInfoText("您已经获得了<高级冒险家>头衔. 您可以从达赖尔获得勋章.");
+        qm.showInfoText("您已经获得了<高级冒险家>头衔. 您可以从德烈处获得勋章.");
     }
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29903.js
+++ b/gms-server/scripts-zh-CN/quest/29903.js
@@ -29,7 +29,7 @@ var status = -1;
 
 function start(mode, type, selection) {
     if (qm.forceStartQuest()) {
-        qm.showInfoText("你已经获得了<大师冒险家>头衔. 你可以去找达赖尔领取勋章.");
+        qm.showInfoText("你已经获得了<大师冒险家>头衔. 你可以去找德烈领取勋章.");
     }
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29903.js
+++ b/gms-server/scripts-zh-CN/quest/29903.js
@@ -29,7 +29,7 @@ var status = -1;
 
 function start(mode, type, selection) {
     if (qm.forceStartQuest()) {
-        qm.showInfoText("你已经获得 <冒险大师> 头衔. 你可以去找达赖尔领取勋章.");
+        qm.showInfoText("你已经获得了<大师冒险家>头衔. 你可以去找达赖尔领取勋章.");
     }
     qm.dispose();
 }
@@ -41,7 +41,7 @@ function end(mode, type, selection) {
         qm.dispose();
     } else {
         if (status == 0) {
-            qm.sendNext("恭喜你获得了 #b<冒险大师>#k 头衔. 祝您在未来的工作中一切顺利！ 继续加油吧勇士.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142110:# #t1142110# 1");
+            qm.sendNext("恭喜你获得了 #b<大师冒险家>#k 头衔. 祝您在未来的工作中一切顺利！ 继续加油吧勇士.\r\n\r\n#fUI/UIWindow.img/QuestIcon/4/0#\r\n #v1142110:# #t1142110# 1");
         } else if (status == 1) {
             if (qm.canHold(1142110)) {
                 qm.gainItem(1142110);

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9724,10 +9724,10 @@
         <string name="name" value="新手冒险家"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
-        <string name="0" value="You can earn the #b&lt;Beginner Adventurer&gt;#k title by completing your 1st Job Advancement as an Adventurer."/>
-        <string name="1" value="Adventurers who complete the 1st Job Advancement will receive the #b&lt;Beginner Adventurer&gt;#k title. Go find NPC #p9000040#, who can be found in every town."/>
-        <string name="2" value="You have earned the #b&lt;Beginner Adventurer&gt;#k title by completing the 2nd Job Advancement as an Adventurer."/>
-        <string name="demandSummary" value="Report to NPC #b#p900040##k and receive the honorable #t1142107# Medal."/>
+        <string name="0" value="完成冒险家的1转后，即可获得#b&lt;新手冒险家&gt;#k称号。"/>
+        <string name="1" value="完成冒险家的1转后，即可获得#b&lt;新手冒险家&gt;#k称号。请前往各个村庄寻找NPC #p9000040#。"/>
+        <string name="2" value="你已完成冒险家的1转，获得了#b&lt;新手冒险家&gt;#k称号。"/>
+        <string name="demandSummary" value="向NPC #b#p9000040##k报告，并领取光荣的#t1142107#。"/>
         <string name="rewardSummary" value="#Wbasic#"/>
         <int name="autoAccept" value="1"/>
         <int name="viewMedalItem" value="1142107"/>
@@ -9736,10 +9736,10 @@
         <string name="name" value="中级冒险家"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
-        <string name="0" value="Adventurers who complete the 2nd Job Advancement will receive the #b&lt;Junior Adventurer&gt;#k title."/>
-        <string name="1" value="Adventurers who complete the 2nd Job Advancement will receive the #b&lt;Junior Adventurer&gt;#k title. Go find NPC #p9000040#, who can be found in every town."/>
-        <string name="2" value="You have earned the #b&lt;Junior Adventurer&gt;#k title by completing the 2nd Job Advancement as an Adventurer."/>
-        <string name="demandSummary" value="Report to NPC #b#p900040##k and receive the honorable #t1142108# Medal."/>
+        <string name="0" value="完成冒险家的2转后，即可获得#b&lt;中级冒险家&gt;#k称号。"/>
+        <string name="1" value="完成冒险家的2转后，即可获得#b&lt;中级冒险家&gt;#k称号。请前往各个村庄寻找NPC #p9000040#。"/>
+        <string name="2" value="你已完成冒险家的2转，获得了#b&lt;中级冒险家&gt;#k称号。"/>
+        <string name="demandSummary" value="向NPC #b#p9000040##k报告，并领取光荣的#t1142108#。"/>
         <string name="rewardSummary" value="#Wbasic#"/>
         <int name="autoAccept" value="1"/>
         <int name="viewMedalItem" value="1142108"/>
@@ -9748,10 +9748,10 @@
         <string name="name" value="高级冒险家"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
-        <string name="0" value="You can earn the #b&lt;Veteran Adventurer&gt;#k title by completing your 3rd Job Advancement as an Adventurer."/>
-        <string name="1" value="Adventurers who complete the 3rd Job Advancement will receive the #b&lt;Veteran Adventurer&gt;#k title. Go find NPC #p9000040#, who can be found in every town."/>
-        <string name="2" value="You have earned the #b&lt;Junior Adventurer&gt;#k title by completing your 3rd Job Advancement as an Adventurer."/>
-        <string name="demandSummary" value="Report to NPC #b#p900040##k and receive the honorable #t1142109# Medal."/>
+        <string name="0" value="完成冒险家的3转后，即可获得#b&lt;高级冒险家&gt;#k称号。"/>
+        <string name="1" value="完成冒险家的3转后，即可获得#b&lt;高级冒险家&gt;#k称号。请前往各个村庄寻找NPC #p9000040#。"/>
+        <string name="2" value="你已完成冒险家的3转，获得了#b&lt;高级冒险家&gt;#k称号。"/>
+        <string name="demandSummary" value="向NPC #b#p9000040##k报告，并领取光荣的#t1142109#。"/>
         <string name="rewardSummary" value="#Wbasic#"/>
         <int name="autoAccept" value="1"/>
         <int name="viewMedalItem" value="1142109"/>
@@ -9760,10 +9760,10 @@
         <string name="name" value="大师冒险家"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
-        <string name="0" value="You can earn the #b&lt;Master Adventurer&gt;#k title by completing your 4th Job Advancement as an Adventurer."/>
-        <string name="1" value="Adventurers who complete the 4th Job Advancement will receive the #b&lt;Master Adventurer&gt;#k title. Go find NPC #p9000040#, who can be found in every town."/>
-        <string name="2" value="You have earned the #b&lt;Master Adventurer&gt;#k title by completing your 4th Job Advancement as an Adventurer."/>
-        <string name="demandSummary" value="Report to NPC #b#p900040##k and receive the honorable #t1142110# Medal."/>
+        <string name="0" value="完成冒险家的4转后，即可获得#b&lt;大师冒险家&gt;#k称号。"/>
+        <string name="1" value="完成冒险家的4转后，即可获得#b&lt;大师冒险家&gt;#k称号。请前往各个村庄寻找NPC #p9000040#。"/>
+        <string name="2" value="你已完成冒险家的4转，获得了#b&lt;大师冒险家&gt;#k称号。"/>
+        <string name="demandSummary" value="向NPC #b#p9000040##k报告，并领取光荣的#t1142110#。"/>
         <string name="rewardSummary" value="#Wbasic#"/>
         <int name="autoAccept" value="1"/>
         <int name="viewMedalItem" value="1142110"/>

--- a/gms-server/wz-zh-CN/String.wz/Eqp.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Eqp.img.xml
@@ -1423,7 +1423,7 @@
                 <string name="name" value="高级冒险家勋章" />
             </imgdir>
             <imgdir name="1142110">
-                <string name="name" value="大师级冒险家勋章" />
+                <string name="name" value="大师冒险家勋章" />
             </imgdir>
             <imgdir name="1142111">
                 <string name="name" value="站在巅峰的人勋章" />


### PR DESCRIPTION
## 改动内容
- 统一 29900、29901、29902、29903 冒险家勋章任务的中文名称与任务说明，分别对应新手冒险家、中级冒险家、高级冒险家、大师冒险家。
- 修正任务说明中的勋章领取 NPC 引用，将错误的 NPC 标记改为德烈的正确 NPC 标记 #p9000040#。
- 统一 1142107、1142108、1142109、1142110 勋章相关的中文提示文本，并修正大师冒险家勋章名称。
- 本次为 zh-CN 文本修复，仅修改中文脚本与中文 WZ 资源，未修改英文原版目录。
- 当前分支包含 2 个提交：统一冒险家勋章任务中文文本、修正德烈 NPC 名称提示。

## 影响范围
- 影响服务端中文任务脚本中的任务提示文本。
- 影响客户端任务面板与装备名称显示所依赖的中文 WZ/XML 资源。
- 需要同步客户端资源包。

## 验证情况
- 已执行 29900、29901、29902、29903 中文任务脚本的 JS 语法检查。
- 已执行 QuestInfo 与 Eqp 中文 XML 解析检查。
- 已执行变更文件中文乱码检查。
- 已检查 PR 正文不包含本地路径、本机目录、用户名或个人环境信息。
- 未重新构建 Jar。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。