### PR TITLE
fix: 修复 299xx 勋章称号任务脚本与中文文本

### DIFF
--- a/gms-server/scripts-zh-CN/quest/29915.js
+++ b/gms-server/scripts-zh-CN/quest/29915.js
@@ -1,0 +1,55 @@
+var questId = 29915;
+var requiredMedal = 1142064;
+var titleName = "武陵道场征服者";
+var medalName = "武陵道场征服者勋章";
+var praiseMessage = "你的意志已经回响在武陵道场的每一层。你直面所有大师怪物，从未退缩；从今天起，武陵道场征服者的荣耀将与你的名字并列。";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> 称号已获得。");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("你已经获得过#b<" + titleName + ">#k称号。");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("请先获得#b" + medalName + "#k后，再来领取这个称号。");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts-zh-CN/quest/29916.js
+++ b/gms-server/scripts-zh-CN/quest/29916.js
@@ -1,0 +1,55 @@
+var questId = 29916;
+var requiredMedal = 1142014;
+var titleName = "射手村爱心使者";
+var medalName = "射手村爱心使者勋章";
+var praiseMessage = "你的善意像清晨的阳光一样洒落在射手村。这里的人们会记得，是你把温暖和希望留在了这片宁静的村庄。";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> 称号已获得。");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("你已经获得过#b<" + titleName + ">#k称号。");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("请先获得#b" + medalName + "#k后，再来领取这个称号。");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts-zh-CN/quest/29917.js
+++ b/gms-server/scripts-zh-CN/quest/29917.js
@@ -1,0 +1,55 @@
+var questId = 29917;
+var requiredMedal = 1142015;
+var titleName = "魔法密林爱心使者";
+var medalName = "魔法密林爱心使者勋章";
+var praiseMessage = "你的慷慨如同清澈的魔力，流淌在魔法密林的枝叶之间。连古老的树木，也仿佛在为你的善举低声致谢。";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> 称号已获得。");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("你已经获得过#b<" + titleName + ">#k称号。");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("请先获得#b" + medalName + "#k后，再来领取这个称号。");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts-zh-CN/quest/29918.js
+++ b/gms-server/scripts-zh-CN/quest/29918.js
@@ -1,0 +1,55 @@
+var questId = 29918;
+var requiredMedal = 1142016;
+var titleName = "勇士部落爱心使者";
+var medalName = "勇士部落爱心使者勋章";
+var praiseMessage = "在勇士部落粗犷的风声里，你的善意像岩石一样坚定。你证明了真正的强大，不只来自战斗，也来自愿意给予的心。";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> 称号已获得。");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("你已经获得过#b<" + titleName + ">#k称号。");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("请先获得#b" + medalName + "#k后，再来领取这个称号。");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts-zh-CN/quest/29919.js
+++ b/gms-server/scripts-zh-CN/quest/29919.js
@@ -1,0 +1,55 @@
+var questId = 29919;
+var requiredMedal = 1142017;
+var titleName = "废弃都市爱心使者";
+var medalName = "废弃都市爱心使者勋章";
+var praiseMessage = "因为你的慷慨，废弃都市的街巷也多了一束光。即使人们步履匆匆，你留下的善意仍会被长久记住。";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> 称号已获得。");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("你已经获得过#b<" + titleName + ">#k称号。");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("请先获得#b" + medalName + "#k后，再来领取这个称号。");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts-zh-CN/quest/29920.js
+++ b/gms-server/scripts-zh-CN/quest/29920.js
@@ -1,0 +1,55 @@
+var questId = 29920;
+var requiredMedal = 1142018;
+var titleName = "林中之城爱心使者";
+var medalName = "林中之城爱心使者勋章";
+var praiseMessage = "在林中之城深邃的树影之下，你的慷慨成为了一盏安稳的灯。它会照亮这里的人们，也照亮后来者前行的路。";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> 称号已获得。");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("你已经获得过#b<" + titleName + ">#k称号。");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("请先获得#b" + medalName + "#k后，再来领取这个称号。");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts-zh-CN/quest/29921.js
+++ b/gms-server/scripts-zh-CN/quest/29921.js
@@ -1,0 +1,55 @@
+var questId = 29921;
+var requiredMedal = 1142019;
+var titleName = "诺特勒斯爱心使者";
+var medalName = "诺特勒斯爱心使者勋章";
+var praiseMessage = "你的名字将随着海风传遍诺特勒斯的甲板。你给予的不只是财富，更是让船员继续远航的勇气。";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> 称号已获得。");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("你已经获得过#b<" + titleName + ">#k称号。");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("请先获得#b" + medalName + "#k后，再来领取这个称号。");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts-zh-CN/quest/29922.js
+++ b/gms-server/scripts-zh-CN/quest/29922.js
@@ -1,0 +1,55 @@
+var questId = 29922;
+var requiredMedal = 1142004;
+var titleName = "勤奋冒险家";
+var medalName = "勤奋冒险家勋章";
+var praiseMessage = "无数次狩猎磨炼了你的脚步，也见证了你的坚持。你已经配得上勤奋冒险家的称号，这份荣誉属于真正不懈前行的人。";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> 称号已获得。");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("你已经获得过#b<" + titleName + ">#k称号。");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("请先获得#b" + medalName + "#k后，再来领取这个称号。");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts-zh-CN/quest/29923.js
+++ b/gms-server/scripts-zh-CN/quest/29923.js
@@ -1,0 +1,55 @@
+var questId = 29923;
+var requiredMedal = 1142005;
+var titleName = "传说中的冒险家";
+var medalName = "传说中的冒险家勋章";
+var praiseMessage = "你的狩猎技艺已经超越了寻常赞美。你留下的足迹本身就是传说，后来者会从中看见真正的极致与荣耀。";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> 称号已获得。");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("你已经获得过#b<" + titleName + ">#k称号。");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("请先获得#b" + medalName + "#k后，再来领取这个称号。");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts-zh-CN/quest/29933.js
+++ b/gms-server/scripts-zh-CN/quest/29933.js
@@ -1,0 +1,55 @@
+var questId = 29933;
+var requiredMedal = 1142030;
+var titleName = "明珠港爱心使者";
+var medalName = "明珠港爱心使者勋章";
+var praiseMessage = "在明珠港，旅程从潮声与告别中开始。而你的慷慨，已经成为送给每一位旅人的祝福。";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> 称号已获得。");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("你已经获得过#b<" + titleName + ">#k称号。");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("请先获得#b" + medalName + "#k后，再来领取这个称号。");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts-zh-CN/quest/medalQuest.js
+++ b/gms-server/scripts-zh-CN/quest/medalQuest.js
@@ -8,8 +8,8 @@ function start(mode, type, selection) {
     qm.forceCompleteQuest();
 
     var medalname = qm.getMedalName();
-    qm.message("<" + medalname + "> 没有找到.");
-    qm.earnTitle("<" + medalname + "> 已领取奖励.");
+    qm.message("<" + medalname + "> 尚未编写专用脚本。");
+    qm.earnTitle("<" + medalname + "> 奖励已获得。");
     qm.dispose();
 }
 
