### PR TITLE
fix: 统一德烈勋章与称号任务命名

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -9352,38 +9352,38 @@
         <string name="2" value="I helped Scadur in his &quot;Leather Festival&quot;, held on El Nath."/>
     </imgdir>
     <imgdir name="29000">
-        <string name="name" value="挑战勋章-组队任务狂人勋章"/>
-        <string name="0" value="#b#e挑战勋章-组队任务狂人勋章#n\n#k听说完成5个组队任务，且每个任务的成绩都达到S级，就能获得#e#b组队任务狂人勋章#k#n？勋章老人等待着那些敢于挑战名誉勋章的勇士们。"/>
-        <string name="1" value="#b#e挑战勋章-组队任务狂人勋章#n\n#k \n - 组队任务S级: #b#jscnt##k个数 / 5个 \n                              #jgaugePqS# #jperPqS# %"/>
-        <string name="2" value="#b#e挑战勋章-组队任务狂人勋章#n\n#k \n - 组队任务S级: #b#jscnt##k个数 / 5个 \n                              #jgaugePqS# #jperPqS# %\n\n已经成功完成了5个成绩为S级的组队任务！勋章老人赐予我&apos;#b组队任务狂人勋章#k&apos;。他说只有像我这样热衷于组队任务的少数冒险家才能获得这个荣誉。"/>
+        <string name="name" value="挑战 - 组队任务狂人"/>
+        <string name="0" value="#b#e挑战 - 组队任务狂人#n\n#k听说完成 5 个组队任务，且每个任务的成绩都达到 S 级，就能获得#e#b组队任务狂人勋章#k#n。勋章老人正在等待那些敢于挑战荣誉的勇士们。"/>
+        <string name="1" value="#b#e挑战 - 组队任务狂人#n\n#k \n - 组队任务S级: #b#jscnt##k个数 / 5个 \n                              #jgaugePqS# #jperPqS# %"/>
+        <string name="2" value="#b#e挑战 - 组队任务狂人#n\n#k \n - 组队任务S级: #b#jscnt##k个数 / 5个 \n                              #jgaugePqS# #jperPqS# %\n\n已经成功完成了 5 个成绩为 S 级的组队任务！勋章老人赐予我&apos;#b组队任务狂人勋章#k&apos;。他说只有像我这样热衷于组队任务的少数冒险家才能获得这个荣誉。"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142001"/>
     </imgdir>
     <imgdir name="29001">
-        <string name="name" value="挑战勋章-任务狂人勋章"/>
-        <string name="0" value="#b#e挑战勋章-任务狂人勋章#n\n#k有在活动任务以外还能完成800个任务的勇士吗？……很难说吧。勋章老人将授予取得如此伟大成就的冒险家#e#b任务狂人勋章#k#n。"/>
-        <string name="1" value="#b#e挑战勋章-任务狂人勋章#n\n\n#k - 完成任务数: #b#jcmpcnt##k / 800个(活动任务除外)\n                              #jgaugeQCnt# #jperQCnt# %"/>
-        <string name="2" value="#b#e挑战勋章-任务狂人勋章#n\n\n#k - 完成任务数: #b#jcmpcnt##k / 800个(活动任务除外)\n                              #jgaugeQCnt# #jperQCnt# %\n\n成功完成了除活动任务外的800个任务！勋章老人以名誉神官的名义赐予我&apos;#b任务狂人勋章#k&apos;。"/>
+        <string name="name" value="挑战 - 任务狂人"/>
+        <string name="0" value="#b#e挑战 - 任务狂人#n\n#k有在活动任务以外还能完成 800 个任务的勇士吗？……很难说吧。勋章老人将授予取得如此伟大成就的冒险家#e#b任务狂人勋章#k#n。"/>
+        <string name="1" value="#b#e挑战 - 任务狂人#n\n\n#k - 完成任务数: #b#jcmpcnt##k / 800个(活动任务除外)\n                              #jgaugeQCnt# #jperQCnt# %"/>
+        <string name="2" value="#b#e挑战 - 任务狂人#n\n\n#k - 完成任务数: #b#jcmpcnt##k / 800个(活动任务除外)\n                              #jgaugeQCnt# #jperQCnt# %\n\n成功完成了除活动任务外的 800 个任务！勋章老人以名誉神官的名义赐予我&apos;#b任务狂人勋章#k&apos;。"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142002"/>
     </imgdir>
     <imgdir name="29002">
