### PR TITLE
fix: 修正战神、冬季王/女王、地铁与法老勋章任务交互与文案

### DIFF
--- a/gms-server/scripts-zh-CN/npc/1052115.js
+++ b/gms-server/scripts-zh-CN/npc/1052115.js
@@ -1,7 +1,7 @@
 var status = 0;
 var section = 0;
 
-//questid 29931, infoquest 7662
+// questid 29931, infoquest 7662
 
 function start() {
     action(1, 0, 0);
@@ -20,38 +20,37 @@ function action(mode, type, selection) {
         } else if (cm.getMapId() == 910330001) {
             var itemid = 4001321;
             if (!cm.canHold(itemid)) {
-                cm.sendOk("请为1个杂项槽腾出空间。");
+                cm.sendOk("请在其它栏空出 1 个位置。");
             } else {
                 cm.gainItem(itemid, 1);
                 cm.warp(910320000, 0);
             }
             cm.dispose();
         } else if (cm.getMapId() >= 910320100 && cm.getMapId() <= 910320304) {
-            cm.sendYesNo("你想要离开这个地方吗？");
+            cm.sendYesNo("你想离开这里吗？");
             status = 99;
         } else {
-            cm.sendSimple("我的名字是林先生。\r\n#b#e#L1#进入尘土飞扬的平台。#l#n\r\n#L2#前往999号列车。#l\r\n#L3#获得<荣誉员工>勋章。#l#k");
+            cm.sendSimple("我的名字是林车长。\r\n#b#e#L1#进入尘土飞扬的平台。#l#n\r\n#L2#前往 999 号列车。#l\r\n#L3#询问<荣誉乘务员>勋章。#l#k");
         }
     } else if (status == 2) {
         section = selection;
         if (selection == 1) {
             if (cm.getPlayer().getLevel() < 25 || cm.getPlayer().getLevel() > 30 || !cm.isLeader()) {
-                cm.sendOk("你必须处于25-30级的等级范围，并且是队伍的队长。");
+                cm.sendOk("你必须处于 25-30 级范围内，并且是队长。");
             } else {
                 if (!cm.start_PyramidSubway(-1)) {
-                    cm.sendOk("尘土飞扬平台目前已满。");
+                    cm.sendOk("尘土飞扬的平台目前已满。");
                 }
             }
-            //todo
         } else if (selection == 2) {
             if (cm.haveItem(4001321)) {
                 if (cm.bonus_PyramidSubway(-1)) {
                     cm.gainItem(4001321, -1);
                 } else {
-                    cm.sendOk("目前列车999已经满员了");
+                    cm.sendOk("999 号列车目前已满。");
                 }
             } else {
-                cm.sendOk("您没有登机证。");
+                cm.sendOk("你没有登车证。");
             }
         } else if (selection == 3) {
             var record = cm.getQuestRecord(7662);
@@ -62,13 +61,9 @@ function action(mode, type, selection) {
             }
             var mons = parseInt(data);
             if (mons < 10000) {
-                cm.sendOk("请在站点击败至少10,000只怪物，然后再来找我。击杀数：mons");
-            } else if (cm.canHold(1142141) && !cm.haveItem(1142141)) {
-                cm.gainItem(1142141, 1);
-                cm.startQuest(29931);
-                cm.completeQuest(29931);
+                cm.sendOk("请在月台消灭至少 10,000 只怪物后再来找我。\r\n击杀数：#r" + mons + "#k / 10000");
             } else {
-                cm.sendOk("请腾出空间。");
+                cm.sendOk("你已经足以被称为荣誉乘务员。请前往德烈处领取勋章。");
             }
         }
         cm.dispose();

--- a/gms-server/scripts-zh-CN/quest/29924.js
+++ b/gms-server/scripts-zh-CN/quest/29924.js
@@ -1,45 +1,54 @@
-var status = -1;
+var MEDAL_ID = 1142129;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(MEDAL_ID, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
 
 function start(mode, type, selection) {
-	if (qm.getPlayer().getLevel() >= 10 && ((qm.getPlayer().getJob().getId() / 100) | 0) == 21) {
-                if(!qm.haveItem(1142129)) {
-                        if(qm.canHold(1142129)) {
-                                qm.gainItem(1142129,1);
-                        } else {
-                                qm.dispose();
-                                return;
-                        }
-                }
-                
-                var medalname = qm.getMedalName();
-                qm.message("<" + medalname + "> 奖励已获取.");
-                qm.earnTitle("<" + medalname + "> 奖励已获取.");
-                
-		qm.forceStartQuest();
-		qm.forceCompleteQuest();
-	}
-        
-	qm.dispose();
+    if (finishIfAlreadyAwarded()) {
+        return;
+    }
+    qm.forceStartQuest();
+    qm.sendOk("成为 10 级以上战神后，前往德烈处领取#b#t1142129##k。");
+    qm.dispose();
 }
 
 function end(mode, type, selection) {
-	if (qm.getPlayer().getLevel() >= 10 && ((qm.getPlayer().getJob().getId() / 100) | 0) == 21) {
-                if(!qm.haveItem(1142129)) {
-                        if(qm.canHold(1142129)) {
-                                qm.gainItem(1142129,1);
-                        } else {
-                                qm.dispose();
-                                return;
-                        }
-                }
-            
-                var medalname = qm.getMedalName();
-                qm.message("<" + medalname + "> 奖励已获取.");
-                qm.earnTitle("<" + medalname + "> 奖励已获取.");
-            
-		qm.forceStartQuest();
-		qm.forceCompleteQuest();
-	}
-        
-	qm.dispose();
+    if (finishIfAlreadyAwarded()) {
+        return;
+    }
+    var player = qm.getPlayer();
+    if (player.getLevel() < 10 || ((player.getJob().getId() / 100) | 0) != 21) {
+        qm.sendOk("领取这枚勋章需要成为 #b10 级以上战神#k。");
+        qm.dispose();
+        return;
+    }
+    awardMedal();
+}
+
+function awardMedal() {
+    if (!qm.haveItem(MEDAL_ID)) {
+        if (!qm.canHold(MEDAL_ID)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(MEDAL_ID, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("封住你的寒冰终于开始融化。即使记忆尚未完全归来，你握紧武器的勇气，已经证明了你是谁。\r\n\r\n请收下#b#t1142129##k。从这一刻起，苏醒的英雄将再次踏上冒险之路。");
+    qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29925.js
+++ b/gms-server/scripts-zh-CN/quest/29925.js
@@ -1,19 +1,54 @@
-var status = -1;
+var MEDAL_ID = 1142130;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(MEDAL_ID, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
 
 function start(mode, type, selection) {
-    if (qm.canHold(1142130) && !qm.haveItem(1142130, 1) && qm.getPlayer().getLevel() >= 30 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142130, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    qm.forceStartQuest();
+    qm.sendOk("成为 30 级以上战神后，前往德烈处领取#b#t1142130##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
-    if (qm.canHold(1142130) && !qm.haveItem(1142130, 1) && qm.getPlayer().getLevel() >= 30 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142130, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    var player = qm.getPlayer();
+    if (player.getLevel() < 30 || ((player.getJob().getId() / 100) | 0) != 21) {
+        qm.sendOk("领取这枚勋章需要成为 #b30 级以上战神#k。");
+        qm.dispose();
+        return;
+    }
+    awardMedal();
+}
+
+function awardMedal() {
+    if (!qm.haveItem(MEDAL_ID)) {
+        if (!qm.canHold(MEDAL_ID)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(MEDAL_ID, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("遗失的记忆正一点一点回到你的心中，像雪地里的火光重新聚拢。你与玛哈、与过去的羁绊，已经不再只是遥远的梦。\r\n\r\n请收下#b#t1142130##k。愿它陪伴你继续找回属于战神的一切。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29926.js
+++ b/gms-server/scripts-zh-CN/quest/29926.js
@@ -1,19 +1,54 @@
-var status = -1;
+var MEDAL_ID = 1142131;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(MEDAL_ID, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
 
 function start(mode, type, selection) {
-    if (qm.canHold(1142131) && !qm.haveItem(1142131, 1) && qm.getPlayer().getLevel() >= 70 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142131, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    qm.forceStartQuest();
+    qm.sendOk("成为 70 级以上战神后，前往德烈处领取#b#t1142131##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
-    if (qm.canHold(1142131) && !qm.haveItem(1142131, 1) && qm.getPlayer().getLevel() >= 70 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142131, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    var player = qm.getPlayer();
+    if (player.getLevel() < 70 || ((player.getJob().getId() / 100) | 0) != 21) {
+        qm.sendOk("领取这枚勋章需要成为 #b70 级以上战神#k。");
+        qm.dispose();
+        return;
+    }
+    awardMedal();
+}
+
+function awardMedal() {
+    if (!qm.haveItem(MEDAL_ID)) {
+        if (!qm.canHold(MEDAL_ID)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(MEDAL_ID, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("痛苦与迷惘曾不断考验你，却没能让你停下脚步。真正的英雄并非没有伤痕，而是在伤痕之中依然选择前进。\r\n\r\n请收下#b#t1142131##k。它会证明你的意志从未被击垮。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29927.js
+++ b/gms-server/scripts-zh-CN/quest/29927.js
@@ -1,19 +1,54 @@
-var status = -1;
+var MEDAL_ID = 1142132;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(MEDAL_ID, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
 
 function start(mode, type, selection) {
-    if (qm.canHold(1142132) && !qm.haveItem(1142132, 1) && qm.getPlayer().getLevel() >= 120 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142132, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    qm.forceStartQuest();
+    qm.sendOk("成为 120 级以上战神后，前往德烈处领取#b#t1142132##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
-    if (qm.canHold(1142132) && !qm.haveItem(1142132, 1) && qm.getPlayer().getLevel() >= 120 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142132, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    var player = qm.getPlayer();
+    if (player.getLevel() < 120 || ((player.getJob().getId() / 100) | 0) != 21) {
+        qm.sendOk("领取这枚勋章需要成为 #b120 级以上战神#k。");
+        qm.dispose();
+        return;
+    }
+    awardMedal();
+}
+
+function awardMedal() {
+    if (!qm.haveItem(MEDAL_ID)) {
+        if (!qm.canHold(MEDAL_ID)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(MEDAL_ID, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("希望已经在愤怒与混乱散去的地方重新生长。那个为了守护他人而战的英雄，终于又一次挺直了身影。\r\n\r\n请收下#b#t1142132##k。愿它承载你重新点燃的希望。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29928.js
+++ b/gms-server/scripts-zh-CN/quest/29928.js
@@ -1,19 +1,54 @@
-var status = -1;
+var MEDAL_ID = 1142133;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(MEDAL_ID, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
 
 function start(mode, type, selection) {
-    if (qm.canHold(1142133) && !qm.haveItem(1142133, 1) && qm.getPlayer().getLevel() >= 200 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142133, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    qm.forceStartQuest();
+    qm.sendOk("成为 200 级战神后，前往德烈处领取#b#t1142133##k。");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
-    if (qm.canHold(1142133) && !qm.haveItem(1142133, 1) && qm.getPlayer().getLevel() >= 200 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142133, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    var player = qm.getPlayer();
+    if (player.getLevel() < 200 || ((player.getJob().getId() / 100) | 0) != 21) {
+        qm.sendOk("领取这枚勋章需要成为 #b200 级以上战神#k。");
+        qm.dispose();
+        return;
+    }
+    awardMedal();
+}
+
+function awardMedal() {
+    if (!qm.haveItem(MEDAL_ID)) {
+        if (!qm.canHold(MEDAL_ID)) {
+            qm.sendOk("请在装备栏空出 1 个位置。");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(MEDAL_ID, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("失去的力量、记忆与名字，都已经回到你的身边。战神的传说不再沉睡于冰雪之下，而是由你亲手续写。\r\n\r\n请收下#b#t1142133##k。这份荣耀，属于归来的英雄。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29929.js
+++ b/gms-server/scripts-zh-CN/quest/29929.js
@@ -1,15 +1,15 @@
-var MEDAL_ID = 1142132;
+var MEDAL_ID = 1140001;
 
 function finishIfAlreadyAwarded() {
     if (qm.isQuestCompleted(qm.getQuest())) {
-        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
         qm.dispose();
         return true;
     }
     if (qm.haveItemWithId(MEDAL_ID, true)) {
         qm.forceCompleteQuest();
         qm.earnTitle(qm.getMedalName());
-        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
         qm.dispose();
         return true;
     }
@@ -21,7 +21,7 @@ function start(mode, type, selection) {
         return;
     }
     qm.forceStartQuest();
-    qm.sendOk("Reach level 120 as an Aran, then speak with Dalair to receive #b#t1142132##k.");
+    qm.sendOk("男性角色达到 13 级后，前往德烈处领取#b#t1140001##k。");
     qm.dispose();
 }
 
@@ -30,8 +30,8 @@ function end(mode, type, selection) {
         return;
     }
     var player = qm.getPlayer();
-    if (player.getLevel() < 120 || ((player.getJob().getId() / 100) | 0) != 21) {
-        qm.sendOk("You must be a level 120 or higher Aran to receive this medal.");
+    if (player.getLevel() < 13 || player.getGender() != 0) {
+        qm.sendOk("领取这枚勋章需要男性角色达到 #b13 级以上#k。");
         qm.dispose();
         return;
     }
@@ -41,7 +41,7 @@ function end(mode, type, selection) {
 function awardMedal() {
     if (!qm.haveItem(MEDAL_ID)) {
         if (!qm.canHold(MEDAL_ID)) {
-            qm.sendOk("Please make 1 empty slot in your Equip inventory.");
+            qm.sendOk("请在装备栏空出 1 个位置。");
             qm.dispose();
             return;
         }
@@ -49,6 +49,6 @@ function awardMedal() {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
-    qm.sendOk("Hope has taken root where rage and confusion once stood. The hero who protects others has begun to stand tall again.\r\n\r\nPlease accept #b#t1142132##k. Let it carry the hope you have restored.");
+    qm.sendOk("冬天会把道路变得寒冷，却无法冻结继续前进的心。你用坚持为这个季节点亮了王者的光芒。\r\n\r\n请收下#b#t1140001##k。愿你的名字像雪光一样，在冬日里被人记住。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29930.js
+++ b/gms-server/scripts-zh-CN/quest/29930.js
@@ -1,15 +1,15 @@
-var MEDAL_ID = 1142132;
+var MEDAL_ID = 1141001;
 
 function finishIfAlreadyAwarded() {
     if (qm.isQuestCompleted(qm.getQuest())) {
-        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
         qm.dispose();
         return true;
     }
     if (qm.haveItemWithId(MEDAL_ID, true)) {
         qm.forceCompleteQuest();
         qm.earnTitle(qm.getMedalName());
-        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
         qm.dispose();
         return true;
     }
@@ -21,7 +21,7 @@ function start(mode, type, selection) {
         return;
     }
     qm.forceStartQuest();
-    qm.sendOk("Reach level 120 as an Aran, then speak with Dalair to receive #b#t1142132##k.");
+    qm.sendOk("女性角色达到 13 级后，前往德烈处领取#b#t1141001##k。");
     qm.dispose();
 }
 
@@ -30,8 +30,8 @@ function end(mode, type, selection) {
         return;
     }
     var player = qm.getPlayer();
-    if (player.getLevel() < 120 || ((player.getJob().getId() / 100) | 0) != 21) {
-        qm.sendOk("You must be a level 120 or higher Aran to receive this medal.");
+    if (player.getLevel() < 13 || player.getGender() != 1) {
+        qm.sendOk("领取这枚勋章需要女性角色达到 #b13 级以上#k。");
         qm.dispose();
         return;
     }
@@ -41,7 +41,7 @@ function end(mode, type, selection) {
 function awardMedal() {
     if (!qm.haveItem(MEDAL_ID)) {
         if (!qm.canHold(MEDAL_ID)) {
-            qm.sendOk("Please make 1 empty slot in your Equip inventory.");
+            qm.sendOk("请在装备栏空出 1 个位置。");
             qm.dispose();
             return;
         }
@@ -49,6 +49,6 @@ function awardMedal() {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
-    qm.sendOk("Hope has taken root where rage and confusion once stood. The hero who protects others has begun to stand tall again.\r\n\r\nPlease accept #b#t1142132##k. Let it carry the hope you have restored.");
+    qm.sendOk("冬天会考验每一位冒险家的脚步，而你的优雅与坚韧没有被寒风夺走半分。这个季节，理应为你加冕。\r\n\r\n请收下#b#t1141001##k。愿你的名字如冬雪般明亮。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29931.js
+++ b/gms-server/scripts-zh-CN/quest/29931.js
@@ -1,15 +1,15 @@
-var MEDAL_ID = 1142132;
+var MEDAL_ID = 1142141;
 
 function finishIfAlreadyAwarded() {
     if (qm.isQuestCompleted(qm.getQuest())) {
-        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
         qm.dispose();
         return true;
     }
     if (qm.haveItemWithId(MEDAL_ID, true)) {
         qm.forceCompleteQuest();
         qm.earnTitle(qm.getMedalName());
-        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
         qm.dispose();
         return true;
     }
@@ -21,7 +21,7 @@ function start(mode, type, selection) {
         return;
     }
     qm.forceStartQuest();
-    qm.sendOk("Reach level 120 as an Aran, then speak with Dalair to receive #b#t1142132##k.");
+    qm.sendOk("在废弃地铁月台消灭 10,000 只怪物后，前往林车长或德烈处领取#b#t1142141##k。");
     qm.dispose();
 }
 
@@ -30,8 +30,9 @@ function end(mode, type, selection) {
         return;
     }
     var player = qm.getPlayer();
-    if (player.getLevel() < 120 || ((player.getJob().getId() / 100) | 0) != 21) {
-        qm.sendOk("You must be a level 120 or higher Aran to receive this medal.");
+    var count = qm.getQuestProgressInt(29931, 7662);
+    if (count < 10000) {
+        qm.sendOk("请继续在废弃地铁月台消灭怪物。\r\n当前进度：#r" + count + "#k / 10000");
         qm.dispose();
         return;
     }
@@ -41,7 +42,7 @@ function end(mode, type, selection) {
 function awardMedal() {
     if (!qm.haveItem(MEDAL_ID)) {
         if (!qm.canHold(MEDAL_ID)) {
-            qm.sendOk("Please make 1 empty slot in your Equip inventory.");
+            qm.sendOk("请在装备栏空出 1 个位置。");
             qm.dispose();
             return;
         }
@@ -49,6 +50,6 @@ function awardMedal() {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
-    qm.sendOk("Hope has taken root where rage and confusion once stood. The hero who protects others has begun to stand tall again.\r\n\r\nPlease accept #b#t1142132##k. Let it carry the hope you have restored.");
+    qm.sendOk("废弃月台因为你的坚持而重新看见了安全的希望。你击退的不只是怪物，也是笼罩在地铁线路上的阴影。\r\n\r\n请收下#b#t1142141##k。废都的轨道，会记住你的付出。");
     qm.dispose();
 }

--- a/gms-server/scripts-zh-CN/quest/29932.js
+++ b/gms-server/scripts-zh-CN/quest/29932.js
@@ -1,15 +1,15 @@
-var MEDAL_ID = 1142132;
+var MEDAL_ID = 1142142;
 
 function finishIfAlreadyAwarded() {
     if (qm.isQuestCompleted(qm.getQuest())) {
-        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
         qm.dispose();
         return true;
     }
     if (qm.haveItemWithId(MEDAL_ID, true)) {
         qm.forceCompleteQuest();
         qm.earnTitle(qm.getMedalName());
-        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.sendOk("你已经获得过#b#t" + MEDAL_ID + "##k，这项挑战已经记录在你的冒险履历里了。");
         qm.dispose();
         return true;
     }
@@ -21,7 +21,7 @@ function start(mode, type, selection) {
         return;
     }
     qm.forceStartQuest();
-    qm.sendOk("Reach level 120 as an Aran, then speak with Dalair to receive #b#t1142132##k.");
+    qm.sendOk("在奈特的金字塔中消灭 50,000 只怪物后，前往杜阿特或德烈处领取#b#t1142142##k。");
     qm.dispose();
 }
 
@@ -30,8 +30,9 @@ function end(mode, type, selection) {
         return;
     }
     var player = qm.getPlayer();
-    if (player.getLevel() < 120 || ((player.getJob().getId() / 100) | 0) != 21) {
-        qm.sendOk("You must be a level 120 or higher Aran to receive this medal.");
+    var count = qm.getQuestProgressInt(29932, 7760);
+    if (count < 50000) {
+        qm.sendOk("请继续在奈特的金字塔中消灭怪物。\r\n当前进度：#r" + count + "#k / 50000");
         qm.dispose();
         return;
     }
@@ -41,7 +42,7 @@ function end(mode, type, selection) {
 function awardMedal() {
     if (!qm.haveItem(MEDAL_ID)) {
         if (!qm.canHold(MEDAL_ID)) {
-            qm.sendOk("Please make 1 empty slot in your Equip inventory.");
+            qm.sendOk("请在装备栏空出 1 个位置。");
             qm.dispose();
             return;
         }
@@ -49,6 +50,6 @@ function awardMedal() {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
-    qm.sendOk("Hope has taken root where rage and confusion once stood. The hero who protects others has begun to stand tall again.\r\n\r\nPlease accept #b#t1142132##k. Let it carry the hope you have restored.");
+    qm.sendOk("古老金字塔的寂静，由你的力量重新守护。无数怪物倒下，而你的信念始终没有退后一步。\r\n\r\n请收下#b#t1142142##k。从现在起，法老守护者的称号属于你。");
     qm.dispose();
 }

--- a/gms-server/scripts/npc/1052115.js
+++ b/gms-server/scripts/npc/1052115.js
@@ -1,7 +1,7 @@
 var status = 0;
 var section = 0;
 
-//questid 29931, infoquest 7662
+// questid 29931, infoquest 7662
 
 function start() {
     action(1, 0, 0);
@@ -30,25 +30,24 @@ function action(mode, type, selection) {
             cm.sendYesNo("Would you like to exit this place?");
             status = 99;
         } else {
-            cm.sendSimple("My name is Mr.Lim.\r\n#b#e#L1#Enter the Dusty Platform.#l#n\r\n#L2#Head towards Train 999.#l\r\n#L3#Receive a medal of <Honorary Employee>.#l#k");
+            cm.sendSimple("My name is Mr. Lim.\r\n#b#e#L1#Enter the Dusty Platform.#l#n\r\n#L2#Head towards Train 999.#l\r\n#L3#Ask about the <Honorary Subway Worker> medal.#l#k");
         }
     } else if (status == 2) {
         section = selection;
         if (selection == 1) {
             if (cm.getPlayer().getLevel() < 25 || cm.getPlayer().getLevel() > 30 || !cm.isLeader()) {
-                cm.sendOk("You must be in the Level Range 25-30 and be the party leader.");
+                cm.sendOk("You must be in the level range 25-30 and be the party leader.");
             } else {
                 if (!cm.start_PyramidSubway(-1)) {
-                    cm.sendOk("The Dusty Platform is currently full at the moment.");
+                    cm.sendOk("The Dusty Platform is currently full.");
                 }
             }
-            //todo
         } else if (selection == 2) {
             if (cm.haveItem(4001321)) {
                 if (cm.bonus_PyramidSubway(-1)) {
                     cm.gainItem(4001321, -1);
                 } else {
-                    cm.sendOk("The Train 999 is currently full at the moment");
+                    cm.sendOk("Train 999 is currently full.");
                 }
             } else {
                 cm.sendOk("You do not have the Boarding Pass.");
@@ -62,13 +61,9 @@ function action(mode, type, selection) {
             }
             var mons = parseInt(data);
             if (mons < 10000) {
-                cm.sendOk("Please defeat at least 10,000 monsters in the Station and look for me again. Kills : " + mons);
-            } else if (cm.canHold(1142141) && !cm.haveItem(1142141)) {
-                cm.gainItem(1142141, 1);
-                cm.startQuest(29931);
-                cm.completeQuest(29931);
+                cm.sendOk("Please defeat at least 10,000 monsters on the platform and look for me again.\r\nKills: #r" + mons + "#k / 10000");
             } else {
-                cm.sendOk("Please make room.");
+                cm.sendOk("You have done enough to be recognized as an Honorary Subway Worker. Speak with Dalair to receive the medal.");
             }
         }
         cm.dispose();

--- a/gms-server/scripts/quest/29924.js
+++ b/gms-server/scripts/quest/29924.js
@@ -1,45 +1,54 @@
-var status = -1;
+var MEDAL_ID = 1142129;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(MEDAL_ID, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
 
 function start(mode, type, selection) {
-    if (qm.getPlayer().getLevel() >= 10 && ((qm.getPlayer().getJob().getId() / 100) | 0) == 21) {
-        if (!qm.haveItem(1142129)) {
-            if (qm.canHold(1142129)) {
-                qm.gainItem(1142129, 1);
-            } else {
-                qm.dispose();
-                return;
-            }
-        }
-
-        var medalname = qm.getMedalName();
-        qm.message("<" + medalname + "> has been awarded.");
-        qm.earnTitle("<" + medalname + "> has been awarded.");
-
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
-
+    qm.forceStartQuest();
+    qm.sendOk("Reach level 10 as an Aran, then speak with Dalair to receive #b#t1142129##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
-    if (qm.getPlayer().getLevel() >= 10 && ((qm.getPlayer().getJob().getId() / 100) | 0) == 21) {
-        if (!qm.haveItem(1142129)) {
-            if (qm.canHold(1142129)) {
-                qm.gainItem(1142129, 1);
-            } else {
-                qm.dispose();
-                return;
-            }
-        }
-
-        var medalname = qm.getMedalName();
-        qm.message("<" + medalname + "> has been awarded.");
-        qm.earnTitle("<" + medalname + "> has been awarded.");
-
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    var player = qm.getPlayer();
+    if (player.getLevel() < 10 || ((player.getJob().getId() / 100) | 0) != 21) {
+        qm.sendOk("You must be a level 10 or higher Aran to receive this medal.");
+        qm.dispose();
+        return;
+    }
+    awardMedal();
+}
 
+function awardMedal() {
+    if (!qm.haveItem(MEDAL_ID)) {
+        if (!qm.canHold(MEDAL_ID)) {
+            qm.sendOk("Please make 1 empty slot in your Equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(MEDAL_ID, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("The ice that sealed you has finally begun to melt. Even without all of your memories, your courage has already answered for who you are.\r\n\r\nPlease accept #b#t1142129##k. This medal marks the first step of the hero who has awakened again.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29925.js
+++ b/gms-server/scripts/quest/29925.js
@@ -1,19 +1,54 @@
-var status = -1;
+var MEDAL_ID = 1142130;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(MEDAL_ID, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
 
 function start(mode, type, selection) {
-    if (qm.canHold(1142130) && !qm.haveItem(1142130, 1) && qm.getPlayer().getLevel() >= 30 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142130, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    qm.forceStartQuest();
+    qm.sendOk("Reach level 30 as an Aran, then speak with Dalair to receive #b#t1142130##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
-    if (qm.canHold(1142130) && !qm.haveItem(1142130, 1) && qm.getPlayer().getLevel() >= 30 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142130, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    var player = qm.getPlayer();
+    if (player.getLevel() < 30 || ((player.getJob().getId() / 100) | 0) != 21) {
+        qm.sendOk("You must be a level 30 or higher Aran to receive this medal.");
+        qm.dispose();
+        return;
+    }
+    awardMedal();
+}
+
+function awardMedal() {
+    if (!qm.haveItem(MEDAL_ID)) {
+        if (!qm.canHold(MEDAL_ID)) {
+            qm.sendOk("Please make 1 empty slot in your Equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(MEDAL_ID, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("Fragments of memory are returning one by one, like sparks gathering in the snow. Your bond with Maha and your past is no longer only a distant dream.\r\n\r\nPlease accept #b#t1142130##k. May it shine beside the memories you have reclaimed.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29926.js
+++ b/gms-server/scripts/quest/29926.js
@@ -1,19 +1,54 @@
-var status = -1;
+var MEDAL_ID = 1142131;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(MEDAL_ID, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
 
 function start(mode, type, selection) {
-    if (qm.canHold(1142131) && !qm.haveItem(1142131, 1) && qm.getPlayer().getLevel() >= 70 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142131, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    qm.forceStartQuest();
+    qm.sendOk("Reach level 70 as an Aran, then speak with Dalair to receive #b#t1142131##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
-    if (qm.canHold(1142131) && !qm.haveItem(1142131, 1) && qm.getPlayer().getLevel() >= 70 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142131, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    var player = qm.getPlayer();
+    if (player.getLevel() < 70 || ((player.getJob().getId() / 100) | 0) != 21) {
+        qm.sendOk("You must be a level 70 or higher Aran to receive this medal.");
+        qm.dispose();
+        return;
+    }
+    awardMedal();
+}
+
+function awardMedal() {
+    if (!qm.haveItem(MEDAL_ID)) {
+        if (!qm.canHold(MEDAL_ID)) {
+            qm.sendOk("Please make 1 empty slot in your Equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(MEDAL_ID, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("Pain and doubt have tested you, but they could not stop your steps. A true hero is not one without agony, but one who rises through it.\r\n\r\nPlease accept #b#t1142131##k. It is proof that your will did not break.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29928.js
+++ b/gms-server/scripts/quest/29928.js
@@ -1,19 +1,54 @@
-var status = -1;
+var MEDAL_ID = 1142133;
+
+function finishIfAlreadyAwarded() {
+    if (qm.isQuestCompleted(qm.getQuest())) {
+        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.dispose();
+        return true;
+    }
+    if (qm.haveItemWithId(MEDAL_ID, true)) {
+        qm.forceCompleteQuest();
+        qm.earnTitle(qm.getMedalName());
+        qm.sendOk("You have already received #b#t" + MEDAL_ID + "##k, and this achievement is already recorded in your journey.");
+        qm.dispose();
+        return true;
+    }
+    return false;
+}
 
 function start(mode, type, selection) {
-    if (qm.canHold(1142133) && !qm.haveItem(1142133, 1) && qm.getPlayer().getLevel() >= 200 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142133, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    qm.forceStartQuest();
+    qm.sendOk("Reach level 200 as an Aran, then speak with Dalair to receive #b#t1142133##k.");
     qm.dispose();
 }
 
 function end(mode, type, selection) {
-    if (qm.canHold(1142133) && !qm.haveItem(1142133, 1) && qm.getPlayer().getLevel() >= 200 && ((qm.getPlayer().getJob() / 100) | 0) == 21) {
-        qm.gainItem(1142133, 1);
-        qm.forceStartQuest();
-        qm.forceCompleteQuest();
+    if (finishIfAlreadyAwarded()) {
+        return;
     }
+    var player = qm.getPlayer();
+    if (player.getLevel() < 200 || ((player.getJob().getId() / 100) | 0) != 21) {
+        qm.sendOk("You must be a level 200 or higher Aran to receive this medal.");
+        qm.dispose();
+        return;
+    }
+    awardMedal();
+}
+
+function awardMedal() {
+    if (!qm.haveItem(MEDAL_ID)) {
+        if (!qm.canHold(MEDAL_ID)) {
+            qm.sendOk("Please make 1 empty slot in your Equip inventory.");
+            qm.dispose();
+            return;
+        }
+        qm.gainItem(MEDAL_ID, 1);
+    }
+    qm.forceCompleteQuest();
+    qm.earnTitle(qm.getMedalName());
+    qm.sendOk("Your lost power, your memories, and your name have all found their way back to you. The legend of Aran is no longer a story buried in ice.\r\n\r\nPlease accept #b#t1142133##k. This honor belongs to the hero who returned.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29929.js
+++ b/gms-server/scripts/quest/29929.js
@@ -1,4 +1,4 @@
-var MEDAL_ID = 1142132;
+var MEDAL_ID = 1140001;
 
 function finishIfAlreadyAwarded() {
     if (qm.isQuestCompleted(qm.getQuest())) {
@@ -21,7 +21,7 @@ function start(mode, type, selection) {
         return;
     }
     qm.forceStartQuest();
-    qm.sendOk("Reach level 120 as an Aran, then speak with Dalair to receive #b#t1142132##k.");
+    qm.sendOk("Reach level 13 with a male character, then speak with Dalair to receive #b#t1140001##k.");
     qm.dispose();
 }
 
@@ -30,8 +30,8 @@ function end(mode, type, selection) {
         return;
     }
     var player = qm.getPlayer();
-    if (player.getLevel() < 120 || ((player.getJob().getId() / 100) | 0) != 21) {
-        qm.sendOk("You must be a level 120 or higher Aran to receive this medal.");
+    if (player.getLevel() < 13 || player.getGender() != 0) {
+        qm.sendOk("A male character of level 13 or higher is required to receive this medal.");
         qm.dispose();
         return;
     }
@@ -49,6 +49,6 @@ function awardMedal() {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
-    qm.sendOk("Hope has taken root where rage and confusion once stood. The hero who protects others has begun to stand tall again.\r\n\r\nPlease accept #b#t1142132##k. Let it carry the hope you have restored.");
+    qm.sendOk("Winter crowns those who keep moving even when the cold tries to slow every step. Your resolve has given this season a worthy king.\r\n\r\nPlease accept #b#t1140001##k. May your name be remembered with the brightness of winter snow.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29930.js
+++ b/gms-server/scripts/quest/29930.js
@@ -1,4 +1,4 @@
-var MEDAL_ID = 1142132;
+var MEDAL_ID = 1141001;
 
 function finishIfAlreadyAwarded() {
     if (qm.isQuestCompleted(qm.getQuest())) {
@@ -21,7 +21,7 @@ function start(mode, type, selection) {
         return;
     }
     qm.forceStartQuest();
-    qm.sendOk("Reach level 120 as an Aran, then speak with Dalair to receive #b#t1142132##k.");
+    qm.sendOk("Reach level 13 with a female character, then speak with Dalair to receive #b#t1141001##k.");
     qm.dispose();
 }
 
@@ -30,8 +30,8 @@ function end(mode, type, selection) {
         return;
     }
     var player = qm.getPlayer();
-    if (player.getLevel() < 120 || ((player.getJob().getId() / 100) | 0) != 21) {
-        qm.sendOk("You must be a level 120 or higher Aran to receive this medal.");
+    if (player.getLevel() < 13 || player.getGender() != 1) {
+        qm.sendOk("A female character of level 13 or higher is required to receive this medal.");
         qm.dispose();
         return;
     }
@@ -49,6 +49,6 @@ function awardMedal() {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
-    qm.sendOk("Hope has taken root where rage and confusion once stood. The hero who protects others has begun to stand tall again.\r\n\r\nPlease accept #b#t1142132##k. Let it carry the hope you have restored.");
+    qm.sendOk("Winter crowns those whose grace does not fade before the cold. Your resolve has given this season a worthy queen.\r\n\r\nPlease accept #b#t1141001##k. May your name shine as beautifully as winter snow.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29931.js
+++ b/gms-server/scripts/quest/29931.js
@@ -1,4 +1,4 @@
-var MEDAL_ID = 1142132;
+var MEDAL_ID = 1142141;
 
 function finishIfAlreadyAwarded() {
     if (qm.isQuestCompleted(qm.getQuest())) {
@@ -21,7 +21,7 @@ function start(mode, type, selection) {
         return;
     }
     qm.forceStartQuest();
-    qm.sendOk("Reach level 120 as an Aran, then speak with Dalair to receive #b#t1142132##k.");
+    qm.sendOk("Defeat 10,000 monsters on the Abandoned Subway Platform, then speak with Mr. Lim or Dalair to receive #b#t1142141##k.");
     qm.dispose();
 }
 
@@ -30,8 +30,9 @@ function end(mode, type, selection) {
         return;
     }
     var player = qm.getPlayer();
-    if (player.getLevel() < 120 || ((player.getJob().getId() / 100) | 0) != 21) {
-        qm.sendOk("You must be a level 120 or higher Aran to receive this medal.");
+    var count = qm.getQuestProgressInt(29931, 7662);
+    if (count < 10000) {
+        qm.sendOk("Please keep eliminating monsters on the Abandoned Subway Platform.\r\nProgress: #r" + count + "#k / 10000");
         qm.dispose();
         return;
     }
@@ -49,6 +50,6 @@ function awardMedal() {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
-    qm.sendOk("Hope has taken root where rage and confusion once stood. The hero who protects others has begun to stand tall again.\r\n\r\nPlease accept #b#t1142132##k. Let it carry the hope you have restored.");
+    qm.sendOk("The abandoned platform is safer because you refused to abandon it. Every monster you drove back helped the subway breathe again.\r\n\r\nPlease accept #b#t1142141##k. Kerning City's rails will remember your work.");
     qm.dispose();
 }

--- a/gms-server/scripts/quest/29932.js
+++ b/gms-server/scripts/quest/29932.js
@@ -1,4 +1,4 @@
-var MEDAL_ID = 1142132;
+var MEDAL_ID = 1142142;
 
 function finishIfAlreadyAwarded() {
     if (qm.isQuestCompleted(qm.getQuest())) {
@@ -21,7 +21,7 @@ function start(mode, type, selection) {
         return;
     }
     qm.forceStartQuest();
-    qm.sendOk("Reach level 120 as an Aran, then speak with Dalair to receive #b#t1142132##k.");
+    qm.sendOk("Defeat 50,000 monsters in Nett's Pyramid, then speak with Duarte or Dalair to receive #b#t1142142##k.");
     qm.dispose();
 }
 
@@ -30,8 +30,9 @@ function end(mode, type, selection) {
         return;
     }
     var player = qm.getPlayer();
-    if (player.getLevel() < 120 || ((player.getJob().getId() / 100) | 0) != 21) {
-        qm.sendOk("You must be a level 120 or higher Aran to receive this medal.");
+    var count = qm.getQuestProgressInt(29932, 7760);
+    if (count < 50000) {
+        qm.sendOk("Please keep eliminating monsters in Nett's Pyramid.\r\nProgress: #r" + count + "#k / 50000");
         qm.dispose();
         return;
     }
@@ -49,6 +50,6 @@ function awardMedal() {
     }
     qm.forceCompleteQuest();
     qm.earnTitle(qm.getMedalName());
-    qm.sendOk("Hope has taken root where rage and confusion once stood. The hero who protects others has begun to stand tall again.\r\n\r\nPlease accept #b#t1142132##k. Let it carry the hope you have restored.");
+    qm.sendOk("The pyramid's ancient silence was guarded by your strength. Countless monsters fell, but your resolve never did.\r\n\r\nPlease accept #b#t1142142##k. The title of Pharaoh's protector now belongs to you.");
     qm.dispose();
 }

--- a/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
@@ -36418,6 +36418,8 @@
             </imgdir>
         </imgdir>
         <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29924e"/>
         </imgdir>
     </imgdir>
     <imgdir name="29925">
@@ -36439,6 +36441,8 @@
             </imgdir>
         </imgdir>
         <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29925e"/>
         </imgdir>
     </imgdir>
     <imgdir name="29926">
@@ -36459,6 +36463,8 @@
             </imgdir>
         </imgdir>
         <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29926e"/>
         </imgdir>
     </imgdir>
     <imgdir name="29927">
@@ -36478,6 +36484,8 @@
             </imgdir>
         </imgdir>
         <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29927e"/>
         </imgdir>
     </imgdir>
     <imgdir name="29928">
@@ -36497,29 +36505,36 @@
             </imgdir>
         </imgdir>
         <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29928e"/>
         </imgdir>
     </imgdir>
     <imgdir name="29929">
         <imgdir name="0">
             <int name="npc" value="9000066"/>
-            <string name="end" value="2009090100"/>
+            <string name="startscript" value="q29929s"/>
             <int name="lvmin" value="13"/>
         </imgdir>
         <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29929e"/>
         </imgdir>
     </imgdir>
     <imgdir name="29930">
         <imgdir name="0">
             <int name="npc" value="9000066"/>
-            <string name="end" value="2009090100"/>
+            <string name="startscript" value="q29930s"/>
             <int name="lvmin" value="13"/>
         </imgdir>
         <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29930e"/>
         </imgdir>
     </imgdir>
     <imgdir name="29931">
         <imgdir name="1">
             <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29931e"/>
             <int name="infoNumber" value="7662"/>
             <imgdir name="infoex">
                 <imgdir name="0">
@@ -36530,12 +36545,14 @@
         </imgdir>
         <imgdir name="0">
             <int name="npc" value="9000066"/>
+            <string name="startscript" value="q29931s"/>
             <int name="lvmin" value="25"/>
         </imgdir>
     </imgdir>
     <imgdir name="29932">
         <imgdir name="1">
             <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29932e"/>
             <int name="infoNumber" value="7760"/>
             <imgdir name="infoex">
                 <imgdir name="0">
@@ -36546,6 +36563,7 @@
         </imgdir>
         <imgdir name="0">
             <int name="npc" value="9000066"/>
+            <string name="startscript" value="q29932s"/>
             <int name="lvmin" value="40"/>
         </imgdir>
     </imgdir>

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9962,91 +9962,95 @@
         <int name="autoAccept" value="1"/>
     </imgdir>
     <imgdir name="29924">
-        <string name="name" value="The Revived Aran"/>
+        <string name="name" value="苏醒的战神"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142129"/>
-        <string name="0" value="You still don&apos;t remember anything…"/>
-        <string name="1" value="You still don&apos;t remember anything…"/>
-        <string name="2" value="You still don&apos;t remember anything…"/>
+        <string name="0" value="你仍未完全想起过去的一切，但苏醒的英雄已经迈出了第一步。准备好后，去找德烈领取称号吧。"/>
+        <string name="1" value="成为 10 级以上战神后，前往德烈处领取称号。"/>
+        <string name="2" value="获得称号#b苏醒的战神#k。"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
     </imgdir>
     <imgdir name="29925">
-        <string name="name" value="Aran and Memory"/>
+        <string name="name" value="记忆中的战神"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142130"/>
-        <string name="0" value="Maha…was your weapon…? You&apos;re beginning to remember...little by little…"/>
-        <string name="1" value="Maha…was your weapon…? You&apos;re beginning to remember...little by little…"/>
-        <string name="2" value="Maha…was your weapon…? You&apos;re beginning to remember...little by little…"/>
+        <string name="0" value="玛哈曾是你的武器，记忆也正一点一点回到心中。准备好后，去找德烈领取称号吧。"/>
+        <string name="1" value="成为 30 级以上战神后，前往德烈处领取称号。"/>
+        <string name="2" value="获得称号#b记忆中的战神#k。"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
     </imgdir>
     <imgdir name="29926">
-        <string name="name" value="Aran in Agony"/>
+        <string name="name" value="试炼中的战神"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142131"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="0" value="You made a Red Jade for Maha. This should help him relax for a bit, right?"/>
-        <string name="1" value="You made a Red Jade for Maha. This should help him relax for a bit, right?"/>
-        <string name="2" value="You made a Red Jade for Maha. This should help him relax for a bit, right?"/>
+        <string name="0" value="你在找回昔日英雄之名的路上又经历了一次试炼。准备好后，去找德烈领取称号吧。"/>
+        <string name="1" value="成为 70 级以上战神后，前往德烈处领取称号。"/>
+        <string name="2" value="获得称号#b试炼中的战神#k。"/>
     </imgdir>
     <imgdir name="29927">
-        <string name="name" value="Aran of Hope"/>
+        <string name="name" value="希望中的战神"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142132"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="0" value="You finally managed to put the enraged Maha to sleep."/>
-        <string name="1" value="You finally managed to put the enraged Maha to sleep."/>
-        <string name="2" value="You finally managed to put the enraged Maha to sleep."/>
+        <string name="0" value="希望已经重新回到苏醒的英雄心中。准备好后，去找德烈领取称号吧。"/>
+        <string name="1" value="成为 120 级以上战神后，前往德烈处领取称号。"/>
+        <string name="2" value="获得称号#b希望中的战神#k。"/>
     </imgdir>
     <imgdir name="29928">
-        <string name="name" value="Aran the Hero"/>
+        <string name="name" value="英雄战神"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142133"/>
         <int name="autoStart" value="1"/>
         <int name="autoAccept" value="1"/>
-        <string name="0" value="You feel like you&apos;ve restored most of your past memories as well as your abilities."/>
-        <string name="1" value="You feel like you&apos;ve restored most of your past memories as well as your abilities."/>
-        <string name="2" value="You feel like you&apos;ve restored most of your past memories as well as your abilities."/>
+        <string name="0" value="你感觉自己的记忆与能力几乎都回来了。准备好后，去找德烈领取称号吧。"/>
+        <string name="1" value="成为 200 级战神后，前往德烈处领取称号。"/>
+        <string name="2" value="获得称号#b英雄战神#k。"/>
     </imgdir>
     <imgdir name="29929">
         <int name="area" value="51"/>
         <int name="medalCategory" value="3"/>
         <int name="viewMedalItem" value="1140001"/>
-        <string name="name" value="2010 Winter King"/>
-        <string name="0" value="With the chilly winter once again here, a special title has been prepared for everyone. Visit #b#p9010010##k, located in every town! \r\n#b*Note: You are only eligible for the 2010 Winter King or 2010 Winter Queen title that matches your gender."/>
-        <string name="1" value="#e#bChallenge yourself to the 2010 Winter King title#k#n\r\n* Requirements : #bAcquire at least 20 #t1140000:#s#kduring the event period\r\n* Event: #b20/1/2010 16/2/2010#k\r\n"/>
-        <string name="2" value="Acquired the title #b2010 Winter King#."/>
+        <string name="name" value="2010冬季王者"/>
+        <string name="0" value="为足够强大的男性冒险家准备的冬季称号正在等待你。去找德烈领取称号吧。"/>
+        <string name="1" value="男性角色达到 13 级后，前往德烈处领取称号。"/>
+        <string name="2" value="获得称号#b2010冬季王者#k。"/>
     </imgdir>
     <imgdir name="29930">
         <int name="area" value="51"/>
         <int name="medalCategory" value="3"/>
         <int name="viewMedalItem" value="1141001"/>
-        <string name="name" value="2010 Winter Queen"/>
-        <string name="0" value="With the chilly winter once again here, a special title has been prepared for everyone. Visit #b#p9010010##k, located in every town! \r\n#b*Note: You are only eligible for the 2010 Winter King or 2010 Winter Queen title that matches your gender."/>
-        <string name="1" value="#e#bChallenge yourself to the 2010 Winter Queen title#k#n\r\n* Requirements : #bAcquire at least 20 #t1140000:#s#kduring the event period\r\n* Event: #b20/1/2010 16/2/2010#k"/>
-        <string name="2" value="Acquired the title #b2010 Winter Queen#."/>
+        <string name="name" value="2010冬季女王"/>
+        <string name="0" value="为足够强大的女性冒险家准备的冬季称号正在等待你。去找德烈领取称号吧。"/>
+        <string name="1" value="女性角色达到 13 级后，前往德烈处领取称号。"/>
+        <string name="2" value="获得称号#b2010冬季女王#k。"/>
     </imgdir>
     <imgdir name="29931">
-        <string name="name" value="Honorary Subway Worker"/>
+        <string name="name" value="荣誉乘务员"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142141"/>
-        <string name="0" value="The subway lines in the northern part of Kerning City is about to shut down construction because of monsters. Rescue #e#bMr. Lim#k#n from the abandoned subway station and acquire the title #b&lt;Honorary Subway Worker&gt;#k."/>
-        <string name="2" value="Acquired the title #bHonorary Subway Worker#k."/>
-        <string name="1" value="#e#bHonorary Subway Worker title#k#n\r\n* Requirements: Eliminate at least #b10,000 monsters#k on the Abandoned Subway Platform\r\n* Current count: #b#R7762##k\r\nAfter completing the requirements, see #bMr. Lim#k to receive your medal.\r\n"/>
+        <string name="0" value="废弃地铁月台需要勇敢的协助者。击退威胁铁路的怪物，领取属于你的称号吧。"/>
+        <string name="2" value="获得称号#b荣誉乘务员#k。"/>
+        <string name="1" value="在废弃地铁月台消灭至少 #b10,000 只怪物#k。
+当前数量：#b#R7762##k
+完成条件后，前往德烈处领取勋章。"/>
     </imgdir>
     <imgdir name="29932">
-        <string name="name" value="Protector of Pharaoh"/>
+        <string name="name" value="法老守护者"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="1"/>
         <int name="viewMedalItem" value="1142142"/>
-        <string name="0" value="Visit the mysterious pyramid in Ariant. You may be able to acquire the #b&lt;Protector of Pharaoh&gt;#k title."/>
-        <string name="2" value="Acquired the #bProtector of Pharaoh#k title."/>
-        <string name="1" value="#e#bChallenge yourself to earn the Protector of Pharaoh title!#k#n\r\n* Requirements: Eliminate #b50,000 monsters#k in Nett&apos;s Pyramid \r\n* Current Count: #b#R7760##k\r\nAfter completing the requirements, see #bDuarte#k to receive your medal.\r\n"/>
+        <string name="0" value="阿里安特神秘的金字塔需要坚定的守护者。击退其中的怪物，领取属于你的称号吧。"/>
+        <string name="2" value="获得称号#b法老守护者#k。"/>
+        <string name="1" value="在奈特的金字塔中消灭 #b50,000 只怪物#k。
+当前数量：#b#R7760##k
+完成条件后，前往德烈处领取勋章。"/>
     </imgdir>
     <imgdir name="29933">
         <string name="name" value="明珠港爱心使者"/>

--- a/gms-server/wz-zh-CN/String.wz/Eqp.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Eqp.img.xml
@@ -1090,19 +1090,19 @@
                 <string name="name" value="特级考古学家腰带" />
             </imgdir>
             <imgdir name="1140000">
-                <string name="name" value="2010暑假国王勋章" />
+                <string name="name" value="2010冬季王者勋章" />
             </imgdir>
             <imgdir name="1140001">
-                <string name="name" value="2010暑假冒险家勋章" />
+                <string name="name" value="2010冬季王者勋章" />
             </imgdir>
             <imgdir name="1140002">
                 <string name="name" value="2010暑假冒险家勋章" />
             </imgdir>
             <imgdir name="1141000">
-                <string name="name" value="2010暑假女皇勋章" />
+                <string name="name" value="2010冬季女王勋章" />
             </imgdir>
             <imgdir name="1141001">
-                <string name="name" value="2010暑假冒险家勋章" />
+                <string name="name" value="2010冬季女王勋章" />
             </imgdir>
             <imgdir name="1141002">
                 <string name="name" value="2010暑假冒险家勋章" />

--- a/gms-server/wz-zh-CN/String.wz/Npc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Npc.img.xml
@@ -5632,12 +5632,12 @@
         <string name="n1" value="다른 요원들은 어딜 갔지?"/>
     </imgdir>
     <imgdir name="9000066">
-        <string name="name" value="勋章老人"/>
+        <string name="name" value="德烈"/>
         <string name="d0" value="由我来判定你是否有足够的爱心吧."/>
         <string name="d1" value="并不是所有的人都可以获得爱心使者勋章的."/>
         <string name="func" value="爱心神官"/>
         <string name="n0" value="我负责整个冒险岛大陆的公共设施的建设,你有没有听说过各个村庄的爱心使者?"/>
-        <string name="n1" value="我的本名是达里奥,但人们都叫我勋章老人.我巡游各个村庄只想找个爱心使者能贡献与冒险岛的建设."/>
+        <string name="n1" value="我的名字是德烈. 我巡游各个村庄, 只想寻找能为冒险岛建设作出贡献的爱心使者."/>
         <string name="s0" value="我负责选拔可以获得名誉的勇士。"/>
         <string name="s1" value="我负责选拔可以获得名誉的勇士。"/>
     </imgdir>

--- a/gms-server/wz/Quest.wz/Check.img.xml
+++ b/gms-server/wz/Quest.wz/Check.img.xml
@@ -36507,6 +36507,8 @@
       </imgdir>
     </imgdir>
     <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29924e"/>
     </imgdir>
   </imgdir>
   <imgdir name="29925">
@@ -36528,6 +36530,8 @@
       </imgdir>
     </imgdir>
     <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29925e"/>
     </imgdir>
   </imgdir>
   <imgdir name="29926">
@@ -36548,6 +36552,8 @@
       </imgdir>
     </imgdir>
     <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29926e"/>
     </imgdir>
   </imgdir>
   <imgdir name="29927">
@@ -36567,6 +36573,8 @@
       </imgdir>
     </imgdir>
     <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29927e"/>
     </imgdir>
   </imgdir>
   <imgdir name="29928">
@@ -36586,32 +36594,40 @@
       </imgdir>
     </imgdir>
     <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29928e"/>
     </imgdir>
   </imgdir>
   <imgdir name="29929">
     <imgdir name="0">
       <int name="npc" value="9000066"/>
-      <string name="end" value="2009090100"/>
+            <string name="startscript" value="q29929s"/>
       <int name="lvmin" value="13"/>
     </imgdir>
     <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29929e"/>
     </imgdir>
   </imgdir>
   <imgdir name="29930">
     <imgdir name="0">
       <int name="npc" value="9000066"/>
-      <string name="end" value="2009090100"/>
+            <string name="startscript" value="q29930s"/>
       <int name="lvmin" value="13"/>
     </imgdir>
     <imgdir name="1">
+            <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29930e"/>
     </imgdir>
   </imgdir>
   <imgdir name="29931">
     <imgdir name="1">
       <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29931e"/>
       <int name="infoNumber" value="7662"/>
       <imgdir name="infoex">
         <imgdir name="0">
+            <string name="startscript" value="q29931s"/>
           <string name="value" value="10000"/>
           <int name="cond" value="1"/>
         </imgdir>
@@ -36625,9 +36641,11 @@
   <imgdir name="29932">
     <imgdir name="1">
       <int name="npc" value="9000066"/>
+            <string name="endscript" value="q29932e"/>
       <int name="infoNumber" value="7760"/>
       <imgdir name="infoex">
         <imgdir name="0">
+            <string name="startscript" value="q29932s"/>
           <string name="value" value="50000"/>
           <int name="cond" value="1"/>
         </imgdir>

--- a/gms-server/wz/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz/Quest.wz/QuestInfo.img.xml
@@ -10950,9 +10950,9 @@ Able to proceed to &apos;For the peace of Victoria Island...&apos; as next quest
     <string name="name" value="The Revived Aran"/>
     <int name="area" value="51"/>
     <int name="viewMedalItem" value="1142129"/>
-    <string name="0" value="You still don&apos;t remember anything…"/>
-    <string name="1" value="You still don&apos;t remember anything…"/>
-    <string name="2" value="You still don&apos;t remember anything…"/>
+    <string name="0" value="You still do not remember everything, but the first sign of the awakened hero has returned. Speak with Dalair when you are ready to receive the title."/>
+    <string name="1" value="Reach level 10 as an Aran, then speak with Dalair to receive the title."/>
+    <string name="2" value="Received the title #bThe Revived Aran#k."/>
     <int name="autoStart" value="1"/>
     <int name="autoAccept" value="1"/>
   </imgdir>
@@ -10961,9 +10961,9 @@ Able to proceed to &apos;For the peace of Victoria Island...&apos; as next quest
     <int name="area" value="51"/>
     <int name="medalCategory" value="1"/>
     <int name="viewMedalItem" value="1142130"/>
-    <string name="0" value="Maha…was your weapon…? You&apos;re beginning to remember...little by little…"/>
-    <string name="1" value="Maha…was your weapon…? You&apos;re beginning to remember...little by little…"/>
-    <string name="2" value="Maha…was your weapon…? You&apos;re beginning to remember...little by little…"/>
+    <string name="0" value="Maha was your weapon, and the memories are returning little by little. Speak with Dalair when you are ready to receive the title."/>
+    <string name="1" value="Reach level 30 as an Aran, then speak with Dalair to receive the title."/>
+    <string name="2" value="Received the title #bAran and Memory#k."/>
     <int name="autoStart" value="1"/>
     <int name="autoAccept" value="1"/>
   </imgdir>
@@ -10973,9 +10973,9 @@ Able to proceed to &apos;For the peace of Victoria Island...&apos; as next quest
     <int name="viewMedalItem" value="1142131"/>
     <int name="autoStart" value="1"/>
     <int name="autoAccept" value="1"/>
-    <string name="0" value="You made a Red Jade for Maha. This should help him relax for a bit, right?"/>
-    <string name="1" value="You made a Red Jade for Maha. This should help him relax for a bit, right?"/>
-    <string name="2" value="You made a Red Jade for Maha. This should help him relax for a bit, right?"/>
+    <string name="0" value="You have endured another trial on the path to reclaiming the hero you once were. Speak with Dalair when you are ready to receive the title."/>
+    <string name="1" value="Reach level 70 as an Aran, then speak with Dalair to receive the title."/>
+    <string name="2" value="Received the title #bAran in Agony#k."/>
   </imgdir>
   <imgdir name="29927">
     <string name="name" value="Aran of Hope"/>
@@ -10983,9 +10983,9 @@ Able to proceed to &apos;For the peace of Victoria Island...&apos; as next quest
     <int name="viewMedalItem" value="1142132"/>
     <int name="autoStart" value="1"/>
     <int name="autoAccept" value="1"/>
-    <string name="0" value="You finally managed to put the enraged Maha to sleep."/>
-    <string name="1" value="You finally managed to put the enraged Maha to sleep."/>
-    <string name="2" value="You finally managed to put the enraged Maha to sleep."/>
+    <string name="0" value="Hope has returned to the heart of the awakened hero. Speak with Dalair when you are ready to receive the title."/>
+    <string name="1" value="Reach level 120 as an Aran, then speak with Dalair to receive the title."/>
+    <string name="2" value="Received the title #bAran of Hope#k."/>
   </imgdir>
   <imgdir name="29928">
     <string name="name" value="Aran the Hero"/>
@@ -10993,45 +10993,49 @@ Able to proceed to &apos;For the peace of Victoria Island...&apos; as next quest
     <int name="viewMedalItem" value="1142133"/>
     <int name="autoStart" value="1"/>
     <int name="autoAccept" value="1"/>
-    <string name="0" value="You feel like you&apos;ve restored most of your past memories as well as your abilities."/>
-    <string name="1" value="You feel like you&apos;ve restored most of your past memories as well as your abilities."/>
-    <string name="2" value="You feel like you&apos;ve restored most of your past memories as well as your abilities."/>
+    <string name="0" value="You feel that your memories and abilities have nearly returned. Speak with Dalair when you are ready to receive the title."/>
+    <string name="1" value="Reach level 200 as an Aran, then speak with Dalair to receive the title."/>
+    <string name="2" value="Received the title #bAran the Hero#k."/>
   </imgdir>
   <imgdir name="29929">
     <int name="area" value="51"/>
     <int name="medalCategory" value="3"/>
     <int name="viewMedalItem" value="1140001"/>
     <string name="name" value="2010 Winter King"/>
-    <string name="0" value="With the chilly winter once again here, a special title has been prepared for everyone. Visit #b#p9010010##k, located in every town! \r\n#b*Note: You are only eligible for the 2010 Winter King or 2010 Winter Queen title that matches your gender."/>
-    <string name="1" value="#e#bChallenge yourself to the 2010 Winter King title#k#n\r\n* Requirements : #bAcquire at least 20 #t1140000:#s#kduring the event period\r\n* Event: #b20/1/2010 16/2/2010#k\r\n"/>
-    <string name="2" value="Acquired the title #b2010 Winter King#."/>
+    <string name="0" value="A winter title awaits male adventurers who have grown strong enough to wear it. Speak with Dalair to receive the title."/>
+    <string name="1" value="Reach level 13 with a male character, then speak with Dalair."/>
+    <string name="2" value="Received the title #b2010 Winter King#k."/>
   </imgdir>
   <imgdir name="29930">
     <int name="area" value="51"/>
     <int name="medalCategory" value="3"/>
     <int name="viewMedalItem" value="1141001"/>
     <string name="name" value="2010 Winter Queen"/>
-    <string name="0" value="With the chilly winter once again here, a special title has been prepared for everyone. Visit #b#p9010010##k, located in every town! \r\n#b*Note: You are only eligible for the 2010 Winter King or 2010 Winter Queen title that matches your gender."/>
-    <string name="1" value="#e#bChallenge yourself to the 2010 Winter Queen title#k#n\r\n* Requirements : #bAcquire at least 20 #t1140000:#s#kduring the event period\r\n* Event: #b20/1/2010 16/2/2010#k"/>
-    <string name="2" value="Acquired the title #b2010 Winter Queen#."/>
+    <string name="0" value="A winter title awaits female adventurers who have grown strong enough to wear it. Speak with Dalair to receive the title."/>
+    <string name="1" value="Reach level 13 with a female character, then speak with Dalair."/>
+    <string name="2" value="Received the title #b2010 Winter Queen#k."/>
   </imgdir>
   <imgdir name="29931">
     <string name="name" value="Honorary Subway Worker"/>
     <int name="area" value="51"/>
     <int name="medalCategory" value="1"/>
     <int name="viewMedalItem" value="1142141"/>
-    <string name="0" value="The subway lines in the northern part of Kerning City is about to shut down construction because of monsters. Rescue #e#bMr. Lim#k#n from the abandoned subway station and acquire the title #b&lt;Honorary Subway Worker&gt;#k."/>
-    <string name="2" value="Acquired the title #bHonorary Subway Worker#k."/>
-    <string name="1" value="#e#bHonorary Subway Worker title#k#n\r\n* Requirements: Eliminate at least #b10,000 monsters#k on the Abandoned Subway Platform\r\n* Current count: #b#R7762##k\r\nAfter completing the requirements, see #bMr. Lim#k to receive your medal.\r\n"/>
+    <string name="0" value="The abandoned subway platform needs a brave helper. Defeat the monsters threatening the railway and claim the title."/>
+    <string name="2" value="Received the title #bHonorary Subway Worker#k."/>
+    <string name="1" value="Eliminate at least #b10,000 monsters#k on the Abandoned Subway Platform.
+Current count: #b#R7762##k
+After completing the requirement, speak with Dalair to receive your medal."/>
   </imgdir>
   <imgdir name="29932">
     <string name="name" value="Protector of Pharaoh"/>
     <int name="area" value="51"/>
     <int name="medalCategory" value="1"/>
     <int name="viewMedalItem" value="1142142"/>
-    <string name="0" value="Visit the mysterious pyramid in Ariant. You may be able to acquire the #b&lt;Protector of Pharaoh&gt;#k title."/>
-    <string name="2" value="Acquired the #bProtector of Pharaoh#k title."/>
-    <string name="1" value="#e#bChallenge yourself to earn the Protector of Pharaoh title!#k#n\r\n* Requirements: Eliminate #b50,000 monsters#k in Nett&apos;s Pyramid \r\n* Current Count: #b#R7760##k\r\nAfter completing the requirements, see #bDuarte#k to receive your medal.\r\n"/>
+    <string name="0" value="The mysterious pyramid in Ariant needs a steadfast protector. Defeat the monsters within and claim the title."/>
+    <string name="2" value="Received the title #bProtector of Pharaoh#k."/>
+    <string name="1" value="Eliminate #b50,000 monsters#k in Nett&#x27;s Pyramid.
+Current count: #b#R7760##k
+After completing the requirement, speak with Dalair to receive your medal."/>
   </imgdir>
   <imgdir name="29933">
     <string name="name" value="Lith Harbor Donor"/>


### PR DESCRIPTION
改动内容
- 调整 29924-29928 战神系列勋章任务，改为在满足等级条件后与德烈对话领取 1142129-1142133，并补齐开始/完成脚本与重复领取保护。
- 新增并修正 29929-29932 勋章任务脚本，覆盖 2010冬季王者、2010冬季女王、荣誉乘务员、法老守护者，涉及德烈、林车长、废弃地铁月台、奈特的金字塔等任务交互。
- 同步更新 `scripts` 与 `scripts-zh-CN` 的对称改动，统一相关 NPC 称呼、提示文本与奖励说明，避免同一任务链中出现不一致文案。
- 修正 `Quest.wz` 与 `String.wz` 中的任务条件、任务说明、NPC 名称与勋章名称，确保任务数据与脚本行为一致。

影响范围
- 影响服务端脚本与任务数据。
- 影响客户端显示文本与任务数据，两者都需要同步。
- 需要同步客户端资源包。

验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查。
- 已执行中文乱码检查。
- 已完成本地游戏内测试通过。

客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。