### PR TITLE
fix: 汉化骑士团等级勋章任务文本

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9769,65 +9769,65 @@
         <int name="viewMedalItem" value="1142110"/>
     </imgdir>
     <imgdir name="29904">
-        <string name="name" value="Noblesse"/>
+        <string name="name" value="骑士团初心者"/>
         <int name="area" value="51"/>
-        <string name="1" value="Prove that you&apos;re one of the Cygnus Knights and receive the #b&lt;Noblesse&gt;#k title."/>
+        <string name="1" value="证明你是皇家骑士团的一员，并获得#b&lt;骑士团初心者&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
-        <string name="2" value="As a member of the honorable knighthood, you have received your first title, the #b&lt;Noblesse&gt;#k, upon pledging your loyalty to the Empress."/>
-        <string name="demandSummary" value="20000 Greetings from the Young Empress Chain Quest"/>
+        <string name="2" value="作为光荣骑士团的一员，在向女皇宣誓效忠后，你获得了第一个称号：#b&lt;骑士团初心者&gt;#k。"/>
+        <string name="demandSummary" value="完成 20000 小女王的问候 连锁任务。"/>
         <int name="autoAccept" value="1"/>
-        <string name="0" value="Prove that you&apos;re one of the Cygnus Knights and receive the #b&lt;Noblesse&gt;#k title."/>
+        <string name="0" value="证明你是皇家骑士团的一员，并获得#b&lt;骑士团初心者&gt;#k称号。"/>
         <int name="viewMedalItem" value="1142065"/>
     </imgdir>
     <imgdir name="29905">
-        <string name="name" value="Noblesse"/>
+        <string name="name" value="骑士团初心者"/>
         <int name="area" value="51"/>
-        <string name="1" value="Prove that you&apos;re one of the Cygnus Knights and receive the #b&lt;Noblesse&gt;#k title."/>
+        <string name="1" value="证明你是皇家骑士团的一员，并获得#b&lt;骑士团初心者&gt;#k称号。"/>
         <int name="autoStart" value="1"/>
-        <string name="2" value="As a member of the honorable knighthood, you have received your first title, the #b&lt;Noblesse&gt;#k, upon pledging your loyalty to the Empress."/>
+        <string name="2" value="作为光荣骑士团的一员，在向女皇宣誓效忠后，你获得了第一个称号：#b&lt;骑士团初心者&gt;#k。"/>
         <int name="autoAccept" value="1"/>
-        <string name="0" value="Prove that you&apos;re one of the Cygnus Knights and receive the #b&lt;Noblesse&gt;#k title."/>
+        <string name="0" value="证明你是皇家骑士团的一员，并获得#b&lt;骑士团初心者&gt;#k称号。"/>
         <int name="viewMedalItem" value="1142065"/>
     </imgdir>
     <imgdir name="29906">
-        <string name="name" value="Knight-in-Training"/>
+        <string name="name" value="修炼骑士"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
-        <string name="0" value="You can acquire the #b&lt;Knight-in-Training&gt;#k title by completing the 1st Job Advancement as a Knight."/>
-        <string name="2" value="You have earned the #b&lt;Knight-in-Training&gt;#k title, which is given to those who are determined to follow the honorable path of the Knight."/>
-        <string name="demandSummary" value="Acquire the #b&lt;Knight-in-Training&gt;#k title by completing the 1st Job Advancement as a Knight."/>
+        <string name="0" value="完成皇家骑士团第1次转职后，可以获得#b&lt;修炼骑士&gt;#k称号。"/>
+        <string name="2" value="你获得了#b&lt;修炼骑士&gt;#k称号。这是授予决心踏上光荣骑士之路者的称号。"/>
+        <string name="demandSummary" value="完成皇家骑士团第1次转职，获得#b&lt;修炼骑士&gt;#k称号。"/>
         <int name="autoAccept" value="1"/>
-        <string name="1" value="You can earn the #b&lt;Knight-in-Training&gt;#k title by completing the 1st Job Advancement as a Knight."/>
+        <string name="1" value="完成皇家骑士团第1次转职后，可以获得#b&lt;修炼骑士&gt;#k称号。"/>
         <int name="viewMedalItem" value="1142066"/>
     </imgdir>
     <imgdir name="29907">