-        <string name="name" value="挑战勋章-超人气王勋章!"/>
-        <string name="0" value="#b#e挑战勋章-超人气王勋章#n\n#k在限定的30天内将人气度提高1000，就能获得这个荣誉。去找勋章老人挑战#e#b超人气王勋章#n#k吧。"/>
-        <string name="1" value="#b#e挑战勋章-超人气王勋章#n\n#k - 剩余时间: #Qdaylimit#天 #Qhourlimit#小时 #Qminlimit#分\n - 人气度增加量: #b#jpopgap##k / #jpopG#\n               #jgaugePop# #jperPop# %"/>
-        <string name="2" value="#b#e挑战勋章-超人气王勋章#n\n#k - 剩余时间: #Qdaylimit#天 #Qhourlimit#小时 #Qminlimit#分\n - 人气度增加量 : #b#jpopgap##k / #jpopG#\n               #jgaugePop# #jperPop# %\n\n成功在30天内将人气度提高了1000！连勋章老人也对我刮目相看，终于从名誉神官的手中获得了&apos;#b超人气王勋章#k&apos;。呼，再来挑战&apos;#b冒险岛偶像明星勋章(特级)#k&apos;试试？"/>
+        <string name="name" value="挑战 - 超人气王"/>
+        <string name="0" value="#b#e挑战 - 超人气王#n\n#k在限定的 30 天内将人气度提高 1000，就能获得这个荣誉。去找勋章老人挑战#e#b超人气王勋章#n#k吧。"/>
+        <string name="1" value="#b#e挑战 - 超人气王#n\n#k - 剩余时间: #Qdaylimit#天 #Qhourlimit#小时 #Qminlimit#分\n - 人气度增加量: #b#jpopgap##k / #jpopG#\n               #jgaugePop# #jperPop# %"/>
+        <string name="2" value="#b#e挑战 - 超人气王#n\n#k - 剩余时间: #Qdaylimit#天 #Qhourlimit#小时 #Qminlimit#分\n - 人气度增加量 : #b#jpopgap##k / #jpopG#\n               #jgaugePop# #jperPop# %\n\n成功在 30 天内将人气度提高了 1000！连勋章老人也对我刮目相看，终于从名誉神官的手中获得了&apos;#b超人气王勋章#k&apos;。呼，再来挑战&apos;#b冒险岛偶像明星勋章(特级)#k&apos;试试？"/>
         <int name="timeLimit2" value="2592000"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142003"/>
     </imgdir>
     <imgdir name="29003">
