### PR TITLE
fix: 修复超人气王勋章任务29002的接取与领奖流程

### DIFF
--- a/gms-server/scripts-zh-CN/quest/29002.js
+++ b/gms-server/scripts-zh-CN/quest/29002.js
@@ -1,0 +1,82 @@
+﻿var medalId = 1142003;
+var requiredFameGain = 1000;
+var challengeDurationMs = 30 * 24 * 60 * 60 * 1000;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + medalId + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
+function getRecordedStartFame() {
+    var progress = qm.getQuestProgress(qm.getQuest());
+    if (progress == null || progress.length === 0) {
+        return -1;
+    }
+
+    var startFame = parseInt(progress, 10);
+    return isNaN(startFame) ? -1 : startFame;
+}
+
+function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded()) {
+        return;
+    }
+
+    qm.forceStartQuest();
+    qm.setQuestProgress(qm.getQuest(), "" + qm.getPlayer().getFame());
+    qm.sendOk("请在 30 天内把人气提高 #b" + requiredFameGain + "#k 点，再来领取#b#t" + medalId + "##k。");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded()) {
+        return;
+    }
+
+    var questRecord = qm.getQuestRecord(qm.getQuest());
+    if (questRecord == null || System.currentTimeMillis() > questRecord.getCompletionTime() + challengeDurationMs) {
+        qm.sendOk("30 天挑战期限已经结束了。如果你还想挑战#b#t" + medalId + "##k，请先重新接取任务。");
+        qm.dispose();
+        return;
+    }
+
+    var startFame = getRecordedStartFame();
+    if (startFame < 0) {
+        qm.sendOk("无法确认你接取挑战时的人气记录，请先放弃任务后重新接取。");
+        qm.dispose();
+        return;
+    }
+
+    var currentFame = qm.getPlayer().getFame();
+    var gainedFame = currentFame - startFame;
+    if (gainedFame < requiredFameGain) {
+        qm.sendOk("领取这枚勋章需要你在 30 天内提高 #b" + requiredFameGain + "#k 点人气。\r\n当前已提升：#r" + gainedFame + "#k");
+        qm.dispose();
+        return;
+    }
+
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("你在 30 天内成功提高了 #b" + gainedFame + "#k 点人气，已经证明自己是真正的超人气冒险家。\r\n\r\n请收下#b#t" + medalId + "##k。");
+    qm.dispose();
+}

--- a/gms-server/scripts/quest/29002.js
+++ b/gms-server/scripts/quest/29002.js
@@ -1,0 +1,82 @@
+﻿var medalId = 1142003;
+var requiredFameGain = 1000;
+var challengeDurationMs = 30 * 24 * 60 * 60 * 1000;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(medalId, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received the #b#t" + medalId + "##k. This challenge is already recorded in your adventure history.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
+
+function getRecordedStartFame() {
+    var progress = qm.getQuestProgress(qm.getQuest());
+    if (progress == null || progress.length === 0) {
+        return -1;
+    }
+
+    var startFame = parseInt(progress, 10);
+    return isNaN(startFame) ? -1 : startFame;
+}
+
+function start(mode, type, selection) {
+    if (finishIfAlreadyAwarded()) {
+        return;
+    }
+
+    qm.forceStartQuest();
+    qm.setQuestProgress(qm.getQuest(), "" + qm.getPlayer().getFame());
+    qm.sendOk("Raise your fame by #b" + requiredFameGain + "#k within 30 days, then return to receive the #b#t" + medalId + "##k.");
+    qm.dispose();
+}
+
+function end(mode, type, selection) {
+    if (finishIfAlreadyAwarded()) {
+        return;
+    }
+
+    var questRecord = qm.getQuestRecord(qm.getQuest());
+    if (questRecord == null || System.currentTimeMillis() > questRecord.getCompletionTime() + challengeDurationMs) {
+        qm.sendOk("The 30-day challenge period has expired. Please restart the challenge if you want to try for the #b#t" + medalId + "##k again.");
+        qm.dispose();
+        return;
+    }
+
+    var startFame = getRecordedStartFame();
+    if (startFame < 0) {
+        qm.sendOk("Your starting fame for this challenge could not be verified. Please forfeit the challenge and start it again.");
+        qm.dispose();
+        return;
+    }
+
+    var currentFame = qm.getPlayer().getFame();
+    var gainedFame = currentFame - startFame;
+    if (gainedFame < requiredFameGain) {
+        qm.sendOk("You need to gain #b" + requiredFameGain + "#k fame within 30 days to receive this medal.\r\nCurrent fame gained: #r" + gainedFame + "#k");
+        qm.dispose();
+        return;
+    }
+
+    if (!qm.haveItem(medalId)) {
+        if (!qm.canHold(medalId)) {
+            qm.sendOk("Please make room in your equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(medalId, 1);
+    }
+
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("You raised your fame by #b" + gainedFame + "#k within 30 days and proved that your popularity is backed by real adventures.\r\n\r\nPlease accept the #b#t" + medalId + "##k.");
+    qm.dispose();
+}

--- a/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
@@ -34951,7 +34951,6 @@
         <imgdir name="0">
             <int name="npc" value="9000040"/>
             <int name="lvmin" value="20"/>
-            <int name="interval" value="0"/>
             <string name="startscript" value="q29002s"/>
             <imgdir name="item">
                 <imgdir name="0">

--- a/gms-server/wz/Quest.wz/Check.img.xml
+++ b/gms-server/wz/Quest.wz/Check.img.xml
@@ -34978,13 +34978,12 @@
       <int name="npc" value="9000040"/>
       <string name="endscript" value="q29002e"/>
     </imgdir>
-    <imgdir name="0">
-      <int name="npc" value="9000040"/>
-      <int name="lvmin" value="20"/>
-      <int name="interval" value="0"/>
-      <string name="startscript" value="q29002s"/>
-      <imgdir name="item">
         <imgdir name="0">
+            <int name="npc" value="9000040"/>
+            <int name="lvmin" value="20"/>
+            <string name="startscript" value="q29002s"/>
+            <imgdir name="item">
+                <imgdir name="0">
           <int name="id" value="1142003"/>
         </imgdir>
       </imgdir>


### PR DESCRIPTION
改动内容
- 为挑战勋章任务 `29002` 补齐中英文专用任务脚本，避免任务流程回退到通用占位脚本后提示“没有找到”。
- 修复 NPC `9000040` 发放《超人气王勋章》时的接取与领奖流程，奖励道具为 `1142003`。
- 接取任务时记录当前人气，完成任务时校验 30 天内人气是否累计提升 1000。
- 增加重复领取保护：任务已完成或角色已持有该勋章时，不再允许重复接取或重复领奖。
- 调整 `29002` 在中英文 `Quest.wz/Check.img.xml` 中的任务定义，移除重复接取判定，使角色完成后不再被视为可重复挑战任务。
- 本次同时修改 `scripts`、`scripts-zh-CN`、`wz` 与 `wz-zh-CN` 目录，保持中英文逻辑与定义对称。

影响范围
- 影响服务端任务脚本与任务定义判定逻辑。
- 涉及客户端 `Quest/Check` 数据同步，测试或发布时需要同步客户端资源包。

验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查。
- 已执行中文乱码检查。
- 已确认分支 diff 仅包含本次任务脚本与任务定义修复文件。
- 已确认同步后的测试服务端完成 WZ 加载，频道端口与登录端口启动正常。

客户端资源
- 本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。