### PR TITLE
fix: 修复奈特金字塔组队任务流程

### DIFF
--- a/gms-server/scripts-zh-CN/map/onFirstUserEnter/killing_BonusSetting.js
+++ b/gms-server/scripts-zh-CN/map/onFirstUserEnter/killing_BonusSetting.js
@@ -1,0 +1,19 @@
+function start(ms) {
+    var player = ms.getPlayer();
+    var map = player.getMap();
+
+    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+    const Point = Java.type('java.awt.Point');
+    const PacketCreator = Java.type('org.gms.util.PacketCreator');
+
+    var mobId = (map.getId() == 926010013 || map.getId() == 926010070) ? 9700029 : 9700019;
+    var spawnX = [-360, -280, -200, -120, -40, 40, 120, 200, 280, 360];
+
+    map.killAllMonsters();
+    map.broadcastMessage(PacketCreator.getClock(60));
+    ms.scheduleWarpMap(60, map.getReturnMapId());
+    player.resetEnteredScript(map.getId());
+    for (var i = 0; i < spawnX.length; i++) {
+        map.spawnMonsterOnGroundBelow(LifeFactory.getMonster(mobId), new Point(spawnX[i], 100));
+    }
+}

--- a/gms-server/scripts-zh-CN/map/onUserEnter/Massacre_first.js
+++ b/gms-server/scripts-zh-CN/map/onUserEnter/Massacre_first.js
@@ -1,0 +1,6 @@
+function start(ms) {
+    var py = ms.getPyramid();
+    if (py != null) {
+        py.timer();
+    }
+}