-        <string name="name" value="挑战勋章-诚实的冒险家"/>
-        <string name="0" value="#b#e挑战勋章-诚实的冒险家#n\n#k在30天的限制时间内，如果成功地达到27天在线3小时以上，就可以获得#e#b诚实的冒险家#k#n称号。去见见名誉之神官达利尔吧。"/>
-        <string name="1" value="#b#e挑战勋章-诚实的冒险家#n\n#k - 剩余时间：#Qdaylimit#天#Qhourlimit#小时#Qminlimit#分#Qseclimit#秒\n -今天游戏时间：#Dhour#小时#Dmin#分#Dsec#秒/ #Dminhour#小时\n - 成功日/目标日：#Dcount#天/ #Ddaylimit#天\n                             #jgaugeDays#  #jperDays#%"/>
-        <string name="2" value="#b#e挑战勋章-诚实的冒险家#n\n#k - 剩余时间：#Qdaylimit#天#Qhourlimit#小时#Qminlimit#分#Qseclimit#秒\n - 今天游戏时间：#Dhour#小时#Dmin#分#Dsec#秒/ #Dminhour#小时\n - 成功日/目标日#Dcount#天/ #Ddaylimit#天\n                             #jgaugeDays#  #jperDays#%\n\n名誉之神官达利尔称赞了我，说诚实才是冒险家的首要条件，并给成功完成挑战的我颁发了”#b诚实的冒险家#k“称号。"/>
+        <string name="name" value="挑战 - 诚实的冒险家"/>
+        <string name="0" value="#b#e挑战 - 诚实的冒险家#n\n#k在 30 天的限制时间内，如果成功地达到 27 天在线 3 小时以上，就可以获得#e#b诚实的冒险家#k#n称号。去见见名誉之神官达利尔吧。"/>
+        <string name="1" value="#b#e挑战 - 诚实的冒险家#n\n#k - 剩余时间：#Qdaylimit#天#Qhourlimit#小时#Qminlimit#分#Qseclimit#秒\n -今天游戏时间：#Dhour#小时#Dmin#分#Dsec#秒/ #Dminhour#小时\n - 成功日/目标日：#Dcount#天/ #Ddaylimit#天\n                             #jgaugeDays#  #jperDays#%"/>
+        <string name="2" value="#b#e挑战 - 诚实的冒险家#n\n#k - 剩余时间：#Qdaylimit#天#Qhourlimit#小时#Qminlimit#分#Qseclimit#秒\n - 今天游戏时间：#Dhour#小时#Dmin#分#Dsec#秒/ #Dminhour#小时\n - 成功日/目标日#Dcount#天/ #Ddaylimit#天\n                             #jgaugeDays#  #jperDays#%\n\n名誉之神官达利尔称赞了我，说诚实才是冒险家的首要条件，并给成功完成挑战的我颁发了”#b诚实的冒险家#k“称号。"/>
         <int name="timeLimit2" value="2592000"/>
         <int name="dailyPlayTime" value="10800"/>
         <int name="area" value="51"/>
@@ -9400,9 +9400,9 @@
         <int name="viewMedalItem" value="1142111"/>
     </imgdir>
     <imgdir name="29005">
-        <string name="name" value="挑战勋章-新手探险家"/>
+        <string name="name" value="新手探险家勋章"/>
         <int name="area" value="51"/>
-        <string name="0" value="让我们开始探索吧！你可以获得#b&lt;新手探险家&gt;#k 通过探索冒险岛的地区来获得勋章。"/>
+        <string name="0" value="让我们开始探索吧！通过探索冒险岛的主要地区，你可以获得#b&lt;新手探险家&gt;#k勋章。"/>
         <string name="1" value="#b#e勋章 - 新手探险家#k#n\r\n探索冒险岛的20个主要地区。\r\n#b● 状态 : #R27010# / 20 完成#k"/>
         <string name="2" value="你已获得#b&lt;新手探险家&gt;#k探索冒险岛各地之旅的勋章，所有冒险都从这里开始。"/>
         <int name="medalCategory" value="1"/>
@@ -9546,13 +9546,13 @@
         <string name="rewardSummary" value="#Wbasic#\r\n#i1142140:# #t1142140:# 1 \r\n"/>
     </imgdir>
     <imgdir name="29020">
-        <string name="name" value="Title - Dynamic Hair"/>
+        <string name="name" value="称号挑战 - 发型变换达人"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142122"/>
-        <string name="0" value="If you change your hairstyle more than 50 times, the Maple Hair Association will offer you the title of #b&lt;Dynamic Hair&gt;#k..."/>
-        <string name="1" value="#b#eTitle - Dynamic Hair#k#n\r\nUse Hair Salon\n(Change hairstyles, whether it be regular, special, or random. Hair color not included.)\r\n#b- Current Progress\nHair Changes #R29020# / 50 completed."/>
-        <string name="2" value="You changed your hairstyle 50 times and received the title #b&lt;Dynamic Hair&gt;#k."/>
+        <string name="0" value="听说冒险岛发型师协会正在寻找热衷造型变化的冒险家。只要累计变换发型 50 次以上，就能获得#b&lt;发型变换达人&gt;#k称号。"/>
+        <string name="1" value="#b#e称号挑战 - 发型变换达人#k#n\r\n使用理发店变换发型\n（包括普通、特别或随机发型，不包含染发。）\r\n#b- 当前进度\n变换发型次数 #R29020# / 50 次完成。"/>
+        <string name="2" value="你已累计变换发型 50 次，获得了#b&lt;发型变换达人&gt;#k称号。"/>
         <int name="autoComplete" value="1"/>
         <string name="rewardSummary" value="#Wbasic#\r\n#i1142122:# #t1142122:# 1 \r\n"/>
     </imgdir>