-        <string name="name" value="Official Knight"/>
+        <string name="name" value="正式骑士"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
-        <string name="0" value="You can acquire the #b&lt;Official Knight&gt;#k title by completing the 2nd Job Advancement as a Knight."/>
-        <string name="2" value="Your prowess has been recognized! You have earned the #b&lt;Official Knight&gt;#k title."/>
+        <string name="0" value="完成皇家骑士团第2次转职后，可以获得#b&lt;正式骑士&gt;#k称号。"/>
+        <string name="2" value="你的实力获得了认可！你获得了#b&lt;正式骑士&gt;#k称号。"/>
         <int name="autoAccept" value="1"/>
-        <string name="1" value="You can acquire the #b&lt;Official Knight&gt;#k title by completing the 2nd Job Advancement as a Knight."/>
+        <string name="1" value="完成皇家骑士团第2次转职后，可以获得#b&lt;正式骑士&gt;#k称号。"/>
         <int name="viewMedalItem" value="1142067"/>
     </imgdir>
     <imgdir name="29908">
-        <string name="name" value="Advanced Knight"/>
+        <string name="name" value="高级骑士"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
-        <string name="0" value="You can acquire the #b&lt;Advanced Knight&gt;#k title by completing the 3rd Job Advancement as a Knight."/>
-        <string name="2" value="You have been given the #b&lt;Advanced Knight&gt;#k title for guarding Shinsoo&apos;s Teardrop."/>
+        <string name="0" value="完成皇家骑士团第3次转职后，可以获得#b&lt;高级骑士&gt;#k称号。"/>
+        <string name="2" value="你守护了神兽之泪，因此获得了#b&lt;高级骑士&gt;#k称号。"/>
         <int name="autoAccept" value="1"/>
-        <string name="1" value="You can acquire the #b&lt;Advanced Knight&gt;#k title by completing the 3rd Job Advancement as a Knight."/>
+        <string name="1" value="完成皇家骑士团第3次转职后，可以获得#b&lt;高级骑士&gt;#k称号。"/>
         <int name="viewMedalItem" value="1142068"/>
     </imgdir>
     <imgdir name="29909">
-        <string name="name" value="Chief Knight"/>
+        <string name="name" value="骑士团长"/>
         <int name="area" value="51"/>
         <int name="autoStart" value="1"/>
-        <string name="0" value="You can acquire the #b&lt;Chief Knight&gt;#k title by blocking the curse of the Black Witch."/>
-        <string name="2" value="You have saved the Empress from danger by blocking the curse of the Black Witch. For your tremendous accomplishment, you have received the#b&lt;Chief Knight&gt;#k title, the highest position in the Cygnus Knights."/>
+        <string name="0" value="阻止黑巫婆的诅咒后，可以获得#b&lt;骑士团长&gt;#k称号。"/>
+        <string name="2" value="你阻止了黑巫婆的诅咒，将女皇从危险中拯救出来。凭借这项伟大的功绩，你获得了皇家骑士团最高职位的称号：#b&lt;骑士团长&gt;#k。"/>
         <int name="autoAccept" value="1"/>
-        <string name="1" value="You can acquire the #&lt;Chief Knight&gt;#k title by blocking the curse of the Black Witch."/>
+        <string name="1" value="阻止黑巫婆的诅咒后，可以获得#b&lt;骑士团长&gt;#k称号。"/>
         <int name="viewMedalItem" value="1142069"/>
     </imgdir>
     <imgdir name="29910">


### PR DESCRIPTION
## 改动内容
- 汉化骑士团等级勋章系列任务 29904、29905、29906、29907、29908、29909 的任务名称、任务说明、完成说明与摘要文本。
- 修复 29909「骑士团长」称号说明中的颜色标记缺失与文本连接问题。
- 清理 29904、29905 任务对话中的英文占位与韩文测试残留。
- 涉及 NPC：女皇相关勋章任务入口；涉及道具：1142065、1142066、1142067、1142068、1142069。
- 本次仅修改中文 WZ 文本，不修改英文目录，也不修改任务接取、完成条件或脚本逻辑。

## 影响范围
- 影响服务端中文 WZ 文本与客户端任务显示文本。
- 本次没有修改任务流程、掉落、NPC 条件、Java 逻辑或 JS 脚本。
- 需要同步客户端资源包，以便客户端任务名称和任务说明显示为中文。

## 验证情况
- XML 解析检查通过。
- 目标任务范围乱码检查通过，未发现替换字符、问号乱码、韩文测试残留或英文旧任务名残留。
- Git diff 空白检查通过。
- 未执行 JS 语法检查：本次未修改 JS 脚本。
- 未执行 Maven 构建：本次不影响 Java 或 JAR。
- 未进行游戏内实测。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。