### PR TITLE
fix: 修复战神人偶师洞穴任务无法完成

### DIFF
--- a/gms-server/scripts-zh-CN/quest/21728.js
+++ b/gms-server/scripts-zh-CN/quest/21728.js
@@ -1,0 +1,47 @@
+/*
+    This file is part of the HeavenMS MapleStory Server
+    Copyleft (L) 2016 - 2019 RonanLana
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+var status = -1;
+
+function end(mode, type, selection) {
+    if (mode == -1 || (mode == 0 && status == 0)) {
+        qm.dispose();
+        return;
+    }
+
+    if (mode == 1) {
+        status++;
+    } else {
+        status--;
+    }
+
+    if (status == 0) {
+        if (qm.getQuestProgress(21728, 21761) == "0") {
+            qm.sendNext("你真的找到了人偶师的根据地？可惜因为暗号没办法进去……看来还需要更多线索。");
+        } else {
+            qm.sendOk("你还没有找到人偶师的根据地。去火独眼兽洞穴附近仔细调查一下吧。");
+            qm.dispose();
+        }
+    } else if (status == 1) {
+        qm.forceCompleteQuest();
+        qm.gainExp(200);
+        qm.dispose();
+    }
+}

--- a/gms-server/scripts/quest/21728.js
+++ b/gms-server/scripts/quest/21728.js
@@ -1,0 +1,47 @@
+/*
+    This file is part of the HeavenMS MapleStory Server
+    Copyleft (L) 2016 - 2019 RonanLana
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+var status = -1;
+
+function end(mode, type, selection) {
+    if (mode == -1 || (mode == 0 && status == 0)) {
+        qm.dispose();
+        return;
+    }
+
+    if (mode == 1) {
+        status++;
+    } else {
+        status--;
+    }
+
+    if (status == 0) {
+        if (qm.getQuestProgress(21728, 21761) == "0") {
+            qm.sendNext("You found the Puppeteer's hideout? If a password blocks the way, we will need another clue.");
+        } else {
+            qm.sendOk("You have not found the Puppeteer's hideout yet. Search near the Fire Boar cave.");
+            qm.dispose();
+        }
+    } else if (status == 1) {
+        qm.forceCompleteQuest();
+        qm.gainExp(200);
+        qm.dispose();
+    }
+}

--- a/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/Check.img.xml
@@ -22134,6 +22134,12 @@
         <imgdir name="1">
             <int name="npc" value="1061019"/>
             <string name="endscript" value="q21728e"/>
+            <int name="infoNumber" value="21761"/>
+            <imgdir name="infoex">
+                <imgdir name="0">
+                    <string name="value" value="0"/>
+                </imgdir>
+            </imgdir>
         </imgdir>
     </imgdir>
     <imgdir name="21729">

--- a/gms-server/wz/Quest.wz/Check.img.xml
+++ b/gms-server/wz/Quest.wz/Check.img.xml
@@ -22139,6 +22139,7 @@
     </imgdir>
     <imgdir name="1">
       <int name="npc" value="1061019"/>
+      <string name="endscript" value="q21728e"/>
       <int name="infoNumber" value="21761"/>
       <imgdir name="infoex">
         <imgdir name="0">


### PR DESCRIPTION
## 改动内容
- 修复战神任务 21728「人偶师的洞穴」在 NPC 日吉处无法完成的问题。
- 将中文 Quest.wz 中任务 21728 的完成条件从错误的脚本结束节点改为检查调查洞穴后写入的任务进度 21761=0。
- 新增任务 21728 的中英文兜底脚本，兼容仍触发脚本结束流程的客户端或资源状态，并避免未调查洞穴时直接完成任务。
- 涉及 NPC：日吉；涉及地图：火独眼兽洞穴附近的人偶师洞穴；涉及任务进度：21761。
- 按功能性改动要求，新增脚本在英文与中文目录保持对称；WZ 修复仅调整存在问题的中文任务条件。

## 影响范围
- 影响服务端任务脚本和中文任务 WZ 完成条件。
- 影响客户端 Quest.wz 的任务完成条件，需要同步客户端资源包。

## 验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查，并确认任务 21728 的中文完成节点已移除错误 endscript，改为 infoNumber=21761 与 infoex=0。
- 已执行乱码检查，未发现新增中文文本乱码。
- 已在测试环境同步服务端与客户端资源并重启服务端，确认 WZ 加载、频道端口与登录端口启动完成。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。