@@ -9597,10 +9597,10 @@
         <int name="viewMedalItem" value="1142013"/>
     </imgdir>
     <imgdir name="29400">
-        <string name="name" value="挑战勋章-勤奋冒险家勋章"/>
-        <string name="0" value="#b#e挑战勋章 - 勤奋冒险家勋章#n\n#k在30天内狩猎等级符合条件的#r100000只#k怪物！达利尔正在寻找最聪明伶俐、韧劲十足的勇士。完成挑战后，将被授予#e#b勤奋冒险家勋章#k#n。"/>
-        <string name="1" value="#b#e挑战勋章 - 勤奋冒险家勋章#b#n\n\n#k - 剩余时间：#Qdaylimit#天 #Qhourlimit#小时 #Qminlimit#分 #Qseclimit#秒\n - 已杀怪物数：#r#a294001##k\n\n※ 120级以下角色：必须狩猎等级高于自身等级的怪物。\n※ 120级及以上角色：必须狩猎120级及以上的怪物。\n" />
-        <string name="2" value="#b#e挑战勋章 - 勤奋冒险家勋章#b#n\n\n#k - 已完成：#r100000#k / 100000\n\n你已经完成挑战，获得了#b勤奋冒险家勋章#k。勋章遗失时，需要重新接受挑战并再次完成100000只怪物狩猎目标后才能重新领取。" />
+        <string name="name" value="挑战 - 勤奋冒险家"/>
+        <string name="0" value="#b#e挑战 - 勤奋冒险家#n\n#k在30天内狩猎等级符合条件的#r100000只#k怪物！达利尔正在寻找最聪明伶俐、韧劲十足的勇士。完成挑战后，将被授予#e#b勤奋冒险家勋章#k#n。"/>
+        <string name="1" value="#b#e挑战 - 勤奋冒险家#b#n\n\n#k - 剩余时间：#Qdaylimit#天 #Qhourlimit#小时 #Qminlimit#分 #Qseclimit#秒\n - 已杀怪物数：#r#a294001##k\n\n※ 120级以下角色：必须狩猎等级高于自身等级的怪物。\n※ 120级及以上角色：必须狩猎120级及以上的怪物。\n" />
+        <string name="2" value="#b#e挑战 - 勤奋冒险家#b#n\n\n#k - 已完成：#r100000#k / 100000\n\n你已经完成挑战，获得了#b勤奋冒险家勋章#k。勋章遗失时，需要重新接受挑战并再次完成100000只怪物狩猎目标后才能重新领取。" />
         <string name="demandSummary" value="已杀怪物数：#a294001#\r\n30天内击杀100000只符合等级条件的怪物。" />
         <string name="rewardSummary" value="#Wbasic# #v1142004:##t1142004:# 1"/>
         <int name="timeLimit2" value="2592000"/>
@@ -9609,36 +9609,36 @@
         <int name="viewMedalItem" value="1142004"/>
     </imgdir>
     <imgdir name="29500">