--- a/gms-server/scripts-zh-CN/npc/2103013.js
+++ b/gms-server/scripts-zh-CN/npc/2103013.js
@@ -1,5 +1,5 @@
 /*
-	This file is part of the OdinMS Maple Story Server
+	T\r\nis file is part of the OdinMS Maple Story Server
     Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
 		       Matthias Butz <matze@odinms.de>
 		       Jan Christian Meyer <vimes@odinms.de>
@@ -19,28 +19,33 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-var status = 0;
+var status = -1;
 var selected = -1;
 var party = 0;
+var questComplete = false;
 
 function start() {
-    cm.sendOk("金字塔任务（PyramidPQ）目前不可用。");
-    cm.dispose();
-}
+    status = -1;
+    selected = -1;
+    party = 0;
+    questComplete = false;
 
-/*function start() {
-	status = -1;
-	var text = "You should NOT talk to this NPC in this map.";
-	if (cm.getMapId() == 926020001)
-		text = "Stop! You've succesfully passed Nett's test. By Nett's grace, you will now be given the opportunity to enter Pharaoh Yeti's Tomb. Do you wish to enter it now?\r\n\r\n#b#L0# Yes, I will go now.#l\r\n#L1# No, I will go later.#l";
-	else if (cm.getMapId() == 926010000)
-		text = "I am Duarte.\r\n\r\n#b#L0# Ask about the Pyramid.#l\r\n#e#L1# Enter the Pyramid.#l#n\r\n\r\n#L2# Find a Party.#l\r\n\r\n#L3# Enter Pharaoh Yeti's Tomb.#l\r\n#L4# Ask about Pharaoh Yeti's treasures.#l\r\n#L5# Receive the <Protector of Pharaoh> Medal.#l";
-	else 
-		text = "Do you want to forfeit the challenge and leave?\r\n\r\n#b#L0# Leave#l";
-		
-	cm.sendSimple(text);
+    var text = "你不应该在这张地图和这个 NPC 对话。";
+    if (cm.getMapId() == 926020001 || cm.getMapId() == 926010001) {
+        text = "站住！你成功通过了奈特的试炼。承蒙奈特的恩典，现在你获得了进入法老雪人之墓的机会。现在要进去吗？\r\n\r\n#b#L0# 是的，现在就去。#l\r\n#L1# 不，我之后再去。#l";
+    } else if (cm.getMapId() == 926010000) {
+        if (cm.isQuestStarted(3955)) {
+            questComplete = true;
+            cm.sendNext("站住，愚蠢的人！你不怕死吗？\r\n\r\n#b#L0# 我是替学者巴一岚来的。#l#k");
+            return;
+        }
+        text = "我是杜阿特。\r\n\r\n#b#L0# 询问金字塔的事情。#l\r\n#e#L1# 进入金字塔。#l#n\r\n\r\n#L2# 寻找队伍。#l\r\n\r\n#L3# 进入法老雪人之墓。#l\r\n#L4# 询问法老雪人的宝物。#l\r\n#L5# 领取 <法老守护者> 勋章。#l";
+    } else {
+        text = "你想放弃挑战并离开吗？\r\n\r\n#b#L0# 离开#l";
+    }
+
+    cm.sendSimple(text);
 }
-*/
 
 function action(mode, type, selection) {
     if (mode == 0 && type == 0) {
@@ -52,106 +57,99 @@ function action(mode, type, selection) {
         status++;
     }
 
+    if (questComplete) {
+        if (status == 0) {
+            cm.sendNext("原来如此。那个蠢货。我好心把他从死亡边缘救回来，他却又把自己推向另一扇死亡之门。也罢，就让我看看他能不能逃过阿努比斯的气息。 ");
+        } else if (status == 1) {
+            cm.forceCompleteQuest(3955);
+            cm.sendNext("从今天开始，我允许你出入。但是金字塔是否允许你出入，还得走着瞧。如果金字塔认可了你，在探险结束的时候，你就可以得到法老雪人的宝石。把它交给我，我就会把你送到可以获得珍贵宝物的地方。 ");
+        } else {
+            cm.dispose();
+        }
+        return;
+    }
+
     if (cm.getMapId() == 926010000) {
         if (status == 0) {
             if (selection > -1) {
                 selected = selection;
             }
             if (selection == 0 || selected == 0) {
-                cm.sendNext("这是Nett金字塔，混沌和复仇之神。长期以来，它一直被埋在沙漠深处，但Nett已命令它升起地面。如果你不惧混乱和可能的死亡，你可以挑战沉睡在金字塔内的Yeti法老。无论结果如何，选择权在你手中。");
+                cm.sendNext("这是奈特金字塔，混沌与复仇之神的金字塔。长久以来，它一直埋在沙漠深处，但奈特命令它重现地面。如果你不惧混乱和死亡，就可以挑战沉睡在金字塔里的法老雪人。无论结果如何，选择权都在你手中。");
             } else if (selection == 1) {
-                cm.sendSimple("你这些不知道尼特之怒的愚蠢家伙，现在是选择你们命运的时刻！\r\n\r\n#b#L0# 独自进入。#l\r\n#L1# 与2人或更多的队伍一起进入。#l");
+                cm.sendSimple("不知畏惧奈特之怒的愚蠢之人，现在是选择命运的时候了！\r\n\r\n#b#L0# 独自进入。#l\r\n#L1# 和 2 人以上的队伍一起进入。#l");
             } else if (selection == 2) {
                 cm.openUI(0x16);
-                cm.showInfoText("Use the Party Search (Hotkey O) window to search for a party to join anytime and anywhere!");
+                cm.showInfoText("可以使用队伍搜索窗口（快捷键 O）随时随地寻找可加入的队伍！");
                 cm.dispose();
             } else if (selection == 3) {
-                cm.sendSimple("你带来了什么宝石？\r\n\r\n#L0##i4001322# #t4001322##l\r\n#L1##i4001323# #t4001323##l\r\n#L2##i4001324# #t4001324##l\r\n#L3##i4001325# #t4001325##l");
+                cm.sendSimple("你带来了哪颗宝石？\r\n\r\n#L0##i4001322# #t4001322##l\r\n#L1##i4001323# #t4001323##l\r\n#L2##i4001324# #t4001324##l\r\n#L3##i4001325# #t4001325##l");
             } else if (selection == 4) {
-                cm.sendNext("在法老雪人的墓穴内，你可以通过证明自己有能力击败法老雪人的克隆体——法老雪人小弟，获得#e#b#t2022613##k#n。在那个盒子里藏着一份非常特别的宝藏。那就是#e#b#t1132012##k#n。\r\n#i1132012:# #t1132012#\r\n\r\n而且，如果你以某种方式能够在地狱模式中生存下来，你将获得#e#b#t1132013##k#n。\r\n\r\n#i1132013:# #t1132013#\r\n\r\n当然，Nett是不会允许这种事情发生的。");
+                cm.sendNext("在法老雪人之墓中，你可以通过击败法老雪人的分身 #b法老小雪人#k 来证明自己的能力，并获得 #e#b#t2022613##k#n。那个盒子里藏着非常特别的宝物，也就是 #e#b#t1132012##k#n。\r\n#i1132012:# #t1132012#\r\n\r\n如果你能在地狱模式中幸存，更强的法老小雪人会掉落 #e#b#t2022618##k#n，里面还有机会获得 #e#b#t1132013##k#n。\r\n\r\n#i1132013:# #t1132013#\r\n\r\n当然，奈特不会轻易允许这种事发生。 ");
             } else if (selection == 5) {
-                var progress = cm.getQuestProgressInt(29932);
-                if (progress >= 50000) {
-                    cm.dispose();
+                var progress = cm.getQuestProgressInt(29932, 7760);
+                if (cm.isQuestCompleted(29932) || cm.haveItem(1142142)) {
+                    cm.sendOk("你已经领取过 <法老守护者> 勋章。");
+                } else if (progress >= 50000) {
+                    if (!cm.canHold(1142142)) {
+                        cm.sendOk("领取勋章前，请确认装备栏有足够空间。");
+                    } else {
+                        cm.gainItem(1142142, 1);
+                        cm.forceCompleteQuest(29932);
+                        cm.sendOk("你已经证明了自己拥有成为法老守护者的资格。请收下这枚勋章。");
+                    }
                 } else {
-                    cm.sendNext("抱歉，我无法完成你的要求。");
+                    cm.sendNext("你还没有达到条件。请在奈特金字塔击败 50000 只怪物后再来找我。\r\n当前已击败 " + progress + " 只怪物。");
                 }
-
             }
         } else if (status == 1) {
             if (selected == 0) {
-                cm.sendNextPrev("一旦你进入金字塔，你将面对内特的愤怒。由于你看起来不太聪明，我会给你一些建议和规则。记住它们。#b\r\n1. 小心你的#e#r行动槽#b#n不要减少。保持你的槽水平的唯一方法是不停地与怪物战斗。\r\n2. 无法做到的人将付出昂贵的代价。小心不要造成任何#r失误#b。\r\n3. 小心带有#v04032424#标记的法老少年雪人。如果错误地攻击他，你会后悔的。\r\n4. 明智地使用赋予你的技能来完成击杀成就。");
+                cm.sendNextPrev("一旦进入金字塔，你就会面对奈特的愤怒。看你似乎不太聪明，我就给你一些建议和规则，牢牢记住。#b\r\n\r\n1. 小心不要让你的 #e#r行动槽#b#n 减少。维持行动槽的唯一方法，就是不停地和怪物战斗。\r\n2. 做不到的人会付出沉重代价。小心不要造成任何 #rMISS#b。\r\n3. 小心带有 #v04032424# 标记的法老小雪人。误伤它的话，你一定会后悔。\r\n4. 善用赐予你的技能来完成击杀成就。 ");
             } else if (selected == 1) {
                 party = selection;
-                cm.sendSimple("你这个不怕死亡残酷的人，做出你的决定！\r\n#L0##i3994115##l#L1##i3994116##l#L2##i3994117##l#L3##i3994118##l");
+                cm.sendSimple("不惧死亡残酷的人啊，做出你的决定！\r\n#L0##i3994115##l#L1##i3994116##l#L2##i3994117##l#L3##i3994118##l");
             } else if (selected == 3) {
-                if (selection == 0) {
-                    if (cm.haveItem(4001322)) {
-                        return;
-                    }
-                } else if (selection == 1) {
-                    if (cm.haveItem(4001323)) {
-                        return;
-                    }
-                } else if (selection == 2) {
-                    if (cm.haveItem(4001324)) {
-                        return;
-                    }
-                } else if (selection == 3) {
-                    if (cm.haveItem(4001325)) {
-                        return;
-                    }
+                var gems = [4001322, 4001323, 4001324, 4001325];
+                if (selection >= 0 && selection < gems.length && cm.haveItem(gems[selection])) {
+                    cm.gainItem(gems[selection], -1);
+                    cm.warp(926010010 + selection);
+                } else {
+                    cm.sendOk("你需要一颗宝石才能进入法老雪人之墓。确认你真的带着宝石吗？");
                 }
-                cm.sendOk("你需要一颗宝石才能进入法老雪人的墓室。你确定你有吗？");
                 cm.dispose();
-            } else if (selected == 5) {
             } else {
                 cm.dispose();
             }
         } else if (status == 2) {
             if (selected == 0) {
-                cm.sendNextPrev("那些能够经受住尼特的愤怒的人将受到尊敬，但那些失败的人将面临毁灭。这就是我能给你的所有建议。剩下的就看你们了。");
+                cm.sendNextPrev("能够承受奈特愤怒的人会获得荣耀，失败者则会面临毁灭。这就是我能给你的全部建议，剩下的就看你自己了。 ");
             } else if (selected == 1) {
                 var mode = "EASY";
-                //Finish this
-                var pqparty = cm.getPlayer().getParty();
                 if (party == 1) {
-                    if (pqparty == null) {
-                        cm.sendOk("请先创建队伍");
+                    if (cm.getParty() == null) {
+                        cm.sendOk("请先创建队伍。 ");
                         cm.dispose();
                         return;
-                    } else {
-                        if (pqparty.getMembers().size() < 2) {
-                            cm.sendOk("获得更多成员...");
-                            cm.dispose();
-                            return;
-                        } else {
-                            var i = 0;
-                            for (var a = 0; a < pq.getMembers().size(); a++) {
-                                var pqchar = pq.getMembers().get(a);
-                                if (i > 1) {
-                                    break;
-                                }
-                                if (pqchar != null && pqchar.getMapId() == 926010000) {
-                                    i++;
-                                }
-                            }
-                            if (i < 2) {
-                                cm.sendOk("确保你的地图上有2名或更多队员。");
-                                cm.dispose();
-                                return;
-                            }
-                        }
+                    }
+                    if (!cm.isLeader()) {
+                        cm.sendOk("只有队长可以申请队伍挑战。 ");
+                        cm.dispose();
+                        return;
+                    }
+                    if (cm.partyMembersInMap() < 2) {
+                        cm.sendOk("请确认当前地图中有 2 名或更多队员。 ");
+                        cm.dispose();
+                        return;
                     }
                 }
 
                 if (cm.getPlayer().getLevel() < 40) {
-                    cm.sendOk("你必须达到40级以上才能进入这个组队任务。");
+                    cm.sendOk("你必须达到 40 级以上才能进入这个组队任务。 ");
                     cm.dispose();
                     return;
                 }
                 if (selection < 3 && cm.getPlayer().getLevel() > 60) {
-                    cm.sendOk("只有等级超过60级的玩家才能进入地狱模式。");
+                    cm.sendOk("等级超过 60 级的玩家只能进入地狱模式。 ");
                     cm.dispose();
                     return;
                 }
@@ -164,45 +162,38 @@ function action(mode, type, selection) {
                 }
 
                 if (!cm.createPyramid(mode, party == 1)) {
-                    cm.sendOk("所有房间都已满，请稍后再试或者换一个频道:)");
+                    cm.sendOk("该模式的所有房间都已满，请稍后再试或换一个频道。 ");
                 }
                 cm.dispose();
             }
         } else if (status == 3) {
             cm.dispose();
         }
-    } else if (cm.getMapId() == 926020001) {
+    } else if (cm.getMapId() == 926020001 || cm.getMapId() == 926010001) {
         if (status == 0) {
             if (selection == 0) {
+                cm.warp(926010010);
                 cm.dispose();
-            }//:(
-            else if (selection == 1) {
-                cm.sendNext("我会给你法老雪人的宝石。有了这个宝石，你随时可以进入法老雪人的墓穴。检查一下你的杂项窗口里是否至少有一个空位。");
+            } else if (selection == 1) {
+                cm.sendNext("我会给你法老雪人的宝石。有了这颗宝石，你就可以随时进入法老雪人之墓。请确认你的其他栏至少有 1 个空位。 ");
             }
-
         } else if (status == 1) {
             var itemid = 4001325;
-            if (cm.getPlayer().getLevel() >= 60) {
-                itemid = 4001325;
-            }
             if (cm.canHold(itemid)) {
                 cm.gainItem(itemid);
                 cm.warp(926010000);
             } else {
-                cm.showInfoText("You must have at least 1 empty slot in your Etc window to receive the reward.");
+                cm.showInfoText("其他栏至少需要 1 个空位才能领取奖励。 ");
             }
-
             cm.dispose();
         }
     } else {
-        cm.warp(926010000);
-        cm.getPlayer().setPartyQuest(null);
+        var pyramid = cm.getPyramid();
+        if (pyramid != null) {
+            pyramid.leave(926010000);
+        } else {
+            cm.warp(926010000);
+        }
         cm.dispose();
     }
-}/*Do you want to forfeit the challenge and leave?
-
-Your allotted time has passed. Do you want to leave now?
-
-
-
-*/
+}

--- a/gms-server/scripts/map/onFirstUserEnter/killing_BonusSetting.js
+++ b/gms-server/scripts/map/onFirstUserEnter/killing_BonusSetting.js
@@ -1,0 +1,19 @@
+function start(ms) {
+    var player = ms.getPlayer();
+    var map = player.getMap();
+
+    const LifeFactory = Java.type('org.gms.server.life.LifeFactory');
+    const Point = Java.type('java.awt.Point');
+    const PacketCreator = Java.type('org.gms.util.PacketCreator');
+
+    var mobId = (map.getId() == 926010013 || map.getId() == 926010070) ? 9700029 : 9700019;
+    var spawnX = [-360, -280, -200, -120, -40, 40, 120, 200, 280, 360];
+
+    map.killAllMonsters();
+    map.broadcastMessage(PacketCreator.getClock(60));
+    ms.scheduleWarpMap(60, map.getReturnMapId());
+    player.resetEnteredScript(map.getId());
+    for (var i = 0; i < spawnX.length; i++) {
+        map.spawnMonsterOnGroundBelow(LifeFactory.getMonster(mobId), new Point(spawnX[i], 100));
+    }
+}

--- a/gms-server/scripts/map/onUserEnter/Massacre_first.js
+++ b/gms-server/scripts/map/onUserEnter/Massacre_first.js
@@ -1,0 +1,6 @@
+function start(ms) {
+    var py = ms.getPyramid();
+    if (py != null) {
+        py.timer();
+    }
+}

--- a/gms-server/scripts/npc/2103013.js
+++ b/gms-server/scripts/npc/2103013.js
@@ -19,28 +19,33 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-var status = 0;
+var status = -1;
 var selected = -1;
 var party = 0;
+var questComplete = false;
 
 function start() {
-    cm.sendOk("The PyramidPQ is currently unavailable.");
-    cm.dispose();
-}
+    status = -1;
+    selected = -1;
+    party = 0;
+    questComplete = false;
 
-/*function start() {
-	status = -1;
-	var text = "You should NOT talk to this NPC in this map.";
-	if (cm.getMapId() == 926020001)
-		text = "Stop! You've succesfully passed Nett's test. By Nett's grace, you will now be given the opportunity to enter Pharaoh Yeti's Tomb. Do you wish to enter it now?\r\n\r\n#b#L0# Yes, I will go now.#l\r\n#L1# No, I will go later.#l";
-	else if (cm.getMapId() == 926010000)
-		text = "I am Duarte.\r\n\r\n#b#L0# Ask about the Pyramid.#l\r\n#e#L1# Enter the Pyramid.#l#n\r\n\r\n#L2# Find a Party.#l\r\n\r\n#L3# Enter Pharaoh Yeti's Tomb.#l\r\n#L4# Ask about Pharaoh Yeti's treasures.#l\r\n#L5# Receive the <Protector of Pharaoh> Medal.#l";
-	else 
-		text = "Do you want to forfeit the challenge and leave?\r\n\r\n#b#L0# Leave#l";
-		
-	cm.sendSimple(text);
+    var text = "You should NOT talk to this NPC in this map.";
+    if (cm.getMapId() == 926020001 || cm.getMapId() == 926010001) {
+        text = "Stop! You've successfully passed Nett's test. By Nett's grace, you will now be given the opportunity to enter Pharaoh Yeti's Tomb. Do you wish to enter it now?\r\n\r\n#b#L0# Yes, I will go now.#l\r\n#L1# No, I will go later.#l";
+    } else if (cm.getMapId() == 926010000) {
+        if (cm.isQuestStarted(3955)) {
+            questComplete = true;
+            cm.sendNext("Fools. A sea of fools. Are all humans this foolish? Even one who called himself a scholar dared to venture here. But is not death something to avoid?\r\n\r\n#b#L0# I am here on behalf of that scholar, Byron.#l#k");
+            return;
+        }
+        text = "I am Duarte.\r\n\r\n#b#L0# Ask about the Pyramid.#l\r\n#e#L1# Enter the Pyramid.#l#n\r\n\r\n#L2# Find a Party.#l\r\n\r\n#L3# Enter Pharaoh Yeti's Tomb.#l\r\n#L4# Ask about Pharaoh Yeti's treasures.#l\r\n#L5# Receive the <Protector of Pharaoh> Medal.#l";
+    } else {
+        text = "Do you want to forfeit the challenge and leave?\r\n\r\n#b#L0# Leave#l";
+    }
+
+    cm.sendSimple(text);
 }
-*/
 
 function action(mode, type, selection) {
     if (mode == 0 && type == 0) {
@@ -50,6 +55,18 @@ function action(mode, type, selection) {
         return;
     } else {
         status++;
+    }
+
+    if (questComplete) {
+        if (status == 0) {
+            cm.sendNext("I see. That fool. I was merciful enough to save him from the throngs of death, and instead he drags himself to another one of its doorsteps. So be it. Let us see if he can escape the breath of Anubis.");
+        } else if (status == 1) {
+            cm.forceCompleteQuest(3955);
+            cm.sendNext("I will permit your entrance, but it remains to be seen if the Pyramid will accept you as well. If it does, then you will acquire the Pharaoh Yeti's Gem. If you bring that to me, I will lead you directly to a spot where you can acquire many other rare gems.");
+        } else {
+            cm.dispose();
+        }
+        return;
     }
 
     if (cm.getMapId() == 926010000) {
@@ -68,15 +85,22 @@ function action(mode, type, selection) {
             } else if (selection == 3) {
                 cm.sendSimple("What gem have you brought?\r\n\r\n#L0##i4001322# #t4001322##l\r\n#L1##i4001323# #t4001323##l\r\n#L2##i4001324# #t4001324##l\r\n#L3##i4001325# #t4001325##l");
             } else if (selection == 4) {
-                cm.sendNext("Inside Pharaoh Yeti's Tomb, you can acquire a #e#b#t2022613##k#n by proving yourself capable of defeating the #bPharaoh Jr. Yeti#k, the Pharaoh's clone. Inside that box lies a very special treasure. It is the #e#b#t1132012##k#n.\r\n#i1132012:# #t1132012#\r\n\r\n And if you are somehow able to survive Hell Mode, you will receive the #e#b#t1132013##k#n.\r\n\r\n#i1132013:# #t1132013#\r\n\r\n Though, of course, Nett won't allow that to happen.");
+                cm.sendNext("Inside Pharaoh Yeti's Tomb, you can acquire a #e#b#t2022613##k#n by proving yourself capable of defeating the #bPharaoh Jr. Yeti#k, the Pharaoh's clone. Inside that box lies a very special treasure. It is the #e#b#t1132012##k#n.\r\n#i1132012:# #t1132012#\r\n\r\nIf you survive Hell Mode, the stronger Pharaoh Jr. Yeti can drop #e#b#t2022618##k#n, which also contains the #e#b#t1132013##k#n.\r\n\r\n#i1132013:# #t1132013#\r\n\r\nThough, of course, Nett won't allow that to happen.");
             } else if (selection == 5) {
-                var progress = cm.getQuestProgressInt(29932);
-                if (progress >= 50000) {
-                    cm.dispose();
+                var progress = cm.getQuestProgressInt(29932, 7760);
+                if (cm.isQuestCompleted(29932) || cm.haveItem(1142142)) {
+                    cm.sendOk("You have already received the <Protector of Pharaoh> Medal.");
+                } else if (progress >= 50000) {
+                    if (!cm.canHold(1142142)) {
+                        cm.sendOk("Please make sure your Equip inventory has enough space before receiving the medal.");
+                    } else {
+                        cm.gainItem(1142142, 1);
+                        cm.forceCompleteQuest(29932);
+                        cm.sendOk("You have proven yourself as the Protector of Pharaoh. Please accept the medal.");
+                    }
                 } else {
-                    cm.sendNext("");
+                    cm.sendNext("You have not yet met the requirement. Defeat 50,000 monsters in Nett's Pyramid, then return to me.\r\nCurrent defeated monsters: " + progress + ".");
                 }
-
             }
         } else if (status == 1) {
             if (selected == 0) {
@@ -85,26 +109,14 @@ function action(mode, type, selection) {
                 party = selection;
                 cm.sendSimple("You who lack fear of death's cruelty, make your decision!\r\n#L0##i3994115##l#L1##i3994116##l#L2##i3994117##l#L3##i3994118##l");
             } else if (selected == 3) {
-                if (selection == 0) {
-                    if (cm.haveItem(4001322)) {
-                        return;
-                    }
-                } else if (selection == 1) {
-                    if (cm.haveItem(4001323)) {
-                        return;
-                    }
-                } else if (selection == 2) {
-                    if (cm.haveItem(4001324)) {
-                        return;
-                    }
-                } else if (selection == 3) {
-                    if (cm.haveItem(4001325)) {
-                        return;
-                    }
+                var gems = [4001322, 4001323, 4001324, 4001325];
+                if (selection >= 0 && selection < gems.length && cm.haveItem(gems[selection])) {
+                    cm.gainItem(gems[selection], -1);
+                    cm.warp(926010010 + selection);
+                } else {
+                    cm.sendOk("You'll need a gem to enter Pharaoh Yeti's Tomb. Are you sure you have one?");
                 }
-                cm.sendOk("You'll need a gem to enter Pharaoh Yeti's Tomb. Are you sure you have one?");
                 cm.dispose();
-            } else if (selected == 5) {
             } else {
                 cm.dispose();
             }
@@ -113,35 +125,21 @@ function action(mode, type, selection) {
                 cm.sendNextPrev("Those who are able to withstand Nett's wrath will be honored, but those who fail will face destruction. This is all the advice I can give you. The rest is in your hands.");
             } else if (selected == 1) {
                 var mode = "EASY";
-                //Finish this
-                var pqparty = cm.getPlayer().getParty();
                 if (party == 1) {
-                    if (pqparty == null) {
-                        cm.sendOk("Create a party first.");//BE NICE
+                    if (cm.getParty() == null) {
+                        cm.sendOk("Create a party first.");
                         cm.dispose();
                         return;
-                    } else {
-                        if (pqparty.getMembers().size() < 2) {
-                            cm.sendOk("Get more members...");
-                            cm.dispose();
-                            return;
-                        } else {
-                            var i = 0;
-                            for (var a = 0; a < pq.getMembers().size(); a++) {
-                                var pqchar = pq.getMembers().get(a);
-                                if (i > 1) {
-                                    break;
-                                }
-                                if (pqchar != null && pqchar.getMapId() == 926010000) {
-                                    i++;
-                                }
-                            }
-                            if (i < 2) {
-                                cm.sendOk("Make sure that 2 or more party members are in your map.");
-                                cm.dispose();
-                                return;
-                            }
-                        }
+                    }
+                    if (!cm.isLeader()) {
+                        cm.sendOk("Only the party leader may apply for the party challenge.");
+                        cm.dispose();
+                        return;
+                    }
+                    if (cm.partyMembersInMap() < 2) {
+                        cm.sendOk("Make sure that 2 or more party members are in your map.");
+                        cm.dispose();
+                        return;
                     }
                 }
 
@@ -151,7 +149,7 @@ function action(mode, type, selection) {
                     return;
                 }
                 if (selection < 3 && cm.getPlayer().getLevel() > 60) {
-                    cm.sendOk("Only Hell mode is avaible for players that are over Lv. 60.");
+                    cm.sendOk("Only Hell mode is available for players that are over Lv. 60.");
                     cm.dispose();
                     return;
                 }
@@ -164,45 +162,38 @@ function action(mode, type, selection) {
                 }
 
                 if (!cm.createPyramid(mode, party == 1)) {
-                    cm.sendOk("All rooms are full for this mode, please try it again later or on another channel ):");
+                    cm.sendOk("All rooms are full for this mode, please try it again later or on another channel.");
                 }
                 cm.dispose();
             }
         } else if (status == 3) {
             cm.dispose();
         }
-    } else if (cm.getMapId() == 926020001) {
+    } else if (cm.getMapId() == 926020001 || cm.getMapId() == 926010001) {
         if (status == 0) {
             if (selection == 0) {
+                cm.warp(926010010);
                 cm.dispose();
-            }//:(
-            else if (selection == 1) {
+            } else if (selection == 1) {
                 cm.sendNext("I will give you Pharaoh Yeti's Gem. You will be able to enter Pharaoh Yeti's Tomb anytime with this Gem. Check to see if you have at least 1 empty slot in your Etc window.");
             }
-
         } else if (status == 1) {
             var itemid = 4001325;
-            if (cm.getPlayer().getLevel() >= 60) {
-                itemid = 4001325;
-            }
             if (cm.canHold(itemid)) {
                 cm.gainItem(itemid);
                 cm.warp(926010000);
             } else {
                 cm.showInfoText("You must have at least 1 empty slot in your Etc window to receive the reward.");
             }
-
             cm.dispose();
         }
     } else {
-        cm.warp(926010000);
-        cm.getPlayer().setPartyQuest(null);
+        var pyramid = cm.getPyramid();
+        if (pyramid != null) {
+            pyramid.leave(926010000);
+        } else {
+            cm.warp(926010000);
+        }
         cm.dispose();
     }
-}/*Do you want to forfeit the challenge and leave?
-
-Your allotted time has passed. Do you want to leave now?
-
-
-
-*/
+}

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/CloseRangeDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/CloseRangeDamageHandler.java
@@ -39,6 +39,8 @@ import org.gms.constants.skills.Rogue;
 import org.gms.constants.skills.WindArcher;
 import org.gms.net.packet.InPacket;
 import org.gms.server.StatEffect;
+import org.gms.server.partyquest.Pyramid;
+import org.gms.util.I18nUtil;
 import org.gms.util.PacketCreator;
 import org.gms.util.Pair;
 
@@ -69,8 +71,12 @@ public final class CloseRangeDamageHandler extends AbstractDealDamageHandler {
             }
         }
 
-        if (chr.getDojoEnergy() < 10000 && (attack.skill == 1009 || attack.skill == 10001009 || attack.skill == 20001009)) // PE hacking or maybe just lagging
-        {
+        boolean pyramidSkill = MapId.isNettsPyramid(chr.getMap().getId()) && isRageOfPharaoh(attack.skill);
+        if (pyramidSkill) {
+            if (!(chr.getPartyQuest() instanceof Pyramid pyramid) || !pyramid.useSkill()) {
+                return;
+            }
+        } else if (chr.getDojoEnergy() < 10000 && isBambooRain(attack.skill)) { // PE hacking or maybe just lagging
             return;
         }
         if (MapId.isDojo(chr.getMap().getId()) && attack.numAttacked > 0) {
@@ -163,17 +169,17 @@ public final class CloseRangeDamageHandler extends AbstractDealDamageHandler {
         if (numFinisherOrbs == 0 && GameConstants.isFinisherSkill(attack.skill)) {
             return;
         }
-        if (attack.skill % 10000000 == 1009) { // bamboo
+        if (isBambooRain(attack.skill)) { // bamboo
             if (chr.getDojoEnergy() < 10000) { // PE hacking or maybe just lagging
                 return;
             }
-
             chr.setDojoEnergy(0);
             c.sendPacket(PacketCreator.getEnergy("energy", chr.getDojoEnergy()));
-            c.sendPacket(PacketCreator.serverNotice(5, "As you used the secret skill, your energy bar has been reset."));
+            c.sendPacket(PacketCreator.serverNotice(5, I18nUtil.getMessage("Dojo.secretSkill.energyReset")));
         } else if (attack.skill > 0) {
             Skill skill = SkillFactory.getSkill(attack.skill);
-            StatEffect effect_ = skill.getEffect(chr.getSkillLevel(skill));
+            int skillLevel = pyramidSkill ? 1 : chr.getSkillLevel(skill);
+            StatEffect effect_ = skill.getEffect(skillLevel);
             if (effect_.getCooldown() > 0) {
                 if (chr.skillIsCooling(attack.skill)) {
                     return;
@@ -192,5 +198,13 @@ public final class CloseRangeDamageHandler extends AbstractDealDamageHandler {
         }
 
         applyAttack(attack, chr, attackCount);
+    }
+
+    private boolean isBambooRain(int skillId) {
+        return skillId % 10000000 == 1009;
+    }
+
+    private boolean isRageOfPharaoh(int skillId) {
+        return skillId % 10000000 == 1020;
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/ItemRewardHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/ItemRewardHandler.java
@@ -54,30 +54,40 @@ public final class ItemRewardHandler extends AbstractPacketHandler {
 
         ItemInformationProvider ii = ItemInformationProvider.getInstance();
         Pair<Integer, List<RewardItem>> rewards = ii.getItemReward(itemId);
-        for (RewardItem reward : rewards.getRight()) {
-            if (!InventoryManipulator.checkSpace(c, reward.itemid, reward.quantity, "")) {
-                c.sendPacket(PacketCreator.getShowInventoryFull());
-                break;
+        RewardItem selectedReward = null;
+        int totalProb = rewards.getLeft();
+        if (totalProb > 0) {
+            int rewardRoll = Randomizer.nextInt(totalProb);
+            int cumulativeProb = 0;
+            for (RewardItem reward : rewards.getRight()) {
+                cumulativeProb += reward.prob;
+                if (rewardRoll < cumulativeProb) {
+                    selectedReward = reward;
+                    break;
+                }
             }
-            if (Randomizer.nextInt(rewards.getLeft()) < reward.prob) {//Is it even possible to get an item with prob 1?
-                if (ItemConstants.getInventoryType(reward.itemid) == InventoryType.EQUIP) {
-                    final Item item = ii.getEquipById(reward.itemid);
-                    if (reward.period != -1) {
+        }
+        if (selectedReward != null) {
+            if (!InventoryManipulator.checkSpace(c, selectedReward.itemid, selectedReward.quantity, "")) {
+                c.sendPacket(PacketCreator.getShowInventoryFull());
+            } else {
+                if (ItemConstants.getInventoryType(selectedReward.itemid) == InventoryType.EQUIP) {
+                    final Item item = ii.getEquipById(selectedReward.itemid);
+                    if (selectedReward.period != -1) {
                         // TODO is this a bug, meant to be 60 * 60 * 1000?
-                        item.setExpiration(currentServerTime() + reward.period * 60 * 60 * 10);
+                        item.setExpiration(currentServerTime() + selectedReward.period * 60 * 60 * 10);
                     }
                     InventoryManipulator.addFromDrop(c, item, false);
                 } else {
-                    InventoryManipulator.addById(c, reward.itemid, reward.quantity, "", -1);
+                    InventoryManipulator.addById(c, selectedReward.itemid, selectedReward.quantity, "", -1);
                 }
                 InventoryManipulator.removeById(c, InventoryType.USE, itemId, 1, false, false);
-                if (reward.worldmsg != null) {
-                    String msg = reward.worldmsg;
+                if (selectedReward.worldmsg != null) {
+                    String msg = selectedReward.worldmsg;
                     msg = msg.replaceAll("/name", c.getPlayer().getName());
-                    msg = msg.replaceAll("/item", ii.getName(reward.itemid));
+                    msg = msg.replaceAll("/item", ii.getName(selectedReward.itemid));
                     Server.getInstance().broadcastMessage(c.getWorld(), PacketCreator.serverNotice(6, msg));
                 }
-                break;
             }
         }
         c.sendPacket(PacketCreator.enableActions());

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/SpecialMoveHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/SpecialMoveHandler.java
@@ -38,6 +38,7 @@ import org.gms.net.packet.InPacket;
 import org.gms.net.server.Server;
 import org.gms.server.StatEffect;
 import org.gms.server.life.Monster;
+import org.gms.util.I18nUtil;
 import org.gms.util.PacketCreator;
 
 import java.awt.*;
@@ -73,7 +74,7 @@ public final class SpecialMoveHandler extends AbstractPacketHandler {
             skillLevel = 1;
             chr.setDojoEnergy(0);
             c.sendPacket(PacketCreator.getEnergy("energy", chr.getDojoEnergy()));
-            c.sendPacket(PacketCreator.serverNotice(5, "As you used the secret skill, your energy bar has been reset."));
+            c.sendPacket(PacketCreator.serverNotice(5, I18nUtil.getMessage("Dojo.secretSkill.energyReset")));
         }
         if (skillLevel == 0 || skillLevel != __skillLevel) {
             return;

--- a/gms-server/src/main/java/org/gms/scripting/map/MapScriptMethods.java
+++ b/gms-server/src/main/java/org/gms/scripting/map/MapScriptMethods.java
@@ -26,8 +26,12 @@ import org.gms.client.QuestStatus;
 import org.gms.constants.game.DelayedQuestUpdate;
 import org.gms.constants.id.MapId;
 import org.gms.scripting.AbstractPlayerInteraction;
+import org.gms.server.TimerManager;
+import org.gms.server.maps.MapleMap;
 import org.gms.server.quest.Quest;
 import org.gms.util.PacketCreator;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class MapScriptMethods extends AbstractPlayerInteraction {
 
@@ -35,6 +39,11 @@ public class MapScriptMethods extends AbstractPlayerInteraction {
 
     public MapScriptMethods(Client c) {
         super(c);
+    }
+
+    public void scheduleWarpMap(int seconds, int mapId) {
+        MapleMap sourceMap = getMap();
+        TimerManager.getInstance().schedule(() -> sourceMap.warpEveryone(mapId), SECONDS.toMillis(seconds));
     }
 
     public void displayCygnusIntro() {

--- a/gms-server/src/main/java/org/gms/scripting/npc/NPCConversationManager.java
+++ b/gms-server/src/main/java/org/gms/scripting/npc/NPCConversationManager.java
@@ -545,33 +545,41 @@ public class NPCConversationManager extends AbstractPlayerInteraction {
         Party partyz = getPlayer().getParty();
         MapManager mapManager = c.getChannelServer().getMapFactory();
 
-        MapleMap map = null;
         int mapid = MapId.NETTS_PYRAMID_SOLO_BASE;
         if (party) {
             mapid += 10000;
         }
         mapid += (mod.getMode() * 1000);
 
-        for (byte b = 0; b < 5; b++) {//They cannot warp to the next map before the timer ends (:
-            map = mapManager.getMap(mapid + b);
-            if (map.getCharacters().isEmpty()) {
-                return false;
+        MapleMap map = null;
+        for (byte room = 0; room < 5; room++) {
+            boolean roomAvailable = true;
+            for (byte stage = 0; stage < 5; stage++) {
+                if (!mapManager.getMap(mapid + room + (stage * 100)).getCharacters().isEmpty()) {
+                    roomAvailable = false;
+                    break;
+                }
             }
+            if (roomAvailable) {
+                mapid += room;
+                map = mapManager.getMap(mapid);
+                break;
+            }
+        }
+        if (map == null) {
+            return false;
         }
 
         if (!party) {
-            // 修复单人组队金字塔空指针的问题
             PartyCharacter single = new PartyCharacter(getPlayer());
             partyz = new Party(-1, single);
             partyz.addMember(single);
         }
         Pyramid py = new Pyramid(partyz, mod, map.getId());
-        getPlayer().setPartyQuest(py);
         py.warp(mapid);
         dispose();
         return true;
     }
-
     public boolean itemExists(int itemid) {
         return ItemInformationProvider.getInstance().getName(itemid) != null;
     }

--- a/gms-server/src/main/java/org/gms/server/ItemInformationProvider.java
+++ b/gms-server/src/main/java/org/gms/server/ItemInformationProvider.java
@@ -1692,7 +1692,7 @@ public class ItemInformationProvider {
         for (Data child : getItemData(itemId).getChildByPath("reward").getChildren()) {
             RewardItem reward = new RewardItem();
             reward.itemid = DataTool.getInt("item", child, 0);
-            reward.prob = (byte) DataTool.getInt("prob", child, 0);
+            reward.prob = DataTool.getInt("prob", child, 0);
             reward.quantity = (short) DataTool.getInt("count", child, 0);
             reward.effect = DataTool.getString("Effect", child, "");
             reward.worldmsg = DataTool.getString("worldMsg", child, null);
@@ -2353,8 +2353,8 @@ public class ItemInformationProvider {
 
     public static final class RewardItem {
 
-        public int itemid, period;
-        public short prob, quantity;
+        public int itemid, period, prob;
+        public short quantity;
         public String effect, worldmsg;
     }
 

--- a/gms-server/src/main/java/org/gms/server/life/Monster.java
+++ b/gms-server/src/main/java/org/gms/server/life/Monster.java
@@ -31,6 +31,7 @@ import org.gms.client.SkillFactory;
 import org.gms.client.status.MonsterStatus;
 import org.gms.client.status.MonsterStatusEffect;
 import org.gms.config.GameConfig;
+import org.gms.constants.id.MapId;
 import org.gms.constants.id.MobId;
 import org.gms.constants.skills.Crusader;
 import org.gms.constants.skills.FPMage;
@@ -63,6 +64,7 @@ import org.gms.server.maps.AbstractAnimatedMapObject;
 import org.gms.server.maps.MapObjectType;
 import org.gms.server.maps.MapleMap;
 import org.gms.server.maps.Summon;
+import org.gms.server.partyquest.Pyramid;
 import org.gms.server.quest.medal.SpecialChallengeMedal;
 import org.gms.server.quest.medal.VeteranHunterMedal;
 
@@ -416,34 +418,26 @@ public class Monster extends AbstractLoadedLife {
                 return false;
             }
 
-            /* pyramid not implemented
-            Pair<Integer, Integer> cool = this.getStats().getCool();
-            if (cool != null) {
-                Pyramid pq = (Pyramid) chr.getPartyQuest();
-                if (pq != null) {
-                    if (damage > 0) {
-                        if (damage >= cool.getLeft()) {
-                            if ((Math.random() * 100) < cool.getRight()) {
-                                pq.cool();
-                            } else {
-                                pq.kill();
-                            }
-                        } else {
-                            pq.kill();
-                        }
-                    } else {
-                        pq.miss();
-                    }
-                    killed = true;
-                }
+            Pyramid pyramid = null;
+            if (attacker.getPartyQuest() instanceof Pyramid && MapId.isNettsPyramid(attacker.getMapId())) {
+                pyramid = (Pyramid) attacker.getPartyQuest();
             }
-            */
 
             if (damage > 0) {
                 this.applyDamage(attacker, damage, stayAlive, false);
                 if (!this.isAlive()) {  // monster just died
                     lastHit = true;
+                    if (pyramid != null) {
+                        Pair<Integer, Integer> cool = this.getStats().getCool();
+                        if (cool != null && damage >= cool.getLeft() && Randomizer.nextInt(100) < cool.getRight()) {
+                            pyramid.cool();
+                        } else {
+                            pyramid.kill();
+                        }
+                    }
                 }
+            } else if (pyramid != null) {
+                pyramid.miss();
             }
         } finally {
             this.unlockMonster();

--- a/gms-server/src/main/java/org/gms/server/partyquest/Pyramid.java
+++ b/gms-server/src/main/java/org/gms/server/partyquest/Pyramid.java
@@ -28,6 +28,7 @@ import org.gms.constants.id.MapId;
 import org.gms.net.server.world.Party;
 import org.gms.server.ItemInformationProvider;
 import org.gms.server.TimerManager;
+import org.gms.server.quest.Quest;
 import org.gms.util.PacketCreator;
 
 import java.util.concurrent.ScheduledFuture;
@@ -38,6 +39,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * @author kevintjuh93
  */
 public class Pyramid extends PartyQuest {
+    private static final int PROTECTOR_OF_PHARAOH_QUEST = 29932;
+    private static final int PROTECTOR_OF_PHARAOH_INFO = 7760;
+    private static final int PROTECTOR_OF_PHARAOH_NPC = 9000066;
+    private static final int PROTECTOR_OF_PHARAOH_REQUIRED_KILLS = 50000;
+
     public enum PyramidMode {
         EASY(0), NORMAL(1), HARD(2), HELL(3);
         int mode;
@@ -51,10 +57,10 @@ public class Pyramid extends PartyQuest {
         }
     }
 
-    int kill = 0, miss = 0, cool = 0, exp = 0, map, count;
+    int kill = 0, miss = 0, cool = 0, exp = 0, map, count, skill = 0;
     byte coolAdd = 5, missSub = 4, decrease = 1;//hmmm
     short gauge;
-    byte rank, skill = 0, stage = 0, buffcount = 0;//buffcount includes buffs + skills
+    byte rank, stage = 0, buffcount = 0;//buffcount includes buffs + skills
     PyramidMode mode;
 
     ScheduledFuture<?> timer = null;
@@ -64,6 +70,9 @@ public class Pyramid extends PartyQuest {
         super(party);
         this.mode = mode;
         this.map = mapid;
+        for (Character chr : getParticipants()) {
+            chr.setPartyQuest(this);
+        }
 
         byte plus = (byte) mode.getMode();
         coolAdd += plus;
@@ -71,11 +80,14 @@ public class Pyramid extends PartyQuest {
         switch (plus) {
             case 0:
                 decrease = 1;
+                break;
             case 1:
             case 2:
                 decrease = 2;
+                break;
             case 3:
                 decrease = 3;
+                break;
         }
     }
 
@@ -95,6 +107,7 @@ public class Pyramid extends PartyQuest {
 
     public void kill() {
         kill++;
+        recordProtectorOfPharaohKill();
         if (gauge < 100) {
             count++;
         }
@@ -108,6 +121,7 @@ public class Pyramid extends PartyQuest {
 
     public void cool() {
         cool++;
+        recordProtectorOfPharaohKill();
         int plus = coolAdd;
         if ((gauge + coolAdd) > 100) {
             plus -= ((gauge + coolAdd) - 100);
@@ -129,7 +143,30 @@ public class Pyramid extends PartyQuest {
         broadcastInfo("miss", miss);
     }
 
+    private void recordProtectorOfPharaohKill() {
+        for (Character chr : getParticipants()) {
+            if (chr.getQuestStatus(PROTECTOR_OF_PHARAOH_QUEST) == 2) {
+                continue;
+            }
+            if (chr.getQuestStatus(PROTECTOR_OF_PHARAOH_QUEST) != 1) {
+                Quest.getInstance(PROTECTOR_OF_PHARAOH_QUEST).forceStart(chr, PROTECTOR_OF_PHARAOH_NPC);
+            }
+
+            int progress;
+            try {
+                progress = Integer.parseInt(chr.getQuest(Quest.getInstance(PROTECTOR_OF_PHARAOH_INFO)).getProgress(0));
+            } catch (NumberFormatException nfe) {
+                progress = 0;
+            }
+            if (progress < PROTECTOR_OF_PHARAOH_REQUIRED_KILLS) {
+                chr.setQuestProgress(PROTECTOR_OF_PHARAOH_QUEST, PROTECTOR_OF_PHARAOH_INFO, Integer.toString(progress + 1));
+            }
+        }
+    }
+
     public int timer() {
+        stopTimer();
+
         int value;
         if (stage > 0) {
             value = 180;
@@ -138,8 +175,13 @@ public class Pyramid extends PartyQuest {
         }
 
         timer = TimerManager.getInstance().schedule(() -> {
-            stage++;
-            warp(map + (stage * 100));//Should work :D
+            byte nextStage = (byte) (stage + 1);
+            if (nextStage >= 5) {
+                stage = 5;
+                warp(MapId.NETTS_PYRAMID);
+            } else {
+                warp(map + (nextStage * 100));//Should work :D
+            }
         }, SECONDS.toMillis(value));//, 4000
         broadcastInfo("party", getParticipants().size() > 1 ? 1 : 0);
         broadcastInfo("hit", kill);
@@ -148,20 +190,50 @@ public class Pyramid extends PartyQuest {
         broadcastInfo("skill", skill);
         broadcastInfo("laststage", stage);
         startGaugeSchedule();
+        for (Character chr : getParticipants()) {
+            chr.sendPacket(PacketCreator.getClock(value));
+        }
         return value;
     }
 
     public void warp(int mapid) {
+        stopTimer();
+        int stageOffset = mapid - map;
+        boolean nextStageMap = stageOffset >= 0 && stageOffset <= 400 && stageOffset % 100 == 0;
         for (Character chr : getParticipants()) {
             chr.changeMap(mapid, 0);
+            if (!nextStageMap) {
+                chr.setPartyQuest(null);
+            }
         }
-        if (stage > -1) {
-            gaugeSchedule.cancel(false);
-            gaugeSchedule = null;
+        if (nextStageMap) {
+            stage = (byte) (stageOffset / 100);
+            timer();
+        } else {
+            stopGaugeSchedule();
+        }
+    }
+
+    public void leave(int mapid) {
+        stopTimer();
+        stopGaugeSchedule();
+        for (Character chr : getParticipants()) {
+            chr.setPartyQuest(null);
+            chr.changeMap(mapid, 0);
+        }
+    }
+
+    private void stopTimer() {
+        if (timer != null) {
             timer.cancel(false);
             timer = null;
-        } else {
-            stage = 0;
+        }
+    }
+
+    private void stopGaugeSchedule() {
+        if (gaugeSchedule != null) {
+            gaugeSchedule.cancel(false);
+            gaugeSchedule = null;
         }
     }
 
@@ -208,6 +280,7 @@ public class Pyramid extends PartyQuest {
                 ii.getItemEffect(ItemId.PHARAOHS_BLESSING_3).applyTo(chr);
             }
         } else if (buffcount == 3 && total >= 1500) {
+            buffcount++;
             skill++;
             broadcastInfo("skill", skill);
         } else if (buffcount == 4 && total >= 2000) {
@@ -219,9 +292,11 @@ public class Pyramid extends PartyQuest {
                 ii.getItemEffect(ItemId.PHARAOHS_BLESSING_4).applyTo(chr);
             }
         } else if (buffcount == 5 && total >= 2500) {
+            buffcount++;
             skill++;
             broadcastInfo("skill", skill);
         } else if (buffcount == 6 && total >= 3000) {
+            buffcount++;
             skill++;
             broadcastInfo("skill", skill);
         }

--- a/gms-server/src/main/resources/db/migration/V1.11.5__add_netts_pyramid_bonus_drops.sql
+++ b/gms-server/src/main/resources/db/migration/V1.11.5__add_netts_pyramid_bonus_drops.sql
@@ -1,0 +1,9 @@
+INSERT INTO `drop_data` (`dropperid`, `itemid`, `minimum_quantity`, `maximum_quantity`, `questid`, `chance`)
+VALUES
+    (9700019, 2022613, 1, 1, 0, 1000000),
+    (9700029, 2022618, 1, 1, 0, 1000000)
+ON DUPLICATE KEY UPDATE
+    `minimum_quantity` = VALUES(`minimum_quantity`),
+    `maximum_quantity` = VALUES(`maximum_quantity`),
+    `questid` = VALUES(`questid`),
+    `chance` = VALUES(`chance`);

--- a/gms-server/src/main/resources/i18n/message_en_US.properties
+++ b/gms-server/src/main/resources/i18n/message_en_US.properties
@@ -294,6 +294,7 @@ ItemDropCommand.message2 = Syntax: !drop <itemid> <quantity>
 ItemDropCommand.message3 = Pet Syntax: !drop <itemid> <expiration>
 UseItemHandler.message1=You cannot recover from a banish state at the moment.
 UseItemHandler.message2=You cannot go there.\r\nThis item can only be used in Japan/Showa/Shrine maps.
+Dojo.secretSkill.energyReset = As you used the secret skill, your energy bar has been reset.
 LevelCommand.message1 = Set your level.
 LevelCommand.message2 = Syntax: !level <newlevel>
 

--- a/gms-server/src/main/resources/i18n/message_zh_CN.properties
+++ b/gms-server/src/main/resources/i18n/message_zh_CN.properties
@@ -293,6 +293,7 @@ ItemDropCommand.message3 = 宠物请输入：!drop <物品id> <失效时间>
 
 UseItemHandler.message1 = 你目前无法从放逐状态中恢复。
 UseItemHandler.message2 = 不能去那里，\r\n只能在日本/昭和/神社系列地图使用
+Dojo.secretSkill.energyReset = 使用秘密技能后，能量条已重置。
 
 LevelCommand.message1 = 自定义等级，直接更改
 LevelCommand.message2 = 输入：!level <新等级>

--- a/gms-server/wz/Map.wz/Map/Map2/260020700.img.xml
+++ b/gms-server/wz/Map.wz/Map/Map2/260020700.img.xml
@@ -1593,5 +1593,16 @@
       <int name="hideTooltip" value="0"/>
       <int name="delay" value="0"/>
     </imgdir>
+    <imgdir name="6">
+      <string name="pn" value="pyramid00"/>
+      <int name="pt" value="7"/>
+      <int name="x" value="331"/>
+      <int name="y" value="145"/>
+      <int name="tm" value="999999999"/>
+      <string name="tn" value=""/>
+      <string name="script" value="nets_in"/>
+      <int name="hideTooltip" value="0"/>
+      <int name="delay" value="0"/>
+    </imgdir>
   </imgdir>
 </imgdir>


### PR DESCRIPTION
## 改动内容
- 修复 NPC 杜阿特进入奈特金字塔时提示任务不可用、金字塔挑战流程无法正常开始的问题。
- 修复隐藏地图“金字塔山丘”的传送门配置，使其可以进入金字塔相关地图。
- 修复奈特金字塔挑战中的能量条、特殊技能、阶段推进、法老雪人墓室刷怪与计时逻辑。
- 修复 NPC 杜阿特放弃挑战离开时，因计时器未清理导致角色被传回金字塔内部的问题。
- 修复“法老守护者”勋章击杀进度记录与 NPC 进度提示，涉及任务 29932、NPC 杜阿特、金字塔怪物击杀统计。
- 修复“法老的宝石盒”与地狱模式宝石盒奖励逻辑，补充普通/地狱法老小雪人的宝箱掉落配置。
- 中英文脚本目录与 WZ 目录均按功能改动保持对称。

## 影响范围
- 影响服务端脚本、服务端逻辑、数据库迁移与地图 WZ XML。
- 地图 WZ XML 会影响客户端 Data 中的地图资源，需要同步客户端资源包。

## 验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查。
- 已执行中文乱码检查。
- 已执行 Maven 编译校验，未重新构建发布 Jar。
- 已完成本地游戏内测试，验证金字塔进入、特殊技能、墓室刷怪、宝箱奖励、勋章进度与放弃挑战离开流程。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。