### PR TITLE
feat(gachapon): add use_enable_gachapon_log config switch

### DIFF
--- a/gms-server/src/main/java/org/gms/server/gachapon/Gachapon.java
+++ b/gms-server/src/main/java/org/gms/server/gachapon/Gachapon.java
@@ -23,6 +23,7 @@ package org.gms.server.gachapon;
 
 import lombok.Getter;
 import org.gms.client.Character;
+import org.gms.config.GameConfig;
 import org.gms.constants.id.NpcId;
 import org.gms.util.I18nUtil;
 import org.slf4j.Logger;
@@ -162,7 +163,9 @@ public class Gachapon {
     }
 
     public static void log(Character player, int itemId, String map) {
-        String itemName = ItemInformationProvider.getInstance().getName(itemId);
-        log.info(I18nUtil.getLogMessage("Gachapon.log.info"), player.getName(), itemName, itemId, map);
+        if (GameConfig.getServerBoolean("use_enable_gachapon_log")) {
+            String itemName = ItemInformationProvider.getInstance().getName(itemId);
+            log.info(I18nUtil.getLogMessage("Gachapon.log.info"), player.getName(), itemName, itemId, map);
+        }
     }
 }

--- a/gms-server/src/main/resources/db/migration/V1.11.4__insert_game_config_gachapon_log.sql
+++ b/gms-server/src/main/resources/db/migration/V1.11.4__insert_game_config_gachapon_log.sql
@@ -1,0 +1,17 @@
+INSERT INTO `game_config`(`config_type`, `config_sub_type`, `config_clazz`, `config_code`, `config_value`, `config_desc`, `update_time`)
+SELECT 'server', 'Debug', 'java.lang.Boolean', 'use_enable_gachapon_log', 'false', 'use_enable_gachapon_log', '2026-06-23 20:25:36'
+WHERE NOT EXISTS (
+    SELECT 1 FROM `game_config` WHERE `config_code` = 'use_enable_gachapon_log'
+);
+
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'zh-CN', 'game_config', 'use_enable_gachapon_log', '日志是否打印转蛋机抽奖信息', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'zh-CN' AND `lang_code` = 'use_enable_gachapon_log'
+);
+
+INSERT INTO `lang_resources`(`lang_type`, `lang_base`, `lang_code`, `lang_value`, `lang_extend`)
+SELECT 'en-US', 'game_config', 'use_enable_gachapon_log', 'Whether print gachapon log.', NULL
+WHERE NOT EXISTS (
+    SELECT 1 FROM `lang_resources` WHERE `lang_type` = 'en-US' AND `lang_code` = 'use_enable_gachapon_log'
+);


### PR DESCRIPTION
新增转蛋机日志开关配置 use_enable_gachapon_log，默认关闭。
开启后在转蛋抽奖时打印日志。配置项在 chms > Debug 下。