-        <string name="name" value="挑战勋章-冒险岛偶像明星勋章(特级)"/>
-        <string name="0" value="#b#e挑战勋章-冒险岛偶像明星勋章#n(特级)\n#k人气达到 #b1000#k 后，即可领取#e#b冒险岛偶像明星勋章(特级)#k#n。"/>
-        <string name="1" value="#b#e挑战勋章-冒险岛偶像明星勋章#n(特级)\n\n#k - 需要人气度: #b1000#k\n - 当前人气度: #b#jpop##k"/>
-        <string name="2" value="#b#e挑战勋章-冒险岛偶像明星勋章#n(特级)\n\n#k达到指定人气度后获得&apos;#b冒险岛偶像明星勋章(特级)#k&apos;。"/>
+        <string name="name" value="挑战 - 冒险岛偶像明星(特级)"/>
+        <string name="0" value="#b#e挑战 - 冒险岛偶像明星#n(特级)\n#k人气达到 #b1000#k 后，即可领取#e#b冒险岛偶像明星勋章(特级)#k#n。"/>
+        <string name="1" value="#b#e挑战 - 冒险岛偶像明星#n(特级)\n\n#k - 需要人气度: #b1000#k\n - 当前人气度: #b#jpop##k"/>
+        <string name="2" value="#b#e挑战 - 冒险岛偶像明星#n(特级)\n\n#k达到指定人气度后获得&apos;#b冒险岛偶像明星勋章(特级)#k&apos;。"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142006"/>
     </imgdir>
     <imgdir name="29501">
-        <string name="name" value="挑战勋章-暗黑龙王杀手勋章(特级)"/>
-        <string name="0" value="#b#e挑战勋章-暗黑龙王杀手勋章#n(特级)\n#k击败暗黑龙王 #b1#k 次后，即可领取#e#b暗黑龙王杀手勋章(特级)#k#n。"/>
-        <string name="1" value="#b#e挑战勋章-暗黑龙王杀手勋章#n(特级)\n\n#k - 暗黑龙王击败记录: #r#jmon##k / 1 次"/>
-        <string name="2" value="#b#e挑战勋章-暗黑龙王杀手勋章#n(特级)\n\n#k完成个人击败暗黑龙王挑战后获得&apos;#b暗黑龙王杀手勋章(特级)#k&apos;。"/>
+        <string name="name" value="挑战 - 暗黑龙王杀手(特级)"/>
+        <string name="0" value="#b#e挑战 - 暗黑龙王杀手#n(特级)\n#k击败暗黑龙王 #b1#k 次后，即可领取#e#b暗黑龙王杀手勋章(特级)#k#n。"/>
+        <string name="1" value="#b#e挑战 - 暗黑龙王杀手#n(特级)\n\n#k - 暗黑龙王击败记录: #r#jmon##k / 1 次"/>
+        <string name="2" value="#b#e挑战 - 暗黑龙王杀手#n(特级)\n\n#k完成个人击败暗黑龙王挑战后获得&apos;#b暗黑龙王杀手勋章(特级)#k&apos;。"/>
         <int name="area" value="51"/>
         <int name="viewMedalItem" value="1142007"/>
     </imgdir>
     <imgdir name="29502">
-        <string name="name" value="挑战勋章-品克缤杀手勋章(特级)"/>
-        <string name="0" value="#b#e挑战勋章-品克缤杀手勋章#n(特级)\n#k击败品克缤 #b1#k 次后，即可领取#e#b品克缤杀手勋章(特级)#k#n。"/>
-        <string name="1" value="#b#e挑战勋章-品克缤杀手勋章#n(特级)\n\n#k - 品克缤击败记录: #r#jmon##k / 1 次"/>
-        <string name="2" value="#b#e挑战勋章-品克缤杀手勋章#n(特级)\n\n#k完成个人击败品克缤挑战后获得&apos;#b品克缤杀手勋章(特级)#k&apos;。"/>
+        <string name="name" value="挑战 - 品克缤杀手(特级)"/>
+        <string name="0" value="#b#e挑战 - 品克缤杀手#n(特级)\n#k击败品克缤 #b1#k 次后，即可领取#e#b品克缤杀手勋章(特级)#k#n。"/>
+        <string name="1" value="#b#e挑战 - 品克缤杀手#n(特级)\n\n#k - 品克缤击败记录: #r#jmon##k / 1 次"/>
+        <string name="2" value="#b#e挑战 - 品克缤杀手#n(特级)\n\n#k完成个人击败品克缤挑战后获得&apos;#b品克缤杀手勋章(特级)#k&apos;。"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142008"/>
     </imgdir>
     <imgdir name="29503">