@@ -17,7 +17,7 @@ function end(mode, type, selection) {
     qm.forceCompleteQuest();
 
     var medalname = qm.getMedalName();
-    qm.message("<" + medalname + "> 没有找到.");
-    qm.earnTitle("<" + medalname + "> 已领取奖励.");
+    qm.message("<" + medalname + "> 尚未编写专用脚本。");
+    qm.earnTitle("<" + medalname + "> 奖励已获得。");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29915.js
+++ b/gms-server/scripts/quest/29915.js
@@ -1,0 +1,55 @@
+var questId = 29915;
+var requiredMedal = 1142064;
+var titleName = "Mu Lung Dojo Vanquisher";
+var medalName = "Mu Lung Dojo Vanquisher Medal";
+var praiseMessage = "Your discipline has echoed through every floor of Mu Lung Dojo. You stood before each master without turning away, and your name now belongs among the true conquerors of the Dojo.";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> title has been awarded.");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("You have already earned the #b<" + titleName + ">#k title.");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("Please earn the #b" + medalName + "#k first, then claim this title.");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts/quest/29916.js
+++ b/gms-server/scripts/quest/29916.js
@@ -1,0 +1,55 @@
+var questId = 29916;
+var requiredMedal = 1142014;
+var titleName = "Henesys Donor";
+var medalName = "Henesys Donor Medal";
+var praiseMessage = "Your kindness has taken root in Henesys like sunlight over a quiet field. The people will remember the warmth you brought to their town.";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> title has been awarded.");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("You have already earned the #b<" + titleName + ">#k title.");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("Please earn the #b" + medalName + "#k first, then claim this title.");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts/quest/29917.js
+++ b/gms-server/scripts/quest/29917.js
@@ -1,0 +1,55 @@
+var questId = 29917;
+var requiredMedal = 1142015;
+var titleName = "Ellinia Donor";
+var medalName = "Ellinia Donor Medal";
+var praiseMessage = "Your generosity now flows through Ellinia like clear magic among the trees. Even the oldest branches seem to whisper thanks for what you have given.";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> title has been awarded.");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("You have already earned the #b<" + titleName + ">#k title.");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("Please earn the #b" + medalName + "#k first, then claim this title.");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts/quest/29918.js
+++ b/gms-server/scripts/quest/29918.js
@@ -1,0 +1,55 @@
+var questId = 29918;
+var requiredMedal = 1142016;
+var titleName = "Perion Donor";
+var medalName = "Perion Donor Medal";
+var praiseMessage = "In the rugged winds of Perion, your goodwill stands as firm as stone. You have proven that true strength is found not only in battle, but in giving.";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> title has been awarded.");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("You have already earned the #b<" + titleName + ">#k title.");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("Please earn the #b" + medalName + "#k first, then claim this title.");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts/quest/29919.js
+++ b/gms-server/scripts/quest/29919.js
@@ -1,0 +1,55 @@
+var questId = 29919;
+var requiredMedal = 1142017;
+var titleName = "Kerning City Donor";
+var medalName = "Kerning City Donor Medal";
+var praiseMessage = "Kerning City is brighter because of your generosity. In streets where people move quickly and quietly, your kindness will still be remembered.";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> title has been awarded.");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("You have already earned the #b<" + titleName + ">#k title.");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("Please earn the #b" + medalName + "#k first, then claim this title.");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts/quest/29920.js
+++ b/gms-server/scripts/quest/29920.js
@@ -1,0 +1,55 @@
+var questId = 29920;
+var requiredMedal = 1142018;
+var titleName = "Sleepywood Donor";
+var medalName = "Sleepywood Donor Medal";
+var praiseMessage = "Deep in Sleepywood, where shadows gather beneath ancient roots, your generosity has become a steady light for those who call the town home.";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> title has been awarded.");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("You have already earned the #b<" + titleName + ">#k title.");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("Please earn the #b" + medalName + "#k first, then claim this title.");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts/quest/29921.js
+++ b/gms-server/scripts/quest/29921.js
@@ -1,0 +1,55 @@
+var questId = 29921;
+var requiredMedal = 1142019;
+var titleName = "Nautilus Donor";
+var medalName = "Nautilus Donor Medal";
+var praiseMessage = "Across the deck of the Nautilus, your name will travel with the sea wind. You have given more than wealth; you have given courage to a crew that sails onward.";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> title has been awarded.");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("You have already earned the #b<" + titleName + ">#k title.");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("Please earn the #b" + medalName + "#k first, then claim this title.");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts/quest/29922.js
+++ b/gms-server/scripts/quest/29922.js
@@ -1,0 +1,55 @@
+var questId = 29922;
+var requiredMedal = 1142004;
+var titleName = "Veteran Hunter";
+var medalName = "Veteran Hunter Medal";
+var praiseMessage = "Countless battles have shaped your steps, and every hunt has sharpened your resolve. You have earned a hunter's name that others will speak with respect.";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> title has been awarded.");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("You have already earned the #b<" + titleName + ">#k title.");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("Please earn the #b" + medalName + "#k first, then claim this title.");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts/quest/29923.js
+++ b/gms-server/scripts/quest/29923.js
@@ -1,0 +1,55 @@
+var questId = 29923;
+var requiredMedal = 1142005;
+var titleName = "Legendary Hunter";
+var medalName = "Legendary Hunter Medal";
+var praiseMessage = "Your hunting skill has passed beyond ordinary praise. The trail you leave behind is a legend, and those who follow it will know what true mastery looks like.";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> title has been awarded.");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("You have already earned the #b<" + titleName + ">#k title.");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("Please earn the #b" + medalName + "#k first, then claim this title.");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/scripts/quest/29933.js
+++ b/gms-server/scripts/quest/29933.js
@@ -1,0 +1,55 @@
+var questId = 29933;
+var requiredMedal = 1142030;
+var titleName = "Lith Harbor Donor";
+var medalName = "Lith Harbor Donor Medal";
+var praiseMessage = "At Lith Harbor, where journeys begin and farewells linger on the tide, your generosity has become a blessing for every traveler who sets foot on the dock.";
+var status = -1;
+var readyToAward = false;
+
+function hasRequiredMedal() {
+    return qm.haveItemWithId(requiredMedal, true);
+}
+
+function isCompleted() {
+    return qm.getQuestStatus(questId) == 2;
+}
+
+function awardTitle() {
+    qm.forceStartQuest();
+    qm.forceCompleteQuest();
+    qm.message("<" + titleName + "> title has been awarded.");
+    qm.earnTitle(titleName);
+}
+
+function handle(mode) {
+    if (mode == -1) {
+        qm.dispose();
+        return;
+    }
+
+    status++;
+    if (status == 0) {
+        if (isCompleted()) {
+            qm.sendOk("You have already earned the #b<" + titleName + ">#k title.");
+        } else if (!hasRequiredMedal()) {
+            qm.sendOk("Please earn the #b" + medalName + "#k first, then claim this title.");
+        } else {
+            readyToAward = true;
+            qm.sendOk(praiseMessage);
+        }
+        return;
+    }
+
+    if (readyToAward && !isCompleted() && hasRequiredMedal()) {
+        awardTitle();
+    }
+    qm.dispose();
+}
+
+function start(mode, type, selection) {
+    handle(mode);
+}
+
+function end(mode, type, selection) {
+    handle(mode);
+}

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9882,84 +9882,84 @@
         <int name="autoAccept" value="1"/>
     </imgdir>
     <imgdir name="29915">
-        <string name="name" value="Mu Lung Dojo Vanquisher"/>
+        <string name="name" value="武陵道场征服者"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142064"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="0" value="#b#eTitle - Mu Lung Dojo Vanquisher#n#\r\n#k#b&lt;Mu Lung Dojo Vanquisher&gt;#k, a coveted title given only to Mu Lung Dojo experts. \r\n●Requirement(s) : Acquire the #bMu Lung Dojo Vanquisher Medal#k from #bMu Lung Dojo#k."/>
-        <string name="2" value="You have earned the #b&lt;Mu Lung Dojo Vanquisher&gt;#k title by defeating all of the master monsters in Mu Lung Dojo."/>
+        <string name="0" value="#b#e称号 - 武陵道场征服者#n#\r\n#k#b&lt;武陵道场征服者&gt;#k，只有精通武陵道场的勇士才能获得的荣誉称号。\r\n●条件：在#b武陵道场#k获得#b武陵道场征服者勋章#k。"/>
+        <string name="2" value="你已经通过击败武陵道场中的所有大师怪物，获得了#b&lt;武陵道场征服者&gt;#k称号。"/>
     </imgdir>
     <imgdir name="29916">
-        <string name="name" value="Henesys Donor Medal"/>
+        <string name="name" value="射手村爱心使者勋章"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="2" value="Donations are a quick way to give back to the community. You have earned the #b&lt;Henesys Donor&gt;#k title."/>
+        <string name="2" value="捐赠是回馈社区的好方法。你已经获得了#b&lt;射手村爱心使者&gt;#k称号。"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142014"/>
     </imgdir>
     <imgdir name="29917">
-        <string name="name" value="Ellinia Donor Medal"/>
+        <string name="name" value="魔法密林爱心使者勋章"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="2" value="Donations are a quick way to give back to the community. You have earned the #b&lt;Ellinia Donor&gt;#k title."/>
+        <string name="2" value="捐赠是回馈社区的好方法。你已经获得了#b&lt;魔法密林爱心使者&gt;#k称号。"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142015"/>
     </imgdir>
     <imgdir name="29918">
-        <string name="name" value="Perion Donor Medal"/>
+        <string name="name" value="勇士部落爱心使者勋章"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="2" value="Donations are a quick way to give back to the community. You have earned the #b&lt;Perion Donor&gt;#k title."/>
+        <string name="2" value="捐赠是回馈社区的好方法。你已经获得了#b&lt;勇士部落爱心使者&gt;#k称号。"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142016"/>
     </imgdir>
     <imgdir name="29919">
-        <string name="name" value="Kerning City Donor Medal"/>
+        <string name="name" value="废弃都市爱心使者勋章"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="2" value="Donations are a quick way to give back to the community. You have earned the #b&lt;Kerning City Donor&gt;#k title."/>
+        <string name="2" value="捐赠是回馈社区的好方法。你已经获得了#b&lt;废弃都市爱心使者&gt;#k称号。"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142017"/>
     </imgdir>
     <imgdir name="29920">
-        <string name="name" value="Sleepywood Donor Medal"/>
+        <string name="name" value="林中之城爱心使者勋章"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="2" value="Donations are a quick way to give back to the community. You have earned the #b&lt;Sleepywood Donor&gt;#k title."/>
+        <string name="2" value="捐赠是回馈社区的好方法。你已经获得了#b&lt;林中之城爱心使者&gt;#k称号。"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142018"/>
     </imgdir>
     <imgdir name="29921">
-        <string name="name" value="Nautilus Donor Medal"/>
+        <string name="name" value="诺特勒斯爱心使者勋章"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="2" value="Donations are a quick way to give back to the community. You have earned the #b&lt;Nautilus Donor&gt;#k title."/>
+        <string name="2" value="捐赠是回馈社区的好方法。你已经获得了#b&lt;诺特勒斯爱心使者&gt;#k称号。"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142019"/>
     </imgdir>
     <imgdir name="29922">
-        <string name="name" value="Veteran Hunter"/>
+        <string name="name" value="勤奋冒险家"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142004"/>
-        <string name="2" value="You have earned the #b&lt;Veteran Hunter&gt;#k title by hunting 100,000 monsters that are above you in level within 30 days."/>
+        <string name="2" value="你已经在30天内狩猎100,000只符合条件的怪物，获得了#b&lt;勤奋冒险家&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
     </imgdir>
     <imgdir name="29923">
-        <string name="name" value="Legendary Hunter"/>
+        <string name="name" value="传说中的冒险家"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142005"/>
-        <string name="2" value="No one can trump your hunting skills! You have earned the #b&lt;Legendary Hunter&gt;#k title."/>
+        <string name="2" value="无人能超越你的狩猎技巧！你已经获得了#b&lt;传说中的冒险家&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
     </imgdir>
@@ -10051,13 +10051,13 @@
         <string name="1" value="#e#bChallenge yourself to earn the Protector of Pharaoh title!#k#n\r\n* Requirements: Eliminate #b50,000 monsters#k in Nett&apos;s Pyramid \r\n* Current Count: #b#R7760##k\r\nAfter completing the requirements, see #bDuarte#k to receive your medal.\r\n"/>
     </imgdir>
     <imgdir name="29933">
-        <string name="name" value="Lith Harbor Donor"/>
+        <string name="name" value="明珠港爱心使者"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142030"/>
-        <string name="2" value="Charity is key to a prosperous life. Acquired the title #b&lt;Lith Harbor Donor&gt;#k.\r\n"/>
+        <string name="2" value="慈善是美好生活的重要基石。你已经获得了#b&lt;明珠港爱心使者&gt;#k称号。\r\n"/>
     </imgdir>
     <imgdir name="3000">
         <string name="name" value="查里中士"/>


### PR DESCRIPTION
## 改动内容
- 为任务 29915、29916、29917、29918、29919、29920、29921、29922、29923、29933 补充专用称号任务脚本，避免落入通用兜底脚本。
- 为英文脚本目录与中文脚本目录补充对称实现，任务满足条件后先显示 NPC 表扬对话，确认后再完成任务并发送称号获得提示。
- 修复中文通用勋章任务兜底脚本文案，避免显示不自然或异常文本。
- 汉化中文 QuestInfo 中这批称号任务的任务名与完成描述。
- 涉及 NPC：武陵道场相关 NPC 2091005，以及称号勋章相关 NPC 9000066。
- 涉及道具：1142064、1142014、1142015、1142016、1142017、1142018、1142019、1142004、1142005、1142030。
- 涉及地图/玩法：武陵道场、射手村、魔法密林、勇士部落、废弃都市、林中之城、诺特勒斯、明珠港，以及猎人称号系列。

## 影响范围
- 影响服务端任务脚本与中文 WZ 任务文本。
- 中文 QuestInfo 改动会影响客户端任务显示，需要同步客户端资源包。
- 不涉及 Java 代码，不涉及 Jar 构建。

## 验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查。
- 已执行中文文本乱码与异常字符检查。
- 已确认分支相对 master 的 diff 仅包含本次任务相关文件。
- 已在测试环境同步服务端脚本与客户端任务文本，并确认服务端完成 WZ 加载、频道端口与登录端口启动。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。