-        <string name="name" value="挑战勋章-爱心使者"/>
-        <string name="0" value="#b#e挑战勋章-爱心使者#n(特级称号)\n#k贡献 #b10000000#k 金币用于公共设施建设后，即可领取#e#b爱心使者#k#n称号。"/>
-        <string name="1" value="#b#e挑战勋章-爱心使者#n(特级称号)\n\n#k - 需要贡献金币: #b10000000#k"/>
-        <string name="2" value="#b#e挑战勋章-爱心使者#n(特级称号)\n\n#k完成固定金币贡献后获得&apos;#b爱心使者#k&apos;称号。"/>
+        <string name="name" value="称号挑战 - 爱心使者"/>
+        <string name="0" value="#b#e称号挑战 - 爱心使者#n(特级称号)\n#k贡献 #b10000000#k 金币用于公共设施建设后，即可领取#e#b爱心使者#k#n称号。"/>
+        <string name="1" value="#b#e称号挑战 - 爱心使者#n(特级称号)\n\n#k - 需要贡献金币: #b10000000#k"/>
+        <string name="2" value="#b#e称号挑战 - 爱心使者#n(特级称号)\n\n#k完成固定金币贡献后获得&apos;#b爱心使者#k&apos;称号。"/>
         <int name="area" value="51"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142014"/>
@@ -9662,22 +9662,22 @@
         <int name="viewMedalItem" value="1142078"/>
     </imgdir>
     <imgdir name="29507">
-        <string name="name" value="挑战勋章-可爱宠物主人勋章"/>
+        <string name="name" value="称号挑战 - 可爱宠物主人"/>
         <int name="area" value="51"/>
-        <string name="0" value="#b#e挑战勋章-可爱宠物主人勋章#n\n#k将任意宠物亲密度提升到 #r1400#k 后，即可领取#b可爱宠物主人#k称号。"/>
-        <string name="1" value="#b#e挑战勋章-可爱宠物主人勋章#n#k\n\n将任意宠物亲密度提升到 #r1400#k。"/>
-        <string name="2" value="#b#e挑战勋章-可爱宠物主人勋章#n#k\n\n你已获得#b可爱宠物主人#k称号和对应勋章。"/>
+        <string name="0" value="#b#e称号挑战 - 可爱宠物主人#n\n#k将任意宠物亲密度提升到 #r1400#k 后，即可领取#b可爱宠物主人#k称号。"/>
+        <string name="1" value="#b#e称号挑战 - 可爱宠物主人#n#k\n\n将任意宠物亲密度提升到 #r1400#k。"/>
+        <string name="2" value="#b#e称号挑战 - 可爱宠物主人#n#k\n\n你已获得#b可爱宠物主人#k称号和对应勋章。"/>
         <string name="demandSummary" value="任意宠物亲密度达到 1400。"/>
         <string name="rewardSummary" value="#Wbasic# #v1142082:##t1142082:# 1"/>
         <int name="medalCategory" value="2"/>
         <int name="viewMedalItem" value="1142082"/>
     </imgdir>
     <imgdir name="29508">
-        <string name="name" value="挑战勋章 - 最佳公民勋章"/>
+        <string name="name" value="挑战 - 最佳公民"/>
         <int name="area" value="51"/>
-        <string name="0" value="#b#e挑战勋章 - 最佳公民勋章#n\n积极参与#k#b结婚、公会和家族#k活动吧！达利尔代表荣誉之神寻找活跃的市民。只要你已经#b结婚#k、#b加入公会#k，并且#b拥有至少 1 名后辈#k，就能获得#e#b最佳公民勋章#k#n称号。"/>
-        <string name="1" value="#b#e挑战勋章 - 最佳公民勋章#n#k\n积极参与结婚、公会和家族活动。"/>
-        <string name="2" value="#b#e挑战勋章 - 最佳公民勋章#n#k\n\n你已经获得#b最佳公民勋章#k称号和对应勋章。"/>
+        <string name="0" value="#b#e挑战 - 最佳公民#n\n积极参与#k#b结婚、公会和家族#k活动吧！达利尔代表荣誉之神寻找活跃的市民。只要你已经#b结婚#k、#b加入公会#k，并且#b拥有至少 1 名后辈#k，就能获得#e#b最佳公民勋章#k#n称号。"/>
+        <string name="1" value="#b#e挑战 - 最佳公民#n#k\n积极参与结婚、公会和家族活动。"/>
+        <string name="2" value="#b#e挑战 - 最佳公民#n#k\n\n你已经获得#b最佳公民勋章#k称号和对应勋章。"/>
         <string name="demandSummary" value="完成结婚、加入公会，并拥有至少 1 名后辈。"/>
         <string name="rewardSummary" value="#Wbasic# #v1142081:##t1142081:# 1"/>
         <int name="medalCategory" value="2"/>
@@ -9691,11 +9691,11 @@
         <string name="2" value="最佳公民勋章挑战的内部资格状态。"/>
     </imgdir>
     <imgdir name="29509">
-        <string name="name" value="坚强的挑战者"/>
+        <string name="name" value="称号挑战 - 坚强的挑战者"/>
         <int name="area" value="51"/>
-        <string name="0" value="#b#e挑战勋章-坚强的挑战者#n\n#k完成林中之城的 3 个#b危险的迷宫#k任务后，即可领取#b坚强的挑战者#k称号。"/>
-        <string name="1" value="#b#e挑战勋章-坚强的挑战者#n#k\n完成林中之城的 3 个#b危险的迷宫#k任务。"/>
-        <string name="2" value="#b#e挑战勋章-坚强的挑战者#n#k\n\n你已获得#b坚强的挑战者#k称号和对应勋章。"/>
+        <string name="0" value="#b#e称号挑战 - 坚强的挑战者#n\n#k完成林中之城的 3 个#b危险的迷宫#k任务后，即可领取#b坚强的挑战者#k称号。"/>
+        <string name="1" value="#b#e称号挑战 - 坚强的挑战者#n#k\n完成林中之城的 3 个#b危险的迷宫#k任务。"/>
+        <string name="2" value="#b#e称号挑战 - 坚强的挑战者#n#k\n\n你已获得#b坚强的挑战者#k称号和对应勋章。"/>
         <string name="demandSummary" value="- #y2111# (#u2111#) - #y2112# (#u2112#) - #y2113# (#u2113#)"/>
         <string name="rewardSummary" value="#Wbasic# #v1142084:##t1142084:# 1"/>
         <int name="medalCategory" value="2"/>


### PR DESCRIPTION
## 改动内容
- 统一德烈相关勋章/称号任务在 `QuestInfo` 中的中文命名风格，避免同一列表中同时出现“称号-”“挑战勋章-XXXX勋章”等混杂写法。
- 调整组队任务、任务达人、人气、在线时长、狩猎、偶像、捐赠、宠物、迷宫挑战等任务的名称与说明文本，使其在德烈处展示时前缀一致。
- 保留探险类任务使用“XX探险家勋章”的既有命名方式，避免把探索勋章任务误改成挑战类称号任务。
- 本次仅修改中文 `wz-zh-CN` 目录中的任务文本，未改动英文目录，也未改动任务流程、条件或奖励逻辑。

## 影响范围
- 影响服务端中文 WZ 文本与客户端任务显示文本。
- 需要同步客户端资源包。
- 不涉及脚本逻辑、掉落、任务结构或 Java/JAR 行为变更。

## 验证情况
- 已检查分支相对 `upstream/master` 的 diff，仅包含本次任务相关的 `QuestInfo` 中文文本修改。
- 已完成 XML 解析检查。
- 已完成中文乱码检查，未发现异常替换字符。
- 已在本地测试环境完成服务端资源同步、客户端 IMG patch 与服务端启动校验。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。