### PR TITLE
fix: 校正战士职业技能描述

### DIFF
--- a/gms-server/wz-zh-CN/String.wz/Skill.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Skill.img.xml
@@ -156,37 +156,37 @@
     </imgdir>
     <imgdir name="1000000">
         <string name="name" value="生命恢复"/>
-        <string name="h1" value="HP恢复+3"/>
-        <string name="h10" value="HP恢复+30"/>
-        <string name="h11" value="HP恢复+33"/>
-        <string name="h12" value="HP恢复+36"/>
-        <string name="h13" value="HP恢复+39"/>
-        <string name="h14" value="HP恢复+42"/>
-        <string name="h15" value="HP恢复+45"/>
-        <string name="h16" value="HP恢复+50"/>
-        <string name="h2" value="HP恢复+6"/>
-        <string name="h3" value="HP恢复+9"/>
-        <string name="h4" value="HP恢复+12"/>
-        <string name="h5" value="HP恢复+15"/>
-        <string name="h6" value="HP恢复+18"/>
-        <string name="h7" value="HP恢复+21"/>
-        <string name="h8" value="HP恢复+24"/>
-        <string name="h9" value="HP恢复+27"/>
-        <string name="desc" value="[最高等级 : 16]\n增加每5秒的HP恢复量"/>
+        <string name="desc" value="[最高等级：16]\n站立不动时，每10秒额外恢复HP。"/>
+        <string name="h1" value="额外恢复HP +3"/>
+        <string name="h2" value="额外恢复HP +6"/>
+        <string name="h3" value="额外恢复HP +9"/>
+        <string name="h4" value="额外恢复HP +12"/>
+        <string name="h5" value="额外恢复HP +15"/>
+        <string name="h6" value="额外恢复HP +18"/>
+        <string name="h7" value="额外恢复HP +21"/>
+        <string name="h8" value="额外恢复HP +24"/>
+        <string name="h9" value="额外恢复HP +27"/>
+        <string name="h10" value="额外恢复HP +30"/>
+        <string name="h11" value="额外恢复HP +33"/>
+        <string name="h12" value="额外恢复HP +36"/>
+        <string name="h13" value="额外恢复HP +39"/>
+        <string name="h14" value="额外恢复HP +42"/>
+        <string name="h15" value="额外恢复HP +45"/>
+        <string name="h16" value="额外恢复HP +50"/>
     </imgdir>
     <imgdir name="1000001">
         <string name="name" value="生命加强"/>
-        <string name="h1" value="最大HP增加。每次升级时+4，使用AP提高时+3"/>
-        <string name="h10" value="最大HP增加。每次升级时+40，使用AP提高时+30"/>
-        <string name="h2" value="最大HP增加。每次升级时+8，使用AP提高时+6"/>
-        <string name="h3" value="最大HP增加。每次升级时+12，使用AP提高时+9"/>
-        <string name="h4" value="最大HP增加。每次升级时+16，使用AP提高时+12"/>
-        <string name="h5" value="最大HP增加。每次升级时+20，使用AP提高时+15"/>
-        <string name="h6" value="最大HP增加。每次升级时+24，使用AP提高时+18"/>
-        <string name="h7" value="最大HP增加。每次升级时+28，使用AP提高时+21"/>
-        <string name="h8" value="最大HP增加。每次升级时+32，使用AP提高时+24"/>
-        <string name="h9" value="最大HP增加。每次升级时+36，使用AP提高时+27"/>
-        <string name="desc" value="[最高等级 : 10]\n等级上升时以及使用AP增加HP，\n提高最大HP的增加量。\n必需技能:#c提高恢复HP等级5以上#"/>
+        <string name="desc" value="[最高等级：10]\n升级或使用AP增加HP时，额外提高MaxHP增加量。\n需要技能：#c生命恢复5级以上#"/>
+        <string name="h1" value="升级时MaxHP +4；AP加HP时MaxHP +3"/>
+        <string name="h2" value="升级时MaxHP +8；AP加HP时MaxHP +6"/>
+        <string name="h3" value="升级时MaxHP +12；AP加HP时MaxHP +9"/>
+        <string name="h4" value="升级时MaxHP +16；AP加HP时MaxHP +12"/>
+        <string name="h5" value="升级时MaxHP +20；AP加HP时MaxHP +15"/>
+        <string name="h6" value="升级时MaxHP +24；AP加HP时MaxHP +18"/>
+        <string name="h7" value="升级时MaxHP +28；AP加HP时MaxHP +21"/>
+        <string name="h8" value="升级时MaxHP +32；AP加HP时MaxHP +24"/>
+        <string name="h9" value="升级时MaxHP +36；AP加HP时MaxHP +27"/>
+        <string name="h10" value="升级时MaxHP +40；AP加HP时MaxHP +30"/>
     </imgdir>
     <imgdir name="10000012">
         <string name="name" value="精灵的祝福"/>
@@ -223,6 +223,7 @@
     </imgdir>
     <imgdir name="1000002">
         <string name="name" value="恢复术"/>
+        <string name="desc" value="[最高等级：8]\n攀在绳子或梯子上时也能每隔一段时间恢复HP。\n需要技能：#c生命加强3级以上#"/>
         <string name="h1" value="每31秒恢复HP"/>
         <string name="h2" value="每28秒恢复HP"/>
         <string name="h3" value="每25秒恢复HP"/>
@@ -231,7 +232,6 @@
         <string name="h6" value="每16秒恢复HP"/>
         <string name="h7" value="每13秒恢复HP"/>
         <string name="h8" value="每10秒恢复HP"/>
-        <string name="desc" value="[最高等级 : 8]\n在梯子和绳索上面也可以恢复HP.\n必需技能: #c提高恢复HP等级3以上#"/>
     </imgdir>
     <imgdir name="10000100">
         <string name="name" value="椅子大师"/>
@@ -352,75 +352,75 @@
     </imgdir>
     <imgdir name="1001003">
         <string name="name" value="圣甲术"/>
-        <string name="h1" value="持续75秒，消耗MP 8，物理防御力+2"/>
-        <string name="h10" value="持续175秒，消耗MP 10，物理防御力+20"/>
-        <string name="h11" value="持续190秒，消耗MP 11，物理防御力+22"/>
-        <string name="h12" value="持续200秒，消耗MP 11，物理防御力+24"/>
-        <string name="h13" value="持续215秒，消耗MP 12，物理防御力+26"/>
-        <string name="h14" value="持续225秒，消耗MP 12，物理防御力+28"/>
-        <string name="h15" value="持续240秒，消耗MP 13，物理防御力+30"/>
-        <string name="h16" value="持续250秒，消耗MP 13，物理防御力+32"/>
-        <string name="h17" value="持续265秒，消耗MP 14，物理防御力+34"/>
-        <string name="h18" value="持续275秒，消耗MP 14，物理防御力+36"/>
-        <string name="h19" value="持续290秒，消耗MP 15，物理防御力+38"/>
-        <string name="h2" value="持续85秒，消耗MP 8，物理防御力+4"/>
-        <string name="h20" value="持续300秒，消耗MP 15，物理防御力+40"/>
-        <string name="h3" value="持续95秒，消耗MP 8，物理防御力+6"/>
-        <string name="h4" value="持续105秒，消耗MP 8，物理防御力+8"/>
-        <string name="h5" value="持续120秒，消耗MP 9，物理防御力+10"/>
-        <string name="h6" value="持续130秒，消耗MP 9，物理防御力+12"/>
-        <string name="h7" value="持续140秒，消耗MP 9，物理防御力+14"/>
-        <string name="h8" value="持续155秒，消耗MP 10，物理防御力+16"/>
-        <string name="h9" value="持续165秒，消耗MP 10，物理防御力+18"/>
-        <string name="desc" value="[最高等级 : 20]\n一定时间内物理防御力增加.\n必需技能：#c恢复术等级3以上#"/>
+        <string name="desc" value="[最高等级：20]\n一定时间内提高物理防御力。\n需要技能：#c恢复术3级以上#"/>
+        <string name="h1" value="消耗MP 8，物理防御力 +2，持续75秒"/>
+        <string name="h2" value="消耗MP 8，物理防御力 +4，持续85秒"/>
+        <string name="h3" value="消耗MP 8，物理防御力 +6，持续95秒"/>
+        <string name="h4" value="消耗MP 8，物理防御力 +8，持续105秒"/>
+        <string name="h5" value="消耗MP 9，物理防御力 +10，持续120秒"/>
+        <string name="h6" value="消耗MP 9，物理防御力 +12，持续130秒"/>
+        <string name="h7" value="消耗MP 9，物理防御力 +14，持续140秒"/>
+        <string name="h8" value="消耗MP 10，物理防御力 +16，持续155秒"/>
+        <string name="h9" value="消耗MP 10，物理防御力 +18，持续165秒"/>
+        <string name="h10" value="消耗MP 10，物理防御力 +20，持续175秒"/>
+        <string name="h11" value="消耗MP 11，物理防御力 +22，持续190秒"/>
+        <string name="h12" value="消耗MP 11，物理防御力 +24，持续200秒"/>
+        <string name="h13" value="消耗MP 12，物理防御力 +26，持续215秒"/>
+        <string name="h14" value="消耗MP 12，物理防御力 +28，持续225秒"/>
+        <string name="h15" value="消耗MP 13，物理防御力 +30，持续240秒"/>
+        <string name="h16" value="消耗MP 13，物理防御力 +32，持续250秒"/>
+        <string name="h17" value="消耗MP 14，物理防御力 +34，持续265秒"/>
+        <string name="h18" value="消耗MP 14，物理防御力 +36，持续275秒"/>
+        <string name="h19" value="消耗MP 15，物理防御力 +38，持续290秒"/>
+        <string name="h20" value="消耗MP 15，物理防御力 +40，持续300秒"/>
     </imgdir>
     <imgdir name="1001004">
         <string name="name" value="强力攻击"/>
-        <string name="h1" value="消费MP4，攻击力165%"/>
-        <string name="h10" value="消费MP7，攻击力210%"/>
-        <string name="h11" value="消费MP7，攻击力215%"/>
-        <string name="h12" value="消费MP8，攻击力220%"/>
-        <string name="h13" value="消费MP8，攻击力225%"/>
-        <string name="h14" value="消费MP9，攻击力230%"/>
-        <string name="h15" value="消费MP9，攻击力235%"/>
-        <string name="h16" value="消费MP10，攻击力240%"/>
-        <string name="h17" value="消费MP10，攻击力245%"/>
-        <string name="h18" value="消费MP11，攻击力250%"/>
-        <string name="h19" value="消费MP11，攻击力255%"/>
-        <string name="h2" value="消费MP4，攻击力170%"/>
-        <string name="h20" value="消费MP12，攻击力260%"/>
-        <string name="h3" value="消费MP4，攻击力175%"/>
-        <string name="h4" value="消费MP4，攻击力180%"/>
-        <string name="h5" value="消费MP5，攻击力185%"/>
-        <string name="h6" value="消费MP5，攻击力190%"/>
-        <string name="h7" value="消费MP5，攻击力195%"/>
-        <string name="h8" value="消费MP6，攻击力200%"/>
-        <string name="h9" value="消费MP6，攻击力205%"/>
-        <string name="desc" value="[最高等级 : 20]\n消费MP，\n用所装备的武器给怪物以致命一击"/>
+        <string name="desc" value="[最高等级：20]\n消耗MP，用装备中的近战武器对敌人发动强力一击。"/>
+        <string name="h1" value="消耗MP 4，伤害 165%"/>
+        <string name="h2" value="消耗MP 4，伤害 170%"/>
+        <string name="h3" value="消耗MP 4，伤害 175%"/>
+        <string name="h4" value="消耗MP 4，伤害 180%"/>
+        <string name="h5" value="消耗MP 5，伤害 185%"/>
+        <string name="h6" value="消耗MP 5，伤害 190%"/>
+        <string name="h7" value="消耗MP 5，伤害 195%"/>
+        <string name="h8" value="消耗MP 6，伤害 200%"/>
+        <string name="h9" value="消耗MP 6，伤害 205%"/>
+        <string name="h10" value="消耗MP 7，伤害 210%"/>
+        <string name="h11" value="消耗MP 7，伤害 215%"/>
+        <string name="h12" value="消耗MP 8，伤害 220%"/>
+        <string name="h13" value="消耗MP 8，伤害 225%"/>
+        <string name="h14" value="消耗MP 9，伤害 230%"/>
+        <string name="h15" value="消耗MP 9，伤害 235%"/>
+        <string name="h16" value="消耗MP 10，伤害 240%"/>
+        <string name="h17" value="消耗MP 10，伤害 245%"/>
+        <string name="h18" value="消耗MP 11，伤害 250%"/>
+        <string name="h19" value="消耗MP 11，伤害 255%"/>
+        <string name="h20" value="消耗MP 12，伤害 260%"/>
     </imgdir>
     <imgdir name="1001005">
         <string name="name" value="群体攻击"/>
-        <string name="h1" value="消耗HP8和MP6，攻击力72%"/>
-		<string name="h10" value="消耗HP11和MP9，攻击力99%"/>
-		<string name="h11" value="消耗HP11和MP9，攻击力102%"/>
-		<string name="h12" value="消耗HP12和MP10，攻击力105%"/>
-		<string name="h13" value="消耗HP12和MP10，攻击力108%"/>
-		<string name="h14" value="消耗HP13和MP11，攻击力111%"/>
-		<string name="h15" value="消耗HP13和MP11，攻击力114%"/>
-		<string name="h16" value="消耗HP14和MP12，攻击力117%"/>
-		<string name="h17" value="消耗HP14和MP12，攻击力120%"/>
-		<string name="h18" value="消耗HP15和MP13，攻击力123%"/>
-		<string name="h19" value="消耗HP15和MP13，攻击力126%"/>
-		<string name="h2" value="消耗HP8和MP6，攻击力75%"/>
-		<string name="h20" value="消耗HP16和MP14，攻击力130%"/>
-		<string name="h3" value="消耗HP8和MP6，攻击力78%"/>
-		<string name="h4" value="消耗HP8和MP6，攻击力81%"/>
-		<string name="h5" value="消耗HP9和MP7，攻击力84%"/>
-		<string name="h6" value="消耗HP9和MP7，攻击力87%"/>
-		<string name="h7" value="消耗HP9和MP7，攻击力90%"/>
-		<string name="h8" value="消耗HP10和MP8，攻击力93%"/>
-		<string name="h9" value="消耗HP10和MP8，攻击力96%"/>
-        <string name="desc" value="[最高等级 : 20]\n消费HP和MP，\n用装备的武器同时攻击周围的多个怪物.\n必需技能：#c强力攻击等级1以上#"/>
+        <string name="desc" value="[最高等级：20]\n消耗HP和MP，用装备中的近战武器攻击周围多个敌人。\n需要技能：#c强力攻击1级以上#"/>
+        <string name="h1" value="消耗HP 8，消耗MP 6，伤害 72%，最多攻击6个敌人"/>
+        <string name="h2" value="消耗HP 8，消耗MP 6，伤害 75%，最多攻击6个敌人"/>
+        <string name="h3" value="消耗HP 8，消耗MP 6，伤害 78%，最多攻击6个敌人"/>
+        <string name="h4" value="消耗HP 8，消耗MP 6，伤害 81%，最多攻击6个敌人"/>
+        <string name="h5" value="消耗HP 9，消耗MP 7，伤害 84%，最多攻击6个敌人"/>
+        <string name="h6" value="消耗HP 9，消耗MP 7，伤害 87%，最多攻击6个敌人"/>
+        <string name="h7" value="消耗HP 9，消耗MP 7，伤害 90%，最多攻击6个敌人"/>
+        <string name="h8" value="消耗HP 10，消耗MP 8，伤害 93%，最多攻击6个敌人"/>
+        <string name="h9" value="消耗HP 10，消耗MP 8，伤害 96%，最多攻击6个敌人"/>
+        <string name="h10" value="消耗HP 11，消耗MP 9，伤害 99%，最多攻击6个敌人"/>
+        <string name="h11" value="消耗HP 11，消耗MP 9，伤害 102%，最多攻击6个敌人"/>
+        <string name="h12" value="消耗HP 12，消耗MP 10，伤害 105%，最多攻击6个敌人"/>
+        <string name="h13" value="消耗HP 12，消耗MP 10，伤害 108%，最多攻击6个敌人"/>
+        <string name="h14" value="消耗HP 13，消耗MP 11，伤害 111%，最多攻击6个敌人"/>
+        <string name="h15" value="消耗HP 13，消耗MP 11，伤害 114%，最多攻击6个敌人"/>
+        <string name="h16" value="消耗HP 14，消耗MP 12，伤害 117%，最多攻击6个敌人"/>
+        <string name="h17" value="消耗HP 14，消耗MP 12，伤害 120%，最多攻击6个敌人"/>
+        <string name="h18" value="消耗HP 15，消耗MP 13，伤害 123%，最多攻击6个敌人"/>
+        <string name="h19" value="消耗HP 15，消耗MP 13，伤害 126%，最多攻击6个敌人"/>
+        <string name="h20" value="消耗HP 16，消耗MP 14，伤害 130%，最多攻击6个敌人"/>
     </imgdir>
     <imgdir name="110">
         <string name="bookName" value="剑客技能"/>
@@ -430,27 +430,27 @@
     </imgdir>
     <imgdir name="1100000">
         <string name="name" value="精准剑"/>
-        <string name="h1" value="剑系列武器的熟练度+15%， 命中率+1"/>
-        <string name="h10" value="剑系列武器的熟练度+35%， 命中率+10"/>
-        <string name="h11" value="剑系列武器的熟练度+40%， 命中率+11"/>
-        <string name="h12" value="剑系列武器的熟练度+40%， 命中率+12"/>
-        <string name="h13" value="剑系列武器的熟练度+45%， 命中率+13"/>
-        <string name="h14" value="剑系列武器的熟练度+45%， 命中率+14"/>
-        <string name="h15" value="剑系列武器的熟练度+50%， 命中率+15"/>
-        <string name="h16" value="剑系列武器的熟练度+50%， 命中率+16"/>
-        <string name="h17" value="剑系列武器的熟练度+55%， 命中率+17"/>
-        <string name="h18" value="剑系列武器的熟练度+55%， 命中率+18"/>
-        <string name="h19" value="剑系列武器的熟练度+60%， 命中率+19"/>
-        <string name="h2" value="剑系列武器的熟练度+15%， 命中率+2"/>
-        <string name="h20" value="剑系列武器的熟练度+60%， 命中率+20"/>
-        <string name="h3" value="剑系列武器的熟练度+20%， 命中率+3"/>
-        <string name="h4" value="剑系列武器的熟练度+20%， 命中率+4"/>
-        <string name="h5" value="剑系列武器的熟练度+25%， 命中率+5"/>
-        <string name="h6" value="剑系列武器的熟练度+25%， 命中率+6"/>
-        <string name="h7" value="剑系列武器的熟练度+30%， 命中率+7"/>
-        <string name="h8" value="剑系列武器的熟练度+30%， 命中率+8"/>
-        <string name="h9" value="剑系列武器的熟练度+35%， 命中率+9"/>
-        <string name="desc" value="[最高等级 : 20]\n增加使用剑系武器的命中率及熟练度\n(必须装备单手剑或双手剑)"/>
+        <string name="desc" value="[最高等级：20]\n提高剑系武器的熟练度和命中率。只在装备对应武器时生效。"/>
+        <string name="h1" value="剑系武器熟练度 51%，命中率 +1"/>
+        <string name="h2" value="剑系武器熟练度 51%，命中率 +2"/>
+        <string name="h3" value="剑系武器熟练度 52%，命中率 +3"/>
+        <string name="h4" value="剑系武器熟练度 52%，命中率 +4"/>
+        <string name="h5" value="剑系武器熟练度 53%，命中率 +5"/>
+        <string name="h6" value="剑系武器熟练度 53%，命中率 +6"/>
+        <string name="h7" value="剑系武器熟练度 54%，命中率 +7"/>
+        <string name="h8" value="剑系武器熟练度 54%，命中率 +8"/>
+        <string name="h9" value="剑系武器熟练度 55%，命中率 +9"/>
+        <string name="h10" value="剑系武器熟练度 55%，命中率 +10"/>
+        <string name="h11" value="剑系武器熟练度 56%，命中率 +11"/>
+        <string name="h12" value="剑系武器熟练度 56%，命中率 +12"/>
+        <string name="h13" value="剑系武器熟练度 57%，命中率 +13"/>
+        <string name="h14" value="剑系武器熟练度 57%，命中率 +14"/>
+        <string name="h15" value="剑系武器熟练度 58%，命中率 +15"/>
+        <string name="h16" value="剑系武器熟练度 58%，命中率 +16"/>
+        <string name="h17" value="剑系武器熟练度 59%，命中率 +17"/>
+        <string name="h18" value="剑系武器熟练度 59%，命中率 +18"/>
+        <string name="h19" value="剑系武器熟练度 60%，命中率 +19"/>
+        <string name="h20" value="剑系武器熟练度 60%，命中率 +20"/>
     </imgdir>
     <imgdir name="11000000">
         <string name="name" value="生命加强"/>
@@ -468,95 +468,95 @@
     </imgdir>
     <imgdir name="1100001">
         <string name="name" value="精准斧"/>
-        <string name="h1" value="斧系列武器的熟练度+15%， 命中率+1"/>
-        <string name="h10" value="斧系列武器的熟练度+35%， 命中率+10"/>
-        <string name="h11" value="斧系列武器的熟练度+40%， 命中率+11"/>
-        <string name="h12" value="斧系列武器的熟练度+40%， 命中率+12"/>
-        <string name="h13" value="斧系列武器的熟练度+45%， 命中率+13"/>
-        <string name="h14" value="斧系列武器的熟练度+45%， 命中率+14"/>
-        <string name="h15" value="斧系列武器的熟练度+50%， 命中率+15"/>
-        <string name="h16" value="斧系列武器的熟练度+50%， 命中率+16"/>
-        <string name="h17" value="斧系列武器的熟练度+55%， 命中率+17"/>
-        <string name="h18" value="斧系列武器的熟练度+55%， 命中率+18"/>
-        <string name="h19" value="斧系列武器的熟练度+60%， 命中率+19"/>
-        <string name="h2" value="斧系列武器的熟练度+15%， 命中率+2"/>
-        <string name="h20" value="斧系列武器的熟练度+60%， 命中率+20"/>
-        <string name="h3" value="斧系列武器的熟练度+20%， 命中率+3"/>
-        <string name="h4" value="斧系列武器的熟练度+20%， 命中率+4"/>
-        <string name="h5" value="斧系列武器的熟练度+25%， 命中率+5"/>
-        <string name="h6" value="斧系列武器的熟练度+25%， 命中率+6"/>
-        <string name="h7" value="斧系列武器的熟练度+30%， 命中率+7"/>
-        <string name="h8" value="斧系列武器的熟练度+30%， 命中率+8"/>
-        <string name="h9" value="斧系列武器的熟练度+35%， 命中率+9"/>
-        <string name="desc" value="[最高等级 : 20]\n增加使用斧系武器的命中率及熟练度\n(必须装备单手斧，双手斧)"/>
+        <string name="desc" value="[最高等级：20]\n提高斧系武器的熟练度和命中率。只在装备对应武器时生效。"/>
+        <string name="h1" value="斧系武器熟练度 51%，命中率 +1"/>
+        <string name="h2" value="斧系武器熟练度 51%，命中率 +2"/>
+        <string name="h3" value="斧系武器熟练度 52%，命中率 +3"/>
+        <string name="h4" value="斧系武器熟练度 52%，命中率 +4"/>
+        <string name="h5" value="斧系武器熟练度 53%，命中率 +5"/>
+        <string name="h6" value="斧系武器熟练度 53%，命中率 +6"/>
+        <string name="h7" value="斧系武器熟练度 54%，命中率 +7"/>
+        <string name="h8" value="斧系武器熟练度 54%，命中率 +8"/>
+        <string name="h9" value="斧系武器熟练度 55%，命中率 +9"/>
+        <string name="h10" value="斧系武器熟练度 55%，命中率 +10"/>
+        <string name="h11" value="斧系武器熟练度 56%，命中率 +11"/>
+        <string name="h12" value="斧系武器熟练度 56%，命中率 +12"/>
+        <string name="h13" value="斧系武器熟练度 57%，命中率 +13"/>
+        <string name="h14" value="斧系武器熟练度 57%，命中率 +14"/>
+        <string name="h15" value="斧系武器熟练度 58%，命中率 +15"/>
+        <string name="h16" value="斧系武器熟练度 58%，命中率 +16"/>
+        <string name="h17" value="斧系武器熟练度 59%，命中率 +17"/>
+        <string name="h18" value="斧系武器熟练度 59%，命中率 +18"/>
+        <string name="h19" value="斧系武器熟练度 60%，命中率 +19"/>
+        <string name="h20" value="斧系武器熟练度 60%，命中率 +20"/>
     </imgdir>
     <imgdir name="1100002">
         <string name="name" value="终极剑"/>
-        <string name="h1" value="出现概率2%，发挥105%的最终攻击"/>
-        <string name="h10" value="出现概率20%，发挥150%的最终攻击"/>
-        <string name="h11" value="出现概率22%，发挥155%的最终攻击"/>
-        <string name="h12" value="出现概率24%，发挥160%的最终攻击"/>
-        <string name="h13" value="出现概率26%，发挥165%的最终攻击"/>
-        <string name="h14" value="出现概率28%，发挥170%的最终攻击"/>
-        <string name="h15" value="出现概率30%，发挥175%的最终攻击"/>
-        <string name="h16" value="出现概率32%，发挥180%的最终攻击"/>
-        <string name="h17" value="出现概率34%，发挥185%的最终攻击"/>
-        <string name="h18" value="出现概率36%，发挥190%的最终攻击"/>
-        <string name="h19" value="出现概率38%，发挥195%的最终攻击"/>
-        <string name="h2" value="出现概率4%，发挥110%的最终攻击"/>
-        <string name="h20" value="出现概率40%，发挥200%的最终攻击"/>
-        <string name="h21" value="出现概率42%，发挥205%的最终攻击"/>
-        <string name="h22" value="出现概率44%，发挥210%的最终攻击"/>
-        <string name="h23" value="出现概率46%，发挥215%的最终攻击"/>
-        <string name="h24" value="出现概率48%，发挥220%的最终攻击"/>
-        <string name="h25" value="出现概率50%，发挥225%的最终攻击"/>
-        <string name="h26" value="出现概率52%，发挥230%的最终攻击"/>
-        <string name="h27" value="出现概率54%，发挥235%的最终攻击"/>
-        <string name="h28" value="出现概率56%，发挥240%的最终攻击"/>
-        <string name="h29" value="出现概率58%，发挥245%的最终攻击"/>
-        <string name="h3" value="出现概率6%，发挥115%的最终攻击"/>
-        <string name="h30" value="出现概率60%，发挥250%的最终攻击"/>
-        <string name="h4" value="出现概率8%，发挥120%的最终攻击"/>
-        <string name="h5" value="出现概率10%，发挥125%的最终攻击"/>
-        <string name="h6" value="出现概率12%，发挥130%的最终攻击"/>
-        <string name="h7" value="出现概率14%，发挥135%的最终攻击"/>
-        <string name="h8" value="出现概率16%，发挥140%的最终攻击"/>
-        <string name="h9" value="出现概率18%，发挥145%的最终攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n第一次攻击后发动连续攻击\n(必须装备单手剑或双手剑)\n必需技能 : #c精准剑等级3以上#"/>
+        <string name="desc" value="[最高等级：30]\n使用部分攻击技能后，有一定概率追加一次终极攻击。只在装备剑时生效。\n需要技能：#c对应精准武器3级以上#"/>
+        <string name="h1" value="2%概率发动终极攻击，伤害 105%"/>
+        <string name="h2" value="4%概率发动终极攻击，伤害 110%"/>
+        <string name="h3" value="6%概率发动终极攻击，伤害 115%"/>
+        <string name="h4" value="8%概率发动终极攻击，伤害 120%"/>
+        <string name="h5" value="10%概率发动终极攻击，伤害 125%"/>
+        <string name="h6" value="12%概率发动终极攻击，伤害 130%"/>
+        <string name="h7" value="14%概率发动终极攻击，伤害 135%"/>
+        <string name="h8" value="16%概率发动终极攻击，伤害 140%"/>
+        <string name="h9" value="18%概率发动终极攻击，伤害 145%"/>
+        <string name="h10" value="20%概率发动终极攻击，伤害 150%"/>
+        <string name="h11" value="22%概率发动终极攻击，伤害 155%"/>
+        <string name="h12" value="24%概率发动终极攻击，伤害 160%"/>
+        <string name="h13" value="26%概率发动终极攻击，伤害 165%"/>
+        <string name="h14" value="28%概率发动终极攻击，伤害 170%"/>
+        <string name="h15" value="30%概率发动终极攻击，伤害 175%"/>
+        <string name="h16" value="32%概率发动终极攻击，伤害 180%"/>
+        <string name="h17" value="34%概率发动终极攻击，伤害 185%"/>
+        <string name="h18" value="36%概率发动终极攻击，伤害 190%"/>
+        <string name="h19" value="38%概率发动终极攻击，伤害 195%"/>
+        <string name="h20" value="40%概率发动终极攻击，伤害 200%"/>
+        <string name="h21" value="42%概率发动终极攻击，伤害 205%"/>
+        <string name="h22" value="44%概率发动终极攻击，伤害 210%"/>
+        <string name="h23" value="46%概率发动终极攻击，伤害 215%"/>
+        <string name="h24" value="48%概率发动终极攻击，伤害 220%"/>
+        <string name="h25" value="50%概率发动终极攻击，伤害 225%"/>
+        <string name="h26" value="52%概率发动终极攻击，伤害 230%"/>
+        <string name="h27" value="54%概率发动终极攻击，伤害 235%"/>
+        <string name="h28" value="56%概率发动终极攻击，伤害 240%"/>
+        <string name="h29" value="58%概率发动终极攻击，伤害 245%"/>
+        <string name="h30" value="60%概率发动终极攻击，伤害 250%"/>
     </imgdir>
     <imgdir name="1100003">
         <string name="name" value="终极斧"/>
-        <string name="h1" value="出现概率2%，发挥105%的最终攻击"/>
-        <string name="h10" value="出现概率20%，发挥150%的最终攻击"/>
-        <string name="h11" value="出现概率22%，发挥155%的最终攻击"/>
-        <string name="h12" value="出现概率24%，发挥160%的最终攻击"/>
-        <string name="h13" value="出现概率26%，发挥165%的最终攻击"/>
-        <string name="h14" value="出现概率28%，发挥170%的最终攻击"/>
-        <string name="h15" value="出现概率30%，发挥175%的最终攻击"/>
-        <string name="h16" value="出现概率32%，发挥180%的最终攻击"/>
-        <string name="h17" value="出现概率34%，发挥185%的最终攻击"/>
-        <string name="h18" value="出现概率36%，发挥190%的最终攻击"/>
-        <string name="h19" value="出现概率38%，发挥195%的最终攻击"/>
-        <string name="h2" value="出现概率4%，发挥110%的最终攻击"/>
-        <string name="h20" value="出现概率40%，发挥200%的最终攻击"/>
-        <string name="h21" value="出现概率42%，发挥205%的最终攻击"/>
-        <string name="h22" value="出现概率44%，发挥210%的最终攻击"/>
-        <string name="h23" value="出现概率46%，发挥215%的最终攻击"/>
-        <string name="h24" value="出现概率48%，发挥220%的最终攻击"/>
-        <string name="h25" value="出现概率50%，发挥225%的最终攻击"/>
-        <string name="h26" value="出现概率52%，发挥230%的最终攻击"/>
-        <string name="h27" value="出现概率54%，发挥235%的最终攻击"/>
-        <string name="h28" value="出现概率56%，发挥240%的最终攻击"/>
-        <string name="h29" value="出现概率58%，发挥245%的最终攻击"/>
-        <string name="h3" value="出现概率6%，发挥115%的最终攻击"/>
-        <string name="h30" value="出现概率60%，发挥250%的最终攻击"/>
-        <string name="h4" value="出现概率8%，发挥120%的最终攻击"/>
-        <string name="h5" value="出现概率10%，发挥125%的最终攻击"/>
-        <string name="h6" value="出现概率12%，发挥130%的最终攻击"/>
-        <string name="h7" value="出现概率14%，发挥135%的最终攻击"/>
-        <string name="h8" value="出现概率16%，发挥140%的最终攻击"/>
-        <string name="h9" value="出现概率18%，发挥145%的最终攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n第一次攻击后发动连续攻击\n(必须装备单手斧，双手斧)\n必需技能 : #c精准斧等级3以上#"/>
+        <string name="desc" value="[最高等级：30]\n使用部分攻击技能后，有一定概率追加一次终极攻击。只在装备斧时生效。\n需要技能：#c对应精准武器3级以上#"/>
+        <string name="h1" value="2%概率发动终极攻击，伤害 105%"/>
+        <string name="h2" value="4%概率发动终极攻击，伤害 110%"/>
+        <string name="h3" value="6%概率发动终极攻击，伤害 115%"/>
+        <string name="h4" value="8%概率发动终极攻击，伤害 120%"/>
+        <string name="h5" value="10%概率发动终极攻击，伤害 125%"/>
+        <string name="h6" value="12%概率发动终极攻击，伤害 130%"/>
+        <string name="h7" value="14%概率发动终极攻击，伤害 135%"/>
+        <string name="h8" value="16%概率发动终极攻击，伤害 140%"/>
+        <string name="h9" value="18%概率发动终极攻击，伤害 145%"/>
+        <string name="h10" value="20%概率发动终极攻击，伤害 150%"/>
+        <string name="h11" value="22%概率发动终极攻击，伤害 155%"/>
+        <string name="h12" value="24%概率发动终极攻击，伤害 160%"/>
+        <string name="h13" value="26%概率发动终极攻击，伤害 165%"/>
+        <string name="h14" value="28%概率发动终极攻击，伤害 170%"/>
+        <string name="h15" value="30%概率发动终极攻击，伤害 175%"/>
+        <string name="h16" value="32%概率发动终极攻击，伤害 180%"/>
+        <string name="h17" value="34%概率发动终极攻击，伤害 185%"/>
+        <string name="h18" value="36%概率发动终极攻击，伤害 190%"/>
+        <string name="h19" value="38%概率发动终极攻击，伤害 195%"/>
+        <string name="h20" value="40%概率发动终极攻击，伤害 200%"/>
+        <string name="h21" value="42%概率发动终极攻击，伤害 205%"/>
+        <string name="h22" value="44%概率发动终极攻击，伤害 210%"/>
+        <string name="h23" value="46%概率发动终极攻击，伤害 215%"/>
+        <string name="h24" value="48%概率发动终极攻击，伤害 220%"/>
+        <string name="h25" value="50%概率发动终极攻击，伤害 225%"/>
+        <string name="h26" value="52%概率发动终极攻击，伤害 230%"/>
+        <string name="h27" value="54%概率发动终极攻击，伤害 235%"/>
+        <string name="h28" value="56%概率发动终极攻击，伤害 240%"/>
+        <string name="h29" value="58%概率发动终极攻击，伤害 245%"/>
+        <string name="h30" value="60%概率发动终极攻击，伤害 250%"/>
     </imgdir>
     <imgdir name="11001001">
         <string name="name" value="圣甲术"/>
@@ -646,109 +646,109 @@
     </imgdir>
     <imgdir name="1101004">
         <string name="name" value="快速剑"/>
-        <string name="h1" value="消耗HP29和MP29，持续10秒"/>
-        <string name="h10" value="消耗HP20和MP20，持续100秒"/>
-        <string name="h11" value="消耗HP19和MP19，持续110秒"/>
-        <string name="h12" value="消耗HP18和MP18，持续120秒"/>
-        <string name="h13" value="消耗HP17和MP17，持续130秒"/>
-        <string name="h14" value="消耗HP16和MP16，持续140秒"/>
-        <string name="h15" value="消耗HP15和MP15，持续150秒"/>
-        <string name="h16" value="消耗HP14和MP14，持续160秒"/>
-        <string name="h17" value="消耗HP13和MP13，持续170秒"/>
-        <string name="h18" value="消耗HP12和MP12，持续180秒"/>
-        <string name="h19" value="消耗HP11和MP11，持续190秒"/>
-        <string name="h2" value="消耗HP28和MP28，持续20秒"/>
-        <string name="h20" value="消耗HP10和MP10，持续200秒"/>
-        <string name="h3" value="消耗HP27和MP27，持续30秒"/>
-        <string name="h4" value="消耗HP26和MP26，持续40秒"/>
-        <string name="h5" value="消耗HP25和MP25，持续50秒"/>
-        <string name="h6" value="消耗HP24和MP24，持续60秒"/>
-        <string name="h7" value="消耗HP23和MP23，持续70秒"/>
-        <string name="h8" value="消耗HP22和MP22，持续80秒"/>
-        <string name="h9" value="消耗HP21和MP21，持续90秒"/>
-        <string name="desc" value="[最高等级 : 20]\n消费HP和MP,攻击速度提升两个等级\n(必须装备单手剑，双手剑)\n必需技能 : #c精准剑等级5以上#"/>
+        <string name="desc" value="[最高等级：20]\n消耗HP和MP，在一定时间内提高装备中的剑的攻击速度。\n需要技能：#c对应精准武器5级以上#"/>
+        <string name="h1" value="消耗HP 29，消耗MP 29，剑攻击速度提升，持续10秒"/>
+        <string name="h2" value="消耗HP 28，消耗MP 28，剑攻击速度提升，持续20秒"/>
+        <string name="h3" value="消耗HP 27，消耗MP 27，剑攻击速度提升，持续30秒"/>
+        <string name="h4" value="消耗HP 26，消耗MP 26，剑攻击速度提升，持续40秒"/>
+        <string name="h5" value="消耗HP 25，消耗MP 25，剑攻击速度提升，持续50秒"/>
+        <string name="h6" value="消耗HP 24，消耗MP 24，剑攻击速度提升，持续60秒"/>
+        <string name="h7" value="消耗HP 23，消耗MP 23，剑攻击速度提升，持续70秒"/>
+        <string name="h8" value="消耗HP 22，消耗MP 22，剑攻击速度提升，持续80秒"/>
+        <string name="h9" value="消耗HP 21，消耗MP 21，剑攻击速度提升，持续90秒"/>
+        <string name="h10" value="消耗HP 20，消耗MP 20，剑攻击速度提升，持续100秒"/>
+        <string name="h11" value="消耗HP 19，消耗MP 19，剑攻击速度提升，持续110秒"/>
+        <string name="h12" value="消耗HP 18，消耗MP 18，剑攻击速度提升，持续120秒"/>
+        <string name="h13" value="消耗HP 17，消耗MP 17，剑攻击速度提升，持续130秒"/>
+        <string name="h14" value="消耗HP 16，消耗MP 16，剑攻击速度提升，持续140秒"/>
+        <string name="h15" value="消耗HP 15，消耗MP 15，剑攻击速度提升，持续150秒"/>
+        <string name="h16" value="消耗HP 14，消耗MP 14，剑攻击速度提升，持续160秒"/>
+        <string name="h17" value="消耗HP 13，消耗MP 13，剑攻击速度提升，持续170秒"/>
+        <string name="h18" value="消耗HP 12，消耗MP 12，剑攻击速度提升，持续180秒"/>
+        <string name="h19" value="消耗HP 11，消耗MP 11，剑攻击速度提升，持续190秒"/>
+        <string name="h20" value="消耗HP 10，消耗MP 10，剑攻击速度提升，持续200秒"/>
     </imgdir>
     <imgdir name="1101005">
         <string name="name" value="快速斧"/>
-        <string name="h1" value="消耗HP29和MP29，持续10秒"/>
-        <string name="h10" value="消耗HP20和MP20，持续100秒"/>
-        <string name="h11" value="消耗HP19和MP19，持续110秒"/>
-        <string name="h12" value="消耗HP18和MP18，持续120秒"/>
-        <string name="h13" value="消耗HP17和MP17，持续130秒"/>
-        <string name="h14" value="消耗HP16和MP16，持续140秒"/>
-        <string name="h15" value="消耗HP15和MP15，持续150秒"/>
-        <string name="h16" value="消耗HP14和MP14，持续160秒"/>
-        <string name="h17" value="消耗HP13和MP13，持续170秒"/>
-        <string name="h18" value="消耗HP12和MP12，持续180秒"/>
-        <string name="h19" value="消耗HP11和MP11，持续190秒"/>
-        <string name="h2" value="消耗HP28和MP28，持续20秒"/>
-        <string name="h20" value="消耗HP10和MP10，持续200秒"/>
-        <string name="h3" value="消耗HP27和MP27，持续30秒"/>
-        <string name="h4" value="消耗HP26和MP26，持续40秒"/>
-        <string name="h5" value="消耗HP25和MP25，持续50秒"/>
-        <string name="h6" value="消耗HP24和MP24，持续60秒"/>
-        <string name="h7" value="消耗HP23和MP23，持续70秒"/>
-        <string name="h8" value="消耗HP22和MP22，持续80秒"/>
-        <string name="h9" value="消耗HP21和MP21，持续90秒"/>
-        <string name="desc" value="[最高等级 : 20]\n攻击速度提升三个等级\n(装备单手斧，双手斧）\n必需技能：#c精准斧等级5以上#"/>
+        <string name="desc" value="[最高等级：20]\n消耗HP和MP，在一定时间内提高装备中的斧的攻击速度。\n需要技能：#c对应精准武器5级以上#"/>
+        <string name="h1" value="消耗HP 29，消耗MP 29，斧攻击速度提升，持续10秒"/>
+        <string name="h2" value="消耗HP 28，消耗MP 28，斧攻击速度提升，持续20秒"/>
+        <string name="h3" value="消耗HP 27，消耗MP 27，斧攻击速度提升，持续30秒"/>
+        <string name="h4" value="消耗HP 26，消耗MP 26，斧攻击速度提升，持续40秒"/>
+        <string name="h5" value="消耗HP 25，消耗MP 25，斧攻击速度提升，持续50秒"/>
+        <string name="h6" value="消耗HP 24，消耗MP 24，斧攻击速度提升，持续60秒"/>
+        <string name="h7" value="消耗HP 23，消耗MP 23，斧攻击速度提升，持续70秒"/>
+        <string name="h8" value="消耗HP 22，消耗MP 22，斧攻击速度提升，持续80秒"/>
+        <string name="h9" value="消耗HP 21，消耗MP 21，斧攻击速度提升，持续90秒"/>
+        <string name="h10" value="消耗HP 20，消耗MP 20，斧攻击速度提升，持续100秒"/>
+        <string name="h11" value="消耗HP 19，消耗MP 19，斧攻击速度提升，持续110秒"/>
+        <string name="h12" value="消耗HP 18，消耗MP 18，斧攻击速度提升，持续120秒"/>
+        <string name="h13" value="消耗HP 17，消耗MP 17，斧攻击速度提升，持续130秒"/>
+        <string name="h14" value="消耗HP 16，消耗MP 16，斧攻击速度提升，持续140秒"/>
+        <string name="h15" value="消耗HP 15，消耗MP 15，斧攻击速度提升，持续150秒"/>
+        <string name="h16" value="消耗HP 14，消耗MP 14，斧攻击速度提升，持续160秒"/>
+        <string name="h17" value="消耗HP 13，消耗MP 13，斧攻击速度提升，持续170秒"/>
+        <string name="h18" value="消耗HP 12，消耗MP 12，斧攻击速度提升，持续180秒"/>
+        <string name="h19" value="消耗HP 11，消耗MP 11，斧攻击速度提升，持续190秒"/>
+        <string name="h20" value="消耗HP 10，消耗MP 10，斧攻击速度提升，持续200秒"/>
     </imgdir>
     <imgdir name="1101006">
         <string name="name" value="愤怒之火"/>
-        <string name="h1" value="消耗MP12，持续46秒，物理攻击力+3，物理防御力-3"/>
-        <string name="h10" value="消耗MP12，持续100秒，物理攻击力+7，物理防御力-7"/>
-        <string name="h11" value="消耗MP20，持续106秒，物理攻击力+8，物理防御力-8"/>
-        <string name="h12" value="消耗MP20，持续112秒，物理攻击力+8，物理防御力-8"/>
-        <string name="h13" value="消耗MP20，持续118秒，物理攻击力+9，物理防御力-9"/>
-        <string name="h14" value="消耗MP20，持续124秒，物理攻击力+9，物理防御力-9"/>
-        <string name="h15" value="消耗MP20，持续130秒，物理攻击力+10，物理防御力-10"/>
-        <string name="h16" value="消耗MP20，持续136秒，物理攻击力+10，物理防御力-10"/>
-        <string name="h17" value="消耗MP20，持续142秒，物理攻击力+11，物理防御力-11"/>
-        <string name="h18" value="消耗MP20，持续148秒，物理攻击力+11，物理防御力-11"/>
-        <string name="h19" value="消耗MP20，持续154秒，物理攻击力+12，物理防御力-12"/>
-        <string name="h2" value="消耗MP12，持续52秒，物理攻击力+3，物理防御力-3"/>
-        <string name="h20" value="消耗MP20，持续160秒，物理攻击力+12，物理防御力-12"/>
-        <string name="h3" value="消耗MP12，持续58秒，物理攻击力+4，物理防御力-4"/>
-        <string name="h4" value="消耗MP12，持续64秒，物理攻击力+4，物理防御力-4"/>
-        <string name="h5" value="消耗MP12，持续70秒，物理攻击力+5，物理防御力-5"/>
-        <string name="h6" value="消耗MP12，持续76秒，物理攻击力+5，物理防御力-5"/>
-        <string name="h7" value="消耗MP12，持续82秒，物理攻击力+6，物理防御力-6"/>
-        <string name="h8" value="消耗MP12，持续88秒，物理攻击力+6，物理防御力-6"/>
-        <string name="h9" value="消耗MP12，持续94秒，物理攻击力+7，物理防御力-7"/>
-        <string name="desc" value="[最高等级 : 20]\n提升周围组队成员的物理攻击力，\n降低物理防御力"/>
+        <string name="desc" value="[最高等级：20]\n一定时间内提高周围队员的物理攻击力，但降低物理防御力。"/>
+        <string name="h1" value="消耗MP 12，物理攻击力 +3，物理防御力 -3，持续46秒"/>
+        <string name="h2" value="消耗MP 12，物理攻击力 +3，物理防御力 -3，持续52秒"/>
+        <string name="h3" value="消耗MP 12，物理攻击力 +4，物理防御力 -4，持续58秒"/>
+        <string name="h4" value="消耗MP 12，物理攻击力 +4，物理防御力 -4，持续64秒"/>
+        <string name="h5" value="消耗MP 12，物理攻击力 +5，物理防御力 -5，持续70秒"/>
+        <string name="h6" value="消耗MP 12，物理攻击力 +5，物理防御力 -5，持续76秒"/>
+        <string name="h7" value="消耗MP 12，物理攻击力 +6，物理防御力 -6，持续82秒"/>
+        <string name="h8" value="消耗MP 12，物理攻击力 +6，物理防御力 -6，持续88秒"/>
+        <string name="h9" value="消耗MP 12，物理攻击力 +7，物理防御力 -7，持续94秒"/>
+        <string name="h10" value="消耗MP 12，物理攻击力 +7，物理防御力 -7，持续100秒"/>
+        <string name="h11" value="消耗MP 20，物理攻击力 +8，物理防御力 -8，持续106秒"/>
+        <string name="h12" value="消耗MP 20，物理攻击力 +8，物理防御力 -8，持续112秒"/>
+        <string name="h13" value="消耗MP 20，物理攻击力 +9，物理防御力 -9，持续118秒"/>
+        <string name="h14" value="消耗MP 20，物理攻击力 +9，物理防御力 -9，持续124秒"/>
+        <string name="h15" value="消耗MP 20，物理攻击力 +10，物理防御力 -10，持续130秒"/>
+        <string name="h16" value="消耗MP 20，物理攻击力 +10，物理防御力 -10，持续136秒"/>
+        <string name="h17" value="消耗MP 20，物理攻击力 +11，物理防御力 -11，持续142秒"/>
+        <string name="h18" value="消耗MP 20，物理攻击力 +11，物理防御力 -11，持续148秒"/>
+        <string name="h19" value="消耗MP 20，物理攻击力 +12，物理防御力 -12，持续154秒"/>
+        <string name="h20" value="消耗MP 20，物理攻击力 +12，物理防御力 -12，持续160秒"/>
     </imgdir>
     <imgdir name="1101007">
         <string name="name" value="伤害反击"/>
-        <string name="h1" value="消耗MP15，持续3秒，反馈11%"/>
-        <string name="h10" value="消耗MP15，持续30秒，反馈20%"/>
-        <string name="h11" value="消耗MP15，持续33秒，反馈21%"/>
-        <string name="h12" value="消耗MP15，持续36秒，反馈22%"/>
-        <string name="h13" value="消耗MP15，持续39秒，反馈23%"/>
-        <string name="h14" value="消耗MP15，持续42秒，反馈24%"/>
-        <string name="h15" value="消耗MP15，持续45秒，反馈25%"/>
-        <string name="h16" value="消耗MP30，持续48秒，反馈26%"/>
-        <string name="h17" value="消耗MP30，持续51秒，反馈27%"/>
-        <string name="h18" value="消耗MP30，持续54秒，反馈28%"/>
-        <string name="h19" value="消耗MP30，持续57秒，反馈29%"/>
-        <string name="h2" value="消耗MP15，持续6秒，反馈12%"/>
-        <string name="h20" value="消耗MP30，持续60秒，反馈30%"/>
-        <string name="h21" value="消耗MP30，持续63秒，反馈31%"/>
-        <string name="h22" value="消耗MP30，持续66秒，反馈32%"/>
-        <string name="h23" value="消耗MP30，持续69秒，反馈33%"/>
-        <string name="h24" value="消耗MP30，持续72秒，反馈34%"/>
-        <string name="h25" value="消耗MP30，持续75秒，反馈35%"/>
-        <string name="h26" value="消耗MP30，持续78秒，反馈36%"/>
-        <string name="h27" value="消耗MP30，持续81秒，反馈37%"/>
-        <string name="h28" value="消耗MP30，持续84秒，反馈38%"/>
-        <string name="h29" value="消耗MP30，持续87秒，反馈39%"/>
-        <string name="h3" value="消耗MP15，持续9秒，反馈13%"/>
-        <string name="h30" value="消耗MP30，持续90秒，反馈40%"/>
-        <string name="h4" value="消耗MP15，持续12秒，反馈14%"/>
-        <string name="h5" value="消耗MP15，持续15秒，反馈15%"/>
-        <string name="h6" value="消耗MP15，持续18秒，反馈16%"/>
-        <string name="h7" value="消耗MP15，持续21秒，反馈17%"/>
-        <string name="h8" value="消耗MP15，持续24秒，反馈18%"/>
-        <string name="h9" value="消耗MP15，持续27秒，反馈19%"/>
-        <string name="desc" value="[最高等级 : 30]\n按怪物对自身伤害的一定量反击怪物\n(怪物所受的伤害以最大HP10%为限度)\n必需技能:#c愤怒之火等级3以上#"/>
+        <string name="desc" value="[最高等级：30]\n将受到的接触伤害按比例反弹给敌人，单次反弹不超过怪物MaxHP的10%。\n需要技能：#c愤怒之火3级以上#"/>
+        <string name="h1" value="消耗MP 15，持续3秒，反弹受到伤害的11%"/>
+        <string name="h2" value="消耗MP 15，持续6秒，反弹受到伤害的12%"/>
+        <string name="h3" value="消耗MP 15，持续9秒，反弹受到伤害的13%"/>
+        <string name="h4" value="消耗MP 15，持续12秒，反弹受到伤害的14%"/>
+        <string name="h5" value="消耗MP 15，持续15秒，反弹受到伤害的15%"/>
+        <string name="h6" value="消耗MP 15，持续18秒，反弹受到伤害的16%"/>
+        <string name="h7" value="消耗MP 15，持续21秒，反弹受到伤害的17%"/>
+        <string name="h8" value="消耗MP 15，持续24秒，反弹受到伤害的18%"/>
+        <string name="h9" value="消耗MP 15，持续27秒，反弹受到伤害的19%"/>
+        <string name="h10" value="消耗MP 15，持续30秒，反弹受到伤害的20%"/>
+        <string name="h11" value="消耗MP 15，持续33秒，反弹受到伤害的21%"/>
+        <string name="h12" value="消耗MP 15，持续36秒，反弹受到伤害的22%"/>
+        <string name="h13" value="消耗MP 15，持续39秒，反弹受到伤害的23%"/>
+        <string name="h14" value="消耗MP 15，持续42秒，反弹受到伤害的24%"/>
+        <string name="h15" value="消耗MP 15，持续45秒，反弹受到伤害的25%"/>
+        <string name="h16" value="消耗MP 30，持续48秒，反弹受到伤害的26%"/>
+        <string name="h17" value="消耗MP 30，持续51秒，反弹受到伤害的27%"/>
+        <string name="h18" value="消耗MP 30，持续54秒，反弹受到伤害的28%"/>
+        <string name="h19" value="消耗MP 30，持续57秒，反弹受到伤害的29%"/>
+        <string name="h20" value="消耗MP 30，持续60秒，反弹受到伤害的30%"/>
+        <string name="h21" value="消耗MP 30，持续63秒，反弹受到伤害的31%"/>
+        <string name="h22" value="消耗MP 30，持续66秒，反弹受到伤害的32%"/>
+        <string name="h23" value="消耗MP 30，持续69秒，反弹受到伤害的33%"/>
+        <string name="h24" value="消耗MP 30，持续72秒，反弹受到伤害的34%"/>
+        <string name="h25" value="消耗MP 30，持续75秒，反弹受到伤害的35%"/>
+        <string name="h26" value="消耗MP 30，持续78秒，反弹受到伤害的36%"/>
+        <string name="h27" value="消耗MP 30，持续81秒，反弹受到伤害的37%"/>
+        <string name="h28" value="消耗MP 30，持续84秒，反弹受到伤害的38%"/>
+        <string name="h29" value="消耗MP 30，持续87秒，反弹受到伤害的39%"/>
+        <string name="h30" value="消耗MP 30，持续90秒，反弹受到伤害的40%"/>
     </imgdir>
     <imgdir name="111">
         <string name="bookName" value="勇士技能"/>
@@ -758,27 +758,27 @@
     </imgdir>
     <imgdir name="1110000">
         <string name="name" value="魔力恢复"/>
-        <string name="h1" value="MP恢复增加4"/>
-        <string name="h10" value="MP恢复增加40"/>
-        <string name="h11" value="MP恢复增加42"/>
-        <string name="h12" value="MP恢复增加44"/>
-        <string name="h13" value="MP恢复增加46"/>
-        <string name="h14" value="MP恢复增加48"/>
-        <string name="h15" value="MP恢复增加50"/>
-        <string name="h16" value="MP恢复增加52"/>
-        <string name="h17" value="MP恢复增加54"/>
-        <string name="h18" value="MP恢复增加56"/>
-        <string name="h19" value="MP恢复增加58"/>
-        <string name="h2" value="MP恢复增加8"/>
-        <string name="h20" value="MP恢复增加60"/>
-        <string name="h3" value="MP恢复增加12"/>
-        <string name="h4" value="MP恢复增加16"/>
-        <string name="h5" value="MP恢复增加20"/>
-        <string name="h6" value="MP恢复增加24"/>
-        <string name="h7" value="MP恢复增加28"/>
-        <string name="h8" value="MP恢复增加32"/>
-        <string name="h9" value="MP恢复增加36"/>
-        <string name="desc" value="[最高等级:20]\n增加每10秒的MP恢复量"/>
+        <string name="desc" value="[最高等级：20]\n站立不动时，每10秒额外恢复MP。"/>
+        <string name="h1" value="额外恢复MP +2"/>
+        <string name="h2" value="额外恢复MP +4"/>
+        <string name="h3" value="额外恢复MP +6"/>
+        <string name="h4" value="额外恢复MP +8"/>
+        <string name="h5" value="额外恢复MP +10"/>
+        <string name="h6" value="额外恢复MP +12"/>
+        <string name="h7" value="额外恢复MP +14"/>
+        <string name="h8" value="额外恢复MP +16"/>
+        <string name="h9" value="额外恢复MP +18"/>
+        <string name="h10" value="额外恢复MP +20"/>
+        <string name="h11" value="额外恢复MP +21"/>
+        <string name="h12" value="额外恢复MP +22"/>
+        <string name="h13" value="额外恢复MP +23"/>
+        <string name="h14" value="额外恢复MP +24"/>
+        <string name="h15" value="额外恢复MP +25"/>
+        <string name="h16" value="额外恢复MP +26"/>
+        <string name="h17" value="额外恢复MP +27"/>
+        <string name="h18" value="额外恢复MP +28"/>
+        <string name="h19" value="额外恢复MP +29"/>
+        <string name="h20" value="额外恢复MP +30"/>
     </imgdir>
     <imgdir name="11100000">
         <string name="name" value="精准剑"/>
@@ -806,27 +806,27 @@
     </imgdir>
     <imgdir name="1110001">
         <string name="name" value="盾防精通"/>
-        <string name="h1" value="盾牌的物理防御力增加20%"/>
-        <string name="h10" value="盾牌的物理防御力增加200%"/>
-        <string name="h11" value="盾牌的物理防御力增加210%"/>
-        <string name="h12" value="盾牌的物理防御力增加220%"/>
-        <string name="h13" value="盾牌的物理防御力增加230%"/>
-        <string name="h14" value="盾牌的物理防御力增加240%"/>
-        <string name="h15" value="盾牌的物理防御力增加250%"/>
-        <string name="h16" value="盾牌的物理防御力增加260%"/>
-        <string name="h17" value="盾牌的物理防御力增加270%"/>
-        <string name="h18" value="盾牌的物理防御力增加280%"/>
-        <string name="h19" value="盾牌的物理防御力增加290%"/>
-        <string name="h2" value="盾牌的物理防御力增加40%"/>
-        <string name="h20" value="盾牌的物理防御力增加300%"/>
-        <string name="h3" value="盾牌的物理防御力增加60%"/>
-        <string name="h4" value="盾牌的物理防御力增加80%"/>
-        <string name="h5" value="盾牌的物理防御力增加100%"/>
-        <string name="h6" value="盾牌的物理防御力增加120%"/>
-        <string name="h7" value="盾牌的物理防御力增加140%"/>
-        <string name="h8" value="盾牌的物理防御力增加160%"/>
-        <string name="h9" value="盾牌的物理防御力增加180%"/>
-        <string name="desc" value="[最高等级:20]盾牌的物理防御力增加，必需装备盾牌"/>
+        <string name="desc" value="[最高等级：20]\n装备盾牌时，提高盾牌的防御力。"/>
+        <string name="h1" value="盾牌防御力变为 105%"/>
+        <string name="h2" value="盾牌防御力变为 110%"/>
+        <string name="h3" value="盾牌防御力变为 115%"/>
+        <string name="h4" value="盾牌防御力变为 120%"/>
+        <string name="h5" value="盾牌防御力变为 125%"/>
+        <string name="h6" value="盾牌防御力变为 130%"/>
+        <string name="h7" value="盾牌防御力变为 135%"/>
+        <string name="h8" value="盾牌防御力变为 140%"/>
+        <string name="h9" value="盾牌防御力变为 145%"/>
+        <string name="h10" value="盾牌防御力变为 150%"/>
+        <string name="h11" value="盾牌防御力变为 155%"/>
+        <string name="h12" value="盾牌防御力变为 160%"/>
+        <string name="h13" value="盾牌防御力变为 165%"/>
+        <string name="h14" value="盾牌防御力变为 170%"/>
+        <string name="h15" value="盾牌防御力变为 175%"/>
+        <string name="h16" value="盾牌防御力变为 180%"/>
+        <string name="h17" value="盾牌防御力变为 185%"/>
+        <string name="h18" value="盾牌防御力变为 190%"/>
+        <string name="h19" value="盾牌防御力变为 195%"/>
+        <string name="h20" value="盾牌防御力变为 200%"/>
     </imgdir>
     <imgdir name="11101001">
         <string name="name" value="快速剑"/>
@@ -1011,231 +1011,231 @@
     </imgdir>
     <imgdir name="1111002">
         <string name="name" value="斗气集中"/>
-        <string name="h1" value="消耗MP25,100秒内造成伤害100%,最高不超过3个斗气"/>
-		<string name="h10" value="消耗MP25,120秒内造成伤害111%,最高不超过3个斗气"/>
-		<string name="h11" value="消耗MP30,140秒内造成伤害112%,最高不超过4个斗气"/>
-		<string name="h12" value="消耗MP30,140秒内造成伤害112%,最高不超过4个斗气"/>
-		<string name="h13" value="消耗MP30,140秒内造成伤害113%,最高不超过4个斗气"/>
-		<string name="h14" value="消耗MP30,140秒内造成伤害113%,最高不超过4个斗气"/>
-		<string name="h15" value="消耗MP30,140秒内造成伤害114%,最高不超过4个斗气"/>
-		<string name="h16" value="消耗MP30,160秒内造成伤害114%,最高不超过4个斗气"/>
-		<string name="h17" value="消耗MP30,160秒内造成伤害115%,最高不超过4个斗气"/>
-		<string name="h18" value="消耗MP30,160秒内造成伤害115%,最高不超过4个斗气"/>
-		<string name="h19" value="消耗MP30,160秒内造成伤害116%,最高不超过4个斗气"/>
-		<string name="h2" value="消耗MP25,100秒内造成伤害104%,最高不超过3个斗气"/>
-		<string name="h20" value="消耗MP30,160秒内造成伤害116%,最高不超过4个斗气"/>
-		<string name="h21" value="消耗MP35,180秒内造成伤害117%,最高不超过5个斗气"/>
-		<string name="h22" value="消耗MP35,180秒内造成伤害117%,最高不超过5个斗气"/>
-		<string name="h23" value="消耗MP35,180秒内造成伤害117%,最高不超过5个斗气"/>
-		<string name="h24" value="消耗MP35,180秒内造成伤害118%,最高不超过5个斗气"/>
-		<string name="h25" value="消耗MP35,180秒内造成伤害118%,最高不超过5个斗气"/>
-		<string name="h26" value="消耗MP35,200秒内造成伤害118%,最高不超过5个斗气"/>
-		<string name="h27" value="消耗MP35,200秒内造成伤害119%,最高不超过5个斗气"/>
-		<string name="h28" value="消耗MP35,200秒内造成伤害119%,最高不超过5个斗气"/>
-		<string name="h29" value="消耗MP35,200秒内造成伤害119%,最高不超过5个斗气"/>
-		<string name="h3" value="消耗MP25,100秒内造成伤害105%,最高不超过3个斗气"/>
-		<string name="h30" value="消耗MP35,200秒内造成伤害120%,最高不超过5个斗气"/>
-		<string name="h4" value="消耗MP25,100秒内造成伤害106%,最高不超过3个斗气"/>
-		<string name="h5" value="消耗MP25,100秒内造成伤害107%,最高不超过3个斗气"/>
-		<string name="h6" value="消耗MP25,120秒内造成伤害108%,最高不超过3个斗气"/>
-		<string name="h7" value="消耗MP25,120秒内造成伤害109%,最高不超过3个斗气"/>
-		<string name="h8" value="消耗MP25,120秒内造成伤害110%,最高不超过3个斗气"/>
-		<string name="h9" value="消耗MP25,120秒内造成伤害111%,最高不超过3个斗气"/>
-        <string name="desc" value="[最高等级:30]\n进入斗气集中状态。每次攻击会累积1个斗气，\n最高累积5个斗气。伤害以3个斗气为基准"/>
+        <string name="desc" value="[最高等级：30]\n进入斗气集中状态。攻击时可积累斗气，最多积累到技能显示的上限。"/>
+        <string name="h1" value="消耗MP 25，伤害 100%，最大斗气数量 3，持续100秒"/>
+        <string name="h2" value="消耗MP 25，伤害 104%，最大斗气数量 3，持续100秒"/>
+        <string name="h3" value="消耗MP 25，伤害 105%，最大斗气数量 3，持续100秒"/>
+        <string name="h4" value="消耗MP 25，伤害 106%，最大斗气数量 3，持续100秒"/>
+        <string name="h5" value="消耗MP 25，伤害 107%，最大斗气数量 3，持续100秒"/>
+        <string name="h6" value="消耗MP 25，伤害 108%，最大斗气数量 3，持续120秒"/>
+        <string name="h7" value="消耗MP 25，伤害 109%，最大斗气数量 3，持续120秒"/>
+        <string name="h8" value="消耗MP 25，伤害 110%，最大斗气数量 3，持续120秒"/>
+        <string name="h9" value="消耗MP 25，伤害 111%，最大斗气数量 3，持续120秒"/>
+        <string name="h10" value="消耗MP 25，伤害 111%，最大斗气数量 3，持续120秒"/>
+        <string name="h11" value="消耗MP 30，伤害 112%，最大斗气数量 4，持续140秒"/>
+        <string name="h12" value="消耗MP 30，伤害 112%，最大斗气数量 4，持续140秒"/>
+        <string name="h13" value="消耗MP 30，伤害 113%，最大斗气数量 4，持续140秒"/>
+        <string name="h14" value="消耗MP 30，伤害 113%，最大斗气数量 4，持续140秒"/>
+        <string name="h15" value="消耗MP 30，伤害 114%，最大斗气数量 4，持续140秒"/>
+        <string name="h16" value="消耗MP 30，伤害 114%，最大斗气数量 4，持续160秒"/>
+        <string name="h17" value="消耗MP 30，伤害 115%，最大斗气数量 4，持续160秒"/>
+        <string name="h18" value="消耗MP 30，伤害 115%，最大斗气数量 4，持续160秒"/>
+        <string name="h19" value="消耗MP 30，伤害 116%，最大斗气数量 4，持续160秒"/>
+        <string name="h20" value="消耗MP 30，伤害 116%，最大斗气数量 4，持续160秒"/>
+        <string name="h21" value="消耗MP 35，伤害 117%，最大斗气数量 5，持续180秒"/>
+        <string name="h22" value="消耗MP 35，伤害 117%，最大斗气数量 5，持续180秒"/>
+        <string name="h23" value="消耗MP 35，伤害 117%，最大斗气数量 5，持续180秒"/>
+        <string name="h24" value="消耗MP 35，伤害 118%，最大斗气数量 5，持续180秒"/>
+        <string name="h25" value="消耗MP 35，伤害 118%，最大斗气数量 5，持续180秒"/>
+        <string name="h26" value="消耗MP 35，伤害 118%，最大斗气数量 5，持续200秒"/>
+        <string name="h27" value="消耗MP 35，伤害 119%，最大斗气数量 5，持续200秒"/>
+        <string name="h28" value="消耗MP 35，伤害 119%，最大斗气数量 5，持续200秒"/>
+        <string name="h29" value="消耗MP 35，伤害 119%，最大斗气数量 5，持续200秒"/>
+        <string name="h30" value="消耗MP 35，伤害 120%，最大斗气数量 5，持续200秒"/>
     </imgdir>
     <imgdir name="1111003">
         <string name="name" value="狂乱之剑"/>
-        <string name="h1" value="消耗MP10，造成伤害150%，以32%几率出现黑暗攻击"/>
-        <string name="h10" value="消耗MP10，造成伤害242%，以50%几率出现黑暗攻击"/>
-        <string name="h11" value="消耗MP17，造成伤害248%，以52%几率出现黑暗攻击"/>
-        <string name="h12" value="消耗MP17，造成伤害255%，以54%几率出现黑暗攻击"/>
-        <string name="h13" value="消耗MP17，造成伤害261%，以56%几率出现黑暗攻击"/>
-        <string name="h14" value="消耗MP17，造成伤害267%，以58%几率出现黑暗攻击"/>
-        <string name="h15" value="消耗MP17，造成伤害273%，以60%几率出现黑暗攻击"/>
-        <string name="h16" value="消耗MP17，造成伤害279%，以62%几率出现黑暗攻击"/>
-        <string name="h17" value="消耗MP17，造成伤害285%，以64%几率出现黑暗攻击"/>
-        <string name="h18" value="消耗MP17，造成伤害290%，以66%几率出现黑暗攻击"/>
-        <string name="h19" value="消耗MP17，造成伤害296%，以68%几率出现黑暗攻击"/>
-        <string name="h2" value="消耗MP10，造成伤害171%，以34%几率出现黑暗攻击"/>
-        <string name="h20" value="消耗MP17，造成伤害301%，以70%几率出现黑暗攻击"/>
-        <string name="h21" value="消耗MP24，造成伤害306%，以72%几率出现黑暗攻击"/>
-        <string name="h22" value="消耗MP24，造成伤害311%，以74%几率出现黑暗攻击"/>
-        <string name="h23" value="消耗MP24，造成伤害316%，以76%几率出现黑暗攻击"/>
-        <string name="h24" value="消耗MP24，造成伤害321%，以78%几率出现黑暗攻击"/>
-        <string name="h25" value="消耗MP24，造成伤害326%，以80%几率出现黑暗攻击"/>
-        <string name="h26" value="消耗MP24，造成伤害331%，以82%几率出现黑暗攻击"/>
-        <string name="h27" value="消耗MP24，造成伤害336%，以84%几率出现黑暗攻击"/>
-        <string name="h28" value="消耗MP24，造成伤害341%，以86%几率出现黑暗攻击"/>
-        <string name="h29" value="消耗MP24，造成伤害345%，以88%几率出现黑暗攻击"/>
-        <string name="h3" value="消耗MP10，造成伤害184%，以36%几率出现黑暗攻击"/>
-        <string name="h30" value="消耗MP24，造成伤害350%，以90%几率出现黑暗攻击"/>
-        <string name="h4" value="消耗MP10，造成伤害194%，以38%几率出现黑暗攻击"/>
-        <string name="h5" value="消耗MP10，造成伤害203%，以40%几率出现黑暗攻击"/>
-        <string name="h6" value="消耗MP10，造成伤害212%，以42%几率出现黑暗攻击"/>
-        <string name="h7" value="消耗MP10，造成伤害220%，以44%几率出现黑暗攻击"/>
-        <string name="h8" value="消耗MP10，造成伤害228%，以46%几率出现黑暗攻击"/>
-        <string name="h9" value="消耗MP10，造成伤害235%，以48%几率出现黑暗攻击"/>
-        <string name="desc" value="[最高等级：30]\n对一个敌人进行攻击。\n必须装备剑且处于斗气集中状态。\n必需技能:#c斗气集中等级1以上#"/>
+        <string name="desc" value="[最高等级：30]\n消耗斗气，用黑暗力量攻击单个怪物。只在装备剑时生效。\n需要技能：#c斗气集中1级以上#"/>
+        <string name="h1" value="消耗MP 10，伤害 150%，32%概率造成黑暗效果，持续5秒"/>
+        <string name="h2" value="消耗MP 10，伤害 171%，34%概率造成黑暗效果，持续5秒"/>
+        <string name="h3" value="消耗MP 10，伤害 184%，36%概率造成黑暗效果，持续5秒"/>
+        <string name="h4" value="消耗MP 10，伤害 194%，38%概率造成黑暗效果，持续5秒"/>
+        <string name="h5" value="消耗MP 10，伤害 203%，40%概率造成黑暗效果，持续5秒"/>
+        <string name="h6" value="消耗MP 10，伤害 212%，42%概率造成黑暗效果，持续5秒"/>
+        <string name="h7" value="消耗MP 10，伤害 220%，44%概率造成黑暗效果，持续5秒"/>
+        <string name="h8" value="消耗MP 10，伤害 228%，46%概率造成黑暗效果，持续5秒"/>
+        <string name="h9" value="消耗MP 10，伤害 235%，48%概率造成黑暗效果，持续5秒"/>
+        <string name="h10" value="消耗MP 10，伤害 242%，50%概率造成黑暗效果，持续5秒"/>
+        <string name="h11" value="消耗MP 17，伤害 248%，52%概率造成黑暗效果，持续7秒"/>
+        <string name="h12" value="消耗MP 17，伤害 255%，54%概率造成黑暗效果，持续7秒"/>
+        <string name="h13" value="消耗MP 17，伤害 261%，56%概率造成黑暗效果，持续7秒"/>
+        <string name="h14" value="消耗MP 17，伤害 267%，58%概率造成黑暗效果，持续7秒"/>
+        <string name="h15" value="消耗MP 17，伤害 273%，60%概率造成黑暗效果，持续7秒"/>
+        <string name="h16" value="消耗MP 17，伤害 279%，62%概率造成黑暗效果，持续7秒"/>
+        <string name="h17" value="消耗MP 17，伤害 285%，64%概率造成黑暗效果，持续7秒"/>
+        <string name="h18" value="消耗MP 17，伤害 290%，66%概率造成黑暗效果，持续7秒"/>
+        <string name="h19" value="消耗MP 17，伤害 296%，68%概率造成黑暗效果，持续7秒"/>
+        <string name="h20" value="消耗MP 17，伤害 301%，70%概率造成黑暗效果，持续7秒"/>
+        <string name="h21" value="消耗MP 24，伤害 306%，72%概率造成黑暗效果，持续9秒"/>
+        <string name="h22" value="消耗MP 24，伤害 311%，74%概率造成黑暗效果，持续9秒"/>
+        <string name="h23" value="消耗MP 24，伤害 316%，76%概率造成黑暗效果，持续9秒"/>
+        <string name="h24" value="消耗MP 24，伤害 321%，78%概率造成黑暗效果，持续9秒"/>
+        <string name="h25" value="消耗MP 24，伤害 326%，80%概率造成黑暗效果，持续9秒"/>
+        <string name="h26" value="消耗MP 24，伤害 331%，82%概率造成黑暗效果，持续9秒"/>
+        <string name="h27" value="消耗MP 24，伤害 336%，84%概率造成黑暗效果，持续9秒"/>
+        <string name="h28" value="消耗MP 24，伤害 341%，86%概率造成黑暗效果，持续9秒"/>
+        <string name="h29" value="消耗MP 24，伤害 345%，88%概率造成黑暗效果，持续9秒"/>
+        <string name="h30" value="消耗MP 24，伤害 350%，90%概率造成黑暗效果，持续9秒"/>
     </imgdir>
     <imgdir name="1111004">
         <string name="name" value="狂乱之斧"/>
-        <string name="h1" value="消耗MP10，造成伤害150%，以32%几率出现黑暗攻击"/>
-        <string name="h10" value="消耗MP10，造成伤害242%，以50%几率出现黑暗攻击"/>
-        <string name="h11" value="消耗MP17，造成伤害248%，以52%几率出现黑暗攻击"/>
-        <string name="h12" value="消耗MP17，造成伤害255%，以54%几率出现黑暗攻击"/>
-        <string name="h13" value="消耗MP17，造成伤害261%，以56%几率出现黑暗攻击"/>
-        <string name="h14" value="消耗MP17，造成伤害267%，以58%几率出现黑暗攻击"/>
-        <string name="h15" value="消耗MP17，造成伤害273%，以60%几率出现黑暗攻击"/>
-        <string name="h16" value="消耗MP17，造成伤害279%，以62%几率出现黑暗攻击"/>
-        <string name="h17" value="消耗MP17，造成伤害285%，以64%几率出现黑暗攻击"/>
-        <string name="h18" value="消耗MP17，造成伤害290%，以66%几率出现黑暗攻击"/>
-        <string name="h19" value="消耗MP17，造成伤害296%，以68%几率出现黑暗攻击"/>
-        <string name="h2" value="消耗MP10，造成伤害171%，以34%几率出现黑暗攻击"/>
-        <string name="h20" value="消耗MP17，造成伤害301%，以70%几率出现黑暗攻击"/>
-        <string name="h21" value="消耗MP24，造成伤害306%，以72%几率出现黑暗攻击"/>
-        <string name="h22" value="消耗MP24，造成伤害311%，以74%几率出现黑暗攻击"/>
-        <string name="h23" value="消耗MP24，造成伤害316%，以76%几率出现黑暗攻击"/>
-        <string name="h24" value="消耗MP24，造成伤害321%，以78%几率出现黑暗攻击"/>
-        <string name="h25" value="消耗MP24，造成伤害326%，以80%几率出现黑暗攻击"/>
-        <string name="h26" value="消耗MP24，造成伤害331%，以82%几率出现黑暗攻击"/>
-        <string name="h27" value="消耗MP24，造成伤害336%，以84%几率出现黑暗攻击"/>
-        <string name="h28" value="消耗MP24，造成伤害341%，以86%几率出现黑暗攻击"/>
-        <string name="h29" value="消耗MP24，造成伤害345%，以88%几率出现黑暗攻击"/>
-        <string name="h3" value="消耗MP10，造成伤害184%，以36%几率出现黑暗攻击"/>
-        <string name="h30" value="消耗MP24，造成伤害350%，以90%几率出现黑暗攻击"/>
-        <string name="h4" value="消耗MP10，造成伤害194%，以38%几率出现黑暗攻击"/>
-        <string name="h5" value="消耗MP10，造成伤害203%，以40%几率出现黑暗攻击"/>
-        <string name="h6" value="消耗MP10，造成伤害212%，以42%几率出现黑暗攻击"/>
-        <string name="h7" value="消耗MP10，造成伤害220%，以44%几率出现黑暗攻击"/>
-        <string name="h8" value="消耗MP10，造成伤害228%，以46%几率出现黑暗攻击"/>
-        <string name="h9" value="消耗MP10，造成伤害235%，以48%几率出现黑暗攻击"/>
-        <string name="desc" value="[最高等级：30]\n给一个敌人进行攻击。\n必须装备斧且处于斗气集中状态。\n必需技能:#c斗气集中等级1以上#"/>
+        <string name="desc" value="[最高等级：30]\n消耗斗气，用黑暗力量攻击单个怪物。只在装备斧时生效。\n需要技能：#c斗气集中1级以上#"/>
+        <string name="h1" value="消耗MP 10，伤害 150%，32%概率造成黑暗效果，持续5秒"/>
+        <string name="h2" value="消耗MP 10，伤害 171%，34%概率造成黑暗效果，持续5秒"/>
+        <string name="h3" value="消耗MP 10，伤害 184%，36%概率造成黑暗效果，持续5秒"/>
+        <string name="h4" value="消耗MP 10，伤害 194%，38%概率造成黑暗效果，持续5秒"/>
+        <string name="h5" value="消耗MP 10，伤害 203%，40%概率造成黑暗效果，持续5秒"/>
+        <string name="h6" value="消耗MP 10，伤害 212%，42%概率造成黑暗效果，持续5秒"/>
+        <string name="h7" value="消耗MP 10，伤害 220%，44%概率造成黑暗效果，持续5秒"/>
+        <string name="h8" value="消耗MP 10，伤害 228%，46%概率造成黑暗效果，持续5秒"/>
+        <string name="h9" value="消耗MP 10，伤害 235%，48%概率造成黑暗效果，持续5秒"/>
+        <string name="h10" value="消耗MP 10，伤害 242%，50%概率造成黑暗效果，持续5秒"/>
+        <string name="h11" value="消耗MP 17，伤害 248%，52%概率造成黑暗效果，持续7秒"/>
+        <string name="h12" value="消耗MP 17，伤害 255%，54%概率造成黑暗效果，持续7秒"/>
+        <string name="h13" value="消耗MP 17，伤害 261%，56%概率造成黑暗效果，持续7秒"/>
+        <string name="h14" value="消耗MP 17，伤害 267%，58%概率造成黑暗效果，持续7秒"/>
+        <string name="h15" value="消耗MP 17，伤害 273%，60%概率造成黑暗效果，持续7秒"/>
+        <string name="h16" value="消耗MP 17，伤害 279%，62%概率造成黑暗效果，持续7秒"/>
+        <string name="h17" value="消耗MP 17，伤害 285%，64%概率造成黑暗效果，持续7秒"/>
+        <string name="h18" value="消耗MP 17，伤害 290%，66%概率造成黑暗效果，持续7秒"/>
+        <string name="h19" value="消耗MP 17，伤害 296%，68%概率造成黑暗效果，持续7秒"/>
+        <string name="h20" value="消耗MP 17，伤害 301%，70%概率造成黑暗效果，持续7秒"/>
+        <string name="h21" value="消耗MP 24，伤害 306%，72%概率造成黑暗效果，持续9秒"/>
+        <string name="h22" value="消耗MP 24，伤害 311%，74%概率造成黑暗效果，持续9秒"/>
+        <string name="h23" value="消耗MP 24，伤害 316%，76%概率造成黑暗效果，持续9秒"/>
+        <string name="h24" value="消耗MP 24，伤害 321%，78%概率造成黑暗效果，持续9秒"/>
+        <string name="h25" value="消耗MP 24，伤害 326%，80%概率造成黑暗效果，持续9秒"/>
+        <string name="h26" value="消耗MP 24，伤害 331%，82%概率造成黑暗效果，持续9秒"/>
+        <string name="h27" value="消耗MP 24，伤害 336%，84%概率造成黑暗效果，持续9秒"/>
+        <string name="h28" value="消耗MP 24，伤害 341%，86%概率造成黑暗效果，持续9秒"/>
+        <string name="h29" value="消耗MP 24，伤害 345%，88%概率造成黑暗效果，持续9秒"/>
+        <string name="h30" value="消耗MP 24，伤害 350%，90%概率造成黑暗效果，持续9秒"/>
     </imgdir>
     <imgdir name="1111005">
         <string name="name" value="气绝剑"/>
-        <string name="h1" value="消耗HP15、MP12，造成伤害84%，以32%几率出现昏迷攻击"/>
-        <string name="h10" value="消耗HP15、MP12，造成伤害120%，以50%几率出现昏迷攻击"/>
-        <string name="h11" value="消耗HP20、MP19，造成伤害124%，以52%几率出现昏迷攻击"/>
-        <string name="h12" value="消耗HP20、MP19，造成伤害128%，以54%几率出现昏迷攻击"/>
-        <string name="h13" value="消耗HP20、MP19，造成伤害132%，以56%几率出现昏迷攻击"/>
-        <string name="h14" value="消耗HP20、MP19，造成伤害136%，以58%几率出现昏迷攻击"/>
-        <string name="h15" value="消耗HP20、MP19，造成伤害140%，以60%几率出现昏迷攻击"/>
-        <string name="h16" value="消耗HP20、MP19，造成伤害144%，以62%几率出现昏迷攻击"/>
-        <string name="h17" value="消耗HP20、MP19，造成伤害148%，以64%几率出现昏迷攻击"/>
-        <string name="h18" value="消耗HP20、MP19，造成伤害152%，以66%几率出现昏迷攻击"/>
-        <string name="h19" value="消耗HP20、MP19，造成伤害156%，以68%几率出现昏迷攻击"/>
-        <string name="h2" value="消耗HP15、MP12，造成伤害88%，以34%几率出现昏迷攻击"/>
-        <string name="h20" value="消耗HP20、MP19，造成伤害160%，以70%几率出现昏迷攻击"/>
-        <string name="h21" value="消耗HP25、MP26，造成伤害164%，以72%几率出现昏迷攻击"/>
-        <string name="h22" value="消耗HP25、MP26，造成伤害168%，以74%几率出现昏迷攻击"/>
-        <string name="h23" value="消耗HP25、MP26，造成伤害172%，以76%几率出现昏迷攻击"/>
-        <string name="h24" value="消耗HP25、MP26，造成伤害176%，以78%几率出现昏迷攻击"/>
-        <string name="h25" value="消耗HP25、MP26，造成伤害180%，以80%几率出现昏迷攻击"/>
-        <string name="h26" value="消耗HP25、MP26，造成伤害184%，以82%几率出现昏迷攻击"/>
-        <string name="h27" value="消耗HP25、MP26，造成伤害188%，以84%几率出现昏迷攻击"/>
-        <string name="h28" value="消耗HP25、MP26，造成伤害192%，以86%几率出现昏迷攻击"/>
-        <string name="h29" value="消耗HP25、MP26，造成伤害196%，以88%几率出现昏迷攻击"/>
-        <string name="h3" value="消耗HP15、MP12，造成伤害92%，以36%几率出现昏迷攻击"/>
-        <string name="h30" value="消耗HP25、MP26，造成伤害200%，以90%几率出现昏迷攻击"/>
-        <string name="h4" value="消耗HP15、MP12，造成伤害96%，以38%几率出现昏迷攻击"/>
-        <string name="h5" value="消耗HP15、MP12，造成伤害100%，以40%几率出现昏迷攻击"/>
-        <string name="h6" value="消耗HP15、MP12，造成伤害104%，以42%几率出现昏迷攻击"/>
-        <string name="h7" value="消耗HP15、MP12，造成伤害108%，以44%几率出现昏迷攻击"/>
-        <string name="h8" value="消耗HP15、MP12，造成伤害112%，以46%几率出现昏迷攻击"/>
-        <string name="h9" value="消耗HP15、MP12，造成伤害116%，以48%几率出现昏迷攻击"/>
-        <string name="desc" value="[最高等级：30]\n攻击怪物，一定几率使怪物昏迷\n必须装备剑且处于斗气集中状态。\n必需技能:#c斗气集中等级1以上#"/>
+        <string name="desc" value="[最高等级：30]\n消耗斗气攻击周围怪物，并以一定概率使其昏迷。只在装备剑时生效。\n需要技能：#c斗气集中1级以上#"/>
+        <string name="h1" value="消耗HP 15，消耗MP 12，伤害 84%，最多攻击6个敌人，32%概率昏迷2秒"/>
+        <string name="h2" value="消耗HP 15，消耗MP 12，伤害 88%，最多攻击6个敌人，34%概率昏迷2秒"/>
+        <string name="h3" value="消耗HP 15，消耗MP 12，伤害 92%，最多攻击6个敌人，36%概率昏迷2秒"/>
+        <string name="h4" value="消耗HP 15，消耗MP 12，伤害 96%，最多攻击6个敌人，38%概率昏迷2秒"/>
+        <string name="h5" value="消耗HP 15，消耗MP 12，伤害 100%，最多攻击6个敌人，40%概率昏迷2秒"/>
+        <string name="h6" value="消耗HP 15，消耗MP 12，伤害 104%，最多攻击6个敌人，42%概率昏迷2秒"/>
+        <string name="h7" value="消耗HP 15，消耗MP 12，伤害 108%，最多攻击6个敌人，44%概率昏迷2秒"/>
+        <string name="h8" value="消耗HP 15，消耗MP 12，伤害 112%，最多攻击6个敌人，46%概率昏迷2秒"/>
+        <string name="h9" value="消耗HP 15，消耗MP 12，伤害 116%，最多攻击6个敌人，48%概率昏迷2秒"/>
+        <string name="h10" value="消耗HP 15，消耗MP 12，伤害 120%，最多攻击6个敌人，50%概率昏迷2秒"/>
+        <string name="h11" value="消耗HP 20，消耗MP 19，伤害 124%，最多攻击6个敌人，52%概率昏迷3秒"/>
+        <string name="h12" value="消耗HP 20，消耗MP 19，伤害 128%，最多攻击6个敌人，54%概率昏迷3秒"/>
+        <string name="h13" value="消耗HP 20，消耗MP 19，伤害 132%，最多攻击6个敌人，56%概率昏迷3秒"/>
+        <string name="h14" value="消耗HP 20，消耗MP 19，伤害 136%，最多攻击6个敌人，58%概率昏迷3秒"/>
+        <string name="h15" value="消耗HP 20，消耗MP 19，伤害 140%，最多攻击6个敌人，60%概率昏迷3秒"/>
+        <string name="h16" value="消耗HP 20，消耗MP 19，伤害 144%，最多攻击6个敌人，62%概率昏迷3秒"/>
+        <string name="h17" value="消耗HP 20，消耗MP 19，伤害 148%，最多攻击6个敌人，64%概率昏迷3秒"/>
+        <string name="h18" value="消耗HP 20，消耗MP 19，伤害 152%，最多攻击6个敌人，66%概率昏迷3秒"/>
+        <string name="h19" value="消耗HP 20，消耗MP 19，伤害 156%，最多攻击6个敌人，68%概率昏迷3秒"/>
+        <string name="h20" value="消耗HP 20，消耗MP 19，伤害 160%，最多攻击6个敌人，70%概率昏迷3秒"/>
+        <string name="h21" value="消耗HP 25，消耗MP 26，伤害 164%，最多攻击6个敌人，72%概率昏迷4秒"/>
+        <string name="h22" value="消耗HP 25，消耗MP 26，伤害 168%，最多攻击6个敌人，74%概率昏迷4秒"/>
+        <string name="h23" value="消耗HP 25，消耗MP 26，伤害 172%，最多攻击6个敌人，76%概率昏迷4秒"/>
+        <string name="h24" value="消耗HP 25，消耗MP 26，伤害 176%，最多攻击6个敌人，78%概率昏迷4秒"/>
+        <string name="h25" value="消耗HP 25，消耗MP 26，伤害 180%，最多攻击6个敌人，80%概率昏迷4秒"/>
+        <string name="h26" value="消耗HP 25，消耗MP 26，伤害 184%，最多攻击6个敌人，82%概率昏迷4秒"/>
+        <string name="h27" value="消耗HP 25，消耗MP 26，伤害 188%，最多攻击6个敌人，84%概率昏迷4秒"/>
+        <string name="h28" value="消耗HP 25，消耗MP 26，伤害 192%，最多攻击6个敌人，86%概率昏迷4秒"/>
+        <string name="h29" value="消耗HP 25，消耗MP 26，伤害 196%，最多攻击6个敌人，88%概率昏迷4秒"/>
+        <string name="h30" value="消耗HP 25，消耗MP 26，伤害 200%，最多攻击6个敌人，90%概率昏迷4秒"/>
     </imgdir>
     <imgdir name="1111006">
         <string name="name" value="气绝斧"/>
-        <string name="h1" value="消耗HP15、MP12，造成伤害84%，以32%几率出现昏迷攻击"/>
-        <string name="h10" value="消耗HP15、MP12，造成伤害120%，以50%几率出现昏迷攻击"/>
-        <string name="h11" value="消耗HP20、MP19，造成伤害124%，以52%几率出现昏迷攻击"/>
-        <string name="h12" value="消耗HP20、MP19，造成伤害128%，以54%几率出现昏迷攻击"/>
-        <string name="h13" value="消耗HP20、MP19，造成伤害132%，以56%几率出现昏迷攻击"/>
-        <string name="h14" value="消耗HP20、MP19，造成伤害136%，以58%几率出现昏迷攻击"/>
-        <string name="h15" value="消耗HP20、MP19，造成伤害140%，以60%几率出现昏迷攻击"/>
-        <string name="h16" value="消耗HP20、MP19，造成伤害144%，以62%几率出现昏迷攻击"/>
-        <string name="h17" value="消耗HP20、MP19，造成伤害148%，以64%几率出现昏迷攻击"/>
-        <string name="h18" value="消耗HP20、MP19，造成伤害152%，以66%几率出现昏迷攻击"/>
-        <string name="h19" value="消耗HP20、MP19，造成伤害156%，以68%几率出现昏迷攻击"/>
-        <string name="h2" value="消耗HP15、MP12，造成伤害88%，以34%几率出现昏迷攻击"/>
-        <string name="h20" value="消耗HP20、MP19，造成伤害160%，以70%几率出现昏迷攻击"/>
-        <string name="h21" value="消耗HP25、MP26，造成伤害164%，以72%几率出现昏迷攻击"/>
-        <string name="h22" value="消耗HP25、MP26，造成伤害168%，以74%几率出现昏迷攻击"/>
-        <string name="h23" value="消耗HP25、MP26，造成伤害172%，以76%几率出现昏迷攻击"/>
-        <string name="h24" value="消耗HP25、MP26，造成伤害176%，以78%几率出现昏迷攻击"/>
-        <string name="h25" value="消耗HP25、MP26，造成伤害180%，以80%几率出现昏迷攻击"/>
-        <string name="h26" value="消耗HP25、MP26，造成伤害184%，以82%几率出现昏迷攻击"/>
-        <string name="h27" value="消耗HP25、MP26，造成伤害188%，以84%几率出现昏迷攻击"/>
-        <string name="h28" value="消耗HP25、MP26，造成伤害192%，以86%几率出现昏迷攻击"/>
-        <string name="h29" value="消耗HP25、MP26，造成伤害196%，以88%几率出现昏迷攻击"/>
-        <string name="h3" value="消耗HP15、MP12，造成伤害92%，以36%几率出现昏迷攻击"/>
-        <string name="h30" value="消耗HP25、MP26，造成伤害200%，以90%几率出现昏迷攻击"/>
-        <string name="h4" value="消耗HP15、MP12，造成伤害96%，以38%几率出现昏迷攻击"/>
-        <string name="h5" value="消耗HP15、MP12，造成伤害100%，以40%几率出现昏迷攻击"/>
-        <string name="h6" value="消耗HP15、MP12，造成伤害104%，以42%几率出现昏迷攻击"/>
-        <string name="h7" value="消耗HP15、MP12，造成伤害108%，以44%几率出现昏迷攻击"/>
-        <string name="h8" value="消耗HP15、MP12，造成伤害112%，以46%几率出现昏迷攻击"/>
-        <string name="h9" value="消耗HP15、MP12，造成伤害116%，以48%几率出现昏迷攻击"/>
-        <string name="desc" value="[最高等级：30]\n攻击怪物，一定几率使怪物昏迷\n必须装备斧且处于斗气集中状态。\n必要技能：#c斗气集中等级1以上#"/>
+        <string name="desc" value="[最高等级：30]\n消耗斗气攻击周围怪物，并以一定概率使其昏迷。只在装备斧时生效。\n需要技能：#c斗气集中1级以上#"/>
+        <string name="h1" value="消耗HP 15，消耗MP 12，伤害 84%，最多攻击6个敌人，32%概率昏迷2秒"/>
+        <string name="h2" value="消耗HP 15，消耗MP 12，伤害 88%，最多攻击6个敌人，34%概率昏迷2秒"/>
+        <string name="h3" value="消耗HP 15，消耗MP 12，伤害 92%，最多攻击6个敌人，36%概率昏迷2秒"/>
+        <string name="h4" value="消耗HP 15，消耗MP 12，伤害 96%，最多攻击6个敌人，38%概率昏迷2秒"/>
+        <string name="h5" value="消耗HP 15，消耗MP 12，伤害 100%，最多攻击6个敌人，40%概率昏迷2秒"/>
+        <string name="h6" value="消耗HP 15，消耗MP 12，伤害 104%，最多攻击6个敌人，42%概率昏迷2秒"/>
+        <string name="h7" value="消耗HP 15，消耗MP 12，伤害 108%，最多攻击6个敌人，44%概率昏迷2秒"/>
+        <string name="h8" value="消耗HP 15，消耗MP 12，伤害 112%，最多攻击6个敌人，46%概率昏迷2秒"/>
+        <string name="h9" value="消耗HP 15，消耗MP 12，伤害 116%，最多攻击6个敌人，48%概率昏迷2秒"/>
+        <string name="h10" value="消耗HP 15，消耗MP 12，伤害 120%，最多攻击6个敌人，50%概率昏迷2秒"/>
+        <string name="h11" value="消耗HP 20，消耗MP 19，伤害 124%，最多攻击6个敌人，52%概率昏迷3秒"/>
+        <string name="h12" value="消耗HP 20，消耗MP 19，伤害 128%，最多攻击6个敌人，54%概率昏迷3秒"/>
+        <string name="h13" value="消耗HP 20，消耗MP 19，伤害 132%，最多攻击6个敌人，56%概率昏迷3秒"/>
+        <string name="h14" value="消耗HP 20，消耗MP 19，伤害 136%，最多攻击6个敌人，58%概率昏迷3秒"/>
+        <string name="h15" value="消耗HP 20，消耗MP 19，伤害 140%，最多攻击6个敌人，60%概率昏迷3秒"/>
+        <string name="h16" value="消耗HP 20，消耗MP 19，伤害 144%，最多攻击6个敌人，62%概率昏迷3秒"/>
+        <string name="h17" value="消耗HP 20，消耗MP 19，伤害 148%，最多攻击6个敌人，64%概率昏迷3秒"/>
+        <string name="h18" value="消耗HP 20，消耗MP 19，伤害 152%，最多攻击6个敌人，66%概率昏迷3秒"/>
+        <string name="h19" value="消耗HP 20，消耗MP 19，伤害 156%，最多攻击6个敌人，68%概率昏迷3秒"/>
+        <string name="h20" value="消耗HP 20，消耗MP 19，伤害 160%，最多攻击6个敌人，70%概率昏迷3秒"/>
+        <string name="h21" value="消耗HP 25，消耗MP 26，伤害 164%，最多攻击6个敌人，72%概率昏迷4秒"/>
+        <string name="h22" value="消耗HP 25，消耗MP 26，伤害 168%，最多攻击6个敌人，74%概率昏迷4秒"/>
+        <string name="h23" value="消耗HP 25，消耗MP 26，伤害 172%，最多攻击6个敌人，76%概率昏迷4秒"/>
+        <string name="h24" value="消耗HP 25，消耗MP 26，伤害 176%，最多攻击6个敌人，78%概率昏迷4秒"/>
+        <string name="h25" value="消耗HP 25，消耗MP 26，伤害 180%，最多攻击6个敌人，80%概率昏迷4秒"/>
+        <string name="h26" value="消耗HP 25，消耗MP 26，伤害 184%，最多攻击6个敌人，82%概率昏迷4秒"/>
+        <string name="h27" value="消耗HP 25，消耗MP 26，伤害 188%，最多攻击6个敌人，84%概率昏迷4秒"/>
+        <string name="h28" value="消耗HP 25，消耗MP 26，伤害 192%，最多攻击6个敌人，86%概率昏迷4秒"/>
+        <string name="h29" value="消耗HP 25，消耗MP 26，伤害 196%，最多攻击6个敌人，88%概率昏迷4秒"/>
+        <string name="h30" value="消耗HP 25，消耗MP 26，伤害 200%，最多攻击6个敌人，90%概率昏迷4秒"/>
     </imgdir>
     <imgdir name="1111007">
         <string name="name" value="防御崩坏"/>
-        <string name="h1" value="消耗MP 35，冷却时间 465秒"/>
-        <string name="h10" value="消费MP 17，冷却时间 330秒"/>
-        <string name="h11" value="消费MP 16，冷却时间 315秒"/>
-        <string name="h12" value="消费MP 15，冷却时间 300秒"/>
-        <string name="h13" value="消费MP 14，冷却时间 285秒"/>
-        <string name="h14" value="消费MP 13，冷却时间 270秒"/>
-        <string name="h15" value="消费MP 12，冷却时间 255秒"/>
-        <string name="h16" value="消费MP 11，冷却时间 240秒"/>
-        <string name="h17" value="消费MP 10，冷却时间 225秒"/>
-        <string name="h18" value="消费MP 9，冷却时间 210秒"/>
-        <string name="h19" value="消费MP 8，冷却时间 195秒"/>
-        <string name="h2" value="消费MP 33，冷却时间 450秒"/>
-        <string name="h20" value="消费MP 7，冷却时间 180秒"/>
-        <string name="h3" value="消费MP 31，冷却时间 435秒"/>
-        <string name="h4" value="消费MP 29，冷却时间 420秒"/>
-        <string name="h5" value="消费MP 27，冷却时间 405秒"/>
-        <string name="h6" value="消费MP 25，冷却时间 390秒"/>
-        <string name="h7" value="消费MP 23，冷却时间 375秒"/>
-        <string name="h8" value="消费MP 21，冷却时间 360秒"/>
-        <string name="h9" value="消费MP 19，冷却时间 345秒"/>
-        <string name="desc" value="[最高等级:20]\n取消周围怪物的魔法防御\n冷却时间随着技能等级的增加而减少\n必需技能:#c虎咆哮等级3以上#\n对#c暗黑龙王#无效"/>
+        <string name="desc" value="[最高等级：20]\n以一定概率解除周围怪物的物理防御提升效果。\n需要技能：#c虎咆哮3级以上#"/>
+        <string name="h1" value="消耗MP 35，最多影响6个敌人，成功率 24%"/>
+        <string name="h2" value="消耗MP 33，最多影响6个敌人，成功率 28%"/>
+        <string name="h3" value="消耗MP 31，最多影响6个敌人，成功率 32%"/>
+        <string name="h4" value="消耗MP 29，最多影响6个敌人，成功率 36%"/>
+        <string name="h5" value="消耗MP 27，最多影响6个敌人，成功率 40%"/>
+        <string name="h6" value="消耗MP 25，最多影响6个敌人，成功率 44%"/>
+        <string name="h7" value="消耗MP 23，最多影响6个敌人，成功率 48%"/>
+        <string name="h8" value="消耗MP 21，最多影响6个敌人，成功率 52%"/>
+        <string name="h9" value="消耗MP 19，最多影响6个敌人，成功率 56%"/>
+        <string name="h10" value="消耗MP 17，最多影响6个敌人，成功率 60%"/>
+        <string name="h11" value="消耗MP 16，最多影响6个敌人，成功率 64%"/>
+        <string name="h12" value="消耗MP 15，最多影响6个敌人，成功率 68%"/>
+        <string name="h13" value="消耗MP 14，最多影响6个敌人，成功率 72%"/>
+        <string name="h14" value="消耗MP 13，最多影响6个敌人，成功率 76%"/>
+        <string name="h15" value="消耗MP 12，最多影响6个敌人，成功率 80%"/>
+        <string name="h16" value="消耗MP 11，最多影响6个敌人，成功率 84%"/>
+        <string name="h17" value="消耗MP 10，最多影响6个敌人，成功率 88%"/>
+        <string name="h18" value="消耗MP 9，最多影响6个敌人，成功率 92%"/>
+        <string name="h19" value="消耗MP 8，最多影响6个敌人，成功率 96%"/>
+        <string name="h20" value="消耗MP 7，最多影响6个敌人，成功率 100%"/>
     </imgdir>
     <imgdir name="1111008">
         <string name="name" value="虎咆哮"/>
-        <string name="h1" value="消耗MP8，造成伤害42%，攻击范围 300%， 以52%几率出现昏迷攻击，持续5秒"/>
-        <string name="h10" value="消费MP8，造成伤害60%，攻击范围 300%， 以70%几率出现昏迷攻击，持续6秒"/>
-        <string name="h11" value="消费MP12，造成伤害62%，攻击范围 300%， 以72%几率出现昏迷攻击，持续7秒"/>
-        <string name="h12" value="消费MP12，造成伤害64%，攻击范围 300%， 以74%几率出现昏迷攻击，持续7秒"/>
-        <string name="h13" value="消费MP12，造成伤害66%，攻击范围 300%， 以76%几率出现昏迷攻击，持续7秒"/>
-        <string name="h14" value="消费MP12，造成伤害68%，攻击范围 300%， 以78%几率出现昏迷攻击，持续7秒"/>
-        <string name="h15" value="消费MP12，造成伤害70%，攻击范围 300%， 以80%几率出现昏迷攻击，持续7秒"/>
-        <string name="h16" value="消费MP12，造成伤害72%，攻击范围 300%， 以82%几率出现昏迷攻击，持续8秒"/>
-        <string name="h17" value="消费MP12，造成伤害74%，攻击范围 300%， 以84%几率出现昏迷攻击，持续8秒"/>
-        <string name="h18" value="消费MP12，造成伤害76%，攻击范围 300%， 以86%几率出现昏迷攻击，持续8秒"/>
-        <string name="h19" value="消费MP12，造成伤害78%，攻击范围 300%， 以88%几率出现昏迷攻击，持续8秒"/>
-        <string name="h2" value="消耗MP8，造成伤害44%，攻击范围 300%， 以54%几率出现昏迷攻击，持续5秒"/>
-        <string name="h20" value="消费MP12，造成伤害80%，攻击范围 300%， 以90%几率出现昏迷攻击，持续8秒"/>
-        <string name="h21" value="消费MP16，造成伤害82%，攻击范围 300%， 以91%几率出现昏迷攻击，持续9秒"/>
-        <string name="h22" value="消费MP16，造成伤害84%，攻击范围 300%， 以92%几率出现昏迷攻击，持续9秒"/>
-        <string name="h23" value="消费MP16，造成伤害86%，攻击范围 300%， 以93%几率出现昏迷攻击，持续9秒"/>
-        <string name="h24" value="消费MP16，造成伤害88%，攻击范围 300%， 以94%几率出现昏迷攻击，持续9秒"/>
-        <string name="h25" value="消费MP16，造成伤害90%，攻击范围 300%， 以95%几率出现昏迷攻击，持续9秒"/>
-        <string name="h26" value="消费MP16，造成伤害92%，攻击范围 300%， 以96%几率出现昏迷攻击，持续10秒"/>
-        <string name="h27" value="消费MP16，造成伤害94%，攻击范围 300%， 以97%几率出现昏迷攻击，持续10秒"/>
-        <string name="h28" value="消费MP16，造成伤害96%，攻击范围 300%， 以98%几率出现昏迷攻击，持续10秒"/>
-        <string name="h29" value="消费MP16，造成伤害98%，攻击范围 300%， 以99%几率出现昏迷攻击，持续10秒"/>
-        <string name="h3" value="消耗MP8，造成伤害46%，攻击范围 300%， 以56%几率出现昏迷攻击，持续5秒"/>
-        <string name="h30" value="消费MP16，造成伤害100%，攻击范围 300%， 以100%几率出现昏迷攻击，持续10秒"/>
-        <string name="h4" value="消耗MP8，造成伤害48%，攻击范围 300%， 以58%几率出现昏迷攻击，持续5秒"/>
-        <string name="h5" value="消费MP8，造成伤害50%，攻击范围 300%， 以60%几率出现昏迷攻击，持续5秒"/>
-        <string name="h6" value="消费MP8，造成伤害52%，攻击范围 300%， 以62%几率出现昏迷攻击，持续6秒"/>
-        <string name="h7" value="消费MP8，造成伤害54%，攻击范围 300%， 以64%几率出现昏迷攻击，持续6秒"/>
-        <string name="h8" value="消费MP8，造成伤害56%，攻击范围 300%， 以66%几率出现昏迷攻击，持续6秒"/>
-        <string name="h9" value="消费MP8，造成伤害58%，攻击范围 300%， 以68%几率出现昏迷攻击，持续6秒"/>
-        <string name="desc" value="[最高等级：30]\n向周边怪物发出虎吼施加伤害，\n同时一定几率让其昏迷。一次不能攻击8只以上。\n冷却时间:#c3秒#"/>
+        <string name="desc" value="[最高等级：30]\n对周围怪物造成伤害，并以一定概率使其昏迷。"/>
+        <string name="h1" value="消耗MP 8，伤害 11%，最多攻击6个敌人，52%概率昏迷5秒"/>
+        <string name="h2" value="消耗MP 8，伤害 12%，最多攻击6个敌人，54%概率昏迷5秒"/>
+        <string name="h3" value="消耗MP 8，伤害 13%，最多攻击6个敌人，56%概率昏迷5秒"/>
+        <string name="h4" value="消耗MP 8，伤害 14%，最多攻击6个敌人，%概率昏迷5秒"/>
+        <string name="h5" value="消耗MP 8，伤害 15%，最多攻击6个敌人，60%概率昏迷5秒"/>
+        <string name="h6" value="消耗MP 8，伤害 16%，最多攻击6个敌人，62%概率昏迷6秒"/>
+        <string name="h7" value="消耗MP 8，伤害 17%，最多攻击6个敌人，64%概率昏迷6秒"/>
+        <string name="h8" value="消耗MP 8，伤害 18%，最多攻击6个敌人，66%概率昏迷6秒"/>
+        <string name="h9" value="消耗MP 8，伤害 19%，最多攻击6个敌人，68%概率昏迷6秒"/>
+        <string name="h10" value="消耗MP 8，伤害 20%，最多攻击6个敌人，70%概率昏迷6秒"/>
+        <string name="h11" value="消耗MP 12，伤害 20%，最多攻击6个敌人，72%概率昏迷7秒"/>
+        <string name="h12" value="消耗MP 12，伤害 21%，最多攻击6个敌人，74%概率昏迷7秒"/>
+        <string name="h13" value="消耗MP 12，伤害 21%，最多攻击6个敌人，76%概率昏迷7秒"/>
+        <string name="h14" value="消耗MP 12，伤害 22%，最多攻击6个敌人，78%概率昏迷7秒"/>
+        <string name="h15" value="消耗MP 12，伤害 22%，最多攻击6个敌人，80%概率昏迷7秒"/>
+        <string name="h16" value="消耗MP 12，伤害 23%，最多攻击6个敌人，81%概率昏迷8秒"/>
+        <string name="h17" value="消耗MP 12，伤害 23%，最多攻击6个敌人，82%概率昏迷8秒"/>
+        <string name="h18" value="消耗MP 12，伤害 24%，最多攻击6个敌人，83%概率昏迷8秒"/>
+        <string name="h19" value="消耗MP 12，伤害 24%，最多攻击6个敌人，84%概率昏迷8秒"/>
+        <string name="h20" value="消耗MP 12，伤害 25%，最多攻击6个敌人，85%概率昏迷8秒"/>
+        <string name="h21" value="消耗MP 16，伤害 25%，最多攻击6个敌人，86%概率昏迷9秒"/>
+        <string name="h22" value="消耗MP 16，伤害 26%，最多攻击6个敌人，87%概率昏迷9秒"/>
+        <string name="h23" value="消耗MP 16，伤害 26%，最多攻击6个敌人，88%概率昏迷9秒"/>
+        <string name="h24" value="消耗MP 16，伤害 27%，最多攻击6个敌人，89%概率昏迷9秒"/>
+        <string name="h25" value="消耗MP 16，伤害 27%，最多攻击6个敌人，90%概率昏迷9秒"/>
+        <string name="h26" value="消耗MP 16，伤害 28%，最多攻击6个敌人，91%概率昏迷10秒"/>
+        <string name="h27" value="消耗MP 16，伤害 28%，最多攻击6个敌人，92%概率昏迷10秒"/>
+        <string name="h28" value="消耗MP 16，伤害 29%，最多攻击6个敌人，93%概率昏迷10秒"/>
+        <string name="h29" value="消耗MP 16，伤害 29%，最多攻击6个敌人，94%概率昏迷10秒"/>
+        <string name="h30" value="消耗MP 16，伤害 30%，最多攻击6个敌人，95%概率昏迷10秒"/>
     </imgdir>
     <imgdir name="11111001">
         <string name="name" value="斗气集中"/>
@@ -1409,318 +1409,318 @@
     </imgdir>
     <imgdir name="1120003">
         <string name="name" value="进阶斗气"/>
-        <string name="h1" value="增加1%伤害，最高斗气量增加为 1，31%几率累积两个斗气"/>
-        <string name="h10" value="增加10%伤害，最高斗气量增加为 2，40%几率累积两个斗气"/>
-        <string name="h11" value="增加11%伤害，最高斗气量增加为 2，41%几率累积两个斗气"/>
-        <string name="h12" value="增加12%伤害，最高斗气量增加为 2，42%几率累积两个斗气"/>
-        <string name="h13" value="增加13%伤害，最高斗气量增加为 3，43%几率累积两个斗气"/>
-        <string name="h14" value="增加14%伤害，最高斗气量增加为 3，44%几率累积两个斗气"/>
-        <string name="h15" value="增加15%伤害，最高斗气量增加为 3，45%几率累积两个斗气"/>
-        <string name="h16" value="增加16%伤害，最高斗气量增加为 3，46%几率累积两个斗气"/>
-        <string name="h17" value="增加17%伤害，最高斗气量增加为 3，47%几率累积两个斗气"/>
-        <string name="h18" value="增加18%伤害，最高斗气量增加为 3，48%几率累积两个斗气"/>
-        <string name="h19" value="增加19%伤害，最高斗气量增加为 4，49%几率累积两个斗气"/>
-        <string name="h2" value="增加2%伤害，最高斗气量增加为 1，32%几率累积两个斗气"/>
-        <string name="h20" value="增加20%伤害，最高斗气量增加为 4，50%几率累积两个斗气"/>
-        <string name="h21" value="增加21%伤害，最高斗气量增加为 4，51%几率累积两个斗气"/>
-        <string name="h22" value="增加22%伤害，最高斗气量增加为 4，52%几率累积两个斗气"/>
-        <string name="h23" value="增加23%伤害，最高斗气量增加为 4，53%几率累积两个斗气"/>
-        <string name="h24" value="增加24%伤害，最高斗气量增加为 4，54%几率累积两个斗气"/>
-        <string name="h25" value="增加25%伤害，最高斗气量增加为 5，55%几率累积两个斗气"/>
-        <string name="h26" value="增加26%伤害，最高斗气量增加为 5，56%几率累积两个斗气"/>
-        <string name="h27" value="增加27%伤害，最高斗气量增加为 5，57%几率累积两个斗气"/>
-        <string name="h28" value="增加28%伤害，最高斗气量增加为 5，58%几率累积两个斗气"/>
-        <string name="h29" value="增加29%伤害，最高斗气量增加为 5，59%几率累积两个斗气"/>
-        <string name="h3" value="增加3%伤害，最高斗气量增加为 1，33%几率累积两个斗气"/>
-        <string name="h30" value="增加30%伤害，最高斗气量增加为 5，60%几率累积两个斗气"/>
-        <string name="h4" value="增加4%伤害，最高斗气量增加为 1，34%几率累积两个斗气"/>
-        <string name="h5" value="增加5%伤害，最高斗气量增加为 1，35%几率累积两个斗气"/>
-        <string name="h6" value="增加6%伤害，最高斗气量增加为 1，36%几率累积两个斗气"/>
-        <string name="h7" value="增加7%伤害，最高斗气量增加为 2，37%几率累积两个斗气"/>
-        <string name="h8" value="增加8%伤害，最高斗气量增加为 2，38%几率累积两个斗气"/>
-        <string name="h9" value="增加9%伤害，最高斗气量增加为 2，39%几率累积两个斗气"/>
-        <string name="desc" value="最高斗气量增加为 10\n一定几率以两个为单位累积斗气量\n必要技能：#c斗气集中等级30以上#"/>
+        <string name="desc" value="[最高等级：30]\n强化斗气集中，提高最大斗气数量，并有一定概率一次积累2个斗气。\n需要技能：#c斗气集中30级#"/>
+        <string name="h1" value="伤害 +1%，最大斗气数量 6，31%概率一次积累2个斗气"/>
+        <string name="h2" value="伤害 +2%，最大斗气数量 6，32%概率一次积累2个斗气"/>
+        <string name="h3" value="伤害 +3%，最大斗气数量 6，33%概率一次积累2个斗气"/>
+        <string name="h4" value="伤害 +4%，最大斗气数量 6，34%概率一次积累2个斗气"/>
+        <string name="h5" value="伤害 +5%，最大斗气数量 6，35%概率一次积累2个斗气"/>
+        <string name="h6" value="伤害 +6%，最大斗气数量 6，36%概率一次积累2个斗气"/>
+        <string name="h7" value="伤害 +7%，最大斗气数量 7，37%概率一次积累2个斗气"/>
+        <string name="h8" value="伤害 +8%，最大斗气数量 7，38%概率一次积累2个斗气"/>
+        <string name="h9" value="伤害 +9%，最大斗气数量 7，39%概率一次积累2个斗气"/>
+        <string name="h10" value="伤害 +10%，最大斗气数量 7，40%概率一次积累2个斗气"/>
+        <string name="h11" value="伤害 +11%，最大斗气数量 7，41%概率一次积累2个斗气"/>
+        <string name="h12" value="伤害 +12%，最大斗气数量 7，42%概率一次积累2个斗气"/>
+        <string name="h13" value="伤害 +13%，最大斗气数量 8，43%概率一次积累2个斗气"/>
+        <string name="h14" value="伤害 +14%，最大斗气数量 8，44%概率一次积累2个斗气"/>
+        <string name="h15" value="伤害 +15%，最大斗气数量 8，45%概率一次积累2个斗气"/>
+        <string name="h16" value="伤害 +16%，最大斗气数量 8，46%概率一次积累2个斗气"/>
+        <string name="h17" value="伤害 +17%，最大斗气数量 8，47%概率一次积累2个斗气"/>
+        <string name="h18" value="伤害 +18%，最大斗气数量 8，48%概率一次积累2个斗气"/>
+        <string name="h19" value="伤害 +19%，最大斗气数量 9，49%概率一次积累2个斗气"/>
+        <string name="h20" value="伤害 +20%，最大斗气数量 9，50%概率一次积累2个斗气"/>
+        <string name="h21" value="伤害 +21%，最大斗气数量 9，51%概率一次积累2个斗气"/>
+        <string name="h22" value="伤害 +22%，最大斗气数量 9，52%概率一次积累2个斗气"/>
+        <string name="h23" value="伤害 +23%，最大斗气数量 9，53%概率一次积累2个斗气"/>
+        <string name="h24" value="伤害 +24%，最大斗气数量 9，54%概率一次积累2个斗气"/>
+        <string name="h25" value="伤害 +25%，最大斗气数量 10，55%概率一次积累2个斗气"/>
+        <string name="h26" value="伤害 +26%，最大斗气数量 10，56%概率一次积累2个斗气"/>
+        <string name="h27" value="伤害 +27%，最大斗气数量 10，57%概率一次积累2个斗气"/>
+        <string name="h28" value="伤害 +28%，最大斗气数量 10，58%概率一次积累2个斗气"/>
+        <string name="h29" value="伤害 +29%，最大斗气数量 10，59%概率一次积累2个斗气"/>
+        <string name="h30" value="伤害 +30%，最大斗气数量 10，60%概率一次积累2个斗气"/>
     </imgdir>
     <imgdir name="1120004">
         <string name="name" value="阿基里斯"/>
-        <string name="h1" value="减少伤害 5.5%"/>
-        <string name="h10" value="减少伤害 10%"/>
-        <string name="h11" value="减少伤害 10.5%"/>
-        <string name="h12" value="减少伤害 11%"/>
-        <string name="h13" value="减少伤害 11.5%"/>
-        <string name="h14" value="减少伤害 12%"/>
-        <string name="h15" value="减少伤害 12.5%"/>
-        <string name="h16" value="减少伤害 13%"/>
-        <string name="h17" value="减少伤害 13.5%"/>
-        <string name="h18" value="减少伤害 14%"/>
-        <string name="h19" value="减少伤害 14.5%"/>
-        <string name="h2" value="减少伤害 6%"/>
-        <string name="h20" value="减少伤害 15%"/>
-        <string name="h21" value="减少伤害 15.5%"/>
-        <string name="h22" value="减少伤害 16%"/>
-        <string name="h23" value="减少伤害 16.5%"/>
-        <string name="h24" value="减少伤害 17%"/>
-        <string name="h25" value="减少伤害 17.5%"/>
-        <string name="h26" value="减少伤害 18%"/>
-        <string name="h27" value="减少伤害 18.5%"/>
-        <string name="h28" value="减少伤害 19%"/>
-        <string name="h29" value="减少伤害 19.5%"/>
-        <string name="h3" value="减少伤害 6.5%"/>
-        <string name="h30" value="减少伤害 20%"/>
-        <string name="h4" value="减少伤害 7%"/>
-        <string name="h5" value="减少伤害 7.5%"/>
-        <string name="h6" value="减少伤害 8%"/>
-        <string name="h7" value="减少伤害 8.5%"/>
-        <string name="h8" value="减少伤害 9%"/>
-        <string name="h9" value="减少伤害 9.5%"/>
-        <string name="desc" value="永久强化盔甲,减弱伤害值"/>
+        <string name="desc" value="[最高等级：30]\n永久减少受到的敌人伤害。"/>
+        <string name="h1" value="受到的伤害减少 0.5%"/>
+        <string name="h2" value="受到的伤害减少 1%"/>
+        <string name="h3" value="受到的伤害减少 1.5%"/>
+        <string name="h4" value="受到的伤害减少 2%"/>
+        <string name="h5" value="受到的伤害减少 2.5%"/>
+        <string name="h6" value="受到的伤害减少 3%"/>
+        <string name="h7" value="受到的伤害减少 3.5%"/>
+        <string name="h8" value="受到的伤害减少 4%"/>
+        <string name="h9" value="受到的伤害减少 4.5%"/>
+        <string name="h10" value="受到的伤害减少 5%"/>
+        <string name="h11" value="受到的伤害减少 5.5%"/>
+        <string name="h12" value="受到的伤害减少 6%"/>
+        <string name="h13" value="受到的伤害减少 6.5%"/>
+        <string name="h14" value="受到的伤害减少 7%"/>
+        <string name="h15" value="受到的伤害减少 7.5%"/>
+        <string name="h16" value="受到的伤害减少 8%"/>
+        <string name="h17" value="受到的伤害减少 8.5%"/>
+        <string name="h18" value="受到的伤害减少 9%"/>
+        <string name="h19" value="受到的伤害减少 9.5%"/>
+        <string name="h20" value="受到的伤害减少 10%"/>
+        <string name="h21" value="受到的伤害减少 10.5%"/>
+        <string name="h22" value="受到的伤害减少 11%"/>
+        <string name="h23" value="受到的伤害减少 11.5%"/>
+        <string name="h24" value="受到的伤害减少 12%"/>
+        <string name="h25" value="受到的伤害减少 12.5%"/>
+        <string name="h26" value="受到的伤害减少 13%"/>
+        <string name="h27" value="受到的伤害减少 13.5%"/>
+        <string name="h28" value="受到的伤害减少 14%"/>
+        <string name="h29" value="受到的伤害减少 14.5%"/>
+        <string name="h30" value="受到的伤害减少 15%"/>
     </imgdir>
     <imgdir name="1120005">
-        <string name="name" value="寒冰掌"/>
-        <string name="h1" value="5.5%的几率防御敌人的攻击"/>
-        <string name="h10" value="10%的几率防御敌人的攻击"/>
-        <string name="h11" value="10.5%的几率防御敌人的攻击"/>
-        <string name="h12" value="11%的几率防御敌人的攻击"/>
-        <string name="h13" value="11.5%的几率防御敌人的攻击"/>
-        <string name="h14" value="12%的几率防御敌人的攻击"/>
-        <string name="h15" value="12.5%的几率防御敌人的攻击"/>
-        <string name="h16" value="13%的几率防御敌人的攻击"/>
-        <string name="h17" value="13.5%的几率防御敌人的攻击"/>
-        <string name="h18" value="14%的几率防御敌人的攻击"/>
-        <string name="h19" value="14.5%的几率防御敌人的攻击"/>
-        <string name="h2" value="6%的几率防御敌人的攻击"/>
-        <string name="h20" value="15%的几率防御敌人的攻击"/>
-        <string name="h21" value="15.5%的几率防御敌人的攻击"/>
-        <string name="h22" value="16%的几率防御敌人的攻击"/>
-        <string name="h23" value="16.5%的几率防御敌人的攻击"/>
-        <string name="h24" value="17%的几率防御敌人的攻击"/>
-        <string name="h25" value="17.5%的几率防御敌人的攻击"/>
-        <string name="h26" value="18%的几率防御敌人的攻击"/>
-        <string name="h27" value="18.5%的几率防御敌人的攻击"/>
-        <string name="h28" value="19%的几率防御敌人的攻击"/>
-        <string name="h29" value="19.5%的几率防御敌人的攻击"/>
-        <string name="h3" value="6.5%的几率防御敌人的攻击"/>
-        <string name="h30" value="20%的几率防御敌人的攻击"/>
-        <string name="h4" value="7%的几率防御敌人的攻击"/>
-        <string name="h5" value="7.5%的几率防御敌人的攻击"/>
-        <string name="h6" value="8%的几率防御敌人的攻击"/>
-        <string name="h7" value="8.5%的几率防御敌人的攻击"/>
-        <string name="h8" value="9%的几率防御敌人的攻击"/>
-        <string name="h9" value="9.5%的几率防御敌人的攻击"/>
-        <string name="desc" value="一定概率下用盾牌挡住敌人的攻击，近\n距离攻击防御成功的话，攻击自己的敌人\n2秒内处于昏迷状态，需装备盾牌"/>
+        <string name="name" value="守护之神"/>
+        <string name="desc" value="[最高等级：30]\n装备盾牌时，以一定概率格挡敌人的攻击。若格挡近距离攻击，攻击者会昏迷2秒。"/>
+        <string name="h1" value="0%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h2" value="1%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h3" value="1%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h4" value="2%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h5" value="2%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h6" value="3%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h7" value="3%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h8" value="4%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h9" value="4%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h10" value="5%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h11" value="5%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h12" value="6%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h13" value="6%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h14" value="7%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h15" value="7%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h16" value="8%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h17" value="8%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h18" value="9%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h19" value="9%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h20" value="10%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h21" value="10%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h22" value="11%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h23" value="11%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h24" value="12%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h25" value="12%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h26" value="13%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h27" value="13%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h28" value="14%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h29" value="14%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h30" value="15%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
     </imgdir>
     <imgdir name="1121000">
         <string name="name" value="冒险岛勇士"/>
-        <string name="h1" value="消耗MP 10，30秒内所有的属性点提高 1%"/>
-        <string name="h10" value="消耗MP 20，300秒内所有的属性点提高 5%"/>
-        <string name="h11" value="消耗MP 30，330秒内所有的属性点提高 6%"/>
-        <string name="h12" value="消耗MP 30，360秒内所有的属性点提高 6%"/>
-        <string name="h13" value="消耗MP 30，390秒内所有的属性点提高 7%"/>
-        <string name="h14" value="消耗MP 30，420秒内所有的属性点提高 7%"/>
-        <string name="h15" value="消耗MP 30，450秒内所有的属性点提高 8%"/>
-        <string name="h16" value="消耗MP 40，480秒内所有的属性点提高 8%"/>
-        <string name="h17" value="消耗MP 40，510秒内所有的属性点提高 9%"/>
-        <string name="h18" value="消耗MP 40，540秒内所有的属性点提高 9%"/>
-        <string name="h19" value="消耗MP 40，570秒内所有的属性点提高 10%"/>
-        <string name="h2" value="消耗MP 10，60秒内所有的属性点提高 1%"/>
-        <string name="h20" value="消耗MP 40，600秒内所有的属性点提高 10%"/>
-        <string name="h21" value="消耗MP 50，630秒内所有的属性点提高 11%"/>
-        <string name="h22" value="消耗MP 50，660秒内所有的属性点提高 11%"/>
-        <string name="h23" value="消耗MP 50，690秒内所有的属性点提高 12%"/>
-        <string name="h24" value="消耗MP 50，720秒内所有的属性点提高 12%"/>
-        <string name="h25" value="消耗MP 50，750秒内所有的属性点提高 13%"/>
-        <string name="h26" value="消耗MP 60，780秒内所有的属性点提高 13%"/>
-        <string name="h27" value="消耗MP 60，810秒内所有的属性点提高 14%"/>
-        <string name="h28" value="消耗MP 60，840秒内所有的属性点提高 14%"/>
-        <string name="h29" value="消耗MP 60，870秒内所有的属性点提高 15%"/>
-        <string name="h3" value="消耗MP 10，90秒内所有的属性点提高 2%"/>
-        <string name="h30" value="消耗MP 60，900秒内所有的属性点提高 15%"/>
-        <string name="h4" value="消耗MP 10，120秒内所有的属性点提高 2%"/>
-        <string name="h5" value="消耗MP 10，150秒内所有的属性点提高 3%"/>
-        <string name="h6" value="消耗MP 20，180秒内所有的属性点提高 3%"/>
-        <string name="h7" value="消耗MP 20，210秒内所有的属性点提高 4%"/>
-        <string name="h8" value="消耗MP 20，240秒内所有的属性点提高 4%"/>
-        <string name="h9" value="消耗MP 20，270秒内所有的属性点提高 5%"/>
-        <string name="desc" value="一定时间内把组队成员的所有属性点提高\n一定的百分比"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内按百分比提高自身及周围队员的所有属性。"/>
+        <string name="h1" value="消耗MP 10，所有属性 +1%，持续30秒"/>
+        <string name="h2" value="消耗MP 10，所有属性 +1%，持续60秒"/>
+        <string name="h3" value="消耗MP 10，所有属性 +2%，持续90秒"/>
+        <string name="h4" value="消耗MP 10，所有属性 +2%，持续120秒"/>
+        <string name="h5" value="消耗MP 10，所有属性 +3%，持续150秒"/>
+        <string name="h6" value="消耗MP 20，所有属性 +3%，持续180秒"/>
+        <string name="h7" value="消耗MP 20，所有属性 +4%，持续210秒"/>
+        <string name="h8" value="消耗MP 20，所有属性 +4%，持续240秒"/>
+        <string name="h9" value="消耗MP 20，所有属性 +5%，持续270秒"/>
+        <string name="h10" value="消耗MP 20，所有属性 +5%，持续300秒"/>
+        <string name="h11" value="消耗MP 30，所有属性 +6%，持续330秒"/>
+        <string name="h12" value="消耗MP 30，所有属性 +6%，持续360秒"/>
+        <string name="h13" value="消耗MP 30，所有属性 +7%，持续390秒"/>
+        <string name="h14" value="消耗MP 30，所有属性 +7%，持续420秒"/>
+        <string name="h15" value="消耗MP 30，所有属性 +8%，持续450秒"/>
+        <string name="h16" value="消耗MP 40，所有属性 +8%，持续480秒"/>
+        <string name="h17" value="消耗MP 40，所有属性 +9%，持续510秒"/>
+        <string name="h18" value="消耗MP 40，所有属性 +9%，持续540秒"/>
+        <string name="h19" value="消耗MP 40，所有属性 +10%，持续570秒"/>
+        <string name="h20" value="消耗MP 40，所有属性 +10%，持续600秒"/>
+        <string name="h21" value="消耗MP 50，所有属性 +11%，持续630秒"/>
+        <string name="h22" value="消耗MP 50，所有属性 +11%，持续660秒"/>
+        <string name="h23" value="消耗MP 50，所有属性 +12%，持续690秒"/>
+        <string name="h24" value="消耗MP 50，所有属性 +12%，持续720秒"/>
+        <string name="h25" value="消耗MP 50，所有属性 +13%，持续750秒"/>
+        <string name="h26" value="消耗MP 60，所有属性 +13%，持续780秒"/>
+        <string name="h27" value="消耗MP 60，所有属性 +14%，持续810秒"/>
+        <string name="h28" value="消耗MP 60，所有属性 +14%，持续840秒"/>
+        <string name="h29" value="消耗MP 60，所有属性 +15%，持续870秒"/>
+        <string name="h30" value="消耗MP 60，所有属性 +15%，持续900秒"/>
     </imgdir>
     <imgdir name="1121001">
         <string name="name" value="磁石"/>
-        <string name="h1" value="消耗MP 10，范围 100%，成功率 42%"/>
-        <string name="h10" value="消耗MP 13，范围 100%，成功率 60%"/>
-        <string name="h11" value="消耗MP 18，范围 150%，成功率 62%"/>
-        <string name="h12" value="消耗MP 18，范围 150%，成功率 64%"/>
-        <string name="h13" value="消耗MP 18，范围 150%，成功率 66%"/>
-        <string name="h14" value="消耗MP 18，范围 150%，成功率 68%"/>
-        <string name="h15" value="消耗MP 18，范围 150%，成功率 70%"/>
-        <string name="h16" value="消耗MP 21，范围 150%，成功率 72%"/>
-        <string name="h17" value="消耗MP 21，范围 150%，成功率 74%"/>
-        <string name="h18" value="消耗MP 21，范围 150%，成功率 76%"/>
-        <string name="h19" value="消耗MP 21，范围 150%，成功率 78%"/>
-        <string name="h2" value="消耗MP 10，范围 100%，成功率 44%"/>
-        <string name="h20" value="消耗MP 21，范围 150%，成功率 80%"/>
-        <string name="h21" value="消耗MP 26，范围 200%，成功率 82%"/>
-        <string name="h22" value="消耗MP 26，范围 200%，成功率 84%"/>
-        <string name="h23" value="消耗MP 26，范围 200%，成功率 86%"/>
-        <string name="h24" value="消耗MP 26，范围 200%，成功率 88%"/>
-        <string name="h25" value="消耗MP 26，范围 200%，成功率 90%"/>
-        <string name="h26" value="消耗MP 25，范围 200%，成功率 91%"/>
-        <string name="h27" value="消耗MP 24，范围 200%，成功率 92%"/>
-        <string name="h28" value="消耗MP 23，范围 200%，成功率 93%"/>
-        <string name="h29" value="消耗MP 22，范围 200%，成功率 94%"/>
-        <string name="h3" value="消耗MP 10，范围 100%，成功率 46%"/>
-        <string name="h30" value="消耗MP 21，范围 200%，成功率 95%"/>
-        <string name="h4" value="消耗MP 10，范围 100%，成功率 48%"/>
-        <string name="h5" value="消耗MP 10，范围 100%，成功率 50%"/>
-        <string name="h6" value="消耗MP 13，范围 100%，成功率 52%"/>
-        <string name="h7" value="消耗MP 13，范围 100%，成功率 54%"/>
-        <string name="h8" value="消耗MP 13，范围 100%，成功率 56%"/>
-        <string name="h9" value="消耗MP 13，范围 100%，成功率 58%"/>
-        <string name="desc" value="把远处的敌人最多6只吸到自己面前"/>
+        <string name="desc" value="[最高等级：30]\n以一定概率将远处的怪物拉到自己面前。"/>
+        <string name="h1" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h2" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h3" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h4" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h5" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h6" value="消耗MP 13，最多牵引3个敌人，成功率 100%"/>
+        <string name="h7" value="消耗MP 13，最多牵引3个敌人，成功率 100%"/>
+        <string name="h8" value="消耗MP 13，最多牵引4个敌人，成功率 100%"/>
+        <string name="h9" value="消耗MP 13，最多牵引4个敌人，成功率 100%"/>
+        <string name="h10" value="消耗MP 13，最多牵引4个敌人，成功率 100%"/>
+        <string name="h11" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h12" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h13" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h14" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h15" value="消耗MP 18，最多牵引5个敌人，成功率 100%"/>
+        <string name="h16" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h17" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h18" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h19" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h20" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h21" value="消耗MP 26，最多牵引5个敌人，成功率 100%"/>
+        <string name="h22" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h23" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h24" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h25" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h26" value="消耗MP 25，最多牵引6个敌人，成功率 100%"/>
+        <string name="h27" value="消耗MP 24，最多牵引6个敌人，成功率 100%"/>
+        <string name="h28" value="消耗MP 23，最多牵引6个敌人，成功率 100%"/>
+        <string name="h29" value="消耗MP 22，最多牵引7个敌人，成功率 100%"/>
+        <string name="h30" value="消耗MP 21，最多牵引7个敌人，成功率 100%"/>
     </imgdir>
     <imgdir name="1121002">
         <string name="name" value="稳如泰山"/>
-        <string name="h1" value="消耗MP 30，10秒内有42%的几率不会出现退后现象"/>
-        <string name="h10" value="消耗MP 36，100秒内有60%的几率不会出现退后现象"/>
-        <string name="h11" value="消耗MP 42，110秒内有62%的几率不会出现退后现象"/>
-        <string name="h12" value="消耗MP 42，120秒内有64%的几率不会出现退后现象"/>
-        <string name="h13" value="消耗MP 42，130秒内有66%的几率不会出现退后现象"/>
-        <string name="h14" value="消耗MP 42，140秒内有68%的几率不会出现退后现象"/>
-        <string name="h15" value="消耗MP 42，150秒内有70%的几率不会出现退后现象"/>
-        <string name="h16" value="消耗MP 48，160秒内有72%的几率不会出现退后现象"/>
-        <string name="h17" value="消耗MP 48，170秒内有74%的几率不会出现退后现象"/>
-        <string name="h18" value="消耗MP 48，180秒内有76%的几率不会出现退后现象"/>
-        <string name="h19" value="消耗MP 48，190秒内有78%的几率不会出现退后现象"/>
-        <string name="h2" value="消耗MP 30，20秒内有44%的几率不会出现退后现象"/>
-        <string name="h20" value="消耗MP 48，200秒内有80%的几率不会出现退后现象"/>
-        <string name="h21" value="消耗MP 54，210秒内有81%的几率不会出现退后现象"/>
-        <string name="h22" value="消耗MP 54，220秒内有82%的几率不会出现退后现象"/>
-        <string name="h23" value="消耗MP 54，230秒内有83%的几率不会出现退后现象"/>
-        <string name="h24" value="消耗MP 54，240秒内有84%的几率不会出现退后现象"/>
-        <string name="h25" value="消耗MP 54，250秒内有85%的几率不会出现退后现象"/>
-        <string name="h26" value="消耗MP 53，260秒内有86%的几率不会出现退后现象"/>
-        <string name="h27" value="消耗MP 52，270秒内有87%的几率不会出现退后现象"/>
-        <string name="h28" value="消耗MP 51，280秒内有88%的几率不会出现退后现象"/>
-        <string name="h29" value="消耗MP 50，290秒内有89%的几率不会出现退后现象"/>
-        <string name="h3" value="消耗MP 30，30秒内有46%的几率不会出现退后现象"/>
-        <string name="h30" value="消耗MP 50，300秒内有90%的几率不会出现退后现象"/>
-        <string name="h4" value="消耗MP 30，40秒内有48%的几率不会出现退后现象"/>
-        <string name="h5" value="消耗MP 30，50秒内有50%的几率不会出现退后现象"/>
-        <string name="h6" value="消耗MP 36，60秒内有52%的几率不会出现退后现象"/>
-        <string name="h7" value="消耗MP 36，70秒内有54%的几率不会出现退后现象"/>
-        <string name="h8" value="消耗MP 36，80秒内有56%的几率不会出现退后现象"/>
-        <string name="h9" value="消耗MP 36，90秒内有58%的几率不会出现退后现象"/>
-        <string name="desc" value="凭借着强韧的精神，\n受到敌人的攻击仍不会后退"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内以一定概率抵抗敌人攻击造成的击退。"/>
+        <string name="h1" value="消耗MP 30，42%概率抵抗击退，持续10秒"/>
+        <string name="h2" value="消耗MP 30，44%概率抵抗击退，持续20秒"/>
+        <string name="h3" value="消耗MP 30，46%概率抵抗击退，持续30秒"/>
+        <string name="h4" value="消耗MP 30，48%概率抵抗击退，持续40秒"/>
+        <string name="h5" value="消耗MP 30，50%概率抵抗击退，持续50秒"/>
+        <string name="h6" value="消耗MP 36，52%概率抵抗击退，持续60秒"/>
+        <string name="h7" value="消耗MP 36，54%概率抵抗击退，持续70秒"/>
+        <string name="h8" value="消耗MP 36，56%概率抵抗击退，持续80秒"/>
+        <string name="h9" value="消耗MP 36，58%概率抵抗击退，持续90秒"/>
+        <string name="h10" value="消耗MP 36，60%概率抵抗击退，持续100秒"/>
+        <string name="h11" value="消耗MP 42，62%概率抵抗击退，持续110秒"/>
+        <string name="h12" value="消耗MP 42，64%概率抵抗击退，持续120秒"/>
+        <string name="h13" value="消耗MP 42，66%概率抵抗击退，持续130秒"/>
+        <string name="h14" value="消耗MP 42，68%概率抵抗击退，持续140秒"/>
+        <string name="h15" value="消耗MP 42，70%概率抵抗击退，持续150秒"/>
+        <string name="h16" value="消耗MP 48，72%概率抵抗击退，持续160秒"/>
+        <string name="h17" value="消耗MP 48，74%概率抵抗击退，持续170秒"/>
+        <string name="h18" value="消耗MP 48，76%概率抵抗击退，持续180秒"/>
+        <string name="h19" value="消耗MP 48，78%概率抵抗击退，持续190秒"/>
+        <string name="h20" value="消耗MP 48，80%概率抵抗击退，持续200秒"/>
+        <string name="h21" value="消耗MP 54，81%概率抵抗击退，持续210秒"/>
+        <string name="h22" value="消耗MP 54，82%概率抵抗击退，持续220秒"/>
+        <string name="h23" value="消耗MP 54，83%概率抵抗击退，持续230秒"/>
+        <string name="h24" value="消耗MP 54，84%概率抵抗击退，持续240秒"/>
+        <string name="h25" value="消耗MP 54，85%概率抵抗击退，持续250秒"/>
+        <string name="h26" value="消耗MP 53，86%概率抵抗击退，持续260秒"/>
+        <string name="h27" value="消耗MP 52，87%概率抵抗击退，持续270秒"/>
+        <string name="h28" value="消耗MP 51，88%概率抵抗击退，持续280秒"/>
+        <string name="h29" value="消耗MP 50，89%概率抵抗击退，持续290秒"/>
+        <string name="h30" value="消耗MP 50，90%概率抵抗击退，持续300秒"/>
     </imgdir>
     <imgdir name="1121006">
         <string name="name" value="突进"/>
-        <string name="h1" value="消耗MP 22，伤害 72%，范围 80%"/>
-        <string name="h10" value="消耗MP 40，伤害 90%，范围 90%"/>
-        <string name="h11" value="消耗MP 42，伤害 92%，范围 95%"/>
-        <string name="h12" value="消耗MP 44，伤害 94%，范围 95%"/>
-        <string name="h13" value="消耗MP 46，伤害 96%，范围 95%"/>
-        <string name="h14" value="消耗MP 48，伤害 98%，范围 100%"/>
-        <string name="h15" value="消耗MP 50，伤害 100%，范围 100%"/>
-        <string name="h16" value="消耗MP 52，伤害 102%，范围 100%"/>
-        <string name="h17" value="消耗MP 54，伤害 104%，范围 105%"/>
-        <string name="h18" value="消耗MP 56，伤害 106%，范围 105%"/>
-        <string name="h19" value="消耗MP 58，伤害 108%，范围 105%"/>
-        <string name="h2" value="消耗MP 24，伤害 74%，范围 80%"/>
-        <string name="h20" value="消耗MP 60，伤害 110%，范围 110%"/>
-        <string name="h21" value="消耗MP 59，伤害 112%，范围 110%"/>
-        <string name="h22" value="消耗MP 58，伤害 114%，范围 115%"/>
-        <string name="h23" value="消耗MP 57，伤害 116%，范围 115%"/>
-        <string name="h24" value="消耗MP 56，伤害 118%，范围 115%"/>
-        <string name="h25" value="消耗MP 55，伤害 120%，范围 120%"/>
-        <string name="h26" value="消耗MP 54，伤害 122%，范围 120%"/>
-        <string name="h27" value="消耗MP 53，伤害 124%，范围 120%"/>
-        <string name="h28" value="消耗MP 52，伤害 126%，范围 125%"/>
-        <string name="h29" value="消耗MP 51，伤害 128%，范围 125%"/>
-        <string name="h3" value="消耗MP 26，伤害 76%，范围 80%"/>
-        <string name="h30" value="消耗MP 50，伤害 130%，范围 125%"/>
-        <string name="h4" value="消耗MP 28，伤害 78%，范围 85%"/>
-        <string name="h5" value="消耗MP 30，伤害 80%，范围 85%"/>
-        <string name="h6" value="消耗MP 32，伤害 82%，范围 85%"/>
-        <string name="h7" value="消耗MP 34，伤害 84%，范围 85%"/>
-        <string name="h8" value="消耗MP 36，伤害 86%，范围 90%"/>
-        <string name="h9" value="消耗MP 38，伤害 88%，范围 90%"/>
-        <string name="desc" value="向前攻击，能把前面的15个敌人推开"/>
+        <string name="desc" value="[最高等级：30]\n向前突进，攻击并推动最多15只怪物。"/>
+        <string name="h1" value="消耗MP 22，伤害 72%，最多推动15个敌人"/>
+        <string name="h2" value="消耗MP 24，伤害 74%，最多推动15个敌人"/>
+        <string name="h3" value="消耗MP 26，伤害 76%，最多推动15个敌人"/>
+        <string name="h4" value="消耗MP 28，伤害 78%，最多推动15个敌人"/>
+        <string name="h5" value="消耗MP 30，伤害 80%，最多推动15个敌人"/>
+        <string name="h6" value="消耗MP 32，伤害 82%，最多推动15个敌人"/>
+        <string name="h7" value="消耗MP 34，伤害 84%，最多推动15个敌人"/>
+        <string name="h8" value="消耗MP 36，伤害 86%，最多推动15个敌人"/>
+        <string name="h9" value="消耗MP 38，伤害 88%，最多推动15个敌人"/>
+        <string name="h10" value="消耗MP 40，伤害 90%，最多推动15个敌人"/>
+        <string name="h11" value="消耗MP 42，伤害 92%，最多推动15个敌人"/>
+        <string name="h12" value="消耗MP 44，伤害 94%，最多推动15个敌人"/>
+        <string name="h13" value="消耗MP 46，伤害 96%，最多推动15个敌人"/>
+        <string name="h14" value="消耗MP 48，伤害 98%，最多推动15个敌人"/>
+        <string name="h15" value="消耗MP 50，伤害 100%，最多推动15个敌人"/>
+        <string name="h16" value="消耗MP 52，伤害 102%，最多推动15个敌人"/>
+        <string name="h17" value="消耗MP 54，伤害 104%，最多推动15个敌人"/>
+        <string name="h18" value="消耗MP 56，伤害 106%，最多推动15个敌人"/>
+        <string name="h19" value="消耗MP 58，伤害 108%，最多推动15个敌人"/>
+        <string name="h20" value="消耗MP 60，伤害 110%，最多推动15个敌人"/>
+        <string name="h21" value="消耗MP 59，伤害 112%，最多推动15个敌人"/>
+        <string name="h22" value="消耗MP 58，伤害 114%，最多推动15个敌人"/>
+        <string name="h23" value="消耗MP 57，伤害 116%，最多推动15个敌人"/>
+        <string name="h24" value="消耗MP 56，伤害 118%，最多推动15个敌人"/>
+        <string name="h25" value="消耗MP 55，伤害 120%，最多推动15个敌人"/>
+        <string name="h26" value="消耗MP 54，伤害 122%，最多推动15个敌人"/>
+        <string name="h27" value="消耗MP 53，伤害 124%，最多推动15个敌人"/>
+        <string name="h28" value="消耗MP 52，伤害 126%，最多推动15个敌人"/>
+        <string name="h29" value="消耗MP 51，伤害 128%，最多推动15个敌人"/>
+        <string name="h30" value="消耗MP 50，伤害 130%，最多推动15个敌人"/>
     </imgdir>
     <imgdir name="1121008">
         <string name="name" value="轻舞飞扬"/>
-        <string name="h1" value="消耗MP 16，伤害 135%，3名攻击"/>
-        <string name="h10" value="消耗MP 16，伤害 180%，3名攻击"/>
-        <string name="h11" value="消耗MP 24，伤害 184%，3名攻击"/>
-        <string name="h12" value="消耗MP 24，伤害 188%，3名攻击"/>
-        <string name="h13" value="消耗MP 24，伤害 192%，3名攻击"/>
-        <string name="h14" value="消耗MP 24，伤害 196%，3名攻击"/>
-        <string name="h15" value="消耗MP 24，伤害 200%，3名攻击"/>
-        <string name="h16" value="消耗MP 24，伤害 204%，3名攻击"/>
-        <string name="h17" value="消耗MP 24，伤害 208%，3名攻击"/>
-        <string name="h18" value="消耗MP 24，伤害 212%，3名攻击"/>
-        <string name="h19" value="消耗MP 24，伤害 216%，3名攻击"/>
-        <string name="h2" value="消耗MP 16，伤害 140%，3名攻击"/>
-        <string name="h20" value="消耗MP 24，伤害 220%，3名攻击"/>
-        <string name="h21" value="消耗MP 30，伤害 224%，3名攻击"/>
-        <string name="h22" value="消耗MP 30，伤害 228%，3名攻击"/>
-        <string name="h23" value="消耗MP 30，伤害 232%，3名攻击"/>
-        <string name="h24" value="消耗MP 30，伤害 236%，3名攻击"/>
-        <string name="h25" value="消耗MP 30，伤害 240%，3名攻击"/>
-        <string name="h26" value="消耗MP 29，伤害 244%，3名攻击"/>
-        <string name="h27" value="消耗MP 28，伤害 248%，3名攻击"/>
-        <string name="h28" value="消耗MP 27，伤害 252%，3名攻击"/>
-        <string name="h29" value="消耗MP 26，伤害 256%，3名攻击"/>
-        <string name="h3" value="消耗MP 16，伤害 145%，3名攻击"/>
-        <string name="h30" value="消耗MP 25，伤害 260%，3名攻击"/>
-        <string name="h4" value="消耗MP 16，伤害 150%，3名攻击"/>
-        <string name="h5" value="消耗MP 16，伤害 155%，3名攻击"/>
-        <string name="h6" value="消耗MP 16，伤害 160%，3名攻击"/>
-        <string name="h7" value="消耗MP 16，伤害 165%，3名攻击"/>
-        <string name="h8" value="消耗MP 16，伤害 170%，3名攻击"/>
-        <string name="h9" value="消耗MP 16，伤害 175%，3名攻击"/>
         <string name="desc" value="连续攻击2次前面的敌人"/>
+        <string name="h1" value="消耗MP 16，伤害 135%，攻击2次，最多攻击1个敌人"/>
+        <string name="h2" value="消耗MP 16，伤害 140%，攻击2次，最多攻击1个敌人"/>
+        <string name="h3" value="消耗MP 16，伤害 145%，攻击2次，最多攻击1个敌人"/>
+        <string name="h4" value="消耗MP 16，伤害 150%，攻击2次，最多攻击1个敌人"/>
+        <string name="h5" value="消耗MP 16，伤害 155%，攻击2次，最多攻击1个敌人"/>
+        <string name="h6" value="消耗MP 16，伤害 160%，攻击2次，最多攻击1个敌人"/>
+        <string name="h7" value="消耗MP 16，伤害 165%，攻击2次，最多攻击1个敌人"/>
+        <string name="h8" value="消耗MP 16，伤害 170%，攻击2次，最多攻击1个敌人"/>
+        <string name="h9" value="消耗MP 16，伤害 175%，攻击2次，最多攻击1个敌人"/>
+        <string name="h10" value="消耗MP 16，伤害 180%，攻击2次，最多攻击1个敌人"/>
+        <string name="h11" value="消耗MP 24，伤害 184%，攻击2次，最多攻击2个敌人"/>
+        <string name="h12" value="消耗MP 24，伤害 188%，攻击2次，最多攻击2个敌人"/>
+        <string name="h13" value="消耗MP 24，伤害 192%，攻击2次，最多攻击2个敌人"/>
+        <string name="h14" value="消耗MP 24，伤害 196%，攻击2次，最多攻击2个敌人"/>
+        <string name="h15" value="消耗MP 24，伤害 200%，攻击2次，最多攻击2个敌人"/>
+        <string name="h16" value="消耗MP 24，伤害 204%，攻击2次，最多攻击2个敌人"/>
+        <string name="h17" value="消耗MP 24，伤害 208%，攻击2次，最多攻击2个敌人"/>
+        <string name="h18" value="消耗MP 24，伤害 212%，攻击2次，最多攻击2个敌人"/>
+        <string name="h19" value="消耗MP 24，伤害 216%，攻击2次，最多攻击2个敌人"/>
+        <string name="h20" value="消耗MP 24，伤害 220%，攻击2次，最多攻击2个敌人"/>
+        <string name="h21" value="消耗MP 30，伤害 224%，攻击2次，最多攻击3个敌人"/>
+        <string name="h22" value="消耗MP 30，伤害 228%，攻击2次，最多攻击3个敌人"/>
+        <string name="h23" value="消耗MP 30，伤害 232%，攻击2次，最多攻击3个敌人"/>
+        <string name="h24" value="消耗MP 30，伤害 236%，攻击2次，最多攻击3个敌人"/>
+        <string name="h25" value="消耗MP 30，伤害 240%，攻击2次，最多攻击3个敌人"/>
+        <string name="h26" value="消耗MP 29，伤害 244%，攻击2次，最多攻击3个敌人"/>
+        <string name="h27" value="消耗MP 28，伤害 248%，攻击2次，最多攻击3个敌人"/>
+        <string name="h28" value="消耗MP 27，伤害 252%，攻击2次，最多攻击3个敌人"/>
+        <string name="h29" value="消耗MP 26，伤害 256%，攻击2次，最多攻击3个敌人"/>
+        <string name="h30" value="消耗MP 25，伤害 260%，攻击2次，最多攻击3个敌人"/>
     </imgdir>
     <imgdir name="1121010">
         <string name="name" value="葵花宝典"/>
-        <string name="h1" value="消耗MP 11，持续时间 10秒 攻击力 11 上升"/>
-        <string name="h10" value="消耗MP 20，持续时间 100秒 攻击力 16 上升"/>
-        <string name="h11" value="消耗MP 21，持续时间 110秒 攻击力 16 上升"/>
-        <string name="h12" value="消耗MP 22，持续时间 120秒 攻击力 17 上升"/>
-        <string name="h13" value="消耗MP 23，持续时间 130秒 攻击力 17 上升"/>
-        <string name="h14" value="消耗MP 24，持续时间 140秒 攻击力 18 上升"/>
-        <string name="h15" value="消耗MP 25，持续时间 150秒 攻击力 18 上升"/>
-        <string name="h16" value="消耗MP 26，持续时间 160秒 攻击力 19 上升"/>
-        <string name="h17" value="消耗MP 27，持续时间 170秒 攻击力 19 上升"/>
-        <string name="h18" value="消耗MP 28，持续时间 180秒 攻击力 20 上升"/>
-        <string name="h19" value="消耗MP 29，持续时间 190秒 攻击力 20 上升"/>
-        <string name="h2" value="消耗MP 12，持续时间 20秒 攻击力 12 上升"/>
-        <string name="h20" value="消耗MP 30，持续时间 200秒 攻击力 21 上升"/>
-        <string name="h21" value="消耗MP 31，持续时间 205秒 攻击力 21 上升"/>
-        <string name="h22" value="消耗MP 32，持续时间 210秒 攻击力 22 上升"/>
-        <string name="h23" value="消耗MP 33，持续时间 215秒 攻击力 22 上升"/>
-        <string name="h24" value="消耗MP 34，持续时间 220秒 攻击力 23 上升"/>
-        <string name="h25" value="消耗MP 35，持续时间 225秒 攻击力 23 上升"/>
-        <string name="h26" value="消耗MP 36，持续时间 230秒 攻击力 24 上升"/>
-        <string name="h27" value="消耗MP 37，持续时间 235秒 攻击力 24 上升"/>
-        <string name="h28" value="消耗MP 38，持续时间 240秒 攻击力 25 上升"/>
-        <string name="h29" value="消耗MP 39，持续时间 240秒 攻击力 25 上升"/>
-        <string name="h3" value="消耗MP 13，持续时间 30秒 攻击力 12 上升"/>
-        <string name="h30" value="消耗MP 40，持续时间 240秒 攻击力 26 上升"/>
-        <string name="h4" value="消耗MP 14，持续时间 40秒 攻击力 13 上升"/>
-        <string name="h5" value="消耗MP 15，持续时间 50秒 攻击力 13 上升"/>
-        <string name="h6" value="消耗MP 16，持续时间 60秒 攻击力 14 上升"/>
-        <string name="h7" value="消耗MP 17，持续时间 70秒 攻击力 14 上升"/>
-        <string name="h8" value="消耗MP 18，持续时间 80秒 攻击力 15 上升"/>
-        <string name="h9" value="消耗MP 19，持续时间 90秒 攻击力 15 上升"/>
-        <string name="desc" value="使用10个斗气能量，一定时间内提高攻击力。\n需要技能：#c进阶斗气25级以上\n冷却时间 : 4分钟#"/>
+        <string name="desc" value="[最高等级：30]\n消耗10个斗气，在一定时间内提高物理攻击力。\n需要技能：#c进阶斗气25级以上#"/>
+        <string name="h1" value="消耗MP 11，物理攻击力 +11，持续10秒，冷却时间 360秒"/>
+        <string name="h2" value="消耗MP 12，物理攻击力 +12，持续20秒，冷却时间 360秒"/>
+        <string name="h3" value="消耗MP 13，物理攻击力 +12，持续30秒，冷却时间 360秒"/>
+        <string name="h4" value="消耗MP 14，物理攻击力 +13，持续40秒，冷却时间 360秒"/>
+        <string name="h5" value="消耗MP 15，物理攻击力 +13，持续50秒，冷却时间 360秒"/>
+        <string name="h6" value="消耗MP 16，物理攻击力 +14，持续60秒，冷却时间 360秒"/>
+        <string name="h7" value="消耗MP 17，物理攻击力 +14，持续70秒，冷却时间 360秒"/>
+        <string name="h8" value="消耗MP 18，物理攻击力 +15，持续80秒，冷却时间 360秒"/>
+        <string name="h9" value="消耗MP 19，物理攻击力 +15，持续90秒，冷却时间 360秒"/>
+        <string name="h10" value="消耗MP 20，物理攻击力 +16，持续100秒，冷却时间 360秒"/>
+        <string name="h11" value="消耗MP 21，物理攻击力 +16，持续110秒，冷却时间 360秒"/>
+        <string name="h12" value="消耗MP 22，物理攻击力 +17，持续120秒，冷却时间 360秒"/>
+        <string name="h13" value="消耗MP 23，物理攻击力 +17，持续130秒，冷却时间 360秒"/>
+        <string name="h14" value="消耗MP 24，物理攻击力 +18，持续140秒，冷却时间 360秒"/>
+        <string name="h15" value="消耗MP 25，物理攻击力 +18，持续150秒，冷却时间 360秒"/>
+        <string name="h16" value="消耗MP 26，物理攻击力 +19，持续160秒，冷却时间 360秒"/>
+        <string name="h17" value="消耗MP 27，物理攻击力 +19，持续170秒，冷却时间 360秒"/>
+        <string name="h18" value="消耗MP 28，物理攻击力 +20，持续180秒，冷却时间 360秒"/>
+        <string name="h19" value="消耗MP 29，物理攻击力 +20，持续190秒，冷却时间 360秒"/>
+        <string name="h20" value="消耗MP 30，物理攻击力 +21，持续200秒，冷却时间 360秒"/>
+        <string name="h21" value="消耗MP 31，物理攻击力 +21，持续205秒，冷却时间 360秒"/>
+        <string name="h22" value="消耗MP 32，物理攻击力 +22，持续210秒，冷却时间 360秒"/>
+        <string name="h23" value="消耗MP 33，物理攻击力 +22，持续215秒，冷却时间 360秒"/>
+        <string name="h24" value="消耗MP 34，物理攻击力 +23，持续220秒，冷却时间 360秒"/>
+        <string name="h25" value="消耗MP 35，物理攻击力 +23，持续225秒，冷却时间 360秒"/>
+        <string name="h26" value="消耗MP 36，物理攻击力 +24，持续230秒，冷却时间 360秒"/>
+        <string name="h27" value="消耗MP 37，物理攻击力 +24，持续235秒，冷却时间 360秒"/>
+        <string name="h28" value="消耗MP 38，物理攻击力 +25，持续240秒，冷却时间 360秒"/>
+        <string name="h29" value="消耗MP 39，物理攻击力 +25，持续240秒，冷却时间 360秒"/>
+        <string name="h30" value="消耗MP 40，物理攻击力 +26，持续240秒，冷却时间 360秒"/>
     </imgdir>
     <imgdir name="1121011">
         <string name="name" value="勇士的意志"/>
-        <string name="h1" value="消耗MP 30，解除诱惑异常状态，冷却时间10分钟"/>
-        <string name="h2" value="消耗MP 30，解除诱惑异常状态，冷却时间9分钟"/>
-        <string name="h3" value="消耗MP 30，解除诱惑异常状态，冷却时间8分钟"/>
-        <string name="h4" value="消耗MP 30，解除诱惑异常状态，冷却时间7分钟"/>
-        <string name="h5" value="消耗MP 30，解除诱惑异常状态，冷却时间6分钟"/>
-        <string name="desc" value="从异常状态中恢复。\n随着等级的上升，冷却时间缩短。\n#c冷却时间 : 10分#"/>
+        <string name="desc" value="[最高等级：5]\n解除部分异常状态。技能等级越高，冷却时间越短。"/>
+        <string name="h1" value="消耗MP 30，解除异常状态，冷却时间 600秒"/>
+        <string name="h2" value="消耗MP 30，解除异常状态，冷却时间 540秒"/>
+        <string name="h3" value="消耗MP 30，解除异常状态，冷却时间 480秒"/>
+        <string name="h4" value="消耗MP 30，解除异常状态，冷却时间 420秒"/>
+        <string name="h5" value="消耗MP 30，解除异常状态，冷却时间 360秒"/>
     </imgdir>
     <imgdir name="120">
         <string name="bookName" value="准骑士技能"/>
@@ -1730,27 +1730,27 @@
     </imgdir>
     <imgdir name="1200000">
         <string name="name" value="精准剑"/>
-        <string name="h1" value="剑系列武器的熟练度+15%， 命中率+1"/>
-        <string name="h10" value="剑系列武器的熟练度+35%， 命中率+10"/>
-        <string name="h11" value="剑系列武器的熟练度+40%， 命中率+11"/>
-        <string name="h12" value="剑系列武器的熟练度+40%， 命中率+12"/>
-        <string name="h13" value="剑系列武器的熟练度+45%， 命中率+13"/>
-        <string name="h14" value="剑系列武器的熟练度+45%， 命中率+14"/>
-        <string name="h15" value="剑系列武器的熟练度+50%， 命中率+15"/>
-        <string name="h16" value="剑系列武器的熟练度+50%， 命中率+16"/>
-        <string name="h17" value="剑系列武器的熟练度+55%， 命中率+17"/>
-        <string name="h18" value="剑系列武器的熟练度+55%， 命中率+18"/>
-        <string name="h19" value="剑系列武器的熟练度+60%， 命中率+19"/>
-        <string name="h2" value="剑系列武器的熟练度+15%， 命中率+2"/>
-        <string name="h20" value="剑系列武器的熟练度+60%， 命中率+20"/>
-        <string name="h3" value="剑系列武器的熟练度+20%， 命中率+3"/>
-        <string name="h4" value="剑系列武器的熟练度+20%， 命中率+4"/>
-        <string name="h5" value="剑系列武器的熟练度+25%， 命中率+5"/>
-        <string name="h6" value="剑系列武器的熟练度+25%， 命中率+6"/>
-        <string name="h7" value="剑系列武器的熟练度+30%， 命中率+7"/>
-        <string name="h8" value="剑系列武器的熟练度+30%， 命中率+8"/>
-        <string name="h9" value="剑系列武器的熟练度+35%， 命中率+9"/>
-        <string name="desc" value="[最高等级 : 20]\n增加使用剑系武器的命中率及熟练度\n(必须装备单手剑，双手剑)"/>
+        <string name="desc" value="[最高等级：20]\n提高剑系武器的熟练度和命中率。只在装备对应武器时生效。"/>
+        <string name="h1" value="剑系武器熟练度 51%，命中率 +1"/>
+        <string name="h2" value="剑系武器熟练度 51%，命中率 +2"/>
+        <string name="h3" value="剑系武器熟练度 52%，命中率 +3"/>
+        <string name="h4" value="剑系武器熟练度 52%，命中率 +4"/>
+        <string name="h5" value="剑系武器熟练度 53%，命中率 +5"/>
+        <string name="h6" value="剑系武器熟练度 53%，命中率 +6"/>
+        <string name="h7" value="剑系武器熟练度 54%，命中率 +7"/>
+        <string name="h8" value="剑系武器熟练度 54%，命中率 +8"/>
+        <string name="h9" value="剑系武器熟练度 55%，命中率 +9"/>
+        <string name="h10" value="剑系武器熟练度 55%，命中率 +10"/>
+        <string name="h11" value="剑系武器熟练度 56%，命中率 +11"/>
+        <string name="h12" value="剑系武器熟练度 56%，命中率 +12"/>
+        <string name="h13" value="剑系武器熟练度 57%，命中率 +13"/>
+        <string name="h14" value="剑系武器熟练度 57%，命中率 +14"/>
+        <string name="h15" value="剑系武器熟练度 58%，命中率 +15"/>
+        <string name="h16" value="剑系武器熟练度 58%，命中率 +16"/>
+        <string name="h17" value="剑系武器熟练度 59%，命中率 +17"/>
+        <string name="h18" value="剑系武器熟练度 59%，命中率 +18"/>
+        <string name="h19" value="剑系武器熟练度 60%，命中率 +19"/>
+        <string name="h20" value="剑系武器熟练度 60%，命中率 +20"/>
     </imgdir>
     <imgdir name="12000000">
         <string name="name" value="魔力强化"/>
@@ -1768,95 +1768,95 @@
     </imgdir>
     <imgdir name="1200001">
         <string name="name" value="精准钝器"/>
-        <string name="h1" value="钝器系列武器的熟练度+15%， 命中率+1"/>
-        <string name="h10" value="钝器系列武器的熟练度+35%， 命中率+10"/>
-        <string name="h11" value="钝器系列武器的熟练度+40%， 命中率+11"/>
-        <string name="h12" value="钝器系列武器的熟练度+40%， 命中率+12"/>
-        <string name="h13" value="钝器系列武器的熟练度+45%， 命中率+13"/>
-        <string name="h14" value="钝器系列武器的熟练度+45%， 命中率+14"/>
-        <string name="h15" value="钝器系列武器的熟练度+50%， 命中率+15"/>
-        <string name="h16" value="钝器系列武器的熟练度+50%， 命中率+16"/>
-        <string name="h17" value="钝器系列武器的熟练度+55%， 命中率+17"/>
-        <string name="h18" value="钝器系列武器的熟练度+55%， 命中率+18"/>
-        <string name="h19" value="钝器系列武器的熟练度+60%， 命中率+19"/>
-        <string name="h2" value="钝器系列武器的熟练度+15%， 命中率+2"/>
-        <string name="h20" value="钝器系列武器的熟练度+60%， 命中率+20"/>
-        <string name="h3" value="钝器系列武器的熟练度+20%， 命中率+3"/>
-        <string name="h4" value="钝器系列武器的熟练度+20%， 命中率+4"/>
-        <string name="h5" value="钝器系列武器的熟练度+25%， 命中率+5"/>
-        <string name="h6" value="钝器系列武器的熟练度+25%， 命中率+6"/>
-        <string name="h7" value="钝器系列武器的熟练度+30%， 命中率+7"/>
-        <string name="h8" value="钝器系列武器的熟练度+30%， 命中率+8"/>
-        <string name="h9" value="钝器系列武器的熟练度+35%， 命中率+9"/>
-        <string name="desc" value="[最高等级 : 20]\n增加使用钝器的命中率及熟练度\n(必须装备单手钝器或双手钝器)"/>
+        <string name="desc" value="[最高等级：20]\n提高钝器系武器的熟练度和命中率。只在装备对应武器时生效。"/>
+        <string name="h1" value="钝器系武器熟练度 51%，命中率 +1"/>
+        <string name="h2" value="钝器系武器熟练度 51%，命中率 +2"/>
+        <string name="h3" value="钝器系武器熟练度 52%，命中率 +3"/>
+        <string name="h4" value="钝器系武器熟练度 52%，命中率 +4"/>
+        <string name="h5" value="钝器系武器熟练度 53%，命中率 +5"/>
+        <string name="h6" value="钝器系武器熟练度 53%，命中率 +6"/>
+        <string name="h7" value="钝器系武器熟练度 54%，命中率 +7"/>
+        <string name="h8" value="钝器系武器熟练度 54%，命中率 +8"/>
+        <string name="h9" value="钝器系武器熟练度 55%，命中率 +9"/>
+        <string name="h10" value="钝器系武器熟练度 55%，命中率 +10"/>
+        <string name="h11" value="钝器系武器熟练度 56%，命中率 +11"/>
+        <string name="h12" value="钝器系武器熟练度 56%，命中率 +12"/>
+        <string name="h13" value="钝器系武器熟练度 57%，命中率 +13"/>
+        <string name="h14" value="钝器系武器熟练度 57%，命中率 +14"/>
+        <string name="h15" value="钝器系武器熟练度 58%，命中率 +15"/>
+        <string name="h16" value="钝器系武器熟练度 58%，命中率 +16"/>
+        <string name="h17" value="钝器系武器熟练度 59%，命中率 +17"/>
+        <string name="h18" value="钝器系武器熟练度 59%，命中率 +18"/>
+        <string name="h19" value="钝器系武器熟练度 60%，命中率 +19"/>
+        <string name="h20" value="钝器系武器熟练度 60%，命中率 +20"/>
     </imgdir>
     <imgdir name="1200002">
         <string name="name" value="终极剑"/>
-        <string name="h1" value="出现概率2%，发挥105%的最终攻击"/>
-        <string name="h10" value="出现概率20%，发挥150%的最终攻击"/>
-        <string name="h11" value="出现概率22%，发挥155%的最终攻击"/>
-        <string name="h12" value="出现概率24%，发挥160%的最终攻击"/>
-        <string name="h13" value="出现概率26%，发挥165%的最终攻击"/>
-        <string name="h14" value="出现概率28%，发挥170%的最终攻击"/>
-        <string name="h15" value="出现概率30%，发挥175%的最终攻击"/>
-        <string name="h16" value="出现概率32%，发挥180%的最终攻击"/>
-        <string name="h17" value="出现概率34%，发挥185%的最终攻击"/>
-        <string name="h18" value="出现概率36%，发挥190%的最终攻击"/>
-        <string name="h19" value="出现概率38%，发挥195%的最终攻击"/>
-        <string name="h2" value="出现概率4%，发挥110%的最终攻击"/>
-        <string name="h20" value="出现概率40%，发挥200%的最终攻击"/>
-        <string name="h21" value="出现概率42%，发挥205%的最终攻击"/>
-        <string name="h22" value="出现概率44%，发挥210%的最终攻击"/>
-        <string name="h23" value="出现概率46%，发挥215%的最终攻击"/>
-        <string name="h24" value="出现概率48%，发挥220%的最终攻击"/>
-        <string name="h25" value="出现概率50%，发挥225%的最终攻击"/>
-        <string name="h26" value="出现概率52%，发挥230%的最终攻击"/>
-        <string name="h27" value="出现概率54%，发挥235%的最终攻击"/>
-        <string name="h28" value="出现概率56%，发挥240%的最终攻击"/>
-        <string name="h29" value="出现概率58%，发挥245%的最终攻击"/>
-        <string name="h3" value="出现概率6%，发挥115%的最终攻击"/>
-        <string name="h30" value="出现概率60%，发挥250%的最终攻击"/>
-        <string name="h4" value="出现概率8%，发挥120%的最终攻击"/>
-        <string name="h5" value="出现概率10%，发挥125%的最终攻击"/>
-        <string name="h6" value="出现概率12%，发挥130%的最终攻击"/>
-        <string name="h7" value="出现概率14%，发挥135%的最终攻击"/>
-        <string name="h8" value="出现概率16%，发挥140%的最终攻击"/>
-        <string name="h9" value="出现概率18%，发挥145%的最终攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n第一次攻击后发动连续攻击\n(必须装备单手剑，双手剑)\n必需技能: #c精准剑等级3以上#"/>
+        <string name="desc" value="[最高等级：30]\n使用部分攻击技能后，有一定概率追加一次终极攻击。只在装备剑时生效。\n需要技能：#c对应精准武器3级以上#"/>
+        <string name="h1" value="2%概率发动终极攻击，伤害 105%"/>
+        <string name="h2" value="4%概率发动终极攻击，伤害 110%"/>
+        <string name="h3" value="6%概率发动终极攻击，伤害 115%"/>
+        <string name="h4" value="8%概率发动终极攻击，伤害 120%"/>
+        <string name="h5" value="10%概率发动终极攻击，伤害 125%"/>
+        <string name="h6" value="12%概率发动终极攻击，伤害 130%"/>
+        <string name="h7" value="14%概率发动终极攻击，伤害 135%"/>
+        <string name="h8" value="16%概率发动终极攻击，伤害 140%"/>
+        <string name="h9" value="18%概率发动终极攻击，伤害 145%"/>
+        <string name="h10" value="20%概率发动终极攻击，伤害 150%"/>
+        <string name="h11" value="22%概率发动终极攻击，伤害 155%"/>
+        <string name="h12" value="24%概率发动终极攻击，伤害 160%"/>
+        <string name="h13" value="26%概率发动终极攻击，伤害 165%"/>
+        <string name="h14" value="28%概率发动终极攻击，伤害 170%"/>
+        <string name="h15" value="30%概率发动终极攻击，伤害 175%"/>
+        <string name="h16" value="32%概率发动终极攻击，伤害 180%"/>
+        <string name="h17" value="34%概率发动终极攻击，伤害 185%"/>
+        <string name="h18" value="36%概率发动终极攻击，伤害 190%"/>
+        <string name="h19" value="38%概率发动终极攻击，伤害 195%"/>
+        <string name="h20" value="40%概率发动终极攻击，伤害 200%"/>
+        <string name="h21" value="42%概率发动终极攻击，伤害 205%"/>
+        <string name="h22" value="44%概率发动终极攻击，伤害 210%"/>
+        <string name="h23" value="46%概率发动终极攻击，伤害 215%"/>
+        <string name="h24" value="48%概率发动终极攻击，伤害 220%"/>
+        <string name="h25" value="50%概率发动终极攻击，伤害 225%"/>
+        <string name="h26" value="52%概率发动终极攻击，伤害 230%"/>
+        <string name="h27" value="54%概率发动终极攻击，伤害 235%"/>
+        <string name="h28" value="56%概率发动终极攻击，伤害 240%"/>
+        <string name="h29" value="58%概率发动终极攻击，伤害 245%"/>
+        <string name="h30" value="60%概率发动终极攻击，伤害 250%"/>
     </imgdir>
     <imgdir name="1200003">
         <string name="name" value="终极钝器"/>
-        <string name="h1" value="概率2%，发挥105%的最终攻击"/>
-        <string name="h10" value="概率20%，发挥150%的最终攻击"/>
-        <string name="h11" value="概率22%，发挥155%的最终攻击"/>
-        <string name="h12" value="概率24%，发挥160%的最终攻击"/>
-        <string name="h13" value="概率26%，发挥165%的最终攻击"/>
-        <string name="h14" value="概率28%，发挥170%的最终攻击"/>
-        <string name="h15" value="概率30%，发挥175%的最终攻击"/>
-        <string name="h16" value="概率32%，发挥180%的最终攻击"/>
-        <string name="h17" value="概率34%，发挥185%的最终攻击"/>
-        <string name="h18" value="概率36%，发挥190%的最终攻击"/>
-        <string name="h19" value="概率38%，发挥195%的最终攻击"/>
-        <string name="h2" value="概率4%，发挥110%的最终攻击"/>
-        <string name="h20" value="概率40%，发挥200%的最终攻击"/>
-        <string name="h21" value="概率42%，发挥205%的最终攻击"/>
-        <string name="h22" value="概率44%，发挥210%的最终攻击"/>
-        <string name="h23" value="概率46%，发挥215%的最终攻击"/>
-        <string name="h24" value="概率48%，发挥220%的最终攻击"/>
-        <string name="h25" value="概率50%，发挥225%的最终攻击"/>
-        <string name="h26" value="概率52%，发挥230%的最终攻击"/>
-        <string name="h27" value="概率54%，发挥235%的最终攻击"/>
-        <string name="h28" value="概率56%，发挥240%的最终攻击"/>
-        <string name="h29" value="概率58%，发挥245%的最终攻击"/>
-        <string name="h3" value="概率6%，发挥115%的最终攻击"/>
-        <string name="h30" value="概率60%，发挥250%的最终攻击"/>
-        <string name="h4" value="概率8%，发挥120%的最终攻击"/>
-        <string name="h5" value="概率10%，发挥125%的最终攻击"/>
-        <string name="h6" value="概率12%，发挥130%的最终攻击"/>
-        <string name="h7" value="概率14%，发挥135%的最终攻击"/>
-        <string name="h8" value="概率16%，发挥140%的最终攻击"/>
-        <string name="h9" value="概率18%，发挥145%的最终攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n第一次攻击后发动连续攻击\n(必须装备单手钝器或双手钝器)\n必需技能: #c精准钝器等级3以上#"/>
+        <string name="desc" value="[最高等级：30]\n使用部分攻击技能后，有一定概率追加一次终极攻击。只在装备钝器时生效。\n需要技能：#c对应精准武器3级以上#"/>
+        <string name="h1" value="2%概率发动终极攻击，伤害 105%"/>
+        <string name="h2" value="4%概率发动终极攻击，伤害 110%"/>
+        <string name="h3" value="6%概率发动终极攻击，伤害 115%"/>
+        <string name="h4" value="8%概率发动终极攻击，伤害 120%"/>
+        <string name="h5" value="10%概率发动终极攻击，伤害 125%"/>
+        <string name="h6" value="12%概率发动终极攻击，伤害 130%"/>
+        <string name="h7" value="14%概率发动终极攻击，伤害 135%"/>
+        <string name="h8" value="16%概率发动终极攻击，伤害 140%"/>
+        <string name="h9" value="18%概率发动终极攻击，伤害 145%"/>
+        <string name="h10" value="20%概率发动终极攻击，伤害 150%"/>
+        <string name="h11" value="22%概率发动终极攻击，伤害 155%"/>
+        <string name="h12" value="24%概率发动终极攻击，伤害 160%"/>
+        <string name="h13" value="26%概率发动终极攻击，伤害 165%"/>
+        <string name="h14" value="28%概率发动终极攻击，伤害 170%"/>
+        <string name="h15" value="30%概率发动终极攻击，伤害 175%"/>
+        <string name="h16" value="32%概率发动终极攻击，伤害 180%"/>
+        <string name="h17" value="34%概率发动终极攻击，伤害 185%"/>
+        <string name="h18" value="36%概率发动终极攻击，伤害 190%"/>
+        <string name="h19" value="38%概率发动终极攻击，伤害 195%"/>
+        <string name="h20" value="40%概率发动终极攻击，伤害 200%"/>
+        <string name="h21" value="42%概率发动终极攻击，伤害 205%"/>
+        <string name="h22" value="44%概率发动终极攻击，伤害 210%"/>
+        <string name="h23" value="46%概率发动终极攻击，伤害 215%"/>
+        <string name="h24" value="48%概率发动终极攻击，伤害 220%"/>
+        <string name="h25" value="50%概率发动终极攻击，伤害 225%"/>
+        <string name="h26" value="52%概率发动终极攻击，伤害 230%"/>
+        <string name="h27" value="54%概率发动终极攻击，伤害 235%"/>
+        <string name="h28" value="56%概率发动终极攻击，伤害 240%"/>
+        <string name="h29" value="58%概率发动终极攻击，伤害 245%"/>
+        <string name="h30" value="60%概率发动终极攻击，伤害 250%"/>
     </imgdir>
     <imgdir name="12001001">
         <string name="name" value="魔法盾"/>
@@ -1936,109 +1936,109 @@
     </imgdir>
     <imgdir name="1201004">
         <string name="name" value="快速剑"/>
-        <string name="h1" value="消耗HP29和MP29，增加剑的攻击速度(持续10秒)"/>
-        <string name="h10" value="消耗HP20和MP20，增加剑的攻击速度(持续100秒)"/>
-        <string name="h11" value="消耗HP19和MP19，增加剑的攻击速度(持续110秒)"/>
-        <string name="h12" value="消耗HP18和MP18，增加剑的攻击速度(持续120秒)"/>
-        <string name="h13" value="消耗HP17和MP17，增加剑的攻击速度(持续130秒)"/>
-        <string name="h14" value="消耗HP16和MP16，增加剑的攻击速度(持续140秒)"/>
-        <string name="h15" value="消耗HP15和MP15，增加剑的攻击速度(持续150秒)"/>
-        <string name="h16" value="消耗HP14和MP14，增加剑的攻击速度(持续160秒)"/>
-        <string name="h17" value="消耗HP13和MP13，增加剑的攻击速度(持续170秒)"/>
-        <string name="h18" value="消耗HP12和MP12，增加剑的攻击速度(持续180秒)"/>
-        <string name="h19" value="消耗HP11和MP11，增加剑的攻击速度(持续190秒)"/>
-        <string name="h2" value="消耗HP28和MP28，增加剑的攻击速度(持续20秒)"/>
-        <string name="h20" value="消耗HP10和MP10，增加剑的攻击速度(持续200秒)"/>
-        <string name="h3" value="消耗HP27和MP27，增加剑的攻击速度(持续30秒)"/>
-        <string name="h4" value="消耗HP26和MP26，增加剑的攻击速度(持续40秒)"/>
-        <string name="h5" value="消耗HP25和MP25，增加剑的攻击速度(持续50秒)"/>
-        <string name="h6" value="消耗HP24和MP24，增加剑的攻击速度(持续60秒)"/>
-        <string name="h7" value="消耗HP23和MP23，增加剑的攻击速度(持续70秒)"/>
-        <string name="h8" value="消耗HP22和MP22，增加剑的攻击速度(持续80秒)"/>
-        <string name="h9" value="消耗HP21和MP21，增加剑的攻击速度(持续90秒)"/>
-        <string name="desc" value="[最高等级 : 20]\n攻击速度提升两个等级\n(装备单手剑，双手剑)\n必需技能: #c精准剑等级5以上#"/>
+        <string name="desc" value="[最高等级：20]\n消耗HP和MP，在一定时间内提高装备中的剑的攻击速度。\n需要技能：#c对应精准武器5级以上#"/>
+        <string name="h1" value="消耗HP 29，消耗MP 29，剑攻击速度提升，持续10秒"/>
+        <string name="h2" value="消耗HP 28，消耗MP 28，剑攻击速度提升，持续20秒"/>
+        <string name="h3" value="消耗HP 27，消耗MP 27，剑攻击速度提升，持续30秒"/>
+        <string name="h4" value="消耗HP 26，消耗MP 26，剑攻击速度提升，持续40秒"/>
+        <string name="h5" value="消耗HP 25，消耗MP 25，剑攻击速度提升，持续50秒"/>
+        <string name="h6" value="消耗HP 24，消耗MP 24，剑攻击速度提升，持续60秒"/>
+        <string name="h7" value="消耗HP 23，消耗MP 23，剑攻击速度提升，持续70秒"/>
+        <string name="h8" value="消耗HP 22，消耗MP 22，剑攻击速度提升，持续80秒"/>
+        <string name="h9" value="消耗HP 21，消耗MP 21，剑攻击速度提升，持续90秒"/>
+        <string name="h10" value="消耗HP 20，消耗MP 20，剑攻击速度提升，持续100秒"/>
+        <string name="h11" value="消耗HP 19，消耗MP 19，剑攻击速度提升，持续110秒"/>
+        <string name="h12" value="消耗HP 18，消耗MP 18，剑攻击速度提升，持续120秒"/>
+        <string name="h13" value="消耗HP 17，消耗MP 17，剑攻击速度提升，持续130秒"/>
+        <string name="h14" value="消耗HP 16，消耗MP 16，剑攻击速度提升，持续140秒"/>
+        <string name="h15" value="消耗HP 15，消耗MP 15，剑攻击速度提升，持续150秒"/>
+        <string name="h16" value="消耗HP 14，消耗MP 14，剑攻击速度提升，持续160秒"/>
+        <string name="h17" value="消耗HP 13，消耗MP 13，剑攻击速度提升，持续170秒"/>
+        <string name="h18" value="消耗HP 12，消耗MP 12，剑攻击速度提升，持续180秒"/>
+        <string name="h19" value="消耗HP 11，消耗MP 11，剑攻击速度提升，持续190秒"/>
+        <string name="h20" value="消耗HP 10，消耗MP 10，剑攻击速度提升，持续200秒"/>
     </imgdir>
     <imgdir name="1201005">
         <string name="name" value="快速钝器"/>
-        <string name="h1" value="消耗HP29和MP29，持续10秒"/>
-        <string name="h10" value="消耗HP20和MP20，持续100秒"/>
-        <string name="h11" value="消耗HP19和MP19，持续110秒"/>
-        <string name="h12" value="消耗HP18和MP18，持续120秒"/>
-        <string name="h13" value="消耗HP17和MP17，持续130秒"/>
-        <string name="h14" value="消耗HP16和MP16，持续140秒"/>
-        <string name="h15" value="消耗HP15和MP15，持续150秒"/>
-        <string name="h16" value="消耗HP14和MP14，持续160秒"/>
-        <string name="h17" value="消耗HP13和MP13，持续170秒"/>
-        <string name="h18" value="消耗HP12和MP12，持续180秒"/>
-        <string name="h19" value="消耗HP11和MP11，持续190秒"/>
-        <string name="h2" value="消耗HP28和MP28，持续20秒"/>
-        <string name="h20" value="消耗HP10和MP10，持续200秒"/>
-        <string name="h3" value="消耗HP27和MP27，持续30秒"/>
-        <string name="h4" value="消耗HP26和MP26，持续40秒"/>
-        <string name="h5" value="消耗HP25和MP25，持续50秒"/>
-        <string name="h6" value="消耗HP24和MP24，持续60秒"/>
-        <string name="h7" value="消耗HP23和MP23，持续70秒"/>
-        <string name="h8" value="消耗HP22和MP22，持续80秒"/>
-        <string name="h9" value="消耗HP21和MP21，持续90秒"/>
-        <string name="desc" value="[最高等级 : 20]\n功击速度提升三个等级\n(必须装备单手钝器或双手钝器)\n必需技能: #c精准钝器等级5#"/>
+        <string name="desc" value="[最高等级：20]\n消耗HP和MP，在一定时间内提高装备中的钝器的攻击速度。\n需要技能：#c对应精准武器5级以上#"/>
+        <string name="h1" value="消耗HP 29，消耗MP 29，钝器攻击速度提升，持续10秒"/>
+        <string name="h2" value="消耗HP 28，消耗MP 28，钝器攻击速度提升，持续20秒"/>
+        <string name="h3" value="消耗HP 27，消耗MP 27，钝器攻击速度提升，持续30秒"/>
+        <string name="h4" value="消耗HP 26，消耗MP 26，钝器攻击速度提升，持续40秒"/>
+        <string name="h5" value="消耗HP 25，消耗MP 25，钝器攻击速度提升，持续50秒"/>
+        <string name="h6" value="消耗HP 24，消耗MP 24，钝器攻击速度提升，持续60秒"/>
+        <string name="h7" value="消耗HP 23，消耗MP 23，钝器攻击速度提升，持续70秒"/>
+        <string name="h8" value="消耗HP 22，消耗MP 22，钝器攻击速度提升，持续80秒"/>
+        <string name="h9" value="消耗HP 21，消耗MP 21，钝器攻击速度提升，持续90秒"/>
+        <string name="h10" value="消耗HP 20，消耗MP 20，钝器攻击速度提升，持续100秒"/>
+        <string name="h11" value="消耗HP 19，消耗MP 19，钝器攻击速度提升，持续110秒"/>
+        <string name="h12" value="消耗HP 18，消耗MP 18，钝器攻击速度提升，持续120秒"/>
+        <string name="h13" value="消耗HP 17，消耗MP 17，钝器攻击速度提升，持续130秒"/>
+        <string name="h14" value="消耗HP 16，消耗MP 16，钝器攻击速度提升，持续140秒"/>
+        <string name="h15" value="消耗HP 15，消耗MP 15，钝器攻击速度提升，持续150秒"/>
+        <string name="h16" value="消耗HP 14，消耗MP 14，钝器攻击速度提升，持续160秒"/>
+        <string name="h17" value="消耗HP 13，消耗MP 13，钝器攻击速度提升，持续170秒"/>
+        <string name="h18" value="消耗HP 12，消耗MP 12，钝器攻击速度提升，持续180秒"/>
+        <string name="h19" value="消耗HP 11，消耗MP 11，钝器攻击速度提升，持续190秒"/>
+        <string name="h20" value="消耗HP 10，消耗MP 10，钝器攻击速度提升，持续200秒"/>
     </imgdir>
     <imgdir name="1201006">
         <string name="name" value="压制术"/>
-        <string name="h1" value="消耗MP12，持续44秒，怪物物理攻击力-3，物理防御力-10"/>
-        <string name="h10" value="消耗MP12，持续80秒，怪物物理攻击力-30，物理防御力-100"/>
-        <string name="h11" value="消耗MP20，持续84秒，怪物物理攻击力-33，物理防御力-110"/>
-        <string name="h12" value="消耗MP20，持续88秒，怪物物理攻击力-36，物理防御力-120"/>
-        <string name="h13" value="消耗MP20，持续92秒，怪物物理攻击力-39，物理防御力-130"/>
-        <string name="h14" value="消耗MP20，持续96秒，怪物物理攻击力-42，物理防御力-140"/>
-        <string name="h15" value="消耗MP20，持续100秒，怪物物理攻击力-45，物理防御力-150"/>
-        <string name="h16" value="消耗MP20，持续104秒，怪物物理攻击力-48，物理防御力-160"/>
-        <string name="h17" value="消耗MP20，持续108秒，怪物物理攻击力-51，物理防御力-170"/>
-        <string name="h18" value="消耗MP20，持续112秒，怪物物理攻击力-54，物理防御力-180"/>
-        <string name="h19" value="消耗MP20，持续116秒，怪物物理攻击力-57，物理防御力-190"/>
-        <string name="h2" value="消耗MP12，持续48秒，怪物物理攻击力-6，物理防御力-20"/>
-        <string name="h20" value="消耗MP20，持续120秒，怪物物理攻击力-60，物理防御力-200"/>
-        <string name="h3" value="消耗MP12，持续52秒，怪物物理攻击力-9，物理防御力-30"/>
-        <string name="h4" value="消耗MP12，持续56秒，怪物物理攻击力-12，物理防御力-40"/>
-        <string name="h5" value="消耗MP12，持续60秒，怪物物理攻击力-15，物理防御力-50"/>
-        <string name="h6" value="消耗MP12，持续64秒，怪物物理攻击力-18，物理防御力-60"/>
-        <string name="h7" value="消耗MP12，持续68秒，怪物物理攻击力-21，物理防御力-70"/>
-        <string name="h8" value="消耗MP12，持续72秒，怪物物理攻击力-24，物理防御力-80"/>
-        <string name="h9" value="消耗MP12，持续76秒，怪物物理攻击力-27，物理防御力-90"/>
-        <string name="desc" value="[最高等级 : 20]\n消费MP，让周围的怪物感到压制感，\n降低怪物的物理攻击力与物理防御力"/>
+        <string name="desc" value="[最高等级：20]\n威吓周围怪物，一定时间内降低其物理攻击力和物理防御力。"/>
+        <string name="h1" value="消耗MP 12，敌人物理攻击力 -1，敌人物理防御力 -1，持续44秒"/>
+        <string name="h2" value="消耗MP 12，敌人物理攻击力 -2，敌人物理防御力 -2，持续48秒"/>
+        <string name="h3" value="消耗MP 12，敌人物理攻击力 -3，敌人物理防御力 -3，持续52秒"/>
+        <string name="h4" value="消耗MP 12，敌人物理攻击力 -4，敌人物理防御力 -4，持续56秒"/>
+        <string name="h5" value="消耗MP 12，敌人物理攻击力 -5，敌人物理防御力 -5，持续60秒"/>
+        <string name="h6" value="消耗MP 12，敌人物理攻击力 -6，敌人物理防御力 -6，持续64秒"/>
+        <string name="h7" value="消耗MP 12，敌人物理攻击力 -7，敌人物理防御力 -7，持续68秒"/>
+        <string name="h8" value="消耗MP 12，敌人物理攻击力 -8，敌人物理防御力 -8，持续72秒"/>
+        <string name="h9" value="消耗MP 12，敌人物理攻击力 -9，敌人物理防御力 -9，持续76秒"/>
+        <string name="h10" value="消耗MP 12，敌人物理攻击力 -10，敌人物理防御力 -10，持续80秒"/>
+        <string name="h11" value="消耗MP 20，敌人物理攻击力 -11，敌人物理防御力 -11，持续84秒"/>
+        <string name="h12" value="消耗MP 20，敌人物理攻击力 -12，敌人物理防御力 -12，持续88秒"/>
+        <string name="h13" value="消耗MP 20，敌人物理攻击力 -13，敌人物理防御力 -13，持续92秒"/>
+        <string name="h14" value="消耗MP 20，敌人物理攻击力 -14，敌人物理防御力 -14，持续96秒"/>
+        <string name="h15" value="消耗MP 20，敌人物理攻击力 -15，敌人物理防御力 -15，持续100秒"/>
+        <string name="h16" value="消耗MP 20，敌人物理攻击力 -16，敌人物理防御力 -16，持续104秒"/>
+        <string name="h17" value="消耗MP 20，敌人物理攻击力 -17，敌人物理防御力 -17，持续108秒"/>
+        <string name="h18" value="消耗MP 20，敌人物理攻击力 -18，敌人物理防御力 -18，持续112秒"/>
+        <string name="h19" value="消耗MP 20，敌人物理攻击力 -19，敌人物理防御力 -19，持续116秒"/>
+        <string name="h20" value="消耗MP 20，敌人物理攻击力 -20，敌人物理防御力 -20，持续120秒"/>
     </imgdir>
     <imgdir name="1201007">
         <string name="name" value="伤害反击"/>
-        <string name="h1" value="消耗MP15，持续3秒，反击受到怪物伤害的11%"/>
-        <string name="h10" value="消耗MP15，持续30秒，反击受到怪物伤害的20%"/>
-        <string name="h11" value="消耗MP15，持续33秒，反击受到怪物伤害的21%"/>
-        <string name="h12" value="消耗MP15，持续36秒，反击受到怪物伤害的22%"/>
-        <string name="h13" value="消耗MP15，持续39秒，反击受到怪物伤害的23%"/>
-        <string name="h14" value="消耗MP15，持续42秒，反击受到怪物伤害的24%"/>
-        <string name="h15" value="消耗MP15，持续45秒，反击受到怪物伤害的25%"/>
-        <string name="h16" value="消耗MP30，持续48秒，反击受到怪物伤害的26%"/>
-        <string name="h17" value="消耗MP30，持续51秒，反击受到怪物伤害的27%"/>
-        <string name="h18" value="消耗MP30，持续54秒，反击受到怪物伤害的28%"/>
-        <string name="h19" value="消耗MP30，持续57秒，反击受到怪物伤害的29%"/>
-        <string name="h2" value="消耗MP15，持续6秒，反击受到怪物伤害的12%"/>
-        <string name="h20" value="消耗MP30，持续60秒，反击受到怪物伤害的30%"/>
-        <string name="h21" value="消耗MP30，持续63秒，反击受到怪物伤害的31%"/>
-        <string name="h22" value="消耗MP30，持续66秒，反击受到怪物伤害的32%"/>
-        <string name="h23" value="消耗MP30，持续69秒，反击受到怪物伤害的33%"/>
-        <string name="h24" value="消耗MP30，持续72秒，反击受到怪物伤害的34%"/>
-        <string name="h25" value="消耗MP30，持续75秒，反击受到怪物伤害的35%"/>
-        <string name="h26" value="消耗MP30，持续78秒，反击受到怪物伤害的36%"/>
-        <string name="h27" value="消耗MP30，持续81秒，反击受到怪物伤害的37%"/>
-        <string name="h28" value="消耗MP30，持续84秒，反击受到怪物伤害的38%"/>
-        <string name="h29" value="消耗MP30，持续87秒，反击受到怪物伤害的39%"/>
-        <string name="h3" value="消耗MP15，持续9秒，反击受到怪物伤害的13%"/>
-        <string name="h30" value="消耗MP30，持续90秒，反击受到怪物伤害的40%"/>
-        <string name="h4" value="消耗MP15，持续12秒，反击受到怪物伤害的14%"/>
-        <string name="h5" value="消耗MP15，持续15秒，反击受到怪物伤害的15%"/>
-        <string name="h6" value="消耗MP15，持续18秒，反击受到怪物伤害的16%"/>
-        <string name="h7" value="消耗MP15，持续21秒，反击受到怪物伤害的17%"/>
-        <string name="h8" value="消耗MP15，持续24秒，反击受到怪物伤害的18%"/>
-        <string name="h9" value="消耗MP15，持续27秒，反击受到怪物伤害的19%"/>
-        <string name="desc" value="[最高等级 : 30]\n按怪物对自身伤害的一定量反击怪物\n(怪物所受的伤害以最大HP10%为限度)\n必需技能：#c压制术等级3以上#"/>
+        <string name="desc" value="[最高等级：30]\n将受到的接触伤害按比例反弹给敌人，单次反弹不超过怪物MaxHP的10%。\n需要技能：#c压制术3级以上#"/>
+        <string name="h1" value="消耗MP 15，持续3秒，反弹受到伤害的11%"/>
+        <string name="h2" value="消耗MP 15，持续6秒，反弹受到伤害的12%"/>
+        <string name="h3" value="消耗MP 15，持续9秒，反弹受到伤害的13%"/>
+        <string name="h4" value="消耗MP 15，持续12秒，反弹受到伤害的14%"/>
+        <string name="h5" value="消耗MP 15，持续15秒，反弹受到伤害的15%"/>
+        <string name="h6" value="消耗MP 15，持续18秒，反弹受到伤害的16%"/>
+        <string name="h7" value="消耗MP 15，持续21秒，反弹受到伤害的17%"/>
+        <string name="h8" value="消耗MP 15，持续24秒，反弹受到伤害的18%"/>
+        <string name="h9" value="消耗MP 15，持续27秒，反弹受到伤害的19%"/>
+        <string name="h10" value="消耗MP 15，持续30秒，反弹受到伤害的20%"/>
+        <string name="h11" value="消耗MP 15，持续33秒，反弹受到伤害的21%"/>
+        <string name="h12" value="消耗MP 15，持续36秒，反弹受到伤害的22%"/>
+        <string name="h13" value="消耗MP 15，持续39秒，反弹受到伤害的23%"/>
+        <string name="h14" value="消耗MP 15，持续42秒，反弹受到伤害的24%"/>
+        <string name="h15" value="消耗MP 15，持续45秒，反弹受到伤害的25%"/>
+        <string name="h16" value="消耗MP 30，持续48秒，反弹受到伤害的26%"/>
+        <string name="h17" value="消耗MP 30，持续51秒，反弹受到伤害的27%"/>
+        <string name="h18" value="消耗MP 30，持续54秒，反弹受到伤害的28%"/>
+        <string name="h19" value="消耗MP 30，持续57秒，反弹受到伤害的29%"/>
+        <string name="h20" value="消耗MP 30，持续60秒，反弹受到伤害的30%"/>
+        <string name="h21" value="消耗MP 30，持续63秒，反弹受到伤害的31%"/>
+        <string name="h22" value="消耗MP 30，持续66秒，反弹受到伤害的32%"/>
+        <string name="h23" value="消耗MP 30，持续69秒，反弹受到伤害的33%"/>
+        <string name="h24" value="消耗MP 30，持续72秒，反弹受到伤害的34%"/>
+        <string name="h25" value="消耗MP 30，持续75秒，反弹受到伤害的35%"/>
+        <string name="h26" value="消耗MP 30，持续78秒，反弹受到伤害的36%"/>
+        <string name="h27" value="消耗MP 30，持续81秒，反弹受到伤害的37%"/>
+        <string name="h28" value="消耗MP 30，持续84秒，反弹受到伤害的38%"/>
+        <string name="h29" value="消耗MP 30，持续87秒，反弹受到伤害的39%"/>
+        <string name="h30" value="消耗MP 30，持续90秒，反弹受到伤害的40%"/>
     </imgdir>
     <imgdir name="121">
         <string name="bookName" value="骑士技能"/>
@@ -2048,51 +2048,51 @@
     </imgdir>
     <imgdir name="1210000">
         <string name="name" value="魔力恢复"/>
-        <string name="h1" value="MP恢复增加4"/>
-        <string name="h10" value="MP恢复增加40"/>
-        <string name="h11" value="MP恢复增加42"/>
-        <string name="h12" value="MP恢复增加44"/>
-        <string name="h13" value="MP恢复增加46"/>
-        <string name="h14" value="MP恢复增加48"/>
-        <string name="h15" value="MP恢复增加50"/>
-        <string name="h16" value="MP恢复增加52"/>
-        <string name="h17" value="MP恢复增加54"/>
-        <string name="h18" value="MP恢复增加56"/>
-        <string name="h19" value="MP恢复增加58"/>
-        <string name="h2" value="MP恢复增加8"/>
-        <string name="h20" value="MP恢复增加60"/>
-        <string name="h3" value="MP恢复增加12"/>
-        <string name="h4" value="MP恢复增加16"/>
-        <string name="h5" value="MP恢复增加20"/>
-        <string name="h6" value="MP恢复增加24"/>
-        <string name="h7" value="MP恢复增加28"/>
-        <string name="h8" value="MP恢复增加32"/>
-        <string name="h9" value="MP恢复增加36"/>
-        <string name="desc" value="[最高等级:20]\n增加每10秒的MP恢复量"/>
+        <string name="desc" value="[最高等级：20]\n站立不动时，每10秒额外恢复MP。"/>
+        <string name="h1" value="额外恢复MP +2"/>
+        <string name="h2" value="额外恢复MP +4"/>
+        <string name="h3" value="额外恢复MP +6"/>
+        <string name="h4" value="额外恢复MP +8"/>
+        <string name="h5" value="额外恢复MP +10"/>
+        <string name="h6" value="额外恢复MP +12"/>
+        <string name="h7" value="额外恢复MP +14"/>
+        <string name="h8" value="额外恢复MP +16"/>
+        <string name="h9" value="额外恢复MP +18"/>
+        <string name="h10" value="额外恢复MP +20"/>
+        <string name="h11" value="额外恢复MP +21"/>
+        <string name="h12" value="额外恢复MP +22"/>
+        <string name="h13" value="额外恢复MP +23"/>
+        <string name="h14" value="额外恢复MP +24"/>
+        <string name="h15" value="额外恢复MP +25"/>
+        <string name="h16" value="额外恢复MP +26"/>
+        <string name="h17" value="额外恢复MP +27"/>
+        <string name="h18" value="额外恢复MP +28"/>
+        <string name="h19" value="额外恢复MP +29"/>
+        <string name="h20" value="额外恢复MP +30"/>
     </imgdir>
     <imgdir name="1210001">
         <string name="name" value="盾防精通"/>
-        <string name="h1" value="盾牌的物理防御力增加20%"/>
-        <string name="h10" value="盾牌的物理防御力增加200%"/>
-        <string name="h11" value="盾牌的物理防御力增加210%"/>
-        <string name="h12" value="盾牌的物理防御力增加220%"/>
-        <string name="h13" value="盾牌的物理防御力增加230%"/>
-        <string name="h14" value="盾牌的物理防御力增加240%"/>
-        <string name="h15" value="盾牌的物理防御力增加250%"/>
-        <string name="h16" value="盾牌的物理防御力增加260%"/>
-        <string name="h17" value="盾牌的物理防御力增加270%"/>
-        <string name="h18" value="盾牌的物理防御力增加280%"/>
-        <string name="h19" value="盾牌的物理防御力增加290%"/>
-        <string name="h2" value="盾牌的物理防御力增加40%"/>
-        <string name="h20" value="盾牌的物理防御力增加300%"/>
-        <string name="h3" value="盾牌的物理防御力增加60%"/>
-        <string name="h4" value="盾牌的物理防御力增加80%"/>
-        <string name="h5" value="盾牌的物理防御力增加100%"/>
-        <string name="h6" value="盾牌的物理防御力增加120%"/>
-        <string name="h7" value="盾牌的物理防御力增加140%"/>
-        <string name="h8" value="盾牌的物理防御力增加160%"/>
-        <string name="h9" value="盾牌的物理防御力增加180%"/>
-        <string name="desc" value="[最高等级:20]\n盾牌的物理防御力增加,必需装备盾牌"/>
+        <string name="desc" value="[最高等级：20]\n装备盾牌时，提高盾牌的防御力。"/>
+        <string name="h1" value="盾牌防御力变为 105%"/>
+        <string name="h2" value="盾牌防御力变为 110%"/>
+        <string name="h3" value="盾牌防御力变为 115%"/>
+        <string name="h4" value="盾牌防御力变为 120%"/>
+        <string name="h5" value="盾牌防御力变为 125%"/>
+        <string name="h6" value="盾牌防御力变为 130%"/>
+        <string name="h7" value="盾牌防御力变为 135%"/>
+        <string name="h8" value="盾牌防御力变为 140%"/>
+        <string name="h9" value="盾牌防御力变为 145%"/>
+        <string name="h10" value="盾牌防御力变为 150%"/>
+        <string name="h11" value="盾牌防御力变为 155%"/>
+        <string name="h12" value="盾牌防御力变为 160%"/>
+        <string name="h13" value="盾牌防御力变为 165%"/>
+        <string name="h14" value="盾牌防御力变为 170%"/>
+        <string name="h15" value="盾牌防御力变为 175%"/>
+        <string name="h16" value="盾牌防御力变为 180%"/>
+        <string name="h17" value="盾牌防御力变为 185%"/>
+        <string name="h18" value="盾牌防御力变为 190%"/>
+        <string name="h19" value="盾牌防御力变为 195%"/>
+        <string name="h20" value="盾牌防御力变为 200%"/>
     </imgdir>
     <imgdir name="12101000">
         <string name="name" value="精神力"/>
@@ -2315,265 +2315,265 @@
     </imgdir>
     <imgdir name="1211002">
         <string name="name" value="属性攻击"/>
-        <string name="h1" value="消耗HP15、MP12 造成伤害262%，以32%几率使怪物昏迷"/>
-        <string name="h10" value="消费HP15、MP12 造成伤害280%，以50%几率使怪物昏迷"/>
-        <string name="h11" value="消费HP20、MP19 造成伤害283%，以52%几率使怪物昏迷"/>
-        <string name="h12" value="消费HP20、MP19 造成伤害286%，以54%几率使怪物昏迷"/>
-        <string name="h13" value="消费HP20、MP19 造成伤害289%，以56%几率使怪物昏迷"/>
-        <string name="h14" value="消费HP20、MP19 造成伤害292%，以58%几率使怪物昏迷"/>
-        <string name="h15" value="消费HP20、MP19 造成伤害295%，以60%几率使怪物昏迷"/>
-        <string name="h16" value="消费HP20、MP19 造成伤害298%，以62%几率使怪物昏迷"/>
-        <string name="h17" value="消费HP20、MP19 造成伤害301%，以64%几率使怪物昏迷"/>
-        <string name="h18" value="消费HP20、MP19 造成伤害304%，以66%几率使怪物昏迷"/>
-        <string name="h19" value="消费HP20、MP19 造成伤害307%，以68%几率使怪物昏迷"/>
-        <string name="h2" value="消耗HP15、MP12 造成伤害264%，以34%几率使怪物昏迷"/>
-        <string name="h20" value="消费HP20、MP19 造成伤害310%，以70%几率使怪物昏迷"/>
-        <string name="h21" value="消费HP25、MP26 造成伤害314%，以72%几率使怪物昏迷"/>
-        <string name="h22" value="消费HP25、MP26 造成伤害318%，以74%几率使怪物昏迷"/>
-        <string name="h23" value="消费HP25、MP26 造成伤害322%，以76%几率使怪物昏迷"/>
-        <string name="h24" value="消费HP25、MP26 造成伤害326%，以78%几率使怪物昏迷"/>
-        <string name="h25" value="消费HP25、MP26 造成伤害330%，以80%几率使怪物昏迷"/>
-        <string name="h26" value="消费HP25、MP26 造成伤害334%，以82%几率使怪物昏迷"/>
-        <string name="h27" value="消费HP25、MP26 造成伤害338%，以84%几率使怪物昏迷"/>
-        <string name="h28" value="消费HP25、MP26 造成伤害342%，以86%几率使怪物昏迷"/>
-        <string name="h29" value="消费HP25、MP26 造成伤害346%，以88%几率使怪物昏迷"/>
-        <string name="h3" value="消费HP15、MP12 造成伤害266%，以36%几率使怪物昏迷"/>
-        <string name="h30" value="消费HP25、MP26 造成伤害350%，以90%几率使怪物昏迷"/>
-        <string name="h4" value="消费HP15、MP12 造成伤害268%，以38%几率使怪物昏迷"/>
-        <string name="h5" value="消费HP15、MP12 造成伤害270%，以40%几率使怪物昏迷"/>
-        <string name="h6" value="消费HP15、MP12 造成伤害272%，以42%几率使怪物昏迷"/>
-        <string name="h7" value="消费HP15、MP12 造成伤害274%，以44%几率使怪物昏迷"/>
-        <string name="h8" value="消费HP15、MP12 造成伤害276%，以46%几率使怪物昏迷"/>
-        <string name="h9" value="消费HP15、MP12 造成伤害278%，以48%几率使怪物昏迷"/>
-        <string name="desc" value="[最高等级:30]\n赋予武器全属性，攻击6个以下多个怪物。\n一定的几率使怪物昏迷"/>
+        <string name="desc" value="[最高等级：30]\n使用当前属性蓄力攻击周围怪物，并以一定概率使其昏迷。"/>
+        <string name="h1" value="消耗HP 15，消耗MP 12，伤害 162%，最多攻击6个敌人，32%概率昏迷2秒"/>
+        <string name="h2" value="消耗HP 15，消耗MP 12，伤害 164%，最多攻击6个敌人，34%概率昏迷2秒"/>
+        <string name="h3" value="消耗HP 15，消耗MP 12，伤害 166%，最多攻击6个敌人，36%概率昏迷2秒"/>
+        <string name="h4" value="消耗HP 15，消耗MP 12，伤害 168%，最多攻击6个敌人，38%概率昏迷2秒"/>
+        <string name="h5" value="消耗HP 15，消耗MP 12，伤害 170%，最多攻击6个敌人，40%概率昏迷2秒"/>
+        <string name="h6" value="消耗HP 15，消耗MP 12，伤害 172%，最多攻击6个敌人，42%概率昏迷2秒"/>
+        <string name="h7" value="消耗HP 15，消耗MP 12，伤害 174%，最多攻击6个敌人，44%概率昏迷2秒"/>
+        <string name="h8" value="消耗HP 15，消耗MP 12，伤害 176%，最多攻击6个敌人，46%概率昏迷2秒"/>
+        <string name="h9" value="消耗HP 15，消耗MP 12，伤害 178%，最多攻击6个敌人，48%概率昏迷2秒"/>
+        <string name="h10" value="消耗HP 15，消耗MP 12，伤害 180%，最多攻击6个敌人，50%概率昏迷2秒"/>
+        <string name="h11" value="消耗HP 20，消耗MP 19，伤害 183%，最多攻击6个敌人，52%概率昏迷3秒"/>
+        <string name="h12" value="消耗HP 20，消耗MP 19，伤害 186%，最多攻击6个敌人，54%概率昏迷3秒"/>
+        <string name="h13" value="消耗HP 20，消耗MP 19，伤害 189%，最多攻击6个敌人，56%概率昏迷3秒"/>
+        <string name="h14" value="消耗HP 20，消耗MP 19，伤害 192%，最多攻击6个敌人，58%概率昏迷3秒"/>
+        <string name="h15" value="消耗HP 20，消耗MP 19，伤害 195%，最多攻击6个敌人，60%概率昏迷3秒"/>
+        <string name="h16" value="消耗HP 20，消耗MP 19，伤害 198%，最多攻击6个敌人，62%概率昏迷3秒"/>
+        <string name="h17" value="消耗HP 20，消耗MP 19，伤害 201%，最多攻击6个敌人，64%概率昏迷3秒"/>
+        <string name="h18" value="消耗HP 20，消耗MP 19，伤害 204%，最多攻击6个敌人，66%概率昏迷3秒"/>
+        <string name="h19" value="消耗HP 20，消耗MP 19，伤害 207%，最多攻击6个敌人，68%概率昏迷3秒"/>
+        <string name="h20" value="消耗HP 20，消耗MP 19，伤害 210%，最多攻击6个敌人，70%概率昏迷3秒"/>
+        <string name="h21" value="消耗HP 25，消耗MP 26，伤害 214%，最多攻击6个敌人，72%概率昏迷4秒"/>
+        <string name="h22" value="消耗HP 25，消耗MP 26，伤害 218%，最多攻击6个敌人，74%概率昏迷4秒"/>
+        <string name="h23" value="消耗HP 25，消耗MP 26，伤害 222%，最多攻击6个敌人，76%概率昏迷4秒"/>
+        <string name="h24" value="消耗HP 25，消耗MP 26，伤害 226%，最多攻击6个敌人，78%概率昏迷4秒"/>
+        <string name="h25" value="消耗HP 25，消耗MP 26，伤害 230%，最多攻击6个敌人，80%概率昏迷4秒"/>
+        <string name="h26" value="消耗HP 25，消耗MP 26，伤害 234%，最多攻击6个敌人，82%概率昏迷4秒"/>
+        <string name="h27" value="消耗HP 25，消耗MP 26，伤害 238%，最多攻击6个敌人，84%概率昏迷4秒"/>
+        <string name="h28" value="消耗HP 25，消耗MP 26，伤害 242%，最多攻击6个敌人，86%概率昏迷4秒"/>
+        <string name="h29" value="消耗HP 25，消耗MP 26，伤害 246%，最多攻击6个敌人，88%概率昏迷4秒"/>
+        <string name="h30" value="消耗HP 25，消耗MP 26，伤害 250%，最多攻击6个敌人，90%概率昏迷4秒"/>
     </imgdir>
     <imgdir name="1211003">
         <string name="name" value="烈焰之剑"/>
-        <string name="h1" value="消耗MP25，造成伤害103%,持续时间10秒,属性纯度50%"/>
-        <string name="h10" value="消费MP25，造成伤害130%,持续时间100秒,属性纯度50%"/>
-        <string name="h11" value="消费MP30，造成伤害133%,持续时间110秒,属性纯度50%"/>
-        <string name="h12" value="消费MP30，造成伤害136%,持续时间120秒,属性纯度50%"/>
-        <string name="h13" value="消费MP30，造成伤害139%,持续时间130秒,属性纯度50%"/>
-        <string name="h14" value="消费MP30，造成伤害142%,持续时间140秒,属性纯度50%"/>
-        <string name="h15" value="消费MP30，造成伤害145%,持续时间150秒,属性纯度50%"/>
-        <string name="h16" value="消费MP30，造成伤害148%,持续时间160秒,属性纯度50%"/>
-        <string name="h17" value="消费MP30，造成伤害151%,持续时间170秒,属性纯度50%"/>
-        <string name="h18" value="消费MP30，造成伤害154%,持续时间180秒,属性纯度50%"/>
-        <string name="h19" value="消费MP30，造成伤害157%,持续时间190秒,属性纯度50%"/>
-        <string name="h2" value="消费MP25，造成伤害106%,持续时间20秒,属性纯度50%"/>
-        <string name="h20" value="消费MP35，造成伤害160%,持续时间200秒,属性纯度50%"/>
-        <string name="h21" value="消费MP35，造成伤害160%,持续时间210秒,属性纯度50%"/>
-        <string name="h22" value="消费MP35，造成伤害160%,持续时间220秒,属性纯度50%"/>
-        <string name="h23" value="消费MP35，造成伤害160%,持续时间230秒,属性纯度50%"/>
-        <string name="h24" value="消费MP35，造成伤害160%,持续时间240秒,属性纯度50%"/>
-        <string name="h25" value="消费MP35，造成伤害160%,持续时间250秒,属性纯度50%"/>
-        <string name="h26" value="消费MP35，造成伤害160%,持续时间260秒,属性纯度50%"/>
-        <string name="h27" value="消费MP35，造成伤害160%,持续时间270秒,属性纯度50%"/>
-        <string name="h28" value="消费MP35，造成伤害160%,持续时间280秒,属性纯度50%"/>
-        <string name="h29" value="消费MP35，造成伤害160%,持续时间290秒,属性纯度50%"/>
-        <string name="h3" value="消费MP25，造成伤害109%,持续时间30秒,属性纯度50%"/>
-        <string name="h30" value="消费MP35，造成伤害160%,持续时间300秒,属性纯度50%"/>
-        <string name="h4" value="消费MP25，造成伤害112%,持续时间40秒,属性纯度50%"/>
-        <string name="h5" value="消费MP25，造成伤害115%,持续时间50秒,属性纯度50%"/>
-        <string name="h6" value="消费MP25，造成伤害118%,持续时间60秒,属性纯度50%"/>
-        <string name="h7" value="消费MP25，造成伤害121%,持续时间70秒,属性纯度50%"/>
-        <string name="h8" value="消费MP25，造成伤害124%,持续时间80秒,属性纯度50%"/>
-        <string name="h9" value="消费MP25，造成伤害127%,持续时间90秒,属性纯度50%"/>
-        <string name="desc" value="[最高等级:30]\n一定时间内,给剑赋予火焰属性。\n超过时间或使用属性攻击会被取消。\n（建议只加20点，20点后只增加持续时间）"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内为装备中的剑附加火属性。使用属性攻击时可能消耗该属性，或在持续时间结束后消失。"/>
+        <string name="h1" value="消耗MP 25，伤害 102%，持续12秒"/>
+        <string name="h2" value="消耗MP 25，伤害 103%，持续19秒"/>
+        <string name="h3" value="消耗MP 25，伤害 104%，持续26秒"/>
+        <string name="h4" value="消耗MP 25，伤害 105%，持续33秒"/>
+        <string name="h5" value="消耗MP 25，伤害 106%，持续40秒"/>
+        <string name="h6" value="消耗MP 25，伤害 107%，持续47秒"/>
+        <string name="h7" value="消耗MP 25，伤害 108%，持续54秒"/>
+        <string name="h8" value="消耗MP 25，伤害 109%，持续61秒"/>
+        <string name="h9" value="消耗MP 25，伤害 109%，持续68秒"/>
+        <string name="h10" value="消耗MP 25，伤害 110%，持续75秒"/>
+        <string name="h11" value="消耗MP 30，伤害 110%，持续82秒"/>
+        <string name="h12" value="消耗MP 30，伤害 111%，持续89秒"/>
+        <string name="h13" value="消耗MP 30，伤害 111%，持续96秒"/>
+        <string name="h14" value="消耗MP 30，伤害 112%，持续103秒"/>
+        <string name="h15" value="消耗MP 30，伤害 112%，持续110秒"/>
+        <string name="h16" value="消耗MP 30，伤害 113%，持续116秒"/>
+        <string name="h17" value="消耗MP 30，伤害 113%，持续122秒"/>
+        <string name="h18" value="消耗MP 30，伤害 114%，持续128秒"/>
+        <string name="h19" value="消耗MP 30，伤害 114%，持续134秒"/>
+        <string name="h20" value="消耗MP 30，伤害 115%，持续140秒"/>
+        <string name="h21" value="消耗MP 35，伤害 115%，持续146秒"/>
+        <string name="h22" value="消耗MP 35，伤害 116%，持续152秒"/>
+        <string name="h23" value="消耗MP 35，伤害 116%，持续158秒"/>
+        <string name="h24" value="消耗MP 35，伤害 117%，持续164秒"/>
+        <string name="h25" value="消耗MP 35，伤害 117%，持续170秒"/>
+        <string name="h26" value="消耗MP 35，伤害 118%，持续176秒"/>
+        <string name="h27" value="消耗MP 35，伤害 118%，持续182秒"/>
+        <string name="h28" value="消耗MP 35，伤害 119%，持续188秒"/>
+        <string name="h29" value="消耗MP 35，伤害 119%，持续194秒"/>
+        <string name="h30" value="消耗MP 35，伤害 120%，持续200秒"/>
     </imgdir>
     <imgdir name="1211004">
         <string name="name" value="烈焰钝器"/>
-        <string name="h1" value="消耗MP25，造成伤害103%,持续时间10秒,属性纯度50%"/>
-        <string name="h10" value="消费MP25，造成伤害130%,持续时间100秒,属性纯度50%"/>
-        <string name="h11" value="消费MP30，造成伤害133%,持续时间110秒,属性纯度50%"/>
-        <string name="h12" value="消费MP30，造成伤害136%,持续时间120秒,属性纯度50%"/>
-        <string name="h13" value="消费MP30，造成伤害139%,持续时间130秒,属性纯度50%"/>
-        <string name="h14" value="消费MP30，造成伤害142%,持续时间140秒,属性纯度50%"/>
-        <string name="h15" value="消费MP30，造成伤害145%,持续时间150秒,属性纯度50%"/>
-        <string name="h16" value="消费MP30，造成伤害148%,持续时间160秒,属性纯度50%"/>
-        <string name="h17" value="消费MP30，造成伤害151%,持续时间170秒,属性纯度50%"/>
-        <string name="h18" value="消费MP30，造成伤害154%,持续时间180秒,属性纯度50%"/>
-        <string name="h19" value="消费MP30，造成伤害157%,持续时间190秒,属性纯度50%"/>
-        <string name="h2" value="消费MP25，造成伤害106%,持续时间20秒,属性纯度50%"/>
-        <string name="h20" value="消费MP35，造成伤害160%,持续时间200秒,属性纯度50%"/>
-        <string name="h21" value="消费MP35，造成伤害160%,持续时间210秒,属性纯度50%"/>
-        <string name="h22" value="消费MP35，造成伤害160%,持续时间220秒,属性纯度50%"/>
-        <string name="h23" value="消费MP35，造成伤害160%,持续时间230秒,属性纯度50%"/>
-        <string name="h24" value="消费MP35，造成伤害160%,持续时间240秒,属性纯度50%"/>
-        <string name="h25" value="消费MP35，造成伤害160%,持续时间250秒,属性纯度50%"/>
-        <string name="h26" value="消费MP35，造成伤害160%,持续时间260秒,属性纯度50%"/>
-        <string name="h27" value="消费MP35，造成伤害160%,持续时间270秒,属性纯度50%"/>
-        <string name="h28" value="消费MP35，造成伤害160%,持续时间280秒,属性纯度50%"/>
-        <string name="h29" value="消费MP35，造成伤害160%,持续时间290秒,属性纯度50%"/>
-        <string name="h3" value="消费MP25，造成伤害109%,持续时间30秒,属性纯度50%"/>
-        <string name="h30" value="消费MP35，造成伤害160%,持续时间300秒,属性纯度50%"/>
-        <string name="h4" value="消费MP25，造成伤害112%,持续时间40秒,属性纯度50%"/>
-        <string name="h5" value="消费MP25，造成伤害115%,持续时间50秒,属性纯度50%"/>
-        <string name="h6" value="消费MP25，造成伤害118%,持续时间60秒,属性纯度50%"/>
-        <string name="h7" value="消费MP25，造成伤害121%,持续时间70秒,属性纯度50%"/>
-        <string name="h8" value="消费MP25，造成伤害124%,持续时间80秒,属性纯度50%"/>
-        <string name="h9" value="消费MP25，造成伤害127%,持续时间90秒,属性纯度50%"/>
-        <string name="desc" value="[最高等级:30]\n一定时间内,给钝器赋予火焰属性。\n超过时间或使用属性攻击会被取消.\n（建议只加20点，20点后只增加持续时间）"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内为装备中的钝器附加火属性。使用属性攻击时可能消耗该属性，或在持续时间结束后消失。"/>
+        <string name="h1" value="消耗MP 25，伤害 102%，持续12秒"/>
+        <string name="h2" value="消耗MP 25，伤害 103%，持续19秒"/>
+        <string name="h3" value="消耗MP 25，伤害 104%，持续26秒"/>
+        <string name="h4" value="消耗MP 25，伤害 105%，持续33秒"/>
+        <string name="h5" value="消耗MP 25，伤害 106%，持续40秒"/>
+        <string name="h6" value="消耗MP 25，伤害 107%，持续47秒"/>
+        <string name="h7" value="消耗MP 25，伤害 108%，持续54秒"/>
+        <string name="h8" value="消耗MP 25，伤害 109%，持续61秒"/>
+        <string name="h9" value="消耗MP 25，伤害 109%，持续68秒"/>
+        <string name="h10" value="消耗MP 25，伤害 110%，持续75秒"/>
+        <string name="h11" value="消耗MP 30，伤害 110%，持续82秒"/>
+        <string name="h12" value="消耗MP 30，伤害 111%，持续89秒"/>
+        <string name="h13" value="消耗MP 30，伤害 111%，持续96秒"/>
+        <string name="h14" value="消耗MP 30，伤害 112%，持续103秒"/>
+        <string name="h15" value="消耗MP 30，伤害 112%，持续110秒"/>
+        <string name="h16" value="消耗MP 30，伤害 113%，持续116秒"/>
+        <string name="h17" value="消耗MP 30，伤害 113%，持续122秒"/>
+        <string name="h18" value="消耗MP 30，伤害 114%，持续128秒"/>
+        <string name="h19" value="消耗MP 30，伤害 114%，持续134秒"/>
+        <string name="h20" value="消耗MP 30，伤害 115%，持续140秒"/>
+        <string name="h21" value="消耗MP 35，伤害 115%，持续146秒"/>
+        <string name="h22" value="消耗MP 35，伤害 116%，持续152秒"/>
+        <string name="h23" value="消耗MP 35，伤害 116%，持续158秒"/>
+        <string name="h24" value="消耗MP 35，伤害 117%，持续164秒"/>
+        <string name="h25" value="消耗MP 35，伤害 117%，持续170秒"/>
+        <string name="h26" value="消耗MP 35，伤害 118%，持续176秒"/>
+        <string name="h27" value="消耗MP 35，伤害 118%，持续182秒"/>
+        <string name="h28" value="消耗MP 35，伤害 119%，持续188秒"/>
+        <string name="h29" value="消耗MP 35，伤害 119%，持续194秒"/>
+        <string name="h30" value="消耗MP 35，伤害 120%，持续200秒"/>
     </imgdir>
     <imgdir name="1211005">
         <string name="name" value="寒冰之剑"/>
-        <string name="h1" value="消耗MP25，造成伤害103%,持续时间10秒,属性纯度50%"/>
-        <string name="h10" value="消费MP25，造成伤害130%,持续时间100秒,属性纯度50%"/>
-        <string name="h11" value="消费MP30，造成伤害133%,持续时间110秒,属性纯度50%"/>
-        <string name="h12" value="消费MP30，造成伤害136%,持续时间120秒,属性纯度50%"/>
-        <string name="h13" value="消费MP30，造成伤害139%,持续时间130秒,属性纯度50%"/>
-        <string name="h14" value="消费MP30，造成伤害142%,持续时间140秒,属性纯度50%"/>
-        <string name="h15" value="消费MP30，造成伤害145%,持续时间150秒,属性纯度50%"/>
-        <string name="h16" value="消费MP30，造成伤害148%,持续时间160秒,属性纯度50%"/>
-        <string name="h17" value="消费MP30，造成伤害151%,持续时间170秒,属性纯度50%"/>
-        <string name="h18" value="消费MP30，造成伤害154%,持续时间180秒,属性纯度50%"/>
-        <string name="h19" value="消费MP30，造成伤害157%,持续时间190秒,属性纯度50%"/>
-        <string name="h2" value="消费MP25，造成伤害106%,持续时间20秒,属性纯度50%"/>
-        <string name="h20" value="消费MP35，造成伤害160%,持续时间200秒,属性纯度50%"/>
-        <string name="h21" value="消费MP35，造成伤害160%,持续时间210秒,属性纯度50%"/>
-        <string name="h22" value="消费MP35，造成伤害160%,持续时间220秒,属性纯度50%"/>
-        <string name="h23" value="消费MP35，造成伤害160%,持续时间230秒,属性纯度50%"/>
-        <string name="h24" value="消费MP35，造成伤害160%,持续时间240秒,属性纯度50%"/>
-        <string name="h25" value="消费MP35，造成伤害160%,持续时间250秒,属性纯度50%"/>
-        <string name="h26" value="消费MP35，造成伤害160%,持续时间260秒,属性纯度50%"/>
-        <string name="h27" value="消费MP35，造成伤害160%,持续时间270秒,属性纯度50%"/>
-        <string name="h28" value="消费MP35，造成伤害160%,持续时间280秒,属性纯度50%"/>
-        <string name="h29" value="消费MP35，造成伤害160%,持续时间290秒,属性纯度50%"/>
-        <string name="h3" value="消费MP25，造成伤害109%,持续时间30秒,属性纯度50%"/>
-        <string name="h30" value="消费MP35，造成伤害160%,持续时间300秒,属性纯度50%"/>
-        <string name="h4" value="消费MP25，造成伤害112%,持续时间40秒,属性纯度50%"/>
-        <string name="h5" value="消费MP25，造成伤害115%,持续时间50秒,属性纯度50%"/>
-        <string name="h6" value="消费MP25，造成伤害118%,持续时间60秒,属性纯度50%"/>
-        <string name="h7" value="消费MP25，造成伤害121%,持续时间70秒,属性纯度50%"/>
-        <string name="h8" value="消费MP25，造成伤害124%,持续时间80秒,属性纯度50%"/>
-        <string name="h9" value="消费MP25，造成伤害127%,持续时间90秒,属性纯度50%"/>
-        <string name="desc" value="[最高等级:30]\n一定时间内,给剑赋予冰属性.\n超过时间或使用属性攻击会被取消.\n（建议只加20点，20点后只增加持续时间）"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内为装备中的剑附加冰属性。使用属性攻击时可能消耗该属性，或在持续时间结束后消失。"/>
+        <string name="h1" value="消耗MP 25，伤害 100%，持续12秒"/>
+        <string name="h2" value="消耗MP 25，伤害 101%，持续19秒"/>
+        <string name="h3" value="消耗MP 25，伤害 101%，持续26秒"/>
+        <string name="h4" value="消耗MP 25，伤害 102%，持续33秒"/>
+        <string name="h5" value="消耗MP 25，伤害 102%，持续40秒"/>
+        <string name="h6" value="消耗MP 25，伤害 102%，持续47秒"/>
+        <string name="h7" value="消耗MP 25，伤害 103%，持续54秒"/>
+        <string name="h8" value="消耗MP 25，伤害 103%，持续61秒"/>
+        <string name="h9" value="消耗MP 25，伤害 103%，持续68秒"/>
+        <string name="h10" value="消耗MP 25，伤害 104%，持续75秒"/>
+        <string name="h11" value="消耗MP 30，伤害 104%，持续82秒"/>
+        <string name="h12" value="消耗MP 30，伤害 104%，持续89秒"/>
+        <string name="h13" value="消耗MP 30，伤害 105%，持续96秒"/>
+        <string name="h14" value="消耗MP 30，伤害 105%，持续103秒"/>
+        <string name="h15" value="消耗MP 30，伤害 105%，持续110秒"/>
+        <string name="h16" value="消耗MP 30，伤害 106%，持续116秒"/>
+        <string name="h17" value="消耗MP 30，伤害 106%，持续122秒"/>
+        <string name="h18" value="消耗MP 30，伤害 106%，持续128秒"/>
+        <string name="h19" value="消耗MP 30，伤害 107%，持续134秒"/>
+        <string name="h20" value="消耗MP 30，伤害 107%，持续140秒"/>
+        <string name="h21" value="消耗MP 35，伤害 107%，持续146秒"/>
+        <string name="h22" value="消耗MP 35，伤害 108%，持续152秒"/>
+        <string name="h23" value="消耗MP 35，伤害 108%，持续158秒"/>
+        <string name="h24" value="消耗MP 35，伤害 108%，持续164秒"/>
+        <string name="h25" value="消耗MP 35，伤害 108%，持续170秒"/>
+        <string name="h26" value="消耗MP 35，伤害 109%，持续176秒"/>
+        <string name="h27" value="消耗MP 35，伤害 109%，持续182秒"/>
+        <string name="h28" value="消耗MP 35，伤害 109%，持续188秒"/>
+        <string name="h29" value="消耗MP 35，伤害 109%，持续194秒"/>
+        <string name="h30" value="消耗MP 35，伤害 110%，持续200秒"/>
     </imgdir>
     <imgdir name="1211006">
         <string name="name" value="寒冰钝器"/>
-        <string name="h1" value="消耗MP25，造成伤害103%,持续时间10秒,属性纯度50%"/>
-        <string name="h10" value="消费MP25，造成伤害130%,持续时间100秒,属性纯度50%"/>
-        <string name="h11" value="消费MP30，造成伤害133%,持续时间110秒,属性纯度50%"/>
-        <string name="h12" value="消费MP30，造成伤害136%,持续时间120秒,属性纯度50%"/>
-        <string name="h13" value="消费MP30，造成伤害139%,持续时间130秒,属性纯度50%"/>
-        <string name="h14" value="消费MP30，造成伤害142%,持续时间140秒,属性纯度50%"/>
-        <string name="h15" value="消费MP30，造成伤害145%,持续时间150秒,属性纯度50%"/>
-        <string name="h16" value="消费MP30，造成伤害148%,持续时间160秒,属性纯度50%"/>
-        <string name="h17" value="消费MP30，造成伤害151%,持续时间170秒,属性纯度50%"/>
-        <string name="h18" value="消费MP30，造成伤害154%,持续时间180秒,属性纯度50%"/>
-        <string name="h19" value="消费MP30，造成伤害157%,持续时间190秒,属性纯度50%"/>
-        <string name="h2" value="消费MP25，造成伤害106%,持续时间20秒,属性纯度50%"/>
-        <string name="h20" value="消费MP35，造成伤害160%,持续时间200秒,属性纯度50%"/>
-        <string name="h21" value="消费MP35，造成伤害160%,持续时间210秒,属性纯度50%"/>
-        <string name="h22" value="消费MP35，造成伤害160%,持续时间220秒,属性纯度50%"/>
-        <string name="h23" value="消费MP35，造成伤害160%,持续时间230秒,属性纯度50%"/>
-        <string name="h24" value="消费MP35，造成伤害160%,持续时间240秒,属性纯度50%"/>
-        <string name="h25" value="消费MP35，造成伤害160%,持续时间250秒,属性纯度50%"/>
-        <string name="h26" value="消费MP35，造成伤害160%,持续时间260秒,属性纯度50%"/>
-        <string name="h27" value="消费MP35，造成伤害160%,持续时间270秒,属性纯度50%"/>
-        <string name="h28" value="消费MP35，造成伤害160%,持续时间280秒,属性纯度50%"/>
-        <string name="h29" value="消费MP35，造成伤害160%,持续时间290秒,属性纯度50%"/>
-        <string name="h3" value="消费MP25，造成伤害109%,持续时间30秒,属性纯度50%"/>
-        <string name="h30" value="消费MP35，造成伤害160%,持续时间300秒,属性纯度50%"/>
-        <string name="h4" value="消费MP25，造成伤害112%,持续时间40秒,属性纯度50%"/>
-        <string name="h5" value="消费MP25，造成伤害115%,持续时间50秒,属性纯度50%"/>
-        <string name="h6" value="消费MP25，造成伤害118%,持续时间60秒,属性纯度50%"/>
-        <string name="h7" value="消费MP25，造成伤害121%,持续时间70秒,属性纯度50%"/>
-        <string name="h8" value="消费MP25，造成伤害124%,持续时间80秒,属性纯度50%"/>
-        <string name="h9" value="消费MP25，造成伤害127%,持续时间90秒,属性纯度50%"/>
-        <string name="desc" value="[最高等级:30]\n一定时间内,给钝器赋予冰属性。\n超过时间或使用属性攻击会被取消.\n（建议只加20点，20点后只增加持续时间）"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内为装备中的钝器附加冰属性。使用属性攻击时可能消耗该属性，或在持续时间结束后消失。"/>
+        <string name="h1" value="消耗MP 25，伤害 100%，持续12秒"/>
+        <string name="h2" value="消耗MP 25，伤害 101%，持续19秒"/>
+        <string name="h3" value="消耗MP 25，伤害 101%，持续26秒"/>
+        <string name="h4" value="消耗MP 25，伤害 102%，持续33秒"/>
+        <string name="h5" value="消耗MP 25，伤害 102%，持续40秒"/>
+        <string name="h6" value="消耗MP 25，伤害 102%，持续47秒"/>
+        <string name="h7" value="消耗MP 25，伤害 103%，持续54秒"/>
+        <string name="h8" value="消耗MP 25，伤害 103%，持续61秒"/>
+        <string name="h9" value="消耗MP 25，伤害 103%，持续68秒"/>
+        <string name="h10" value="消耗MP 25，伤害 104%，持续75秒"/>
+        <string name="h11" value="消耗MP 30，伤害 104%，持续82秒"/>
+        <string name="h12" value="消耗MP 30，伤害 104%，持续89秒"/>
+        <string name="h13" value="消耗MP 30，伤害 105%，持续96秒"/>
+        <string name="h14" value="消耗MP 30，伤害 105%，持续103秒"/>
+        <string name="h15" value="消耗MP 30，伤害 105%，持续110秒"/>
+        <string name="h16" value="消耗MP 30，伤害 106%，持续116秒"/>
+        <string name="h17" value="消耗MP 30，伤害 106%，持续122秒"/>
+        <string name="h18" value="消耗MP 30，伤害 106%，持续128秒"/>
+        <string name="h19" value="消耗MP 30，伤害 107%，持续134秒"/>
+        <string name="h20" value="消耗MP 30，伤害 107%，持续140秒"/>
+        <string name="h21" value="消耗MP 35，伤害 107%，持续146秒"/>
+        <string name="h22" value="消耗MP 35，伤害 108%，持续152秒"/>
+        <string name="h23" value="消耗MP 35，伤害 108%，持续158秒"/>
+        <string name="h24" value="消耗MP 35，伤害 108%，持续164秒"/>
+        <string name="h25" value="消耗MP 35，伤害 108%，持续170秒"/>
+        <string name="h26" value="消耗MP 35，伤害 109%，持续176秒"/>
+        <string name="h27" value="消耗MP 35，伤害 109%，持续182秒"/>
+        <string name="h28" value="消耗MP 35，伤害 109%，持续188秒"/>
+        <string name="h29" value="消耗MP 35，伤害 109%，持续194秒"/>
+        <string name="h30" value="消耗MP 35，伤害 110%，持续200秒"/>
     </imgdir>
     <imgdir name="1211007">
         <string name="name" value="雷电之击：剑"/>
-        <string name="h1" value="消耗MP25，造成伤害103%,持续时间10秒,属性纯度50%"/>
-        <string name="h10" value="消费MP25，造成伤害130%,持续时间100秒,属性纯度50%"/>
-        <string name="h11" value="消费MP30，造成伤害133%,持续时间110秒,属性纯度50%"/>
-        <string name="h12" value="消费MP30，造成伤害136%,持续时间120秒,属性纯度50%"/>
-        <string name="h13" value="消费MP30，造成伤害139%,持续时间130秒,属性纯度50%"/>
-        <string name="h14" value="消费MP30，造成伤害142%,持续时间140秒,属性纯度50%"/>
-        <string name="h15" value="消费MP30，造成伤害145%,持续时间150秒,属性纯度50%"/>
-        <string name="h16" value="消费MP30，造成伤害148%,持续时间160秒,属性纯度50%"/>
-        <string name="h17" value="消费MP30，造成伤害151%,持续时间170秒,属性纯度50%"/>
-        <string name="h18" value="消费MP30，造成伤害154%,持续时间180秒,属性纯度50%"/>
-        <string name="h19" value="消费MP30，造成伤害157%,持续时间190秒,属性纯度50%"/>
-        <string name="h2" value="消费MP25，造成伤害106%,持续时间20秒,属性纯度50%"/>
-        <string name="h20" value="消费MP35，造成伤害160%,持续时间200秒,属性纯度50%"/>
-        <string name="h21" value="消费MP35，造成伤害160%,持续时间210秒,属性纯度50%"/>
-        <string name="h22" value="消费MP35，造成伤害160%,持续时间220秒,属性纯度50%"/>
-        <string name="h23" value="消费MP35，造成伤害160%,持续时间230秒,属性纯度50%"/>
-        <string name="h24" value="消费MP35，造成伤害160%,持续时间240秒,属性纯度50%"/>
-        <string name="h25" value="消费MP35，造成伤害160%,持续时间250秒,属性纯度50%"/>
-        <string name="h26" value="消费MP35，造成伤害160%,持续时间260秒,属性纯度50%"/>
-        <string name="h27" value="消费MP35，造成伤害160%,持续时间270秒,属性纯度50%"/>
-        <string name="h28" value="消费MP35，造成伤害160%,持续时间280秒,属性纯度50%"/>
-        <string name="h29" value="消费MP35，造成伤害160%,持续时间290秒,属性纯度50%"/>
-        <string name="h3" value="消费MP25，造成伤害109%,持续时间30秒,属性纯度50%"/>
-        <string name="h30" value="消费MP35，造成伤害160%,持续时间300秒,属性纯度50%"/>
-        <string name="h4" value="消费MP25，造成伤害112%,持续时间40秒,属性纯度50%"/>
-        <string name="h5" value="消费MP25，造成伤害115%,持续时间50秒,属性纯度50%"/>
-        <string name="h6" value="消费MP25，造成伤害118%,持续时间60秒,属性纯度50%"/>
-        <string name="h7" value="消费MP25，造成伤害121%,持续时间70秒,属性纯度50%"/>
-        <string name="h8" value="消费MP25，造成伤害124%,持续时间80秒,属性纯度50%"/>
-        <string name="h9" value="消费MP25，造成伤害127%,持续时间90秒,属性纯度50%"/>
-        <string name="desc" value="[最高等级:30]\n一定时间内,给剑赋予雷属性。\n超过时间或使用属性攻击会被取消.\n（建议只加20点，20点后只增加持续时间）"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内为装备中的剑附加雷属性。使用属性攻击时可能消耗该属性，或在持续时间结束后消失。"/>
+        <string name="h1" value="消耗MP 25，伤害 102%，持续12秒"/>
+        <string name="h2" value="消耗MP 25，伤害 104%，持续19秒"/>
+        <string name="h3" value="消耗MP 25，伤害 106%，持续26秒"/>
+        <string name="h4" value="消耗MP 25，伤害 107%，持续33秒"/>
+        <string name="h5" value="消耗MP 25，伤害 108%，持续40秒"/>
+        <string name="h6" value="消耗MP 25，伤害 109%，持续47秒"/>
+        <string name="h7" value="消耗MP 25，伤害 110%，持续54秒"/>
+        <string name="h8" value="消耗MP 25，伤害 111%，持续61秒"/>
+        <string name="h9" value="消耗MP 25，伤害 112%，持续68秒"/>
+        <string name="h10" value="消耗MP 25，伤害 113%，持续75秒"/>
+        <string name="h11" value="消耗MP 30，伤害 114%，持续82秒"/>
+        <string name="h12" value="消耗MP 30，伤害 115%，持续89秒"/>
+        <string name="h13" value="消耗MP 30，伤害 116%，持续96秒"/>
+        <string name="h14" value="消耗MP 30，伤害 117%，持续103秒"/>
+        <string name="h15" value="消耗MP 30，伤害 117%，持续110秒"/>
+        <string name="h16" value="消耗MP 30，伤害 118%，持续116秒"/>
+        <string name="h17" value="消耗MP 30，伤害 118%，持续122秒"/>
+        <string name="h18" value="消耗MP 30，伤害 119%，持续128秒"/>
+        <string name="h19" value="消耗MP 30，伤害 119%，持续134秒"/>
+        <string name="h20" value="消耗MP 30，伤害 120%，持续140秒"/>
+        <string name="h21" value="消耗MP 35，伤害 120%，持续146秒"/>
+        <string name="h22" value="消耗MP 35，伤害 121%，持续152秒"/>
+        <string name="h23" value="消耗MP 35，伤害 121%，持续158秒"/>
+        <string name="h24" value="消耗MP 35，伤害 122%，持续164秒"/>
+        <string name="h25" value="消耗MP 35，伤害 122%，持续170秒"/>
+        <string name="h26" value="消耗MP 35，伤害 123%，持续176秒"/>
+        <string name="h27" value="消耗MP 35，伤害 123%，持续182秒"/>
+        <string name="h28" value="消耗MP 35，伤害 124%，持续188秒"/>
+        <string name="h29" value="消耗MP 35，伤害 124%，持续194秒"/>
+        <string name="h30" value="消耗MP 35，伤害 125%，持续200秒"/>
     </imgdir>
     <imgdir name="1211008">
         <string name="name" value="雷电之击：钝器"/>
-        <string name="h1" value="消耗MP25，造成伤害103%,持续时间10秒,属性纯度50%"/>
-        <string name="h10" value="消费MP25，造成伤害130%,持续时间100秒,属性纯度50%"/>
-        <string name="h11" value="消费MP30，造成伤害133%,持续时间110秒,属性纯度50%"/>
-        <string name="h12" value="消费MP30，造成伤害136%,持续时间120秒,属性纯度50%"/>
-        <string name="h13" value="消费MP30，造成伤害139%,持续时间130秒,属性纯度50%"/>
-        <string name="h14" value="消费MP30，造成伤害142%,持续时间140秒,属性纯度50%"/>
-        <string name="h15" value="消费MP30，造成伤害145%,持续时间150秒,属性纯度50%"/>
-        <string name="h16" value="消费MP30，造成伤害148%,持续时间160秒,属性纯度50%"/>
-        <string name="h17" value="消费MP30，造成伤害151%,持续时间170秒,属性纯度50%"/>
-        <string name="h18" value="消费MP30，造成伤害154%,持续时间180秒,属性纯度50%"/>
-        <string name="h19" value="消费MP30，造成伤害157%,持续时间190秒,属性纯度50%"/>
-        <string name="h2" value="消费MP25，造成伤害106%,持续时间20秒,属性纯度50%"/>
-        <string name="h20" value="消费MP35，造成伤害160%,持续时间200秒,属性纯度50%"/>
-        <string name="h21" value="消费MP35，造成伤害160%,持续时间210秒,属性纯度50%"/>
-        <string name="h22" value="消费MP35，造成伤害160%,持续时间220秒,属性纯度50%"/>
-        <string name="h23" value="消费MP35，造成伤害160%,持续时间230秒,属性纯度50%"/>
-        <string name="h24" value="消费MP35，造成伤害160%,持续时间240秒,属性纯度50%"/>
-        <string name="h25" value="消费MP35，造成伤害160%,持续时间250秒,属性纯度50%"/>
-        <string name="h26" value="消费MP35，造成伤害160%,持续时间260秒,属性纯度50%"/>
-        <string name="h27" value="消费MP35，造成伤害160%,持续时间270秒,属性纯度50%"/>
-        <string name="h28" value="消费MP35，造成伤害160%,持续时间280秒,属性纯度50%"/>
-        <string name="h29" value="消费MP35，造成伤害160%,持续时间290秒,属性纯度50%"/>
-        <string name="h3" value="消费MP25，造成伤害109%,持续时间30秒,属性纯度50%"/>
-        <string name="h30" value="消费MP35，造成伤害160%,持续时间300秒,属性纯度50%"/>
-        <string name="h4" value="消费MP25，造成伤害112%,持续时间40秒,属性纯度50%"/>
-        <string name="h5" value="消费MP25，造成伤害115%,持续时间50秒,属性纯度50%"/>
-        <string name="h6" value="消费MP25，造成伤害118%,持续时间60秒,属性纯度50%"/>
-        <string name="h7" value="消费MP25，造成伤害121%,持续时间70秒,属性纯度50%"/>
-        <string name="h8" value="消费MP25，造成伤害124%,持续时间80秒,属性纯度50%"/>
-        <string name="h9" value="消费MP25，造成伤害127%,持续时间90秒,属性纯度50%"/>
-        <string name="desc" value="[最高等级:30]\n一定时间内,给钝器赋予雷属性。\n超过时间或使用属性攻击会被取消.\n（建议只加20点，20点后只增加持续时间）"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内为装备中的钝器附加雷属性。使用属性攻击时可能消耗该属性，或在持续时间结束后消失。"/>
+        <string name="h1" value="消耗MP 25，伤害 102%，持续12秒"/>
+        <string name="h2" value="消耗MP 25，伤害 104%，持续19秒"/>
+        <string name="h3" value="消耗MP 25，伤害 106%，持续26秒"/>
+        <string name="h4" value="消耗MP 25，伤害 107%，持续33秒"/>
+        <string name="h5" value="消耗MP 25，伤害 108%，持续40秒"/>
+        <string name="h6" value="消耗MP 25，伤害 109%，持续47秒"/>
+        <string name="h7" value="消耗MP 25，伤害 110%，持续54秒"/>
+        <string name="h8" value="消耗MP 25，伤害 111%，持续61秒"/>
+        <string name="h9" value="消耗MP 25，伤害 112%，持续68秒"/>
+        <string name="h10" value="消耗MP 25，伤害 113%，持续75秒"/>
+        <string name="h11" value="消耗MP 30，伤害 114%，持续82秒"/>
+        <string name="h12" value="消耗MP 30，伤害 115%，持续89秒"/>
+        <string name="h13" value="消耗MP 30，伤害 116%，持续96秒"/>
+        <string name="h14" value="消耗MP 30，伤害 117%，持续103秒"/>
+        <string name="h15" value="消耗MP 30，伤害 117%，持续110秒"/>
+        <string name="h16" value="消耗MP 30，伤害 118%，持续116秒"/>
+        <string name="h17" value="消耗MP 30，伤害 118%，持续122秒"/>
+        <string name="h18" value="消耗MP 30，伤害 119%，持续128秒"/>
+        <string name="h19" value="消耗MP 30，伤害 119%，持续134秒"/>
+        <string name="h20" value="消耗MP 30，伤害 120%，持续140秒"/>
+        <string name="h21" value="消耗MP 35，伤害 120%，持续146秒"/>
+        <string name="h22" value="消耗MP 35，伤害 121%，持续152秒"/>
+        <string name="h23" value="消耗MP 35，伤害 121%，持续158秒"/>
+        <string name="h24" value="消耗MP 35，伤害 122%，持续164秒"/>
+        <string name="h25" value="消耗MP 35，伤害 122%，持续170秒"/>
+        <string name="h26" value="消耗MP 35，伤害 123%，持续176秒"/>
+        <string name="h27" value="消耗MP 35，伤害 123%，持续182秒"/>
+        <string name="h28" value="消耗MP 35，伤害 124%，持续188秒"/>
+        <string name="h29" value="消耗MP 35，伤害 124%，持续194秒"/>
+        <string name="h30" value="消耗MP 35，伤害 125%，持续200秒"/>
     </imgdir>
     <imgdir name="1211009">
-        <string name="name" value="防御崩坏"/>
-        <string name="h1" value="消耗MP 35，冷却时间 465秒"/>
-        <string name="h10" value="消费MP 17，冷却时间 330秒"/>
-        <string name="h11" value="消费MP 16，冷却时间 315秒"/>
-        <string name="h12" value="消费MP 15，冷却时间 300秒"/>
-        <string name="h13" value="消费MP 14，冷却时间 285秒"/>
-        <string name="h14" value="消费MP 13，冷却时间 270秒"/>
-        <string name="h15" value="消费MP 12，冷却时间 255秒"/>
-        <string name="h16" value="消费MP 11，冷却时间 240秒"/>
-        <string name="h17" value="消费MP 10，冷却时间 225秒"/>
-        <string name="h18" value="消费MP 9，冷却时间 210秒"/>
-        <string name="h19" value="消费MP 8，冷却时间 195秒"/>
-        <string name="h2" value="消费MP 33，冷却时间 450秒"/>
-        <string name="h20" value="消费MP 7，冷却时间 180秒"/>
-        <string name="h3" value="消费MP 31，冷却时间 435秒"/>
-        <string name="h4" value="消费MP 29，冷却时间 420秒"/>
-        <string name="h5" value="消费MP 27，冷却时间 405秒"/>
-        <string name="h6" value="消费MP 25，冷却时间 390秒"/>
-        <string name="h7" value="消费MP 23，冷却时间 375秒"/>
-        <string name="h8" value="消费MP 21，冷却时间 360秒"/>
-        <string name="h9" value="消费MP 19，冷却时间 345秒"/>
-        <string name="desc" value="[最高等级:20]\n取消周围怪物的物理防御\n冷却时间随着技能等级的增加而减少\n必需技能: #c属性攻击等级3以上#\n对#c暗黑龙王#无效"/>
+        <string name="name" value="魔法崩坏"/>
+        <string name="desc" value="[最高等级：20]\n以一定概率解除周围怪物的魔法防御提升效果。\n需要技能：#c属性攻击3级以上#"/>
+        <string name="h1" value="消耗MP 35，最多影响6个敌人，成功率 24%"/>
+        <string name="h2" value="消耗MP 33，最多影响6个敌人，成功率 28%"/>
+        <string name="h3" value="消耗MP 31，最多影响6个敌人，成功率 32%"/>
+        <string name="h4" value="消耗MP 29，最多影响6个敌人，成功率 36%"/>
+        <string name="h5" value="消耗MP 27，最多影响6个敌人，成功率 40%"/>
+        <string name="h6" value="消耗MP 25，最多影响6个敌人，成功率 44%"/>
+        <string name="h7" value="消耗MP 23，最多影响6个敌人，成功率 48%"/>
+        <string name="h8" value="消耗MP 21，最多影响6个敌人，成功率 52%"/>
+        <string name="h9" value="消耗MP 19，最多影响6个敌人，成功率 56%"/>
+        <string name="h10" value="消耗MP 17，最多影响6个敌人，成功率 60%"/>
+        <string name="h11" value="消耗MP 16，最多影响6个敌人，成功率 64%"/>
+        <string name="h12" value="消耗MP 15，最多影响6个敌人，成功率 68%"/>
+        <string name="h13" value="消耗MP 14，最多影响6个敌人，成功率 72%"/>
+        <string name="h14" value="消耗MP 13，最多影响6个敌人，成功率 76%"/>
+        <string name="h15" value="消耗MP 12，最多影响6个敌人，成功率 80%"/>
+        <string name="h16" value="消耗MP 11，最多影响6个敌人，成功率 84%"/>
+        <string name="h17" value="消耗MP 10，最多影响6个敌人，成功率 88%"/>
+        <string name="h18" value="消耗MP 9，最多影响6个敌人，成功率 92%"/>
+        <string name="h19" value="消耗MP 8，最多影响6个敌人，成功率 96%"/>
+        <string name="h20" value="消耗MP 7，最多影响6个敌人，成功率 100%"/>
     </imgdir>
     <imgdir name="12111002">
         <string name="name" value="封印术"/>
@@ -2723,346 +2723,346 @@
     </imgdir>
     <imgdir name="1220005">
         <string name="name" value="阿基里斯"/>
-        <string name="h1" value="减少伤害 5.5%"/>
-        <string name="h10" value="减少伤害 10%"/>
-        <string name="h11" value="减少伤害 10.5%"/>
-        <string name="h12" value="减少伤害 11%"/>
-        <string name="h13" value="减少伤害 11.5%"/>
-        <string name="h14" value="减少伤害 12%"/>
-        <string name="h15" value="减少伤害 12.5%"/>
-        <string name="h16" value="减少伤害 13%"/>
-        <string name="h17" value="减少伤害 13.5%"/>
-        <string name="h18" value="减少伤害 14%"/>
-        <string name="h19" value="减少伤害 14.5%"/>
-        <string name="h2" value="减少伤害 6%"/>
-        <string name="h20" value="减少伤害 15%"/>
-        <string name="h21" value="减少伤害 15.5%"/>
-        <string name="h22" value="减少伤害 16%"/>
-        <string name="h23" value="减少伤害 16.5%"/>
-        <string name="h24" value="减少伤害 17%"/>
-        <string name="h25" value="减少伤害 17.5%"/>
-        <string name="h26" value="减少伤害 18%"/>
-        <string name="h27" value="减少伤害 18.5%"/>
-        <string name="h28" value="减少伤害 19%"/>
-        <string name="h29" value="减少伤害 19.5%"/>
-        <string name="h3" value="减少伤害 6.5%"/>
-        <string name="h30" value="减少伤害 20%"/>
-        <string name="h4" value="减少伤害 7%"/>
-        <string name="h5" value="减少伤害 7.5%"/>
-        <string name="h6" value="减少伤害 8%"/>
-        <string name="h7" value="减少伤害 8.5%"/>
-        <string name="h8" value="减少伤害 9%"/>
-        <string name="h9" value="减少伤害 9.5%"/>
-        <string name="desc" value="永久强化盔甲,减弱伤害值"/>
+        <string name="desc" value="[最高等级：30]\n永久减少受到的敌人伤害。"/>
+        <string name="h1" value="受到的伤害减少 0.5%"/>
+        <string name="h2" value="受到的伤害减少 1%"/>
+        <string name="h3" value="受到的伤害减少 1.5%"/>
+        <string name="h4" value="受到的伤害减少 2%"/>
+        <string name="h5" value="受到的伤害减少 2.5%"/>
+        <string name="h6" value="受到的伤害减少 3%"/>
+        <string name="h7" value="受到的伤害减少 3.5%"/>
+        <string name="h8" value="受到的伤害减少 4%"/>
+        <string name="h9" value="受到的伤害减少 4.5%"/>
+        <string name="h10" value="受到的伤害减少 5%"/>
+        <string name="h11" value="受到的伤害减少 5.5%"/>
+        <string name="h12" value="受到的伤害减少 6%"/>
+        <string name="h13" value="受到的伤害减少 6.5%"/>
+        <string name="h14" value="受到的伤害减少 7%"/>
+        <string name="h15" value="受到的伤害减少 7.5%"/>
+        <string name="h16" value="受到的伤害减少 8%"/>
+        <string name="h17" value="受到的伤害减少 8.5%"/>
+        <string name="h18" value="受到的伤害减少 9%"/>
+        <string name="h19" value="受到的伤害减少 9.5%"/>
+        <string name="h20" value="受到的伤害减少 10%"/>
+        <string name="h21" value="受到的伤害减少 10.5%"/>
+        <string name="h22" value="受到的伤害减少 11%"/>
+        <string name="h23" value="受到的伤害减少 11.5%"/>
+        <string name="h24" value="受到的伤害减少 12%"/>
+        <string name="h25" value="受到的伤害减少 12.5%"/>
+        <string name="h26" value="受到的伤害减少 13%"/>
+        <string name="h27" value="受到的伤害减少 13.5%"/>
+        <string name="h28" value="受到的伤害减少 14%"/>
+        <string name="h29" value="受到的伤害减少 14.5%"/>
+        <string name="h30" value="受到的伤害减少 15%"/>
     </imgdir>
     <imgdir name="1220006">
-        <string name="name" value="寒冰掌"/>
-        <string name="h1" value="5.5%的几率防御敌人的攻击"/>
-        <string name="h10" value="10%的几率防御敌人的攻击"/>
-        <string name="h11" value="10.5%的几率防御敌人的攻击"/>
-        <string name="h12" value="11%的几率防御敌人的攻击"/>
-        <string name="h13" value="11.5%的几率防御敌人的攻击"/>
-        <string name="h14" value="12%的几率防御敌人的攻击"/>
-        <string name="h15" value="12.5%的几率防御敌人的攻击"/>
-        <string name="h16" value="13%的几率防御敌人的攻击"/>
-        <string name="h17" value="13.5%的几率防御敌人的攻击"/>
-        <string name="h18" value="14%的几率防御敌人的攻击"/>
-        <string name="h19" value="14.5%的几率防御敌人的攻击"/>
-        <string name="h2" value="6%的几率防御敌人的攻击"/>
-        <string name="h20" value="15%的几率防御敌人的攻击"/>
-        <string name="h21" value="15.5%的几率防御敌人的攻击"/>
-        <string name="h22" value="16%的几率防御敌人的攻击"/>
-        <string name="h23" value="16.5%的几率防御敌人的攻击"/>
-        <string name="h24" value="17%的几率防御敌人的攻击"/>
-        <string name="h25" value="17.5%的几率防御敌人的攻击"/>
-        <string name="h26" value="18%的几率防御敌人的攻击"/>
-        <string name="h27" value="18.5%的几率防御敌人的攻击"/>
-        <string name="h28" value="19%的几率防御敌人的攻击"/>
-        <string name="h29" value="19.5%的几率防御敌人的攻击"/>
-        <string name="h3" value="6.5%的几率防御敌人的攻击"/>
-        <string name="h30" value="20%的几率防御敌人的攻击"/>
-        <string name="h4" value="7%的几率防御敌人的攻击"/>
-        <string name="h5" value="7.5%的几率防御敌人的攻击"/>
-        <string name="h6" value="8%的几率防御敌人的攻击"/>
-        <string name="h7" value="8.5%的几率防御敌人的攻击"/>
-        <string name="h8" value="9%的几率防御敌人的攻击"/>
-        <string name="h9" value="9.5%的几率防御敌人的攻击"/>
-        <string name="desc" value="一定概率下用盾牌挡住敌人的攻击，近\n距离攻击防御成功的话，攻击自己的敌人\n2秒内处于昏迷状态，需装备盾牌"/>
+        <string name="name" value="守护之神"/>
+        <string name="desc" value="[最高等级：30]\n装备盾牌时，以一定概率格挡敌人的攻击。若格挡近距离攻击，攻击者会昏迷2秒。"/>
+        <string name="h1" value="0%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h2" value="1%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h3" value="1%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h4" value="2%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h5" value="2%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h6" value="3%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h7" value="3%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h8" value="4%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h9" value="4%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h10" value="5%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h11" value="5%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h12" value="6%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h13" value="6%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h14" value="7%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h15" value="7%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h16" value="8%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h17" value="8%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h18" value="9%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h19" value="9%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h20" value="10%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h21" value="10%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h22" value="11%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h23" value="11%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h24" value="12%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h25" value="12%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h26" value="13%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h27" value="13%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h28" value="14%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h29" value="14%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
+        <string name="h30" value="15%概率格挡；近距离格挡成功时使攻击者昏迷2秒"/>
     </imgdir>
     <imgdir name="1220010">
         <string name="name" value="万佛归一破"/>
-        <string name="h1" value="伤害 355%，10%的几率不会取消属性"/>
-        <string name="h10" value="伤害 400%，100%的几率不会取消属性"/>
-        <string name="h2" value="伤害 360%，20%的几率不会取消属性"/>
-        <string name="h3" value="伤害 365%，30%的几率不会取消属性"/>
-        <string name="h4" value="伤害 370%，40%的几率不会取消属性"/>
-        <string name="h5" value="伤害 375%，50%的几率不会取消属性"/>
-        <string name="h6" value="伤害 380%，60%的几率不会取消属性"/>
-        <string name="h7" value="伤害 385%，70%的几率不会取消属性"/>
-        <string name="h8" value="伤害 390%，80%的几率不会取消属性"/>
-        <string name="h9" value="伤害 395%，90%的几率不会取消属性"/>
-        <string name="desc" value="使用属性攻击的时候伤害上升，\n一定几率不会取消属性.\n必要技能 : #c属性攻击 30级#"/>
+        <string name="desc" value="[最高等级：10]\n提高属性攻击的伤害，并有一定概率在使用属性攻击后不解除当前属性。\n需要技能：#c属性攻击30级#"/>
+        <string name="h1" value="属性攻击伤害 260%，10%概率不解除属性"/>
+        <string name="h2" value="属性攻击伤害 270%，20%概率不解除属性"/>
+        <string name="h3" value="属性攻击伤害 280%，30%概率不解除属性"/>
+        <string name="h4" value="属性攻击伤害 290%，40%概率不解除属性"/>
+        <string name="h5" value="属性攻击伤害 300%，50%概率不解除属性"/>
+        <string name="h6" value="属性攻击伤害 310%，60%概率不解除属性"/>
+        <string name="h7" value="属性攻击伤害 320%，70%概率不解除属性"/>
+        <string name="h8" value="属性攻击伤害 330%，80%概率不解除属性"/>
+        <string name="h9" value="属性攻击伤害 340%，90%概率不解除属性"/>
+        <string name="h10" value="属性攻击伤害 350%，100%概率不解除属性"/>
     </imgdir>
     <imgdir name="1221000">
         <string name="name" value="冒险岛勇士"/>
-        <string name="h1" value="消耗MP 10，30秒内所有的属性点提高 1%"/>
-        <string name="h10" value="消耗MP 20，300秒内所有的属性点提高 5%"/>
-        <string name="h11" value="消耗MP 30，330秒内所有的属性点提高 6%"/>
-        <string name="h12" value="消耗MP 30，360秒内所有的属性点提高 6%"/>
-        <string name="h13" value="消耗MP 30，390秒内所有的属性点提高 7%"/>
-        <string name="h14" value="消耗MP 30，420秒内所有的属性点提高 7%"/>
-        <string name="h15" value="消耗MP 30，450秒内所有的属性点提高 8%"/>
-        <string name="h16" value="消耗MP 40，480秒内所有的属性点提高 8%"/>
-        <string name="h17" value="消耗MP 40，510秒内所有的属性点提高 9%"/>
-        <string name="h18" value="消耗MP 40，540秒内所有的属性点提高 9%"/>
-        <string name="h19" value="消耗MP 40，570秒内所有的属性点提高 10%"/>
-        <string name="h2" value="消耗MP 10，60秒内所有的属性点提高 1%"/>
-        <string name="h20" value="消耗MP 40，600秒内所有的属性点提高 10%"/>
-        <string name="h21" value="消耗MP 50，630秒内所有的属性点提高 11%"/>
-        <string name="h22" value="消耗MP 50，660秒内所有的属性点提高 11%"/>
-        <string name="h23" value="消耗MP 50，690秒内所有的属性点提高 12%"/>
-        <string name="h24" value="消耗MP 50，720秒内所有的属性点提高 12%"/>
-        <string name="h25" value="消耗MP 50，750秒内所有的属性点提高 13%"/>
-        <string name="h26" value="消耗MP 60，780秒内所有的属性点提高 13%"/>
-        <string name="h27" value="消耗MP 60，810秒内所有的属性点提高 14%"/>
-        <string name="h28" value="消耗MP 60，840秒内所有的属性点提高 14%"/>
-        <string name="h29" value="消耗MP 60，870秒内所有的属性点提高 15%"/>
-        <string name="h3" value="消耗MP 10，90秒内所有的属性点提高 2%"/>
-        <string name="h30" value="消耗MP 60，900秒内所有的属性点提高 15%"/>
-        <string name="h4" value="消耗MP 10，120秒内所有的属性点提高 2%"/>
-        <string name="h5" value="消耗MP 10，150秒内所有的属性点提高 3%"/>
-        <string name="h6" value="消耗MP 20，180秒内所有的属性点提高 3%"/>
-        <string name="h7" value="消耗MP 20，210秒内所有的属性点提高 4%"/>
-        <string name="h8" value="消耗MP 20，240秒内所有的属性点提高 4%"/>
-        <string name="h9" value="消耗MP 20，270秒内所有的属性点提高 5%"/>
-        <string name="desc" value="一定时间内把组队成员的所有属性点提高\n一定的百分比"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内按百分比提高自身及周围队员的所有属性。"/>
+        <string name="h1" value="消耗MP 10，所有属性 +1%，持续30秒"/>
+        <string name="h2" value="消耗MP 10，所有属性 +1%，持续60秒"/>
+        <string name="h3" value="消耗MP 10，所有属性 +2%，持续90秒"/>
+        <string name="h4" value="消耗MP 10，所有属性 +2%，持续120秒"/>
+        <string name="h5" value="消耗MP 10，所有属性 +3%，持续150秒"/>
+        <string name="h6" value="消耗MP 20，所有属性 +3%，持续180秒"/>
+        <string name="h7" value="消耗MP 20，所有属性 +4%，持续210秒"/>
+        <string name="h8" value="消耗MP 20，所有属性 +4%，持续240秒"/>
+        <string name="h9" value="消耗MP 20，所有属性 +5%，持续270秒"/>
+        <string name="h10" value="消耗MP 20，所有属性 +5%，持续300秒"/>
+        <string name="h11" value="消耗MP 30，所有属性 +6%，持续330秒"/>
+        <string name="h12" value="消耗MP 30，所有属性 +6%，持续360秒"/>
+        <string name="h13" value="消耗MP 30，所有属性 +7%，持续390秒"/>
+        <string name="h14" value="消耗MP 30，所有属性 +7%，持续420秒"/>
+        <string name="h15" value="消耗MP 30，所有属性 +8%，持续450秒"/>
+        <string name="h16" value="消耗MP 40，所有属性 +8%，持续480秒"/>
+        <string name="h17" value="消耗MP 40，所有属性 +9%，持续510秒"/>
+        <string name="h18" value="消耗MP 40，所有属性 +9%，持续540秒"/>
+        <string name="h19" value="消耗MP 40，所有属性 +10%，持续570秒"/>
+        <string name="h20" value="消耗MP 40，所有属性 +10%，持续600秒"/>
+        <string name="h21" value="消耗MP 50，所有属性 +11%，持续630秒"/>
+        <string name="h22" value="消耗MP 50，所有属性 +11%，持续660秒"/>
+        <string name="h23" value="消耗MP 50，所有属性 +12%，持续690秒"/>
+        <string name="h24" value="消耗MP 50，所有属性 +12%，持续720秒"/>
+        <string name="h25" value="消耗MP 50，所有属性 +13%，持续750秒"/>
+        <string name="h26" value="消耗MP 60，所有属性 +13%，持续780秒"/>
+        <string name="h27" value="消耗MP 60，所有属性 +14%，持续810秒"/>
+        <string name="h28" value="消耗MP 60，所有属性 +14%，持续840秒"/>
+        <string name="h29" value="消耗MP 60，所有属性 +15%，持续870秒"/>
+        <string name="h30" value="消耗MP 60，所有属性 +15%，持续900秒"/>
     </imgdir>
     <imgdir name="1221001">
         <string name="name" value="磁石"/>
-        <string name="h1" value="消耗MP 10，范围 100%，成功率 42%"/>
-        <string name="h10" value="消耗MP 13，范围 100%，成功率 60%"/>
-        <string name="h11" value="消耗MP 18，范围 150%，成功率 62%"/>
-        <string name="h12" value="消耗MP 18，范围 150%，成功率 64%"/>
-        <string name="h13" value="消耗MP 18，范围 150%，成功率 66%"/>
-        <string name="h14" value="消耗MP 18，范围 150%，成功率 68%"/>
-        <string name="h15" value="消耗MP 18，范围 150%，成功率 70%"/>
-        <string name="h16" value="消耗MP 21，范围 150%，成功率 72%"/>
-        <string name="h17" value="消耗MP 21，范围 150%，成功率 74%"/>
-        <string name="h18" value="消耗MP 21，范围 150%，成功率 76%"/>
-        <string name="h19" value="消耗MP 21，范围 150%，成功率 78%"/>
-        <string name="h2" value="消耗MP 10，范围 100%，成功率 44%"/>
-        <string name="h20" value="消耗MP 21，范围 150%，成功率 80%"/>
-        <string name="h21" value="消耗MP 26，范围 200%，成功率 82%"/>
-        <string name="h22" value="消耗MP 26，范围 200%，成功率 84%"/>
-        <string name="h23" value="消耗MP 26，范围 200%，成功率 86%"/>
-        <string name="h24" value="消耗MP 26，范围 200%，成功率 88%"/>
-        <string name="h25" value="消耗MP 26，范围 200%，成功率 90%"/>
-        <string name="h26" value="消耗MP 25，范围 200%，成功率 91%"/>
-        <string name="h27" value="消耗MP 24，范围 200%，成功率 92%"/>
-        <string name="h28" value="消耗MP 23，范围 200%，成功率 93%"/>
-        <string name="h29" value="消耗MP 22，范围 200%，成功率 94%"/>
-        <string name="h3" value="消耗MP 10，范围 100%，成功率 46%"/>
-        <string name="h30" value="消耗MP 21，范围 200%，成功率 95%"/>
-        <string name="h4" value="消耗MP 10，范围 100%，成功率 48%"/>
-        <string name="h5" value="消耗MP 10，范围 100%，成功率 50%"/>
-        <string name="h6" value="消耗MP 13，范围 100%，成功率 52%"/>
-        <string name="h7" value="消耗MP 13，范围 100%，成功率 54%"/>
-        <string name="h8" value="消耗MP 13，范围 100%，成功率 56%"/>
-        <string name="h9" value="消耗MP 13，范围 100%，成功率 58%"/>
-        <string name="desc" value="把远处的敌人最多能6只吸到自己面前"/>
+        <string name="desc" value="[最高等级：30]\n以一定概率将远处的怪物拉到自己面前。"/>
+        <string name="h1" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h2" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h3" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h4" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h5" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h6" value="消耗MP 13，最多牵引3个敌人，成功率 100%"/>
+        <string name="h7" value="消耗MP 13，最多牵引3个敌人，成功率 100%"/>
+        <string name="h8" value="消耗MP 13，最多牵引4个敌人，成功率 100%"/>
+        <string name="h9" value="消耗MP 13，最多牵引4个敌人，成功率 100%"/>
+        <string name="h10" value="消耗MP 13，最多牵引4个敌人，成功率 100%"/>
+        <string name="h11" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h12" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h13" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h14" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h15" value="消耗MP 18，最多牵引5个敌人，成功率 100%"/>
+        <string name="h16" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h17" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h18" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h19" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h20" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h21" value="消耗MP 26，最多牵引5个敌人，成功率 100%"/>
+        <string name="h22" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h23" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h24" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h25" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h26" value="消耗MP 25，最多牵引6个敌人，成功率 100%"/>
+        <string name="h27" value="消耗MP 24，最多牵引6个敌人，成功率 100%"/>
+        <string name="h28" value="消耗MP 23，最多牵引6个敌人，成功率 100%"/>
+        <string name="h29" value="消耗MP 22，最多牵引7个敌人，成功率 100%"/>
+        <string name="h30" value="消耗MP 21，最多牵引7个敌人，成功率 100%"/>
     </imgdir>
     <imgdir name="1221002">
         <string name="name" value="稳如泰山"/>
-        <string name="h1" value="消耗MP 30，10秒内有42%的几率不会出现退后现象"/>
-        <string name="h10" value="消耗MP 36，100秒内有60%的几率不会出现退后现象"/>
-        <string name="h11" value="消耗MP 41，110秒内有62%的几率不会出现退后现象"/>
-        <string name="h12" value="消耗MP 41，120秒内有64%的几率不会出现退后现象"/>
-        <string name="h13" value="消耗MP 41，130秒内有66%的几率不会出现退后现象"/>
-        <string name="h14" value="消耗MP 41，140秒内有68%的几率不会出现退后现象"/>
-        <string name="h15" value="消耗MP 41，150秒内有70%的几率不会出现退后现象"/>
-        <string name="h16" value="消耗MP 48，160秒内有72%的几率不会出现退后现象"/>
-        <string name="h17" value="消耗MP 48，170秒内有74%的几率不会出现退后现象"/>
-        <string name="h18" value="消耗MP 48，180秒内有76%的几率不会出现退后现象"/>
-        <string name="h19" value="消耗MP 48，190秒内有78%的几率不会出现退后现象"/>
-        <string name="h2" value="消耗MP 30，20秒内有44%的几率不会出现退后现象"/>
-        <string name="h20" value="消耗MP 48，200秒内有80%的几率不会出现退后现象"/>
-        <string name="h21" value="消耗MP 54，210秒内有81%的几率不会出现退后现象"/>
-        <string name="h22" value="消耗MP 54，220秒内有82%的几率不会出现退后现象"/>
-        <string name="h23" value="消耗MP 54，230秒内有83%的几率不会出现退后现象"/>
-        <string name="h24" value="消耗MP 54，240秒内有84%的几率不会出现退后现象"/>
-        <string name="h25" value="消耗MP 54，250秒内有85%的几率不会出现退后现象"/>
-        <string name="h26" value="消耗MP 53，260秒内有86%的几率不会出现退后现象"/>
-        <string name="h27" value="消耗MP 52，270秒内有87%的几率不会出现退后现象"/>
-        <string name="h28" value="消耗MP 51，280秒内有88%的几率不会出现退后现象"/>
-        <string name="h29" value="消耗MP 50，290秒内有89%的几率不会出现退后现象"/>
-        <string name="h3" value="消耗MP 30，30秒内有46%的几率不会出现退后现象"/>
-        <string name="h30" value="消耗MP 50，300秒内有90%的几率不会出现退后现象"/>
-        <string name="h4" value="消耗MP 30，40秒内有48%的几率不会出现退后现象"/>
-        <string name="h5" value="消耗MP 30，50秒内有50%的几率不会出现退后现象"/>
-        <string name="h6" value="消耗MP 36，60秒内有52%的几率不会出现退后现象"/>
-        <string name="h7" value="消耗MP 36，70秒内有54%的几率不会出现退后现象"/>
-        <string name="h8" value="消耗MP 36，80秒内有56%的几率不会出现退后现象"/>
-        <string name="h9" value="消耗MP 36，90秒内有58%的几率不会出现退后现象"/>
-        <string name="desc" value="凭借着强韧的精神，\n受到敌人的攻击仍不会后退"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内以一定概率抵抗敌人攻击造成的击退。"/>
+        <string name="h1" value="消耗MP 30，42%概率抵抗击退，持续10秒"/>
+        <string name="h2" value="消耗MP 30，44%概率抵抗击退，持续20秒"/>
+        <string name="h3" value="消耗MP 30，46%概率抵抗击退，持续30秒"/>
+        <string name="h4" value="消耗MP 30，48%概率抵抗击退，持续40秒"/>
+        <string name="h5" value="消耗MP 30，50%概率抵抗击退，持续50秒"/>
+        <string name="h6" value="消耗MP 36，52%概率抵抗击退，持续60秒"/>
+        <string name="h7" value="消耗MP 36，54%概率抵抗击退，持续70秒"/>
+        <string name="h8" value="消耗MP 36，56%概率抵抗击退，持续80秒"/>
+        <string name="h9" value="消耗MP 36，58%概率抵抗击退，持续90秒"/>
+        <string name="h10" value="消耗MP 36，60%概率抵抗击退，持续100秒"/>
+        <string name="h11" value="消耗MP 42，62%概率抵抗击退，持续110秒"/>
+        <string name="h12" value="消耗MP 42，64%概率抵抗击退，持续120秒"/>
+        <string name="h13" value="消耗MP 42，66%概率抵抗击退，持续130秒"/>
+        <string name="h14" value="消耗MP 42，68%概率抵抗击退，持续140秒"/>
+        <string name="h15" value="消耗MP 42，70%概率抵抗击退，持续150秒"/>
+        <string name="h16" value="消耗MP 48，72%概率抵抗击退，持续160秒"/>
+        <string name="h17" value="消耗MP 48，74%概率抵抗击退，持续170秒"/>
+        <string name="h18" value="消耗MP 48，76%概率抵抗击退，持续180秒"/>
+        <string name="h19" value="消耗MP 48，78%概率抵抗击退，持续190秒"/>
+        <string name="h20" value="消耗MP 48，80%概率抵抗击退，持续200秒"/>
+        <string name="h21" value="消耗MP 54，81%概率抵抗击退，持续210秒"/>
+        <string name="h22" value="消耗MP 54，82%概率抵抗击退，持续220秒"/>
+        <string name="h23" value="消耗MP 54，83%概率抵抗击退，持续230秒"/>
+        <string name="h24" value="消耗MP 54，84%概率抵抗击退，持续240秒"/>
+        <string name="h25" value="消耗MP 54，85%概率抵抗击退，持续250秒"/>
+        <string name="h26" value="消耗MP 53，86%概率抵抗击退，持续260秒"/>
+        <string name="h27" value="消耗MP 52，87%概率抵抗击退，持续270秒"/>
+        <string name="h28" value="消耗MP 51，88%概率抵抗击退，持续280秒"/>
+        <string name="h29" value="消耗MP 50，89%概率抵抗击退，持续290秒"/>
+        <string name="h30" value="消耗MP 50，90%概率抵抗击退，持续300秒"/>
     </imgdir>
     <imgdir name="1221003">
         <string name="name" value="圣灵之剑"/>
-        <string name="h1" value="消耗MP 20，伤害122%，持续时间110秒,属性纯度50%"/>
-        <string name="h10" value="消耗MP 20，伤害140%，持续时间200秒,属性纯度50%"/>
-        <string name="h11" value="消耗MP 20，伤害142%，持续时间210秒,属性纯度50%"/>
-        <string name="h12" value="消耗MP 30，伤害144%，持续时间220秒,属性纯度50%"/>
-        <string name="h13" value="消耗MP 30，伤害146%，持续时间230秒,属性纯度50%"/>
-        <string name="h14" value="消耗MP 30，伤害148%，持续时间240秒,属性纯度50%"/>
-        <string name="h15" value="消耗MP 30，伤害150%，持续时间250秒,属性纯度50%"/>
-        <string name="h16" value="消耗MP 30，伤害152%，持续时间260秒,属性纯度50%"/>
-        <string name="h17" value="消耗MP 30，伤害154%，持续时间270秒,属性纯度50%"/>
-        <string name="h18" value="消耗MP 30，伤害156%，持续时间280秒,属性纯度50%"/>
-        <string name="h19" value="消耗MP 30，伤害158%，持续时间290秒,属性纯度50%"/>
-        <string name="h2" value="消耗MP 20，伤害124%，持续时间120秒,属性纯度50%"/>
-        <string name="h20" value="消耗MP 35，伤害160%，持续时间300秒,属性纯度50%"/>
-        <string name="h3" value="消耗MP 20，伤害126%，持续时间130秒,属性纯度50%"/>
-        <string name="h4" value="消耗MP 20，伤害128%，持续时间140秒,属性纯度50%"/>
-        <string name="h5" value="消耗MP 20，伤害130%，持续时间150秒,属性纯度50%"/>
-        <string name="h6" value="消耗MP 20，伤害132%，持续时间160秒,属性纯度50%"/>
-        <string name="h7" value="消耗MP 20，伤害134%，持续时间170秒,属性纯度50%"/>
-        <string name="h8" value="消耗MP 20，伤害136%，持续时间180秒,属性纯度50%"/>
-        <string name="h9" value="消耗MP 20，伤害138%，持续时间190秒,属性纯度50%"/>
-        <string name="desc" value="在一定时间内赋予剑圣属性。\n若已到时间或使用属性攻击便会取消"/>
+        <string name="desc" value="[最高等级：20]\n一定时间内为装备中的剑附加圣属性。使用属性攻击时可能消耗该属性，或在持续时间结束后消失。"/>
+        <string name="h1" value="消耗MP 20，伤害 102%，持续15秒"/>
+        <string name="h2" value="消耗MP 20，伤害 104%，持续30秒"/>
+        <string name="h3" value="消耗MP 20，伤害 106%，持续45秒"/>
+        <string name="h4" value="消耗MP 20，伤害 108%，持续60秒"/>
+        <string name="h5" value="消耗MP 20，伤害 110%，持续75秒"/>
+        <string name="h6" value="消耗MP 20，伤害 112%，持续90秒"/>
+        <string name="h7" value="消耗MP 20，伤害 114%，持续105秒"/>
+        <string name="h8" value="消耗MP 20，伤害 116%，持续120秒"/>
+        <string name="h9" value="消耗MP 20，伤害 118%，持续135秒"/>
+        <string name="h10" value="消耗MP 20，伤害 120%，持续150秒"/>
+        <string name="h11" value="消耗MP 30，伤害 122%，持续165秒"/>
+        <string name="h12" value="消耗MP 30，伤害 124%，持续180秒"/>
+        <string name="h13" value="消耗MP 30，伤害 126%，持续195秒"/>
+        <string name="h14" value="消耗MP 30，伤害 128%，持续210秒"/>
+        <string name="h15" value="消耗MP 30，伤害 130%，持续225秒"/>
+        <string name="h16" value="消耗MP 30，伤害 132%，持续240秒"/>
+        <string name="h17" value="消耗MP 30，伤害 134%，持续255秒"/>
+        <string name="h18" value="消耗MP 30，伤害 136%，持续270秒"/>
+        <string name="h19" value="消耗MP 30，伤害 138%，持续285秒"/>
+        <string name="h20" value="消耗MP 30，伤害 140%，持续300秒"/>
     </imgdir>
     <imgdir name="1221004">
         <string name="name" value="圣灵之锤"/>
-        <string name="h1" value="消耗MP 20，伤害122%，持续时间110秒,属性纯度50%"/>
-        <string name="h10" value="消耗MP 20，伤害140%，持续时间200秒,属性纯度50%"/>
-        <string name="h11" value="消耗MP 20，伤害142%，持续时间210秒,属性纯度50%"/>
-        <string name="h12" value="消耗MP 30，伤害144%，持续时间220秒,属性纯度50%"/>
-        <string name="h13" value="消耗MP 30，伤害146%，持续时间230秒,属性纯度50%"/>
-        <string name="h14" value="消耗MP 30，伤害148%，持续时间240秒,属性纯度50%"/>
-        <string name="h15" value="消耗MP 30，伤害150%，持续时间250秒,属性纯度50%"/>
-        <string name="h16" value="消耗MP 30，伤害152%，持续时间260秒,属性纯度50%"/>
-        <string name="h17" value="消耗MP 30，伤害154%，持续时间270秒,属性纯度50%"/>
-        <string name="h18" value="消耗MP 30，伤害156%，持续时间280秒,属性纯度50%"/>
-        <string name="h19" value="消耗MP 30，伤害158%，持续时间290秒,属性纯度50%"/>
-        <string name="h2" value="消耗MP 20，伤害124%，持续时间120秒,属性纯度50%"/>
-        <string name="h20" value="消耗MP 35，伤害160%，持续时间300秒,属性纯度50%"/>
-        <string name="h3" value="消耗MP 20，伤害126%，持续时间130秒,属性纯度50%"/>
-        <string name="h4" value="消耗MP 20，伤害128%，持续时间140秒,属性纯度50%"/>
-        <string name="h5" value="消耗MP 20，伤害130%，持续时间150秒,属性纯度50%"/>
-        <string name="h6" value="消耗MP 20，伤害132%，持续时间160秒,属性纯度50%"/>
-        <string name="h7" value="消耗MP 20，伤害134%，持续时间170秒,属性纯度50%"/>
-        <string name="h8" value="消耗MP 20，伤害136%，持续时间180秒,属性纯度50%"/>
-        <string name="h9" value="消耗MP 20，伤害138%，持续时间190秒,属性纯度50%"/>
-        <string name="desc" value="在一定时间内赋予棍圣属性。\n若以到时间或使用属性攻击便会取消"/>
+        <string name="desc" value="[最高等级：20]\n一定时间内为装备中的钝器附加圣属性。使用属性攻击时可能消耗该属性，或在持续时间结束后消失。"/>
+        <string name="h1" value="消耗MP 20，伤害 102%，持续15秒"/>
+        <string name="h2" value="消耗MP 20，伤害 104%，持续30秒"/>
+        <string name="h3" value="消耗MP 20，伤害 106%，持续45秒"/>
+        <string name="h4" value="消耗MP 20，伤害 108%，持续60秒"/>
+        <string name="h5" value="消耗MP 20，伤害 110%，持续75秒"/>
+        <string name="h6" value="消耗MP 20，伤害 112%，持续90秒"/>
+        <string name="h7" value="消耗MP 20，伤害 114%，持续105秒"/>
+        <string name="h8" value="消耗MP 20，伤害 116%，持续120秒"/>
+        <string name="h9" value="消耗MP 20，伤害 118%，持续135秒"/>
+        <string name="h10" value="消耗MP 20，伤害 120%，持续150秒"/>
+        <string name="h11" value="消耗MP 30，伤害 122%，持续165秒"/>
+        <string name="h12" value="消耗MP 30，伤害 124%，持续180秒"/>
+        <string name="h13" value="消耗MP 30，伤害 126%，持续195秒"/>
+        <string name="h14" value="消耗MP 30，伤害 128%，持续210秒"/>
+        <string name="h15" value="消耗MP 30，伤害 130%，持续225秒"/>
+        <string name="h16" value="消耗MP 30，伤害 132%，持续240秒"/>
+        <string name="h17" value="消耗MP 30，伤害 134%，持续255秒"/>
+        <string name="h18" value="消耗MP 30，伤害 136%，持续270秒"/>
+        <string name="h19" value="消耗MP 30，伤害 138%，持续285秒"/>
+        <string name="h20" value="消耗MP 30，伤害 140%，持续300秒"/>
     </imgdir>
     <imgdir name="1221007">
         <string name="name" value="突进"/>
-        <string name="h1" value="消耗MP 22，伤害 72%，范围 80%"/>
-        <string name="h10" value="消耗MP 40，伤害 90%，范围 90%"/>
-        <string name="h11" value="消耗MP 42，伤害 92%，范围 95%"/>
-        <string name="h12" value="消耗MP 44，伤害 94%，范围 95%"/>
-        <string name="h13" value="消耗MP 46，伤害 96%，范围 95%"/>
-        <string name="h14" value="消耗MP 48，伤害 98%，范围 100%"/>
-        <string name="h15" value="消耗MP 50，伤害 100%，范围 100%"/>
-        <string name="h16" value="消耗MP 52，伤害 102%，范围 100%"/>
-        <string name="h17" value="消耗MP 54，伤害 104%，范围 105%"/>
-        <string name="h18" value="消耗MP 56，伤害 106%，范围 105%"/>
-        <string name="h19" value="消耗MP 58，伤害 108%，范围 105%"/>
-        <string name="h2" value="消耗MP 24，伤害 74%，范围 80%"/>
-        <string name="h20" value="消耗MP 60，伤害 110%，范围 110%"/>
-        <string name="h21" value="消耗MP 59，伤害 112%，范围 110%"/>
-        <string name="h22" value="消耗MP 58，伤害 114%，范围 115%"/>
-        <string name="h23" value="消耗MP 57，伤害 116%，范围 115%"/>
-        <string name="h24" value="消耗MP 56，伤害 118%，范围 115%"/>
-        <string name="h25" value="消耗MP 55，伤害 120%，范围 120%"/>
-        <string name="h26" value="消耗MP 54，伤害 122%，范围 120%"/>
-        <string name="h27" value="消耗MP 53，伤害 124%，范围 120%"/>
-        <string name="h28" value="消耗MP 52，伤害 126%，范围 125%"/>
-        <string name="h29" value="消耗MP 51，伤害 128%，范围 125%"/>
-        <string name="h3" value="消耗MP 26，伤害 76%，范围 80%"/>
-        <string name="h30" value="消耗MP 50，伤害 130%，范围 125%"/>
-        <string name="h4" value="消耗MP 28，伤害 78%，范围 85%"/>
-        <string name="h5" value="消耗MP 30，伤害 80%，范围 85%"/>
-        <string name="h6" value="消耗MP 32，伤害 82%，范围 85%"/>
-        <string name="h7" value="消耗MP 34，伤害 84%，范围 85%"/>
-        <string name="h8" value="消耗MP 36，伤害 86%，范围 90%"/>
-        <string name="h9" value="消耗MP 38，伤害 88%，范围 90%"/>
-        <string name="desc" value="向前攻击，把自己前面的敌人推开"/>
+        <string name="desc" value="[最高等级：30]\n向前突进，攻击并推动最多15只怪物。"/>
+        <string name="h1" value="消耗MP 22，伤害 72%，最多推动15个敌人"/>
+        <string name="h2" value="消耗MP 24，伤害 74%，最多推动15个敌人"/>
+        <string name="h3" value="消耗MP 26，伤害 76%，最多推动15个敌人"/>
+        <string name="h4" value="消耗MP 28，伤害 78%，最多推动15个敌人"/>
+        <string name="h5" value="消耗MP 30，伤害 80%，最多推动15个敌人"/>
+        <string name="h6" value="消耗MP 32，伤害 82%，最多推动15个敌人"/>
+        <string name="h7" value="消耗MP 34，伤害 84%，最多推动15个敌人"/>
+        <string name="h8" value="消耗MP 36，伤害 86%，最多推动15个敌人"/>
+        <string name="h9" value="消耗MP 38，伤害 88%，最多推动15个敌人"/>
+        <string name="h10" value="消耗MP 40，伤害 90%，最多推动15个敌人"/>
+        <string name="h11" value="消耗MP 42，伤害 92%，最多推动15个敌人"/>
+        <string name="h12" value="消耗MP 44，伤害 94%，最多推动15个敌人"/>
+        <string name="h13" value="消耗MP 46，伤害 96%，最多推动15个敌人"/>
+        <string name="h14" value="消耗MP 48，伤害 98%，最多推动15个敌人"/>
+        <string name="h15" value="消耗MP 50，伤害 100%，最多推动15个敌人"/>
+        <string name="h16" value="消耗MP 52，伤害 102%，最多推动15个敌人"/>
+        <string name="h17" value="消耗MP 54，伤害 104%，最多推动15个敌人"/>
+        <string name="h18" value="消耗MP 56，伤害 106%，最多推动15个敌人"/>
+        <string name="h19" value="消耗MP 58，伤害 108%，最多推动15个敌人"/>
+        <string name="h20" value="消耗MP 60，伤害 110%，最多推动15个敌人"/>
+        <string name="h21" value="消耗MP 59，伤害 112%，最多推动15个敌人"/>
+        <string name="h22" value="消耗MP 58，伤害 114%，最多推动15个敌人"/>
+        <string name="h23" value="消耗MP 57，伤害 116%，最多推动15个敌人"/>
+        <string name="h24" value="消耗MP 56，伤害 118%，最多推动15个敌人"/>
+        <string name="h25" value="消耗MP 55，伤害 120%，最多推动15个敌人"/>
+        <string name="h26" value="消耗MP 54，伤害 122%，最多推动15个敌人"/>
+        <string name="h27" value="消耗MP 53，伤害 124%，最多推动15个敌人"/>
+        <string name="h28" value="消耗MP 52，伤害 126%，最多推动15个敌人"/>
+        <string name="h29" value="消耗MP 51，伤害 128%，最多推动15个敌人"/>
+        <string name="h30" value="消耗MP 50，伤害 130%，最多推动15个敌人"/>
     </imgdir>
     <imgdir name="1221009">
-        <string name="name" value="连环环破"/>
-        <string name="h1" value="消耗MP 17，伤害 155%"/>
-        <string name="h10" value="消耗MP 20，伤害 200%"/>
-        <string name="h11" value="消耗MP 23，伤害 205%"/>
-        <string name="h12" value="消耗MP 23，伤害 210%"/>
-        <string name="h13" value="消耗MP 23，伤害 215%"/>
-        <string name="h14" value="消耗MP 23，伤害 220%"/>
-        <string name="h15" value="消耗MP 23，伤害 225%"/>
-        <string name="h16" value="消耗MP 26，伤害 230%"/>
-        <string name="h17" value="消耗MP 26，伤害 235%"/>
-        <string name="h18" value="消耗MP 26，伤害 240%"/>
-        <string name="h19" value="消耗MP 26，伤害 245%"/>
-        <string name="h2" value="消耗MP 17，伤害 160%"/>
-        <string name="h20" value="消耗MP 26，伤害 250%"/>
-        <string name="h21" value="消耗MP 29，伤害 255%"/>
-        <string name="h22" value="消耗MP 29，伤害 260%"/>
-        <string name="h23" value="消耗MP 29，伤害 265%"/>
-        <string name="h24" value="消耗MP 29，伤害 270%"/>
-        <string name="h25" value="消耗MP 29，伤害 275%"/>
-        <string name="h26" value="消耗MP 28，伤害 280%"/>
-        <string name="h27" value="消耗MP 27，伤害 285%"/>
-        <string name="h28" value="消耗MP 26，伤害 290%"/>
-        <string name="h29" value="消耗MP 25，伤害 295%"/>
-        <string name="h3" value="消耗MP 17，伤害 165%"/>
-        <string name="h30" value="消耗MP 24，伤害 300%"/>
-        <string name="h4" value="消耗MP 17，伤害 170%"/>
-        <string name="h5" value="消耗MP 17，伤害 175%"/>
-        <string name="h6" value="消耗MP 20，伤害 180%"/>
-        <string name="h7" value="消耗MP 20，伤害 185%"/>
-        <string name="h8" value="消耗MP 20，伤害 190%"/>
-        <string name="h9" value="消耗MP 20，伤害 195%"/>
-        <string name="desc" value="给单个敌人一次强攻击"/>
+        <string name="name" value="连环破"/>
+        <string name="desc" value="[最高等级：30]\n对单个怪物发动强力一击。"/>
+        <string name="h1" value="消耗MP 17，伤害 170%"/>
+        <string name="h2" value="消耗MP 17，伤害 190%"/>
+        <string name="h3" value="消耗MP 17，伤害 210%"/>
+        <string name="h4" value="消耗MP 17，伤害 230%"/>
+        <string name="h5" value="消耗MP 17，伤害 250%"/>
+        <string name="h6" value="消耗MP 20，伤害 270%"/>
+        <string name="h7" value="消耗MP 20，伤害 290%"/>
+        <string name="h8" value="消耗MP 20，伤害 310%"/>
+        <string name="h9" value="消耗MP 20，伤害 330%"/>
+        <string name="h10" value="消耗MP 20，伤害 350%"/>
+        <string name="h11" value="消耗MP 23，伤害 360%"/>
+        <string name="h12" value="消耗MP 23，伤害 370%"/>
+        <string name="h13" value="消耗MP 23，伤害 380%"/>
+        <string name="h14" value="消耗MP 23，伤害 390%"/>
+        <string name="h15" value="消耗MP 23，伤害 400%"/>
+        <string name="h16" value="消耗MP 26，伤害 410%"/>
+        <string name="h17" value="消耗MP 26，伤害 420%"/>
+        <string name="h18" value="消耗MP 26，伤害 430%"/>
+        <string name="h19" value="消耗MP 26，伤害 440%"/>
+        <string name="h20" value="消耗MP 26，伤害 450%"/>
+        <string name="h21" value="消耗MP 29，伤害 460%"/>
+        <string name="h22" value="消耗MP 29，伤害 470%"/>
+        <string name="h23" value="消耗MP 29，伤害 480%"/>
+        <string name="h24" value="消耗MP 29，伤害 490%"/>
+        <string name="h25" value="消耗MP 29，伤害 500%"/>
+        <string name="h26" value="消耗MP 28，伤害 510%"/>
+        <string name="h27" value="消耗MP 27，伤害 520%"/>
+        <string name="h28" value="消耗MP 26，伤害 530%"/>
+        <string name="h29" value="消耗MP 25，伤害 540%"/>
+        <string name="h30" value="消耗MP 24，伤害 550%"/>
     </imgdir>
     <imgdir name="1221011">
         <string name="name" value="圣域"/>
-        <string name="h1" value="消耗MP 31，伤害 420%，冷却时间 310秒"/>
-        <string name="h10" value="消耗MP 40，伤害 600%，冷却时间 220秒"/>
-        <string name="h11" value="消耗MP 41，伤害 620%，冷却时间 210秒"/>
-        <string name="h12" value="消耗MP 42，伤害 640%，冷却时间 200秒"/>
-        <string name="h13" value="消耗MP 43，伤害 660%，冷却时间 190秒"/>
-        <string name="h14" value="消耗MP 44，伤害 680%，冷却时间 180秒"/>
-        <string name="h15" value="消耗MP 45，伤害 700%，冷却时间 170秒"/>
-        <string name="h16" value="消耗MP 46，伤害 720%，冷却时间 160秒"/>
-        <string name="h17" value="消耗MP 47，伤害 740%，冷却时间 150秒"/>
-        <string name="h18" value="消耗MP 48，伤害 760%，冷却时间 140秒"/>
-        <string name="h19" value="消耗MP 49，伤害 780%，冷却时间 130秒"/>
-        <string name="h2" value="消耗MP 32，伤害 440%，冷却时间 300秒"/>
-        <string name="h20" value="消耗MP 50，伤害 800%，冷却时间 120秒"/>
-        <string name="h21" value="消耗MP 51，伤害 810%，冷却时间 110秒"/>
-        <string name="h22" value="消耗MP 52，伤害 820%，冷却时间 100秒"/>
-        <string name="h23" value="消耗MP 53，伤害 830%，冷却时间 90秒"/>
-        <string name="h24" value="消耗MP 54，伤害 840%，冷却时间 80秒"/>
-        <string name="h25" value="消耗MP 55，伤害 850%，冷却时间 70秒"/>
-        <string name="h26" value="消耗MP 56，伤害 860%，冷却时间 60秒"/>
-        <string name="h27" value="消耗MP 57，伤害 870%，冷却时间 50秒"/>
-        <string name="h28" value="消耗MP 58，伤害 880%，冷却时间 40秒"/>
-        <string name="h29" value="消耗MP 59，伤害 890%，冷却时间 30秒"/>
-        <string name="h3" value="消耗MP 33，伤害 460%，冷却时间 290秒"/>
-        <string name="h30" value="消耗MP 60，伤害 900%，冷却时间 20秒"/>
-        <string name="h4" value="消耗MP 34，伤害 480%，冷却时间 280秒"/>
-        <string name="h5" value="消耗MP 35，伤害 500%，冷却时间 270秒"/>
-        <string name="h6" value="消耗MP 36，伤害 520%，冷却时间 260秒"/>
-        <string name="h7" value="消耗MP 37，伤害 540%，冷却时间 250秒"/>
-        <string name="h8" value="消耗MP 38，伤害 560%，冷却时间 240秒"/>
-        <string name="h9" value="消耗MP 39，伤害 580%，冷却时间 230秒"/>
-        <string name="desc" value="用大锤子敲地,攻击15只以下的敌人.\n受到攻击的敌人体力只剩1"/>
+        <string name="desc" value="[最高等级：30]\n用巨锤震击地面，攻击最多15只怪物。普通怪物被命中后HP降至1。"/>
+        <string name="h1" value="消耗MP 31，伤害 420%，最多攻击15个敌人，冷却时间 310秒"/>
+        <string name="h2" value="消耗MP 32，伤害 440%，最多攻击15个敌人，冷却时间 300秒"/>
+        <string name="h3" value="消耗MP 33，伤害 460%，最多攻击15个敌人，冷却时间 290秒"/>
+        <string name="h4" value="消耗MP 34，伤害 480%，最多攻击15个敌人，冷却时间 280秒"/>
+        <string name="h5" value="消耗MP 35，伤害 500%，最多攻击15个敌人，冷却时间 270秒"/>
+        <string name="h6" value="消耗MP 36，伤害 520%，最多攻击15个敌人，冷却时间 260秒"/>
+        <string name="h7" value="消耗MP 37，伤害 540%，最多攻击15个敌人，冷却时间 250秒"/>
+        <string name="h8" value="消耗MP 38，伤害 560%，最多攻击15个敌人，冷却时间 240秒"/>
+        <string name="h9" value="消耗MP 39，伤害 580%，最多攻击15个敌人，冷却时间 230秒"/>
+        <string name="h10" value="消耗MP 40，伤害 600%，最多攻击15个敌人，冷却时间 220秒"/>
+        <string name="h11" value="消耗MP 41，伤害 620%，最多攻击15个敌人，冷却时间 210秒"/>
+        <string name="h12" value="消耗MP 42，伤害 640%，最多攻击15个敌人，冷却时间 200秒"/>
+        <string name="h13" value="消耗MP 43，伤害 660%，最多攻击15个敌人，冷却时间 190秒"/>
+        <string name="h14" value="消耗MP 44，伤害 680%，最多攻击15个敌人，冷却时间 180秒"/>
+        <string name="h15" value="消耗MP 45，伤害 700%，最多攻击15个敌人，冷却时间 170秒"/>
+        <string name="h16" value="消耗MP 46，伤害 720%，最多攻击15个敌人，冷却时间 160秒"/>
+        <string name="h17" value="消耗MP 47，伤害 740%，最多攻击15个敌人，冷却时间 150秒"/>
+        <string name="h18" value="消耗MP 48，伤害 760%，最多攻击15个敌人，冷却时间 140秒"/>
+        <string name="h19" value="消耗MP 49，伤害 780%，最多攻击15个敌人，冷却时间 130秒"/>
+        <string name="h20" value="消耗MP 50，伤害 800%，最多攻击15个敌人，冷却时间 120秒"/>
+        <string name="h21" value="消耗MP 51，伤害 810%，最多攻击15个敌人，冷却时间 110秒"/>
+        <string name="h22" value="消耗MP 52，伤害 820%，最多攻击15个敌人，冷却时间 100秒"/>
+        <string name="h23" value="消耗MP 53，伤害 830%，最多攻击15个敌人，冷却时间 90秒"/>
+        <string name="h24" value="消耗MP 54，伤害 840%，最多攻击15个敌人，冷却时间 80秒"/>
+        <string name="h25" value="消耗MP 55，伤害 850%，最多攻击15个敌人，冷却时间 70秒"/>
+        <string name="h26" value="消耗MP 56，伤害 860%，最多攻击15个敌人，冷却时间 60秒"/>
+        <string name="h27" value="消耗MP 57，伤害 870%，最多攻击15个敌人，冷却时间 50秒"/>
+        <string name="h28" value="消耗MP 58，伤害 880%，最多攻击15个敌人，冷却时间 40秒"/>
+        <string name="h29" value="消耗MP 59，伤害 890%，最多攻击15个敌人，冷却时间 30秒"/>
+        <string name="h30" value="消耗MP 60，伤害 900%，最多攻击15个敌人，冷却时间 20秒"/>
     </imgdir>
     <imgdir name="1221012">
         <string name="name" value="勇士的意志"/>
-        <string name="h1" value="消耗MP 30，解除诱惑异常状态，冷却时间10分钟"/>
-        <string name="h2" value="消耗MP 30，解除诱惑异常状态，冷却时间9分钟"/>
-        <string name="h3" value="消耗MP 30，解除诱惑异常状态，冷却时间8分钟"/>
-        <string name="h4" value="消耗MP 30，解除诱惑异常状态，冷却时间7分钟"/>
-        <string name="h5" value="消耗MP 30，解除诱惑异常状态，冷却时间6分钟"/>
-        <string name="desc" value="从异常状态中恢复. \n随着等级的上升,冷却时间逐渐缩短"/>
+        <string name="desc" value="[最高等级：5]\n解除部分异常状态。技能等级越高，冷却时间越短。"/>
+        <string name="h1" value="消耗MP 30，解除异常状态，冷却时间 600秒"/>
+        <string name="h2" value="消耗MP 30，解除异常状态，冷却时间 540秒"/>
+        <string name="h3" value="消耗MP 30，解除异常状态，冷却时间 480秒"/>
+        <string name="h4" value="消耗MP 30，解除异常状态，冷却时间 420秒"/>
+        <string name="h5" value="消耗MP 30，解除异常状态，冷却时间 360秒"/>
     </imgdir>
     <imgdir name="130">
         <string name="bookName" value="枪战士技能"/>
@@ -3072,27 +3072,27 @@
     </imgdir>
     <imgdir name="1300000">
         <string name="name" value="精准枪"/>
-        <string name="h1" value="枪系列武器的熟练度+15%， 命中率+1"/>
-        <string name="h10" value="枪系列武器的熟练度+35%， 命中率+10"/>
-        <string name="h11" value="枪系列武器的熟练度+40%， 命中率+11"/>
-        <string name="h12" value="枪系列武器的熟练度+40%， 命中率+12"/>
-        <string name="h13" value="枪系列武器的熟练度+45%， 命中率+13"/>
-        <string name="h14" value="枪系列武器的熟练度+45%， 命中率+14"/>
-        <string name="h15" value="枪系列武器的熟练度+50%， 命中率+15"/>
-        <string name="h16" value="枪系列武器的熟练度+50%， 命中率+16"/>
-        <string name="h17" value="枪系列武器的熟练度+55%， 命中率+17"/>
-        <string name="h18" value="枪系列武器的熟练度+55%， 命中率+18"/>
-        <string name="h19" value="枪系列武器的熟练度+60%， 命中率+19"/>
-        <string name="h2" value="枪系列武器的熟练度+15%， 命中率+2"/>
-        <string name="h20" value="枪系列武器的熟练度+60%， 命中率+20"/>
-        <string name="h3" value="枪系列武器的熟练度+20%， 命中率+3"/>
-        <string name="h4" value="枪系列武器的熟练度+20%， 命中率+4"/>
-        <string name="h5" value="枪系列武器的熟练度+25%， 命中率+5"/>
-        <string name="h6" value="枪系列武器的熟练度+25%， 命中率+6"/>
-        <string name="h7" value="枪系列武器的熟练度+30%， 命中率+7"/>
-        <string name="h8" value="枪系列武器的熟练度+30%， 命中率+8"/>
-        <string name="h9" value="枪系列武器的熟练度+35%， 命中率+9"/>
-        <string name="desc" value="[最高等级 : 20]\n增加使用枪系武器的命中率及熟练度\n(必须装备枪)"/>
+        <string name="desc" value="[最高等级：20]\n提高枪系武器的熟练度和命中率。只在装备对应武器时生效。"/>
+        <string name="h1" value="枪系武器熟练度 51%，命中率 +1"/>
+        <string name="h2" value="枪系武器熟练度 51%，命中率 +2"/>
+        <string name="h3" value="枪系武器熟练度 52%，命中率 +3"/>
+        <string name="h4" value="枪系武器熟练度 52%，命中率 +4"/>
+        <string name="h5" value="枪系武器熟练度 53%，命中率 +5"/>
+        <string name="h6" value="枪系武器熟练度 53%，命中率 +6"/>
+        <string name="h7" value="枪系武器熟练度 54%，命中率 +7"/>
+        <string name="h8" value="枪系武器熟练度 54%，命中率 +8"/>
+        <string name="h9" value="枪系武器熟练度 55%，命中率 +9"/>
+        <string name="h10" value="枪系武器熟练度 55%，命中率 +10"/>
+        <string name="h11" value="枪系武器熟练度 56%，命中率 +11"/>
+        <string name="h12" value="枪系武器熟练度 56%，命中率 +12"/>
+        <string name="h13" value="枪系武器熟练度 57%，命中率 +13"/>
+        <string name="h14" value="枪系武器熟练度 57%，命中率 +14"/>
+        <string name="h15" value="枪系武器熟练度 58%，命中率 +15"/>
+        <string name="h16" value="枪系武器熟练度 58%，命中率 +16"/>
+        <string name="h17" value="枪系武器熟练度 59%，命中率 +17"/>
+        <string name="h18" value="枪系武器熟练度 59%，命中率 +18"/>
+        <string name="h19" value="枪系武器熟练度 60%，命中率 +19"/>
+        <string name="h20" value="枪系武器熟练度 60%，命中率 +20"/>
     </imgdir>
     <imgdir name="13000000">
         <string name="name" value="强力箭"/>
@@ -3132,95 +3132,95 @@
     </imgdir>
     <imgdir name="1300001">
         <string name="name" value="精准矛"/>
-        <string name="h1" value="矛系列武器的熟练度+15%， 命中率+1"/>
-        <string name="h10" value="矛系列武器的熟练度+35%， 命中率+10"/>
-        <string name="h11" value="矛系列武器的熟练度+40%， 命中率+11"/>
-        <string name="h12" value="矛系列武器的熟练度+40%， 命中率+12"/>
-        <string name="h13" value="矛系列武器的熟练度+45%， 命中率+13"/>
-        <string name="h14" value="矛系列武器的熟练度+45%， 命中率+14"/>
-        <string name="h15" value="矛系列武器的熟练度+50%， 命中率+15"/>
-        <string name="h16" value="矛系列武器的熟练度+50%， 命中率+16"/>
-        <string name="h17" value="矛系列武器的熟练度+55%， 命中率+17"/>
-        <string name="h18" value="矛系列武器的熟练度+55%， 命中率+18"/>
-        <string name="h19" value="矛系列武器的熟练度+60%， 命中率+19"/>
-        <string name="h2" value="矛系列武器的熟练度+15%， 命中率+2"/>
-        <string name="h20" value="矛系列武器的熟练度+60%， 命中率+20"/>
-        <string name="h3" value="矛系列武器的熟练度+20%， 命中率+3"/>
-        <string name="h4" value="矛系列武器的熟练度+20%， 命中率+4"/>
-        <string name="h5" value="矛系列武器的熟练度+25%， 命中率+5"/>
-        <string name="h6" value="矛系列武器的熟练度+25%， 命中率+6"/>
-        <string name="h7" value="矛系列武器的熟练度+30%， 命中率+7"/>
-        <string name="h8" value="矛系列武器的熟练度+30%， 命中率+8"/>
-        <string name="h9" value="矛系列武器的熟练度+35%， 命中率+9"/>
-        <string name="desc" value="[最高等级 : 20]\n增加使用矛系武器的命中率及熟练度\n(必须装备矛)"/>
+        <string name="desc" value="[最高等级：20]\n提高矛系武器的熟练度和命中率。只在装备对应武器时生效。"/>
+        <string name="h1" value="矛系武器熟练度 51%，命中率 +1"/>
+        <string name="h2" value="矛系武器熟练度 51%，命中率 +2"/>
+        <string name="h3" value="矛系武器熟练度 52%，命中率 +3"/>
+        <string name="h4" value="矛系武器熟练度 52%，命中率 +4"/>
+        <string name="h5" value="矛系武器熟练度 53%，命中率 +5"/>
+        <string name="h6" value="矛系武器熟练度 53%，命中率 +6"/>
+        <string name="h7" value="矛系武器熟练度 54%，命中率 +7"/>
+        <string name="h8" value="矛系武器熟练度 54%，命中率 +8"/>
+        <string name="h9" value="矛系武器熟练度 55%，命中率 +9"/>
+        <string name="h10" value="矛系武器熟练度 55%，命中率 +10"/>
+        <string name="h11" value="矛系武器熟练度 56%，命中率 +11"/>
+        <string name="h12" value="矛系武器熟练度 56%，命中率 +12"/>
+        <string name="h13" value="矛系武器熟练度 57%，命中率 +13"/>
+        <string name="h14" value="矛系武器熟练度 57%，命中率 +14"/>
+        <string name="h15" value="矛系武器熟练度 58%，命中率 +15"/>
+        <string name="h16" value="矛系武器熟练度 58%，命中率 +16"/>
+        <string name="h17" value="矛系武器熟练度 59%，命中率 +17"/>
+        <string name="h18" value="矛系武器熟练度 59%，命中率 +18"/>
+        <string name="h19" value="矛系武器熟练度 60%，命中率 +19"/>
+        <string name="h20" value="矛系武器熟练度 60%，命中率 +20"/>
     </imgdir>
     <imgdir name="1300002">
         <string name="name" value="终极枪"/>
-        <string name="h1" value="出现概率2%，发挥105%的最终攻击"/>
-        <string name="h10" value="出现概率20%，发挥150%的最终攻击"/>
-        <string name="h11" value="出现概率22%，发挥155%的最终攻击"/>
-        <string name="h12" value="出现概率24%，发挥160%的最终攻击"/>
-        <string name="h13" value="出现概率26%，发挥165%的最终攻击"/>
-        <string name="h14" value="出现概率28%，发挥170%的最终攻击"/>
-        <string name="h15" value="出现概率30%，发挥175%的最终攻击"/>
-        <string name="h16" value="出现概率32%，发挥180%的最终攻击"/>
-        <string name="h17" value="出现概率34%，发挥185%的最终攻击"/>
-        <string name="h18" value="出现概率36%，发挥190%的最终攻击"/>
-        <string name="h19" value="出现概率38%，发挥195%的最终攻击"/>
-        <string name="h2" value="出现概率4%，发挥110%的最终攻击"/>
-        <string name="h20" value="出现概率40%，发挥200%的最终攻击"/>
-        <string name="h21" value="出现概率42%，发挥205%的最终攻击"/>
-        <string name="h22" value="出现概率44%，发挥210%的最终攻击"/>
-        <string name="h23" value="出现概率46%，发挥215%的最终攻击"/>
-        <string name="h24" value="出现概率48%，发挥220%的最终攻击"/>
-        <string name="h25" value="出现概率50%，发挥225%的最终攻击"/>
-        <string name="h26" value="出现概率52%，发挥230%的最终攻击"/>
-        <string name="h27" value="出现概率54%，发挥235%的最终攻击"/>
-        <string name="h28" value="出现概率56%，发挥240%的最终攻击"/>
-        <string name="h29" value="出现概率58%，发挥245%的最终攻击"/>
-        <string name="h3" value="出现概率6%，发挥115%的最终攻击"/>
-        <string name="h30" value="出现概率60%，发挥250%的最终攻击"/>
-        <string name="h4" value="出现概率8%，发挥120%的最终攻击"/>
-        <string name="h5" value="出现概率10%，发挥125%的最终攻击"/>
-        <string name="h6" value="出现概率12%，发挥130%的最终攻击"/>
-        <string name="h7" value="出现概率14%，发挥135%的最终攻击"/>
-        <string name="h8" value="出现概率16%，发挥140%的最终攻击"/>
-        <string name="h9" value="出现概率18%，发挥145%的最终攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n第一次攻击后发动连续攻击\n(必须装备枪)\n必需技能: #c精准枪等级3以上#"/>
+        <string name="desc" value="[最高等级：30]\n使用部分攻击技能后，有一定概率追加一次终极攻击。只在装备枪时生效。\n需要技能：#c对应精准武器3级以上#"/>
+        <string name="h1" value="2%概率发动终极攻击，伤害 105%"/>
+        <string name="h2" value="4%概率发动终极攻击，伤害 110%"/>
+        <string name="h3" value="6%概率发动终极攻击，伤害 115%"/>
+        <string name="h4" value="8%概率发动终极攻击，伤害 120%"/>
+        <string name="h5" value="10%概率发动终极攻击，伤害 125%"/>
+        <string name="h6" value="12%概率发动终极攻击，伤害 130%"/>
+        <string name="h7" value="14%概率发动终极攻击，伤害 135%"/>
+        <string name="h8" value="16%概率发动终极攻击，伤害 140%"/>
+        <string name="h9" value="18%概率发动终极攻击，伤害 145%"/>
+        <string name="h10" value="20%概率发动终极攻击，伤害 150%"/>
+        <string name="h11" value="22%概率发动终极攻击，伤害 155%"/>
+        <string name="h12" value="24%概率发动终极攻击，伤害 160%"/>
+        <string name="h13" value="26%概率发动终极攻击，伤害 165%"/>
+        <string name="h14" value="28%概率发动终极攻击，伤害 170%"/>
+        <string name="h15" value="30%概率发动终极攻击，伤害 175%"/>
+        <string name="h16" value="32%概率发动终极攻击，伤害 180%"/>
+        <string name="h17" value="34%概率发动终极攻击，伤害 185%"/>
+        <string name="h18" value="36%概率发动终极攻击，伤害 190%"/>
+        <string name="h19" value="38%概率发动终极攻击，伤害 195%"/>
+        <string name="h20" value="40%概率发动终极攻击，伤害 200%"/>
+        <string name="h21" value="42%概率发动终极攻击，伤害 205%"/>
+        <string name="h22" value="44%概率发动终极攻击，伤害 210%"/>
+        <string name="h23" value="46%概率发动终极攻击，伤害 215%"/>
+        <string name="h24" value="48%概率发动终极攻击，伤害 220%"/>
+        <string name="h25" value="50%概率发动终极攻击，伤害 225%"/>
+        <string name="h26" value="52%概率发动终极攻击，伤害 230%"/>
+        <string name="h27" value="54%概率发动终极攻击，伤害 235%"/>
+        <string name="h28" value="56%概率发动终极攻击，伤害 240%"/>
+        <string name="h29" value="58%概率发动终极攻击，伤害 245%"/>
+        <string name="h30" value="60%概率发动终极攻击，伤害 250%"/>
     </imgdir>
     <imgdir name="1300003">
         <string name="name" value="终极矛"/>
-        <string name="h1" value="出现概率2%，发挥105%的最终攻击"/>
-        <string name="h10" value="出现概率20%，发挥150%的最终攻击"/>
-        <string name="h11" value="出现概率22%，发挥155%的最终攻击"/>
-        <string name="h12" value="出现概率24%，发挥160%的最终攻击"/>
-        <string name="h13" value="出现概率26%，发挥165%的最终攻击"/>
-        <string name="h14" value="出现概率28%，发挥170%的最终攻击"/>
-        <string name="h15" value="出现概率30%，发挥175%的最终攻击"/>
-        <string name="h16" value="出现概率32%，发挥180%的最终攻击"/>
-        <string name="h17" value="出现概率34%，发挥185%的最终攻击"/>
-        <string name="h18" value="出现概率36%，发挥190%的最终攻击"/>
-        <string name="h19" value="出现概率38%，发挥195%的最终攻击"/>
-        <string name="h2" value="出现概率4%，发挥110%的最终攻击"/>
-        <string name="h20" value="出现概率40%，发挥200%的最终攻击"/>
-        <string name="h21" value="出现概率42%，发挥205%的最终攻击"/>
-        <string name="h22" value="出现概率44%，发挥210%的最终攻击"/>
-        <string name="h23" value="出现概率46%，发挥215%的最终攻击"/>
-        <string name="h24" value="出现概率48%，发挥220%的最终攻击"/>
-        <string name="h25" value="出现概率50%，发挥225%的最终攻击"/>
-        <string name="h26" value="出现概率52%，发挥230%的最终攻击"/>
-        <string name="h27" value="出现概率54%，发挥235%的最终攻击"/>
-        <string name="h28" value="出现概率56%，发挥240%的最终攻击"/>
-        <string name="h29" value="出现概率58%，发挥245%的最终攻击"/>
-        <string name="h3" value="出现概率6%，发挥115%的最终攻击"/>
-        <string name="h30" value="出现概率60%，发挥250%的最终攻击"/>
-        <string name="h4" value="出现概率8%，发挥120%的最终攻击"/>
-        <string name="h5" value="出现概率10%，发挥125%的最终攻击"/>
-        <string name="h6" value="出现概率12%，发挥130%的最终攻击"/>
-        <string name="h7" value="出现概率14%，发挥135%的最终攻击"/>
-        <string name="h8" value="出现概率16%，发挥140%的最终攻击"/>
-        <string name="h9" value="出现概率18%，发挥145%的最终攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n第一次攻击后发动连续攻击\n(必须装备矛)\n必需技能: #c精准矛等级3以上#"/>
+        <string name="desc" value="[最高等级：30]\n使用部分攻击技能后，有一定概率追加一次终极攻击。只在装备矛时生效。\n需要技能：#c对应精准武器3级以上#"/>
+        <string name="h1" value="2%概率发动终极攻击，伤害 105%"/>
+        <string name="h2" value="4%概率发动终极攻击，伤害 110%"/>
+        <string name="h3" value="6%概率发动终极攻击，伤害 115%"/>
+        <string name="h4" value="8%概率发动终极攻击，伤害 120%"/>
+        <string name="h5" value="10%概率发动终极攻击，伤害 125%"/>
+        <string name="h6" value="12%概率发动终极攻击，伤害 130%"/>
+        <string name="h7" value="14%概率发动终极攻击，伤害 135%"/>
+        <string name="h8" value="16%概率发动终极攻击，伤害 140%"/>
+        <string name="h9" value="18%概率发动终极攻击，伤害 145%"/>
+        <string name="h10" value="20%概率发动终极攻击，伤害 150%"/>
+        <string name="h11" value="22%概率发动终极攻击，伤害 155%"/>
+        <string name="h12" value="24%概率发动终极攻击，伤害 160%"/>
+        <string name="h13" value="26%概率发动终极攻击，伤害 165%"/>
+        <string name="h14" value="28%概率发动终极攻击，伤害 170%"/>
+        <string name="h15" value="30%概率发动终极攻击，伤害 175%"/>
+        <string name="h16" value="32%概率发动终极攻击，伤害 180%"/>
+        <string name="h17" value="34%概率发动终极攻击，伤害 185%"/>
+        <string name="h18" value="36%概率发动终极攻击，伤害 190%"/>
+        <string name="h19" value="38%概率发动终极攻击，伤害 195%"/>
+        <string name="h20" value="40%概率发动终极攻击，伤害 200%"/>
+        <string name="h21" value="42%概率发动终极攻击，伤害 205%"/>
+        <string name="h22" value="44%概率发动终极攻击，伤害 210%"/>
+        <string name="h23" value="46%概率发动终极攻击，伤害 215%"/>
+        <string name="h24" value="48%概率发动终极攻击，伤害 220%"/>
+        <string name="h25" value="50%概率发动终极攻击，伤害 225%"/>
+        <string name="h26" value="52%概率发动终极攻击，伤害 230%"/>
+        <string name="h27" value="54%概率发动终极攻击，伤害 235%"/>
+        <string name="h28" value="56%概率发动终极攻击，伤害 240%"/>
+        <string name="h29" value="58%概率发动终极攻击，伤害 245%"/>
+        <string name="h30" value="60%概率发动终极攻击，伤害 250%"/>
     </imgdir>
     <imgdir name="13001002">
         <string name="name" value="集中术"/>
@@ -3286,109 +3286,109 @@
     </imgdir>
     <imgdir name="1301004">
         <string name="name" value="快速枪"/>
-        <string name="h1" value="消耗HP29和MP29，持续10秒"/>
-        <string name="h10" value="消耗HP20和MP20，持续100秒"/>
-        <string name="h11" value="消耗HP19和MP19，持续110秒"/>
-        <string name="h12" value="消耗HP18和MP18，持续120秒"/>
-        <string name="h13" value="消耗HP17和MP17，持续130秒"/>
-        <string name="h14" value="消耗HP16和MP16，持续140秒"/>
-        <string name="h15" value="消耗HP15和MP15，持续150秒"/>
-        <string name="h16" value="消耗HP14和MP14，持续160秒"/>
-        <string name="h17" value="消耗HP13和MP13，持续170秒"/>
-        <string name="h18" value="消耗HP12和MP12，持续180秒"/>
-        <string name="h19" value="消耗HP11和MP11，持续190秒"/>
-        <string name="h2" value="消耗HP28和MP28，持续20秒"/>
-        <string name="h20" value="消耗HP10和MP10，持续200秒"/>
-        <string name="h3" value="消耗HP27和MP27，持续30秒"/>
-        <string name="h4" value="消耗HP26和MP26，持续40秒"/>
-        <string name="h5" value="消耗HP25和MP25，持续50秒"/>
-        <string name="h6" value="消耗HP24和MP24，持续60秒"/>
-        <string name="h7" value="消耗HP23和MP23，持续70秒"/>
-        <string name="h8" value="消耗HP22和MP22，持续80秒"/>
-        <string name="h9" value="消耗HP21和MP21，持续90秒"/>
-        <string name="desc" value="[最高等级 : 20]\n攻击速度提升两个等级\n(必须装备枪)\n必需技能: #c精准枪等级5以上#"/>
+        <string name="desc" value="[最高等级：20]\n消耗HP和MP，在一定时间内提高装备中的枪的攻击速度。\n需要技能：#c对应精准武器5级以上#"/>
+        <string name="h1" value="消耗HP 29，消耗MP 29，枪攻击速度提升，持续10秒"/>
+        <string name="h2" value="消耗HP 28，消耗MP 28，枪攻击速度提升，持续20秒"/>
+        <string name="h3" value="消耗HP 27，消耗MP 27，枪攻击速度提升，持续30秒"/>
+        <string name="h4" value="消耗HP 26，消耗MP 26，枪攻击速度提升，持续40秒"/>
+        <string name="h5" value="消耗HP 25，消耗MP 25，枪攻击速度提升，持续50秒"/>
+        <string name="h6" value="消耗HP 24，消耗MP 24，枪攻击速度提升，持续60秒"/>
+        <string name="h7" value="消耗HP 23，消耗MP 23，枪攻击速度提升，持续70秒"/>
+        <string name="h8" value="消耗HP 22，消耗MP 22，枪攻击速度提升，持续80秒"/>
+        <string name="h9" value="消耗HP 21，消耗MP 21，枪攻击速度提升，持续90秒"/>
+        <string name="h10" value="消耗HP 20，消耗MP 20，枪攻击速度提升，持续100秒"/>
+        <string name="h11" value="消耗HP 19，消耗MP 19，枪攻击速度提升，持续110秒"/>
+        <string name="h12" value="消耗HP 18，消耗MP 18，枪攻击速度提升，持续120秒"/>
+        <string name="h13" value="消耗HP 17，消耗MP 17，枪攻击速度提升，持续130秒"/>
+        <string name="h14" value="消耗HP 16，消耗MP 16，枪攻击速度提升，持续140秒"/>
+        <string name="h15" value="消耗HP 15，消耗MP 15，枪攻击速度提升，持续150秒"/>
+        <string name="h16" value="消耗HP 14，消耗MP 14，枪攻击速度提升，持续160秒"/>
+        <string name="h17" value="消耗HP 13，消耗MP 13，枪攻击速度提升，持续170秒"/>
+        <string name="h18" value="消耗HP 12，消耗MP 12，枪攻击速度提升，持续180秒"/>
+        <string name="h19" value="消耗HP 11，消耗MP 11，枪攻击速度提升，持续190秒"/>
+        <string name="h20" value="消耗HP 10，消耗MP 10，枪攻击速度提升，持续200秒"/>
     </imgdir>
     <imgdir name="1301005">
         <string name="name" value="快速矛"/>
-        <string name="h1" value="消耗HP29和MP29，持续10秒"/>
-        <string name="h10" value="消耗HP20和MP20，持续100秒"/>
-        <string name="h11" value="消耗HP19和MP19，持续110秒"/>
-        <string name="h12" value="消耗HP18和MP18，持续120秒"/>
-        <string name="h13" value="消耗HP17和MP17，持续130秒"/>
-        <string name="h14" value="消耗HP16和MP16，持续140秒"/>
-        <string name="h15" value="消耗HP15和MP15，持续150秒"/>
-        <string name="h16" value="消耗HP14和MP14，持续160秒"/>
-        <string name="h17" value="消耗HP13和MP13，持续170秒"/>
-        <string name="h18" value="消耗HP12和MP12，持续180秒"/>
-        <string name="h19" value="消耗HP11和MP11，持续190秒"/>
-        <string name="h2" value="消耗HP28和MP28，持续20秒"/>
-        <string name="h20" value="消耗HP10和MP10，持续200秒"/>
-        <string name="h3" value="消耗HP27和MP27，持续30秒"/>
-        <string name="h4" value="消耗HP26和MP26，持续40秒"/>
-        <string name="h5" value="消耗HP25和MP25，持续50秒"/>
-        <string name="h6" value="消耗HP24和MP24，持续60秒"/>
-        <string name="h7" value="消耗HP23和MP23，持续70秒"/>
-        <string name="h8" value="消耗HP22和MP22，持续80秒"/>
-        <string name="h9" value="消耗HP21和MP21，持续90秒"/>
-        <string name="desc" value="[最高等级 : 20]\n攻击速度提升两个等级\n(必须装备矛)\n必需技能: #c精准矛等级5以上#"/>
+        <string name="desc" value="[最高等级：20]\n消耗HP和MP，在一定时间内提高装备中的矛的攻击速度。\n需要技能：#c对应精准武器5级以上#"/>
+        <string name="h1" value="消耗HP 29，消耗MP 29，矛攻击速度提升，持续10秒"/>
+        <string name="h2" value="消耗HP 28，消耗MP 28，矛攻击速度提升，持续20秒"/>
+        <string name="h3" value="消耗HP 27，消耗MP 27，矛攻击速度提升，持续30秒"/>
+        <string name="h4" value="消耗HP 26，消耗MP 26，矛攻击速度提升，持续40秒"/>
+        <string name="h5" value="消耗HP 25，消耗MP 25，矛攻击速度提升，持续50秒"/>
+        <string name="h6" value="消耗HP 24，消耗MP 24，矛攻击速度提升，持续60秒"/>
+        <string name="h7" value="消耗HP 23，消耗MP 23，矛攻击速度提升，持续70秒"/>
+        <string name="h8" value="消耗HP 22，消耗MP 22，矛攻击速度提升，持续80秒"/>
+        <string name="h9" value="消耗HP 21，消耗MP 21，矛攻击速度提升，持续90秒"/>
+        <string name="h10" value="消耗HP 20，消耗MP 20，矛攻击速度提升，持续100秒"/>
+        <string name="h11" value="消耗HP 19，消耗MP 19，矛攻击速度提升，持续110秒"/>
+        <string name="h12" value="消耗HP 18，消耗MP 18，矛攻击速度提升，持续120秒"/>
+        <string name="h13" value="消耗HP 17，消耗MP 17，矛攻击速度提升，持续130秒"/>
+        <string name="h14" value="消耗HP 16，消耗MP 16，矛攻击速度提升，持续140秒"/>
+        <string name="h15" value="消耗HP 15，消耗MP 15，矛攻击速度提升，持续150秒"/>
+        <string name="h16" value="消耗HP 14，消耗MP 14，矛攻击速度提升，持续160秒"/>
+        <string name="h17" value="消耗HP 13，消耗MP 13，矛攻击速度提升，持续170秒"/>
+        <string name="h18" value="消耗HP 12，消耗MP 12，矛攻击速度提升，持续180秒"/>
+        <string name="h19" value="消耗HP 11，消耗MP 11，矛攻击速度提升，持续190秒"/>
+        <string name="h20" value="消耗HP 10，消耗MP 10，矛攻击速度提升，持续200秒"/>
     </imgdir>
     <imgdir name="1301006">
         <string name="name" value="极限防御"/>
-        <string name="h1" value="消耗MP12,持续15秒，物理防御力+1，魔法防御力+1"/>
-        <string name="h10" value="消耗MP12,持续150秒，物理防御力+10，魔法防御力+10"/>
-        <string name="h11" value="消耗MP24,持续165秒，物理防御力+11，魔法防御力+11"/>
-        <string name="h12" value="消耗MP24,持续180秒，物理防御力+12，魔法防御力+12"/>
-        <string name="h13" value="消耗MP24,持续195秒，物理防御力+13，魔法防御力+13"/>
-        <string name="h14" value="消耗MP24,持续210秒，物理防御力+14，魔法防御力+14"/>
-        <string name="h15" value="消耗MP24,持续225秒，物理防御力+15，魔法防御力+15"/>
-        <string name="h16" value="消耗MP24,持续240秒，物理防御力+16，魔法防御力+16"/>
-        <string name="h17" value="消耗MP24,持续255秒，物理防御力+17，魔法防御力+17"/>
-        <string name="h18" value="消耗MP24,持续270秒，物理防御力+18，魔法防御力+18"/>
-        <string name="h19" value="消耗MP24,持续285秒，物理防御力+19，魔法防御力+19"/>
-        <string name="h2" value="消耗MP12,持续30秒，物理防御力+2，魔法防御力+2"/>
-        <string name="h20" value="消耗MP24,持续300秒，物理防御力+20，魔法防御力+20"/>
-        <string name="h3" value="消耗MP12,持续45秒，物理防御力+3，魔法防御力+3"/>
-        <string name="h4" value="消耗MP12,持续60秒，物理防御力+4，魔法防御力+4"/>
-        <string name="h5" value="消耗MP12,持续75秒，物理防御力+5，魔法防御力+5"/>
-        <string name="h6" value="消耗MP12,持续90秒，物理防御力+6，魔法防御力+6"/>
-        <string name="h7" value="消耗MP12,持续105秒，物理防御力+7，魔法防御力+7"/>
-        <string name="h8" value="消耗MP12,持续120秒，物理防御力+8，魔法防御力+8"/>
-        <string name="h9" value="消耗MP12,持续135秒，物理防御力+9，魔法防御力+9"/>
-        <string name="desc" value="[最高等级 : 20]\n提高周围所有队员的物理防御力\n和魔法防御力"/>
+        <string name="desc" value="[最高等级：20]\n一定时间内提高周围队员的物理防御力和魔法防御力。"/>
+        <string name="h1" value="消耗MP 12，物理防御力 +1，魔法防御力 +1，持续15秒"/>
+        <string name="h2" value="消耗MP 12，物理防御力 +2，魔法防御力 +2，持续30秒"/>
+        <string name="h3" value="消耗MP 12，物理防御力 +3，魔法防御力 +3，持续45秒"/>
+        <string name="h4" value="消耗MP 12，物理防御力 +4，魔法防御力 +4，持续60秒"/>
+        <string name="h5" value="消耗MP 12，物理防御力 +5，魔法防御力 +5，持续75秒"/>
+        <string name="h6" value="消耗MP 12，物理防御力 +6，魔法防御力 +6，持续90秒"/>
+        <string name="h7" value="消耗MP 12，物理防御力 +7，魔法防御力 +7，持续105秒"/>
+        <string name="h8" value="消耗MP 12，物理防御力 +8，魔法防御力 +8，持续120秒"/>
+        <string name="h9" value="消耗MP 12，物理防御力 +9，魔法防御力 +9，持续135秒"/>
+        <string name="h10" value="消耗MP 12，物理防御力 +10，魔法防御力 +10，持续150秒"/>
+        <string name="h11" value="消耗MP 24，物理防御力 +11，魔法防御力 +11，持续165秒"/>
+        <string name="h12" value="消耗MP 24，物理防御力 +12，魔法防御力 +12，持续180秒"/>
+        <string name="h13" value="消耗MP 24，物理防御力 +13，魔法防御力 +13，持续195秒"/>
+        <string name="h14" value="消耗MP 24，物理防御力 +14，魔法防御力 +14，持续210秒"/>
+        <string name="h15" value="消耗MP 24，物理防御力 +15，魔法防御力 +15，持续225秒"/>
+        <string name="h16" value="消耗MP 24，物理防御力 +16，魔法防御力 +16，持续240秒"/>
+        <string name="h17" value="消耗MP 24，物理防御力 +17，魔法防御力 +17，持续255秒"/>
+        <string name="h18" value="消耗MP 24，物理防御力 +18，魔法防御力 +18，持续270秒"/>
+        <string name="h19" value="消耗MP 24，物理防御力 +19，魔法防御力 +19，持续285秒"/>
+        <string name="h20" value="消耗MP 24，物理防御力 +20，魔法防御力 +20，持续300秒"/>
     </imgdir>
     <imgdir name="1301007">
         <string name="name" value="神圣之火"/>
-        <string name="h1" value="消耗MP20，最大HP和最大MP增加2%(持续10秒)"/>
-        <string name="h10" value="消耗MP20，最大HP和最大MP增加20%(持续100秒)"/>
-        <string name="h11" value="消耗MP40，最大HP和最大MP增加22%(持续110秒)"/>
-        <string name="h12" value="消耗MP40，最大HP和最大MP增加24%(持续120秒)"/>
-        <string name="h13" value="消耗MP40，最大HP和最大MP增加26%(持续130秒)"/>
-        <string name="h14" value="消耗MP40，最大HP和最大MP增加28%(持续140秒)"/>
-        <string name="h15" value="消耗MP40，最大HP和最大MP增加30%(持续150秒)"/>
-        <string name="h16" value="消耗MP40，最大HP和最大MP增加32%(持续160秒)"/>
-        <string name="h17" value="消耗MP40，最大HP和最大MP增加34%(持续170秒)"/>
-        <string name="h18" value="消耗MP40，最大HP和最大MP增加36%(持续180秒)"/>
-        <string name="h19" value="消耗MP40，最大HP和最大MP增加38%(持续190秒)"/>
-        <string name="h2" value="消耗MP20，最大HP和最大MP增加4%(持续20秒)"/>
-        <string name="h20" value="消耗MP40，最大HP和最大MP增加40%(持续200秒)"/>
-        <string name="h21" value="消耗MP60，最大HP和最大MP增加42%(持续210秒)"/>
-        <string name="h22" value="消耗MP60，最大HP和最大MP增加44%(持续220秒)"/>
-        <string name="h23" value="消耗MP60，最大HP和最大MP增加46%(持续230秒)"/>
-        <string name="h24" value="消耗MP60，最大HP和最大MP增加48%(持续240秒)"/>
-        <string name="h25" value="消耗MP60，最大HP和最大MP增加60%(持续250秒)"/>
-        <string name="h26" value="消耗MP60，最大HP和最大MP增加52%(持续260秒)"/>
-        <string name="h27" value="消耗MP60，最大HP和最大MP增加54%(持续270秒)"/>
-        <string name="h28" value="消耗MP60，最大HP和最大MP增加56%(持续280秒)"/>
-        <string name="h29" value="消耗MP60，最大HP和最大MP增加58%(持续290秒)"/>
-        <string name="h3" value="消耗MP20，最大HP和最大MP增加6%(持续30秒)"/>
-        <string name="h30" value="消耗MP60，最大HP和最大MP增加60%(持续300秒)"/>
-        <string name="h4" value="消耗MP20，最大HP和最大MP增加8%(持续40秒)"/>
-        <string name="h5" value="消耗MP20，最大HP和最大MP增加10%(持续50秒)"/>
-        <string name="h6" value="消耗MP20，最大HP和最大MP增加12%(持续60秒)"/>
-        <string name="h7" value="消耗MP20，最大HP和最大MP增加14%(持续70秒)"/>
-        <string name="h8" value="消耗MP20，最大HP和最大MP增加16%(持续80秒)"/>
-        <string name="h9" value="消耗MP20，最大HP和最大MP增加18%(持续90秒)"/>
-        <string name="desc" value="[最高等级 : 30]\n增加周围所有队员的最大HP和最大MP.\n必需: #c极限防御等级3以上#"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内提高周围队员的MaxHP和MaxMP。\n需要技能：#c极限防御3级以上#"/>
+        <string name="h1" value="消耗MP 20，MaxHP +2%，MaxMP +2%，持续10秒"/>
+        <string name="h2" value="消耗MP 20，MaxHP +4%，MaxMP +4%，持续20秒"/>
+        <string name="h3" value="消耗MP 20，MaxHP +6%，MaxMP +6%，持续30秒"/>
+        <string name="h4" value="消耗MP 20，MaxHP +8%，MaxMP +8%，持续40秒"/>
+        <string name="h5" value="消耗MP 20，MaxHP +10%，MaxMP +10%，持续50秒"/>
+        <string name="h6" value="消耗MP 20，MaxHP +12%，MaxMP +12%，持续60秒"/>
+        <string name="h7" value="消耗MP 20，MaxHP +14%，MaxMP +14%，持续70秒"/>
+        <string name="h8" value="消耗MP 20，MaxHP +16%，MaxMP +16%，持续80秒"/>
+        <string name="h9" value="消耗MP 20，MaxHP +18%，MaxMP +18%，持续90秒"/>
+        <string name="h10" value="消耗MP 20，MaxHP +20%，MaxMP +20%，持续100秒"/>
+        <string name="h11" value="消耗MP 40，MaxHP +22%，MaxMP +22%，持续110秒"/>
+        <string name="h12" value="消耗MP 40，MaxHP +24%，MaxMP +24%，持续120秒"/>
+        <string name="h13" value="消耗MP 40，MaxHP +26%，MaxMP +26%，持续130秒"/>
+        <string name="h14" value="消耗MP 40，MaxHP +28%，MaxMP +28%，持续140秒"/>
+        <string name="h15" value="消耗MP 40，MaxHP +30%，MaxMP +30%，持续150秒"/>
+        <string name="h16" value="消耗MP 40，MaxHP +32%，MaxMP +32%，持续160秒"/>
+        <string name="h17" value="消耗MP 40，MaxHP +34%，MaxMP +34%，持续170秒"/>
+        <string name="h18" value="消耗MP 40，MaxHP +36%，MaxMP +36%，持续180秒"/>
+        <string name="h19" value="消耗MP 40，MaxHP +38%，MaxMP +38%，持续190秒"/>
+        <string name="h20" value="消耗MP 40，MaxHP +40%，MaxMP +40%，持续200秒"/>
+        <string name="h21" value="消耗MP 60，MaxHP +42%，MaxMP +42%，持续210秒"/>
+        <string name="h22" value="消耗MP 60，MaxHP +44%，MaxMP +44%，持续220秒"/>
+        <string name="h23" value="消耗MP 60，MaxHP +46%，MaxMP +46%，持续230秒"/>
+        <string name="h24" value="消耗MP 60，MaxHP +48%，MaxMP +48%，持续240秒"/>
+        <string name="h25" value="消耗MP 50，MaxHP +50%，MaxMP +50%，持续250秒"/>
+        <string name="h26" value="消耗MP 60，MaxHP +52%，MaxMP +52%，持续260秒"/>
+        <string name="h27" value="消耗MP 60，MaxHP +54%，MaxMP +54%，持续270秒"/>
+        <string name="h28" value="消耗MP 60，MaxHP +56%，MaxMP +56%，持续280秒"/>
+        <string name="h29" value="消耗MP 60，MaxHP +58%，MaxMP +58%，持续290秒"/>
+        <string name="h30" value="消耗MP 60，MaxHP +60%，MaxMP +60%，持续300秒"/>
     </imgdir>
     <imgdir name="131">
         <string name="bookName" value="龙骑士技能"/>
@@ -3398,27 +3398,27 @@
     </imgdir>
     <imgdir name="1310000">
         <string name="name" value="魔法抗性"/>
-        <string name="h1" value="对所有的属性魔法抗性增加12%"/>
-        <string name="h10" value="对所有的属性魔法抗性增加30%"/>
-        <string name="h11" value="对所有的属性魔法抗性增加31%"/>
-        <string name="h12" value="对所有的属性魔法抗性增加32%"/>
-        <string name="h13" value="对所有的属性魔法抗性增加33%"/>
-        <string name="h14" value="对所有的属性魔法抗性增加34%"/>
-        <string name="h15" value="对所有的属性魔法抗性增加35%"/>
-        <string name="h16" value="对所有的属性魔法抗性增加36%"/>
-        <string name="h17" value="对所有的属性魔法抗性增加37%"/>
-        <string name="h18" value="对所有的属性魔法抗性增加38%"/>
-        <string name="h19" value="对所有的属性魔法抗性增加39%"/>
-        <string name="h2" value="对所有的属性魔法抗性增加14%"/>
-        <string name="h20" value="对所有的属性魔法抗性增加40%"/>
-        <string name="h3" value="对所有的属性魔法抗性增加16%"/>
-        <string name="h4" value="对所有的属性魔法抗性增加18%"/>
-        <string name="h5" value="对所有的属性魔法抗性增加20%"/>
-        <string name="h6" value="对所有的属性魔法抗性增加22%"/>
-        <string name="h7" value="对所有的属性魔法抗性增加24%"/>
-        <string name="h8" value="对所有的属性魔法抗性增加26%"/>
-        <string name="h9" value="对所有的属性魔法抗性增加28%"/>
-        <string name="desc" value="[最高等级:20]\n提高对所有属性魔法的抗性"/>
+        <string name="desc" value="[最高等级：20]\n提高对属性魔法攻击的抗性。"/>
+        <string name="h1" value="属性魔法抗性 +12%"/>
+        <string name="h2" value="属性魔法抗性 +14%"/>
+        <string name="h3" value="属性魔法抗性 +16%"/>
+        <string name="h4" value="属性魔法抗性 +18%"/>
+        <string name="h5" value="属性魔法抗性 +20%"/>
+        <string name="h6" value="属性魔法抗性 +22%"/>
+        <string name="h7" value="属性魔法抗性 +24%"/>
+        <string name="h8" value="属性魔法抗性 +26%"/>
+        <string name="h9" value="属性魔法抗性 +28%"/>
+        <string name="h10" value="属性魔法抗性 +30%"/>
+        <string name="h11" value="属性魔法抗性 +31%"/>
+        <string name="h12" value="属性魔法抗性 +32%"/>
+        <string name="h13" value="属性魔法抗性 +33%"/>
+        <string name="h14" value="属性魔法抗性 +34%"/>
+        <string name="h15" value="属性魔法抗性 +35%"/>
+        <string name="h16" value="属性魔法抗性 +36%"/>
+        <string name="h17" value="属性魔法抗性 +37%"/>
+        <string name="h18" value="属性魔法抗性 +38%"/>
+        <string name="h19" value="属性魔法抗性 +39%"/>
+        <string name="h20" value="属性魔法抗性 +40%"/>
     </imgdir>
     <imgdir name="13100000">
         <string name="name" value="精准弓"/>
@@ -3617,255 +3617,255 @@
     </imgdir>
     <imgdir name="1311001">
         <string name="name" value="枪连击"/>
-        <string name="h1" value="消费MP10，造成伤害55%，对一个人三次攻击"/>
-        <string name="h10" value="消费MP13，造成伤害100%，对一个人三次攻击"/>
-        <string name="h11" value="消费MP16，造成伤害104%，对两个人三次攻击"/>
-        <string name="h12" value="消费MP16，造成伤害108%，对两个人三次攻击"/>
-        <string name="h13" value="消费MP16，造成伤害112%，对两个人三次攻击"/>
-        <string name="h14" value="消费MP16，造成伤害116%，对两个人三次攻击"/>
-        <string name="h15" value="消费MP16，造成伤害120%，对两个人三次攻击"/>
-        <string name="h16" value="消费MP19，造成伤害124%，对两个人三次攻击"/>
-        <string name="h17" value="消费MP19，造成伤害128%，对两个人三次攻击"/>
-        <string name="h18" value="消费MP19，造成伤害132%，对两个人三次攻击"/>
-        <string name="h19" value="消费MP19，造成伤害136%，对两个人三次攻击"/>
-        <string name="h2" value="消费MP10，造成伤害60%，对一个人三次攻击"/>
-        <string name="h20" value="消费MP19，造成伤害140%，对两个人三次攻击"/>
-        <string name="h21" value="消费MP21，造成伤害143%，对三个人三次攻击"/>
-        <string name="h22" value="消费MP21，造成伤害146%，对三个人三次攻击"/>
-        <string name="h23" value="消费MP21，造成伤害149%，对三个人三次攻击"/>
-        <string name="h24" value="消费MP21，造成伤害152%，对三个人三次攻击"/>
-        <string name="h25" value="消费MP21，造成伤害155%，对三个人三次攻击"/>
-        <string name="h26" value="消费MP24，造成伤害158%，对三个人三次攻击"/>
-        <string name="h27" value="消费MP24，造成伤害161%，对三个人三次攻击"/>
-        <string name="h28" value="消费MP24，造成伤害164%，对三个人三次攻击"/>
-        <string name="h29" value="消费MP24，造成伤害167%，对三个人三次攻击"/>
-        <string name="h3" value="消费MP10，造成伤害65%，对一个人三次攻击"/>
-        <string name="h30" value="消费MP24，造成伤害170%，对三个人三次攻击"/>
-        <string name="h4" value="消费MP10，造成伤害70%，对一个人三次攻击"/>
-        <string name="h5" value="消费MP10，造成伤害75%，对一个人三次攻击"/>
-        <string name="h6" value="消费MP13，造成伤害80%，对一个人三次攻击"/>
-        <string name="h7" value="消费MP13，造成伤害85%，对一个人三次攻击"/>
-        <string name="h8" value="消费MP13，造成伤害90%，对一个人三次攻击"/>
-        <string name="h9" value="消费MP13，造成伤害95%，对一个人三次攻击"/>
-        <string name="desc" value="[最高等级:30]\n用枪对前方怪物连续刺击"/>
+        <string name="desc" value="[最高等级：30]\n用枪向前连续刺击，多次攻击多个怪物。"/>
+        <string name="h1" value="消耗MP 10，伤害 55%，攻击2次，最多攻击1个敌人"/>
+        <string name="h2" value="消耗MP 10，伤害 60%，攻击2次，最多攻击1个敌人"/>
+        <string name="h3" value="消耗MP 10，伤害 65%，攻击2次，最多攻击1个敌人"/>
+        <string name="h4" value="消耗MP 10，伤害 70%，攻击2次，最多攻击1个敌人"/>
+        <string name="h5" value="消耗MP 10，伤害 75%，攻击2次，最多攻击1个敌人"/>
+        <string name="h6" value="消耗MP 13，伤害 80%，攻击2次，最多攻击2个敌人"/>
+        <string name="h7" value="消耗MP 13，伤害 85%，攻击2次，最多攻击2个敌人"/>
+        <string name="h8" value="消耗MP 13，伤害 90%，攻击2次，最多攻击2个敌人"/>
+        <string name="h9" value="消耗MP 13，伤害 95%，攻击2次，最多攻击2个敌人"/>
+        <string name="h10" value="消耗MP 13，伤害 100%，攻击2次，最多攻击2个敌人"/>
+        <string name="h11" value="消耗MP 16，伤害 104%，攻击2次，最多攻击3个敌人"/>
+        <string name="h12" value="消耗MP 16，伤害 108%，攻击2次，最多攻击3个敌人"/>
+        <string name="h13" value="消耗MP 16，伤害 112%，攻击2次，最多攻击3个敌人"/>
+        <string name="h14" value="消耗MP 16，伤害 116%，攻击2次，最多攻击3个敌人"/>
+        <string name="h15" value="消耗MP 16，伤害 120%，攻击2次，最多攻击3个敌人"/>
+        <string name="h16" value="消耗MP 19，伤害 124%，攻击3次，最多攻击1个敌人"/>
+        <string name="h17" value="消耗MP 19，伤害 128%，攻击3次，最多攻击1个敌人"/>
+        <string name="h18" value="消耗MP 19，伤害 132%，攻击3次，最多攻击1个敌人"/>
+        <string name="h19" value="消耗MP 19，伤害 136%，攻击3次，最多攻击1个敌人"/>
+        <string name="h20" value="消耗MP 19，伤害 140%，攻击3次，最多攻击1个敌人"/>
+        <string name="h21" value="消耗MP 21，伤害 144%，攻击3次，最多攻击2个敌人"/>
+        <string name="h22" value="消耗MP 21，伤害 146%，攻击3次，最多攻击2个敌人"/>
+        <string name="h23" value="消耗MP 21，伤害 149%，攻击3次，最多攻击2个敌人"/>
+        <string name="h24" value="消耗MP 21，伤害 152%，攻击3次，最多攻击2个敌人"/>
+        <string name="h25" value="消耗MP 21，伤害 155%，攻击3次，最多攻击2个敌人"/>
+        <string name="h26" value="消耗MP 24，伤害 158%，攻击3次，最多攻击3个敌人"/>
+        <string name="h27" value="消耗MP 24，伤害 161%，攻击3次，最多攻击3个敌人"/>
+        <string name="h28" value="消耗MP 24，伤害 164%，攻击3次，最多攻击3个敌人"/>
+        <string name="h29" value="消耗MP 24，伤害 167%，攻击3次，最多攻击3个敌人"/>
+        <string name="h30" value="消耗MP 24，伤害 170%，攻击3次，最多攻击3个敌人"/>
     </imgdir>
     <imgdir name="1311002">
         <string name="name" value="矛连击"/>
-        <string name="h1" value="消费MP10，造成伤害80%，对一个人三次攻击"/>
-        <string name="h10" value="消费MP13，造成伤害152%，对一个人三次攻击"/>
-        <string name="h11" value="消费MP16，造成伤害158%，对两个人三次攻击"/>
-        <string name="h12" value="消费MP16，造成伤害164%，对两个人三次攻击"/>
-        <string name="h13" value="消费MP16，造成伤害170%，对两个人三次攻击"/>
-        <string name="h14" value="消费MP16，造成伤害176%，对两个人三次攻击"/>
-        <string name="h15" value="消费MP16，造成伤害182%，对两个人三次攻击"/>
-        <string name="h16" value="消费MP19，造成伤害188%，对两个人三次攻击"/>
-        <string name="h17" value="消费MP19，造成伤害194%，对两个人三次攻击"/>
-        <string name="h18" value="消费MP19，造成伤害200%，对两个人三次攻击"/>
-        <string name="h19" value="消费MP19，造成伤害205%，对两个人三次攻击"/>
-        <string name="h2" value="消费MP10，造成伤害88%，对一个人三次攻击"/>
-        <string name="h20" value="消费MP19，造成伤害210%，对两个人三次攻击"/>
-        <string name="h21" value="消费MP21，造成伤害215%，对三个人三次攻击"/>
-        <string name="h22" value="消费MP21，造成伤害220%，对三个人三次攻击"/>
-        <string name="h23" value="消费MP21，造成伤害225%，对三个人三次攻击"/>
-        <string name="h24" value="消费MP21，造成伤害230%，对三个人三次攻击"/>
-        <string name="h25" value="消费MP21，造成伤害235%，对三个人三次攻击"/>
-        <string name="h26" value="消费MP24，造成伤害240%，对三个人三次攻击"/>
-        <string name="h27" value="消费MP24，造成伤害245%，对三个人三次攻击"/>
-        <string name="h28" value="消费MP24，造成伤害250%，对三个人三次攻击"/>
-        <string name="h29" value="消费MP24，造成伤害255%，对三个人三次攻击"/>
-        <string name="h3" value="消费MP10，造成伤害96%，对一个人三次攻击"/>
-        <string name="h30" value="消费MP24，造成伤害260%，对三个人三次攻击"/>
-        <string name="h4" value="消费MP10，造成伤害104%，对一个人三次攻击"/>
-        <string name="h5" value="消费MP10，造成伤害112%，对一个人三次攻击"/>
-        <string name="h6" value="消费MP13，造成伤害120%，对一个人三次攻击"/>
-        <string name="h7" value="消费MP13，造成伤害128%，对一个人三次攻击"/>
-        <string name="h8" value="消费MP13，造成伤害136%，对一个人三次攻击"/>
-        <string name="h9" value="消费MP13，造成伤害144%，对一个人三次攻击"/>
-        <string name="desc" value="[最高等级:30]\n用矛对前方怪物连续刺击"/>
+        <string name="desc" value="[最高等级：30]\n用矛向前连续刺击，多次攻击多个怪物。"/>
+        <string name="h1" value="消耗MP 10，伤害 55%，攻击2次，最多攻击1个敌人"/>
+        <string name="h2" value="消耗MP 10，伤害 60%，攻击2次，最多攻击1个敌人"/>
+        <string name="h3" value="消耗MP 10，伤害 65%，攻击2次，最多攻击1个敌人"/>
+        <string name="h4" value="消耗MP 10，伤害 70%，攻击2次，最多攻击1个敌人"/>
+        <string name="h5" value="消耗MP 10，伤害 75%，攻击2次，最多攻击1个敌人"/>
+        <string name="h6" value="消耗MP 13，伤害 80%，攻击2次，最多攻击2个敌人"/>
+        <string name="h7" value="消耗MP 13，伤害 85%，攻击2次，最多攻击2个敌人"/>
+        <string name="h8" value="消耗MP 13，伤害 90%，攻击2次，最多攻击2个敌人"/>
+        <string name="h9" value="消耗MP 13，伤害 95%，攻击2次，最多攻击2个敌人"/>
+        <string name="h10" value="消耗MP 13，伤害 100%，攻击2次，最多攻击2个敌人"/>
+        <string name="h11" value="消耗MP 16，伤害 104%，攻击2次，最多攻击3个敌人"/>
+        <string name="h12" value="消耗MP 16，伤害 108%，攻击2次，最多攻击3个敌人"/>
+        <string name="h13" value="消耗MP 16，伤害 112%，攻击2次，最多攻击3个敌人"/>
+        <string name="h14" value="消耗MP 16，伤害 116%，攻击2次，最多攻击3个敌人"/>
+        <string name="h15" value="消耗MP 16，伤害 120%，攻击2次，最多攻击3个敌人"/>
+        <string name="h16" value="消耗MP 19，伤害 124%，攻击3次，最多攻击1个敌人"/>
+        <string name="h17" value="消耗MP 19，伤害 128%，攻击3次，最多攻击1个敌人"/>
+        <string name="h18" value="消耗MP 19，伤害 132%，攻击3次，最多攻击1个敌人"/>
+        <string name="h19" value="消耗MP 19，伤害 136%，攻击3次，最多攻击1个敌人"/>
+        <string name="h20" value="消耗MP 19，伤害 140%，攻击3次，最多攻击1个敌人"/>
+        <string name="h21" value="消耗MP 21，伤害 144%，攻击3次，最多攻击2个敌人"/>
+        <string name="h22" value="消耗MP 21，伤害 146%，攻击3次，最多攻击2个敌人"/>
+        <string name="h23" value="消耗MP 21，伤害 149%，攻击3次，最多攻击2个敌人"/>
+        <string name="h24" value="消耗MP 21，伤害 152%，攻击3次，最多攻击2个敌人"/>
+        <string name="h25" value="消耗MP 21，伤害 155%，攻击3次，最多攻击2个敌人"/>
+        <string name="h26" value="消耗MP 24，伤害 158%，攻击3次，最多攻击3个敌人"/>
+        <string name="h27" value="消耗MP 24，伤害 161%，攻击3次，最多攻击3个敌人"/>
+        <string name="h28" value="消耗MP 24，伤害 164%，攻击3次，最多攻击3个敌人"/>
+        <string name="h29" value="消耗MP 24，伤害 167%，攻击3次，最多攻击3个敌人"/>
+        <string name="h30" value="消耗MP 24，伤害 170%，攻击3次，最多攻击3个敌人"/>
     </imgdir>
     <imgdir name="1311003">
         <string name="name" value="无双枪"/>
-        <string name="h1" value="消费HP20,MP10，造成伤害115%"/>
-        <string name="h10" value="消费HP20,MP10，造成伤害250%"/>
-        <string name="h11" value="消费HP25,MP15，造成伤害258%"/>
-        <string name="h12" value="消费HP25,MP15，造成伤害266%"/>
-        <string name="h13" value="消费HP25,MP15，造成伤害274%"/>
-        <string name="h14" value="消费HP25,MP15，造成伤害282%"/>
-        <string name="h15" value="消费HP25,MP15，造成伤害290%"/>
-        <string name="h16" value="消费HP25,MP15，造成伤害298%"/>
-        <string name="h17" value="消费HP25,MP15，造成伤害306%"/>
-        <string name="h18" value="消费HP25,MP15，造成伤害314%"/>
-        <string name="h19" value="消费HP25,MP15，造成伤害322%"/>
-        <string name="h2" value="消费HP20,MP10，造成伤害130%"/>
-        <string name="h20" value="消费HP25,MP15，造成伤害330%"/>
-        <string name="h21" value="消费HP30,MP20，造成伤害335%"/>
-        <string name="h22" value="消费HP30,MP20，造成伤害340%"/>
-        <string name="h23" value="消费HP30,MP20，造成伤害345%"/>
-        <string name="h24" value="消费HP30,MP20，造成伤害350%"/>
-        <string name="h25" value="消费HP30,MP20，造成伤害355%"/>
-        <string name="h26" value="消费HP30,MP20，造成伤害360%"/>
-        <string name="h27" value="消费HP30,MP20，造成伤害365%"/>
-        <string name="h28" value="消费HP30,MP20，造成伤害370%"/>
-        <string name="h29" value="消费HP30,MP20，造成伤害375%"/>
-        <string name="h3" value="消费HP20,MP10，造成伤害145%"/>
-        <string name="h30" value="消费HP30,MP20，造成伤害380%"/>
-        <string name="h4" value="消费HP20,MP10，造成伤害160%"/>
-        <string name="h5" value="消费HP20,MP10，造成伤害175%"/>
-        <string name="h6" value="消费HP20,MP10，造成伤害190%"/>
-        <string name="h7" value="消费HP20,MP10，造成伤害205%"/>
-        <string name="h8" value="消费HP20,MP10，造成伤害220%"/>
-        <string name="h9" value="消费HP20,MP10，造成伤害235%"/>
-        <string name="desc" value="[最高等级:30]\n对中距离多个怪物进行攻击，\n最多攻击6个怪物"/>
+        <string name="desc" value="[最高等级：30]\n挥动枪攻击周围最多6只怪物。"/>
+        <string name="h1" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 80%，最多攻击6个敌人"/>
+        <string name="h2" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 90%，最多攻击6个敌人"/>
+        <string name="h3" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 100%，最多攻击6个敌人"/>
+        <string name="h4" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 110%，最多攻击6个敌人"/>
+        <string name="h5" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 120%，最多攻击6个敌人"/>
+        <string name="h6" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 130%，最多攻击6个敌人"/>
+        <string name="h7" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 140%，最多攻击6个敌人"/>
+        <string name="h8" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 150%，最多攻击6个敌人"/>
+        <string name="h9" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 160%，最多攻击6个敌人"/>
+        <string name="h10" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 170%，最多攻击6个敌人"/>
+        <string name="h11" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 175%，最多攻击6个敌人"/>
+        <string name="h12" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 180%，最多攻击6个敌人"/>
+        <string name="h13" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 185%，最多攻击6个敌人"/>
+        <string name="h14" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 190%，最多攻击6个敌人"/>
+        <string name="h15" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 195%，最多攻击6个敌人"/>
+        <string name="h16" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 200%，最多攻击6个敌人"/>
+        <string name="h17" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 205%，最多攻击6个敌人"/>
+        <string name="h18" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 210%，最多攻击6个敌人"/>
+        <string name="h19" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 215%，最多攻击6个敌人"/>
+        <string name="h20" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 220%，最多攻击6个敌人"/>
+        <string name="h21" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 223%，最多攻击6个敌人"/>
+        <string name="h22" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 226%，最多攻击6个敌人"/>
+        <string name="h23" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 229%，最多攻击6个敌人"/>
+        <string name="h24" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 232%，最多攻击6个敌人"/>
+        <string name="h25" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 235%，最多攻击6个敌人"/>
+        <string name="h26" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 238%，最多攻击6个敌人"/>
+        <string name="h27" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 241%，最多攻击6个敌人"/>
+        <string name="h28" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 244%，最多攻击6个敌人"/>
+        <string name="h29" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 247%，最多攻击6个敌人"/>
+        <string name="h30" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 250%，最多攻击6个敌人"/>
     </imgdir>
     <imgdir name="1311004">
         <string name="name" value="无双矛"/>
-        <string name="h1" value="消费HP20,MP10，造成伤害80%"/>
-        <string name="h10" value="消费HP20,MP10，造成伤害170%"/>
-        <string name="h11" value="消费HP25,MP15，造成伤害175%"/>
-        <string name="h12" value="消费HP25,MP15，造成伤害180%"/>
-        <string name="h13" value="消费HP25,MP15，造成伤害185%"/>
-        <string name="h14" value="消费HP25,MP15，造成伤害190%"/>
-        <string name="h15" value="消费HP25,MP15，造成伤害195%"/>
-        <string name="h16" value="消费HP25,MP15，造成伤害200%"/>
-        <string name="h17" value="消费HP25,MP15，造成伤害205%"/>
-        <string name="h18" value="消费HP25,MP15，造成伤害210%"/>
-        <string name="h19" value="消费HP25,MP15，造成伤害215%"/>
-        <string name="h2" value="消费HP20,MP10，造成伤害90%"/>
-        <string name="h20" value="消费HP25,MP15，造成伤害220%"/>
-        <string name="h21" value="消费HP30,MP20，造成伤害223%"/>
-        <string name="h22" value="消费HP30,MP20，造成伤害226%"/>
-        <string name="h23" value="消费HP30,MP20，造成伤害229%"/>
-        <string name="h24" value="消费HP30,MP20，造成伤害232%"/>
-        <string name="h25" value="消费HP30,MP20，造成伤害235%"/>
-        <string name="h26" value="消费HP30,MP20，造成伤害238%"/>
-        <string name="h27" value="消费HP30,MP20，造成伤害241%"/>
-        <string name="h28" value="消费HP30,MP20，造成伤害244%"/>
-        <string name="h29" value="消费HP30,MP20，造成伤害247%"/>
-        <string name="h3" value="消费HP20,MP10，造成伤害100%"/>
-        <string name="h30" value="消费HP30,MP20，造成伤害250%"/>
-        <string name="h4" value="消费HP20,MP10，造成伤害110%"/>
-        <string name="h5" value="消费HP20,MP10，造成伤害120%"/>
-        <string name="h6" value="消费HP20,MP10，造成伤害130%"/>
-        <string name="h7" value="消费HP20,MP10，造成伤害140%"/>
-        <string name="h8" value="消费HP20,MP10，造成伤害150%"/>
-        <string name="h9" value="消费HP20,MP10，造成伤害160%"/>
-        <string name="desc" value="[最高等级:30]\n对中距离多个怪物进行攻击，\n最多攻击6个怪物"/>
+        <string name="desc" value="[最高等级：30]\n挥动矛攻击周围最多6只怪物。"/>
+        <string name="h1" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 80%，最多攻击6个敌人"/>
+        <string name="h2" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 90%，最多攻击6个敌人"/>
+        <string name="h3" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 100%，最多攻击6个敌人"/>
+        <string name="h4" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 110%，最多攻击6个敌人"/>
+        <string name="h5" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 120%，最多攻击6个敌人"/>
+        <string name="h6" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 130%，最多攻击6个敌人"/>
+        <string name="h7" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 140%，最多攻击6个敌人"/>
+        <string name="h8" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 150%，最多攻击6个敌人"/>
+        <string name="h9" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 160%，最多攻击6个敌人"/>
+        <string name="h10" value="消耗HP 20，消耗MP 10，消耗HP 20，消耗MP 10，伤害 170%，最多攻击6个敌人"/>
+        <string name="h11" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 175%，最多攻击6个敌人"/>
+        <string name="h12" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 180%，最多攻击6个敌人"/>
+        <string name="h13" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 185%，最多攻击6个敌人"/>
+        <string name="h14" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 190%，最多攻击6个敌人"/>
+        <string name="h15" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 195%，最多攻击6个敌人"/>
+        <string name="h16" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 200%，最多攻击6个敌人"/>
+        <string name="h17" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 205%，最多攻击6个敌人"/>
+        <string name="h18" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 210%，最多攻击6个敌人"/>
+        <string name="h19" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 215%，最多攻击6个敌人"/>
+        <string name="h20" value="消耗HP 25，消耗MP 15，消耗HP 25，消耗MP 15，伤害 220%，最多攻击6个敌人"/>
+        <string name="h21" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 223%，最多攻击6个敌人"/>
+        <string name="h22" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 226%，最多攻击6个敌人"/>
+        <string name="h23" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 229%，最多攻击6个敌人"/>
+        <string name="h24" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 232%，最多攻击6个敌人"/>
+        <string name="h25" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 235%，最多攻击6个敌人"/>
+        <string name="h26" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 238%，最多攻击6个敌人"/>
+        <string name="h27" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 241%，最多攻击6个敌人"/>
+        <string name="h28" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 244%，最多攻击6个敌人"/>
+        <string name="h29" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 247%，最多攻击6个敌人"/>
+        <string name="h30" value="消耗HP 30，消耗MP 20，消耗HP 30，消耗MP 20，伤害 250%，最多攻击6个敌人"/>
     </imgdir>
     <imgdir name="1311005">
         <string name="name" value="龙之献祭"/>
-        <string name="h1" value="消耗MP12，攻击力205%，造成伤害20％减少HP"/>
-        <string name="h10" value="消耗MP12，攻击力250%，造成伤害15％减少HP"/>
-        <string name="h11" value="消耗MP15，攻击力255%，造成伤害15％减少HP"/>
-        <string name="h12" value="消耗MP15，攻击力260%，造成伤害14％减少HP"/>
-        <string name="h13" value="消耗MP15，攻击力265%，造成伤害14％减少HP"/>
-        <string name="h14" value="消耗MP15，攻击力270%，造成伤害13％减少HP"/>
-        <string name="h15" value="消耗MP15，攻击力275%，造成伤害13％减少HP"/>
-        <string name="h16" value="消耗MP15，攻击力280%，造成伤害12％减少HP"/>
-        <string name="h17" value="消耗MP15，攻击力285%，造成伤害12％减少HP"/>
-        <string name="h18" value="消耗MP15，攻击力290%，造成伤害11％减少HP"/>
-        <string name="h19" value="消耗MP15，攻击力295%，造成伤害11％减少HP"/>
-        <string name="h2" value="消耗MP12，攻击力210%，造成伤害19％减少HP"/>
-        <string name="h20" value="消耗MP15，攻击力300%，造成伤害10％减少HP"/>
-        <string name="h21" value="消耗MP18，攻击力305%，造成伤害10％减少HP"/>
-        <string name="h22" value="消耗MP18，攻击力310%，造成伤害9％减少HP"/>
-        <string name="h23" value="消耗MP18，攻击力315%，造成伤害9％减少HP"/>
-        <string name="h24" value="消耗MP18，攻击力320%，造成伤害8％减少HP"/>
-        <string name="h25" value="消耗MP18，攻击力325%，造成伤害8％减少HP"/>
-        <string name="h26" value="消耗MP18，攻击力330%，造成伤害7％减少HP"/>
-        <string name="h27" value="消耗MP18，攻击力335%，造成伤害7％减少HP"/>
-        <string name="h28" value="消耗MP18，攻击力340%，造成伤害6％减少HP"/>
-        <string name="h29" value="消耗MP18，攻击力345%，造成伤害6％减少HP"/>
-        <string name="h3" value="消耗MP12，攻击力215%，造成伤害19％减少HP"/>
-        <string name="h30" value="消耗MP18，攻击力350%，造成伤害5％减少HP"/>
-        <string name="h4" value="消耗MP12，攻击力220%，造成伤害18％减少HP"/>
-        <string name="h5" value="消耗MP12，攻击力225%，造成伤害18％减少HP"/>
-        <string name="h6" value="消耗MP12，攻击力230%，造成伤害17％减少HP"/>
-        <string name="h7" value="消耗MP12，攻击力235%，造成伤害17％减少HP"/>
-        <string name="h8" value="消耗MP12，攻击力240%，造成伤害16％减少HP"/>
-        <string name="h9" value="消耗MP12，攻击力245%，造成伤害16％减少HP"/>
-        <string name="desc" value="[最高等级:30]\n牺牲HP，对单体怪物进行无视物理防御的攻\n击。对BOSS无效，HP不会减少到1以下"/>
+        <string name="desc" value="[最高等级：30]\n无视敌人的防御力攻击单个怪物，但会按造成的伤害消耗自身HP。"/>
+        <string name="h1" value="消耗MP 12，伤害 205%，损失造成伤害20%的HP"/>
+        <string name="h2" value="消耗MP 12，伤害 210%，损失造成伤害19%的HP"/>
+        <string name="h3" value="消耗MP 12，伤害 215%，损失造成伤害19%的HP"/>
+        <string name="h4" value="消耗MP 12，伤害 220%，损失造成伤害18%的HP"/>
+        <string name="h5" value="消耗MP 12，伤害 225%，损失造成伤害18%的HP"/>
+        <string name="h6" value="消耗MP 12，伤害 230%，损失造成伤害17%的HP"/>
+        <string name="h7" value="消耗MP 12，伤害 235%，损失造成伤害17%的HP"/>
+        <string name="h8" value="消耗MP 12，伤害 240%，损失造成伤害16%的HP"/>
+        <string name="h9" value="消耗MP 12，伤害 245%，损失造成伤害16%的HP"/>
+        <string name="h10" value="消耗MP 12，伤害 250%，损失造成伤害15%的HP"/>
+        <string name="h11" value="消耗MP 15，伤害 255%，损失造成伤害15%的HP"/>
+        <string name="h12" value="消耗MP 15，伤害 260%，损失造成伤害14%的HP"/>
+        <string name="h13" value="消耗MP 15，伤害 265%，损失造成伤害14%的HP"/>
+        <string name="h14" value="消耗MP 15，伤害 270%，损失造成伤害13%的HP"/>
+        <string name="h15" value="消耗MP 15，伤害 275%，损失造成伤害13%的HP"/>
+        <string name="h16" value="消耗MP 15，伤害 280%，损失造成伤害12%的HP"/>
+        <string name="h17" value="消耗MP 15，伤害 285%，损失造成伤害12%的HP"/>
+        <string name="h18" value="消耗MP 15，伤害 290%，损失造成伤害11%的HP"/>
+        <string name="h19" value="消耗MP 15，伤害 295%，损失造成伤害11%的HP"/>
+        <string name="h20" value="消耗MP 15，伤害 300%，损失造成伤害10%的HP"/>
+        <string name="h21" value="消耗MP 18，伤害 305%，损失造成伤害10%的HP"/>
+        <string name="h22" value="消耗MP 18，伤害 310%，损失造成伤害9%的HP"/>
+        <string name="h23" value="消耗MP 18，伤害 315%，损失造成伤害9%的HP"/>
+        <string name="h24" value="消耗MP 18，伤害 320%，损失造成伤害8%的HP"/>
+        <string name="h25" value="消耗MP 18，伤害 325%，损失造成伤害8%的HP"/>
+        <string name="h26" value="消耗MP 18，伤害 330%，损失造成伤害7%的HP"/>
+        <string name="h27" value="消耗MP 18，伤害 335%，损失造成伤害7%的HP"/>
+        <string name="h28" value="消耗MP 18，伤害 340%，损失造成伤害6%的HP"/>
+        <string name="h29" value="消耗MP 18，伤害 345%，损失造成伤害6%的HP"/>
+        <string name="h30" value="消耗MP 18，伤害 350%，损失造成伤害5%的HP"/>
     </imgdir>
     <imgdir name="1311006">
         <string name="name" value="龙咆哮"/>
-        <string name="h1" value="消耗MP16、HP59%，造成伤害96%，攻击范围400%，4秒间昏倒"/>
-        <string name="h10" value="消费MP24 HP50%，造成伤害150%，攻击范围400%，3秒间昏倒"/>
-        <string name="h11" value="消费MP24 HP49%，造成伤害155%，攻击范围400%，3秒间昏倒"/>
-        <string name="h12" value="消费MP24 HP48%，造成伤害160%，攻击范围400%，3秒间昏倒"/>
-        <string name="h13" value="消费MP24 HP47%，造成伤害165%，攻击范围400%，3秒间昏倒"/>
-        <string name="h14" value="消费MP24 HP46%，造成伤害170%，攻击范围400%，3秒间昏倒"/>
-        <string name="h15" value="消费MP24 HP45%，造成伤害175%，攻击范围400%，3秒间昏倒"/>
-        <string name="h16" value="消费MP24 HP44%，造成伤害180%，攻击范围400%，3秒间昏倒"/>
-        <string name="h17" value="消费MP24 HP43%，造成伤害185%，攻击范围400%，3秒间昏倒"/>
-        <string name="h18" value="消费MP24 HP42%，造成伤害190%，攻击范围400%，3秒间昏倒"/>
-        <string name="h19" value="消费MP24 HP41%，造成伤害195%，攻击范围400%，3秒间昏倒"/>
-        <string name="h2" value="消费MP16 HP58%，造成伤害102%，攻击范围400%，4秒间昏倒"/>
-        <string name="h20" value="消费MP24 HP40%，造成伤害200%，攻击范围400%，3秒间昏倒"/>
-        <string name="h21" value="消费MP30 HP39%，造成伤害204%，攻击范围400%，2秒间昏倒"/>
-        <string name="h22" value="消费MP30 HP38%，造成伤害208%，攻击范围400%，2秒间昏倒"/>
-        <string name="h23" value="消费MP30 HP37%，造成伤害212%，攻击范围400%，2秒间昏倒"/>
-        <string name="h24" value="消费MP30 HP36%，造成伤害216%，攻击范围400%，2秒间昏倒"/>
-        <string name="h25" value="消费MP30 HP35%，造成伤害220%，攻击范围400%，2秒间昏倒"/>
-        <string name="h26" value="消费MP30 HP34%，造成伤害224%，攻击范围400%，2秒间昏倒"/>
-        <string name="h27" value="消费MP30 HP33%，造成伤害228%，攻击范围400%，2秒间昏倒"/>
-        <string name="h28" value="消费MP30 HP32%，造成伤害232%，攻击范围400%，2秒间昏倒"/>
-        <string name="h29" value="消费MP30 HP31%，造成伤害236%，攻击范围400%，2秒间昏倒"/>
-        <string name="h3" value="消费MP16 HP57%，造成伤害108%，攻击范围400%，4秒间昏倒"/>
-        <string name="h30" value="消费MP30 HP30%，造成伤害360%，攻击范围400%，2秒间昏倒"/>
-        <string name="h4" value="消费MP16 HP56%，造成伤害114%，攻击范围400%，4秒间昏倒"/>
-        <string name="h5" value="消费MP16 HP55%，造成伤害120%，攻击范围400%，4秒间昏倒"/>
-        <string name="h6" value="消费MP16 HP54%，造成伤害126%，攻击范围400%，4秒间昏倒"/>
-        <string name="h7" value="消费MP16 HP53%，造成伤害132%，攻击范围400%，4秒间昏倒"/>
-        <string name="h8" value="消费MP16 HP52%，造成伤害138%，攻击范围400%，4秒间昏倒"/>
-        <string name="h9" value="消费MP16 HP51%，造成伤害144%，攻击范围400%，4秒间昏倒"/>
-        <string name="desc" value="[最高等级:30]\n用巨大的龙的咆哮攻击15个以下的怪物。\n发动时HP会大幅减少，只有HP50％以上时才可以使用.\n#c冷却时间: 3秒#，\n必需技能: #c龙之献祭等级3以上#"/>
+        <string name="desc" value="[最高等级：30]\n消耗HP发出咆哮，攻击并击晕最多15只怪物。只能在HP超过50%时使用。\n需要技能：#c龙之献祭3级以上#"/>
+        <string name="h1" value="消耗MP 16，消耗当前HP的59%，伤害 96%，最多攻击15个敌人，昏迷4秒"/>
+        <string name="h2" value="消耗MP 16，消耗当前HP的58%，伤害 102%，最多攻击15个敌人，昏迷4秒"/>
+        <string name="h3" value="消耗MP 16，消耗当前HP的57%，伤害 108%，最多攻击15个敌人，昏迷4秒"/>
+        <string name="h4" value="消耗MP 16，消耗当前HP的56%，伤害 114%，最多攻击15个敌人，昏迷4秒"/>
+        <string name="h5" value="消耗MP 16，消耗当前HP的55%，伤害 120%，最多攻击15个敌人，昏迷4秒"/>
+        <string name="h6" value="消耗MP 16，消耗当前HP的54%，伤害 126%，最多攻击15个敌人，昏迷4秒"/>
+        <string name="h7" value="消耗MP 16，消耗当前HP的53%，伤害 132%，最多攻击15个敌人，昏迷4秒"/>
+        <string name="h8" value="消耗MP 16，消耗当前HP的52%，伤害 138%，最多攻击15个敌人，昏迷4秒"/>
+        <string name="h9" value="消耗MP 16，消耗当前HP的51%，伤害 144%，最多攻击15个敌人，昏迷4秒"/>
+        <string name="h10" value="消耗MP 16，消耗当前HP的50%，伤害 150%，最多攻击15个敌人，昏迷4秒"/>
+        <string name="h11" value="消耗MP 24，消耗当前HP的49%，伤害 155%，最多攻击15个敌人，昏迷3秒"/>
+        <string name="h12" value="消耗MP 24，消耗当前HP的48%，伤害 160%，最多攻击15个敌人，昏迷3秒"/>
+        <string name="h13" value="消耗MP 24，消耗当前HP的47%，伤害 165%，最多攻击15个敌人，昏迷3秒"/>
+        <string name="h14" value="消耗MP 24，消耗当前HP的46%，伤害 170%，最多攻击15个敌人，昏迷3秒"/>
+        <string name="h15" value="消耗MP 24，消耗当前HP的45%，伤害 175%，最多攻击15个敌人，昏迷3秒"/>
+        <string name="h16" value="消耗MP 24，消耗当前HP的44%，伤害 180%，最多攻击15个敌人，昏迷3秒"/>
+        <string name="h17" value="消耗MP 24，消耗当前HP的43%，伤害 185%，最多攻击15个敌人，昏迷3秒"/>
+        <string name="h18" value="消耗MP 24，消耗当前HP的42%，伤害 190%，最多攻击15个敌人，昏迷3秒"/>
+        <string name="h19" value="消耗MP 24，消耗当前HP的41%，伤害 195%，最多攻击15个敌人，昏迷3秒"/>
+        <string name="h20" value="消耗MP 24，消耗当前HP的40%，伤害 200%，最多攻击15个敌人，昏迷3秒"/>
+        <string name="h21" value="消耗MP 30，消耗当前HP的39%，伤害 204%，最多攻击15个敌人，昏迷2秒"/>
+        <string name="h22" value="消耗MP 30，消耗当前HP的38%，伤害 208%，最多攻击15个敌人，昏迷2秒"/>
+        <string name="h23" value="消耗MP 30，消耗当前HP的37%，伤害 212%，最多攻击15个敌人，昏迷2秒"/>
+        <string name="h24" value="消耗MP 30，消耗当前HP的36%，伤害 216%，最多攻击15个敌人，昏迷2秒"/>
+        <string name="h25" value="消耗MP 30，消耗当前HP的35%，伤害 220%，最多攻击15个敌人，昏迷2秒"/>
+        <string name="h26" value="消耗MP 30，消耗当前HP的34%，伤害 224%，最多攻击15个敌人，昏迷2秒"/>
+        <string name="h27" value="消耗MP 30，消耗当前HP的33%，伤害 228%，最多攻击15个敌人，昏迷2秒"/>
+        <string name="h28" value="消耗MP 30，消耗当前HP的32%，伤害 232%，最多攻击15个敌人，昏迷2秒"/>
+        <string name="h29" value="消耗MP 30，消耗当前HP的31%，伤害 236%，最多攻击15个敌人，昏迷2秒"/>
+        <string name="h30" value="消耗MP 30，消耗当前HP的30%，伤害 240%，最多攻击15个敌人，昏迷2秒"/>
     </imgdir>
     <imgdir name="1311007">
-        <string name="name" value="防御崩坏"/>
-        <string name="h1" value="消耗MP 35，冷却时间 465秒"/>
-        <string name="h10" value="消费MP 17，冷却时间 330秒"/>
-        <string name="h11" value="消费MP 16，冷却时间 315秒"/>
-        <string name="h12" value="消费MP 15，冷却时间 300秒"/>
-        <string name="h13" value="消费MP 14，冷却时间 285秒"/>
-        <string name="h14" value="消费MP 13，冷却时间 270秒"/>
-        <string name="h15" value="消费MP 12，冷却时间 255秒"/>
-        <string name="h16" value="消费MP 11，冷却时间 240秒"/>
-        <string name="h17" value="消费MP 10，冷却时间 225秒"/>
-        <string name="h18" value="消费MP 9，冷却时间 210秒"/>
-        <string name="h19" value="消费MP 8，冷却时间 195秒"/>
-        <string name="h2" value="消费MP 33，冷却时间 450秒"/>
-        <string name="h20" value="消费MP 7，冷却时间 180秒"/>
-        <string name="h3" value="消费MP 31，冷却时间 435秒"/>
-        <string name="h4" value="消费MP 29，冷却时间 420秒"/>
-        <string name="h5" value="消费MP 27，冷却时间 405秒"/>
-        <string name="h6" value="消费MP 25，冷却时间 390秒"/>
-        <string name="h7" value="消费MP 23，冷却时间 375秒"/>
-        <string name="h8" value="消费MP 21，冷却时间 360秒"/>
-        <string name="h9" value="消费MP 19，冷却时间 345秒"/>
-        <string name="desc" value="[最高等级:20]\n取消周围怪物的魔法防御\n冷却时间随着技能等级的增加而减少\n必需技能: #c龙之魂等级3以上#\n对#c暗黑龙王#无效"/>
+        <string name="name" value="力量崩坏"/>
+        <string name="desc" value="[最高等级：20]\n以一定概率解除周围怪物的攻击力提升效果。\n需要技能：#c龙之魂3级以上#"/>
+        <string name="h1" value="消耗MP 35，最多影响6个敌人，成功率 24%"/>
+        <string name="h2" value="消耗MP 33，最多影响6个敌人，成功率 28%"/>
+        <string name="h3" value="消耗MP 31，最多影响6个敌人，成功率 32%"/>
+        <string name="h4" value="消耗MP 29，最多影响6个敌人，成功率 36%"/>
+        <string name="h5" value="消耗MP 27，最多影响6个敌人，成功率 40%"/>
+        <string name="h6" value="消耗MP 25，最多影响6个敌人，成功率 44%"/>
+        <string name="h7" value="消耗MP 23，最多影响6个敌人，成功率 48%"/>
+        <string name="h8" value="消耗MP 21，最多影响6个敌人，成功率 52%"/>
+        <string name="h9" value="消耗MP 19，最多影响6个敌人，成功率 56%"/>
+        <string name="h10" value="消耗MP 17，最多影响6个敌人，成功率 60%"/>
+        <string name="h11" value="消耗MP 16，最多影响6个敌人，成功率 64%"/>
+        <string name="h12" value="消耗MP 15，最多影响6个敌人，成功率 68%"/>
+        <string name="h13" value="消耗MP 14，最多影响6个敌人，成功率 72%"/>
+        <string name="h14" value="消耗MP 13，最多影响6个敌人，成功率 76%"/>
+        <string name="h15" value="消耗MP 12，最多影响6个敌人，成功率 80%"/>
+        <string name="h16" value="消耗MP 11，最多影响6个敌人，成功率 84%"/>
+        <string name="h17" value="消耗MP 10，最多影响6个敌人，成功率 88%"/>
+        <string name="h18" value="消耗MP 9，最多影响6个敌人，成功率 92%"/>
+        <string name="h19" value="消耗MP 8，最多影响6个敌人，成功率 96%"/>
+        <string name="h20" value="消耗MP 7，最多影响6个敌人，成功率 100%"/>
     </imgdir>
     <imgdir name="1311008">
         <string name="name" value="龙之魂"/>
-        <string name="h1" value="消费MP12，每4秒 HP48减少,持续8秒攻击力+1"/>
-        <string name="h10" value="消费MP12，每4秒 HP30减少,持续80秒攻击力+7"/>
-        <string name="h11" value="消费MP24，每4秒 HP29减少,持续88秒攻击力+7"/>
-        <string name="h12" value="消费MP24，每4秒 HP28减少,持续96秒攻击力+8"/>
-        <string name="h13" value="消费MP24，每4秒 HP27减少,持续104秒攻击力+8"/>
-        <string name="h14" value="消费MP24，每4秒 HP26减少,持续112秒攻击力+9"/>
-        <string name="h15" value="消费MP24，每4秒 HP25减少,持续120秒攻击力+9"/>
-        <string name="h16" value="消费MP24，每4秒 HP24减少,持续128秒攻击力+10"/>
-        <string name="h17" value="消费MP24，每4秒 HP23减少,持续136秒攻击力+10"/>
-        <string name="h18" value="消费MP24，每4秒 HP22减少,持续144秒攻击力+11"/>
-        <string name="h19" value="消费MP24，每4秒 HP21减少,持续152秒攻击力+11"/>
-        <string name="h2" value="消费MP12，每4秒 HP46减少,持续16秒攻击力+2"/>
-        <string name="h20" value="消费MP24，每4秒 HP20减少,持续160秒攻击力+12"/>
-        <string name="h3" value="消费MP12，每4秒 HP44减少,持续24秒攻击力+3"/>
-        <string name="h4" value="消费MP12，每4秒 HP42减少,持续32秒攻击力+4"/>
-        <string name="h5" value="消费MP12，每4秒 HP40减少,持续40秒攻击力+4"/>
-        <string name="h6" value="消费MP12，每4秒 HP38减少,持续48秒攻击力+5"/>
-        <string name="h7" value="消费MP12，每4秒 HP36减少,持续56秒攻击力+5"/>
-        <string name="h8" value="消费MP12，每4秒 HP34减少,持续64秒攻击力+6"/>
-        <string name="h9" value="消费MP12，每4秒 HP32减少,持续72秒攻击力+6"/>
-        <string name="desc" value="[最高等级:20]\n一定的时间攻击力上升,但HP缓慢减少。\nHP不足时技能解除"/>
+        <string name="desc" value="[最高等级：20]\n一定时间内提高物理攻击力，但会持续消耗HP。"/>
+        <string name="h1" value="消耗MP 12，物理攻击力 +1，持续8秒，每4秒HP -48"/>
+        <string name="h2" value="消耗MP 12，物理攻击力 +2，持续16秒，每4秒HP -46"/>
+        <string name="h3" value="消耗MP 12，物理攻击力 +3，持续24秒，每4秒HP -44"/>
+        <string name="h4" value="消耗MP 12，物理攻击力 +4，持续32秒，每4秒HP -42"/>
+        <string name="h5" value="消耗MP 12，物理攻击力 +4，持续40秒，每4秒HP -40"/>
+        <string name="h6" value="消耗MP 12，物理攻击力 +5，持续48秒，每4秒HP -38"/>
+        <string name="h7" value="消耗MP 12，物理攻击力 +5，持续56秒，每4秒HP -36"/>
+        <string name="h8" value="消耗MP 12，物理攻击力 +6，持续64秒，每4秒HP -34"/>
+        <string name="h9" value="消耗MP 12，物理攻击力 +6，持续72秒，每4秒HP -32"/>
+        <string name="h10" value="消耗MP 12，物理攻击力 +7，持续80秒，每4秒HP -30"/>
+        <string name="h11" value="消耗MP 24，物理攻击力 +7，持续88秒，每4秒HP -29"/>
+        <string name="h12" value="消耗MP 24，物理攻击力 +8，持续96秒，每4秒HP -28"/>
+        <string name="h13" value="消耗MP 24，物理攻击力 +8，持续104秒，每4秒HP -27"/>
+        <string name="h14" value="消耗MP 24，物理攻击力 +9，持续112秒，每4秒HP -26"/>
+        <string name="h15" value="消耗MP 24，物理攻击力 +9，持续120秒，每4秒HP -25"/>
+        <string name="h16" value="消耗MP 24，物理攻击力 +10，持续128秒，每4秒HP -24"/>
+        <string name="h17" value="消耗MP 24，物理攻击力 +10，持续136秒，每4秒HP -23"/>
+        <string name="h18" value="消耗MP 24，物理攻击力 +11，持续144秒，每4秒HP -22"/>
+        <string name="h19" value="消耗MP 24，物理攻击力 +11，持续152秒，每4秒HP -21"/>
+        <string name="h20" value="消耗MP 24，物理攻击力 +12，持续160秒，每4秒HP -20"/>
     </imgdir>
     <imgdir name="13111000">
         <string name="name" value="箭雨"/>
@@ -4043,288 +4043,288 @@
     </imgdir>
     <imgdir name="1320005">
         <string name="name" value="阿基里斯"/>
-        <string name="h1" value="减少伤害 5.5%"/>
-        <string name="h10" value="减少伤害 10%"/>
-        <string name="h11" value="减少伤害 10.5%"/>
-        <string name="h12" value="减少伤害 11%"/>
-        <string name="h13" value="减少伤害 11.5%"/>
-        <string name="h14" value="减少伤害 12%"/>
-        <string name="h15" value="减少伤害 12.5%"/>
-        <string name="h16" value="减少伤害 13%"/>
-        <string name="h17" value="减少伤害 13.5%"/>
-        <string name="h18" value="减少伤害 14%"/>
-        <string name="h19" value="减少伤害 14.5%"/>
-        <string name="h2" value="减少伤害 6%"/>
-        <string name="h20" value="减少伤害 15%"/>
-        <string name="h21" value="减少伤害 15.5%"/>
-        <string name="h22" value="减少伤害 16%"/>
-        <string name="h23" value="减少伤害 16.5%"/>
-        <string name="h24" value="减少伤害 17%"/>
-        <string name="h25" value="减少伤害 17.5%"/>
-        <string name="h26" value="减少伤害 18%"/>
-        <string name="h27" value="减少伤害 18.5%"/>
-        <string name="h28" value="减少伤害 19%"/>
-        <string name="h29" value="减少伤害 19.5%"/>
-        <string name="h3" value="减少伤害 6.5%"/>
-        <string name="h30" value="减少伤害 20%"/>
-        <string name="h4" value="减少伤害 7%"/>
-        <string name="h5" value="减少伤害 7.5%"/>
-        <string name="h6" value="减少伤害 8%"/>
-        <string name="h7" value="减少伤害 8.5%"/>
-        <string name="h8" value="减少伤害 9%"/>
-        <string name="h9" value="减少伤害 9.5%"/>
-        <string name="desc" value="永久强化盔甲,减弱伤害值"/>
+        <string name="desc" value="[最高等级：30]\n永久减少受到的敌人伤害。"/>
+        <string name="h1" value="受到的伤害减少 0.5%"/>
+        <string name="h2" value="受到的伤害减少 1%"/>
+        <string name="h3" value="受到的伤害减少 1.5%"/>
+        <string name="h4" value="受到的伤害减少 2%"/>
+        <string name="h5" value="受到的伤害减少 2.5%"/>
+        <string name="h6" value="受到的伤害减少 3%"/>
+        <string name="h7" value="受到的伤害减少 3.5%"/>
+        <string name="h8" value="受到的伤害减少 4%"/>
+        <string name="h9" value="受到的伤害减少 4.5%"/>
+        <string name="h10" value="受到的伤害减少 5%"/>
+        <string name="h11" value="受到的伤害减少 5.5%"/>
+        <string name="h12" value="受到的伤害减少 6%"/>
+        <string name="h13" value="受到的伤害减少 6.5%"/>
+        <string name="h14" value="受到的伤害减少 7%"/>
+        <string name="h15" value="受到的伤害减少 7.5%"/>
+        <string name="h16" value="受到的伤害减少 8%"/>
+        <string name="h17" value="受到的伤害减少 8.5%"/>
+        <string name="h18" value="受到的伤害减少 9%"/>
+        <string name="h19" value="受到的伤害减少 9.5%"/>
+        <string name="h20" value="受到的伤害减少 10%"/>
+        <string name="h21" value="受到的伤害减少 10.5%"/>
+        <string name="h22" value="受到的伤害减少 11%"/>
+        <string name="h23" value="受到的伤害减少 11.5%"/>
+        <string name="h24" value="受到的伤害减少 12%"/>
+        <string name="h25" value="受到的伤害减少 12.5%"/>
+        <string name="h26" value="受到的伤害减少 13%"/>
+        <string name="h27" value="受到的伤害减少 13.5%"/>
+        <string name="h28" value="受到的伤害减少 14%"/>
+        <string name="h29" value="受到的伤害减少 14.5%"/>
+        <string name="h30" value="受到的伤害减少 15%"/>
     </imgdir>
     <imgdir name="1320006">
         <string name="name" value="恶龙附身"/>
-        <string name="h1" value="HP 80% 以下时，伤害 104%"/>
-        <string name="h10" value="HP 80% 以下时，伤害 140%"/>
-        <string name="h11" value="HP 80% 以下时，伤害 144%"/>
-        <string name="h12" value="HP 80% 以下时，伤害 148%"/>
-        <string name="h13" value="HP 80% 以下时，伤害 152%"/>
-        <string name="h14" value="HP 80% 以下时，伤害 156%"/>
-        <string name="h15" value="HP 80% 以下时，伤害 160%"/>
-        <string name="h16" value="HP 80% 以下时，伤害 162%"/>
-        <string name="h17" value="HP 80% 以下时，伤害 164%"/>
-        <string name="h18" value="HP 80% 以下时，伤害 166%"/>
-        <string name="h19" value="HP 80% 以下时，伤害 168%"/>
-        <string name="h2" value="HP 80% 以下时，伤害 108%"/>
-        <string name="h20" value="HP 80% 以下时，伤害 170%"/>
-        <string name="h21" value="HP 80% 以下时，伤害 173%"/>
-        <string name="h22" value="HP 80% 以下时，伤害 176%"/>
-        <string name="h23" value="HP 80% 以下时，伤害 179%"/>
-        <string name="h24" value="HP 80% 以下时，伤害 182%"/>
-        <string name="h25" value="HP 80% 以下时，伤害 185%"/>
-        <string name="h26" value="HP 80% 以下时，伤害 188%"/>
-        <string name="h27" value="HP 80% 以下时，伤害 191%"/>
-        <string name="h28" value="HP 80% 以下时，伤害 194%"/>
-        <string name="h29" value="HP 80% 以下时，伤害 197%"/>
-        <string name="h3" value="HP 80% 以下时，伤害 112%"/>
-        <string name="h30" value="HP 80% 以下时，伤害 200%"/>
-        <string name="h4" value="HP 80% 以下时，伤害 116%"/>
-        <string name="h5" value="HP 80% 以下时，伤害 120%"/>
-        <string name="h6" value="HP 80% 以下时，伤害 124%"/>
-        <string name="h7" value="HP 80% 以下时，伤害 128%"/>
-        <string name="h8" value="HP 80% 以下时，伤害 132%"/>
-        <string name="h9" value="HP 80% 以下时，伤害 136%"/>
-        <string name="desc" value="HP下降到一定水平的话，黑骑士内心中\n沉睡的灵魂爆发，使攻击伤害增加。 \n体力恢复的话，技能效果消失"/>
+        <string name="desc" value="[最高等级：30]\nHP低于技能指定比例时提高伤害；HP恢复到该比例以上时效果消失。"/>
+        <string name="h1" value="HP低于21%时，伤害 +132%"/>
+        <string name="h2" value="HP低于22%时，伤害 +134%"/>
+        <string name="h3" value="HP低于23%时，伤害 +136%"/>
+        <string name="h4" value="HP低于24%时，伤害 +138%"/>
+        <string name="h5" value="HP低于25%时，伤害 +140%"/>
+        <string name="h6" value="HP低于26%时，伤害 +142%"/>
+        <string name="h7" value="HP低于27%时，伤害 +144%"/>
+        <string name="h8" value="HP低于28%时，伤害 +146%"/>
+        <string name="h9" value="HP低于29%时，伤害 +148%"/>
+        <string name="h10" value="HP低于30%时，伤害 +150%"/>
+        <string name="h11" value="HP低于31%时，伤害 +152%"/>
+        <string name="h12" value="HP低于32%时，伤害 +154%"/>
+        <string name="h13" value="HP低于33%时，伤害 +156%"/>
+        <string name="h14" value="HP低于34%时，伤害 +158%"/>
+        <string name="h15" value="HP低于35%时，伤害 +160%"/>
+        <string name="h16" value="HP低于36%时，伤害 +162%"/>
+        <string name="h17" value="HP低于37%时，伤害 +164%"/>
+        <string name="h18" value="HP低于38%时，伤害 +166%"/>
+        <string name="h19" value="HP低于39%时，伤害 +168%"/>
+        <string name="h20" value="HP低于40%时，伤害 +170%"/>
+        <string name="h21" value="HP低于41%时，伤害 +173%"/>
+        <string name="h22" value="HP低于42%时，伤害 +176%"/>
+        <string name="h23" value="HP低于43%时，伤害 +179%"/>
+        <string name="h24" value="HP低于44%时，伤害 +182%"/>
+        <string name="h25" value="HP低于45%时，伤害 +185%"/>
+        <string name="h26" value="HP低于46%时，伤害 +188%"/>
+        <string name="h27" value="HP低于47%时，伤害 +191%"/>
+        <string name="h28" value="HP低于48%时，伤害 +194%"/>
+        <string name="h29" value="HP低于49%时，伤害 +197%"/>
+        <string name="h30" value="HP低于50%时，伤害 +200%"/>
     </imgdir>
     <imgdir name="1320008">
         <string name="name" value="灵魂治愈"/>
-        <string name="h1" value="每10秒 HP 40 恢复"/>
-        <string name="h10" value="每8秒 HP 200 恢复"/>
-        <string name="h11" value="每8秒 HP 260 恢复"/>
-        <string name="h12" value="每8秒 HP 270 恢复"/>
-        <string name="h13" value="每7秒 HP 280 恢复"/>
-        <string name="h14" value="每7秒 HP 290 恢复"/>
-        <string name="h15" value="每7秒 HP 300 恢复"/>
-        <string name="h16" value="每7秒 HP 360 恢复"/>
-        <string name="h17" value="每6秒 HP 370 恢复"/>
-        <string name="h18" value="每6秒 HP 380 恢复"/>
-        <string name="h19" value="每6秒 HP 390 恢复"/>
-        <string name="h2" value="每10秒 HP 55 恢复"/>
-        <string name="h20" value="每6秒 HP 400 恢复"/>
-        <string name="h21" value="每5秒 HP 460 恢复"/>
-        <string name="h22" value="每5秒 HP 470 恢复"/>
-        <string name="h23" value="每5秒 HP 480 恢复"/>
-        <string name="h24" value="每5秒 HP 490 恢复"/>
-        <string name="h25" value="每4秒 HP 500 恢复"/>
-        <string name="h3" value="每10秒 HP 70 恢复"/>
-        <string name="h4" value="每10秒 HP 85 恢复"/>
-        <string name="h5" value="每9秒 HP 100 恢复"/>
-        <string name="h6" value="每9秒 HP 160 恢复"/>
-        <string name="h7" value="每9秒 HP 170 恢复"/>
-        <string name="h8" value="每9秒 HP 180 恢复"/>
-        <string name="h9" value="每8秒 HP 190 恢复"/>
-        <string name="desc" value="灵魂治愈在每一定时间内补充黑骑士的体力\n技能级别上升，HP恢复量也上升\n必要技能 : #c灵魂助力 1级 以上#"/>
+        <string name="desc" value="[最高等级：25]\n灵魂助力召唤期间，灵魂会周期性恢复黑骑士的HP。"/>
+        <string name="h1" value="每10秒恢复HP 40"/>
+        <string name="h2" value="每10秒恢复HP 55"/>
+        <string name="h3" value="每10秒恢复HP 70"/>
+        <string name="h4" value="每10秒恢复HP 85"/>
+        <string name="h5" value="每9秒恢复HP 100"/>
+        <string name="h6" value="每9秒恢复HP 160"/>
+        <string name="h7" value="每9秒恢复HP 170"/>
+        <string name="h8" value="每9秒恢复HP 180"/>
+        <string name="h9" value="每8秒恢复HP 190"/>
+        <string name="h10" value="每8秒恢复HP 200"/>
+        <string name="h11" value="每8秒恢复HP 260"/>
+        <string name="h12" value="每8秒恢复HP 270"/>
+        <string name="h13" value="每7秒恢复HP 280"/>
+        <string name="h14" value="每7秒恢复HP 290"/>
+        <string name="h15" value="每7秒恢复HP 300"/>
+        <string name="h16" value="每7秒恢复HP 360"/>
+        <string name="h17" value="每6秒恢复HP 370"/>
+        <string name="h18" value="每6秒恢复HP 380"/>
+        <string name="h19" value="每6秒恢复HP 390"/>
+        <string name="h20" value="每6秒恢复HP 400"/>
+        <string name="h21" value="每5秒恢复HP 460"/>
+        <string name="h22" value="每5秒恢复HP 470"/>
+        <string name="h23" value="每5秒恢复HP 480"/>
+        <string name="h24" value="每5秒恢复HP 490"/>
+        <string name="h25" value="每4秒恢复HP 500"/>
     </imgdir>
     <imgdir name="1320009">
         <string name="name" value="灵魂祝福"/>
-        <string name="h1" value="每48秒施展，持续20秒，提高物理防御力状态"/>
-        <string name="h10" value="每30秒施展，持续40秒，提高物理防御,魔法防御状态"/>
-        <string name="h11" value="每28秒施展，持续60秒，提高物理防御,魔法防御,命中力"/>
-        <string name="h12" value="每26秒施展，持续60秒，提高物理防御,魔法防御,命中力"/>
-        <string name="h13" value="每24秒施展，持续60秒，提高物理防御,魔法防御,命中力"/>
-        <string name="h14" value="每22秒施展，持续60秒，提高物理防御,魔法防御,命中力"/>
-        <string name="h15" value="每20秒施展，持续60秒，提高物理防御,魔法防御,命中力"/>
-        <string name="h16" value="每18秒施展，持续80秒，提高物理防御,魔法防御,命中力,回避力"/>
-        <string name="h17" value="每16秒施展，持续80秒，提高物理防御,魔法防御,命中力,回避力"/>
-        <string name="h18" value="每14秒施展，持续80秒，提高物理防御,魔法防御,命中力,回避力"/>
-        <string name="h19" value="每12秒施展，持续80秒，提高物理防御,魔法防御,命中力,回避力"/>
-        <string name="h2" value="每46秒施展，持续20秒，提高物理防御力状态"/>
-        <string name="h20" value="每10秒施展，持续80秒，提高物理防御,魔法防御,命中力,回避力"/>
-        <string name="h21" value="每8秒施展，持续100秒，提高物理防御,魔法防御,命中力,回避力,攻击力"/>
-        <string name="h22" value="每7秒施展，持续100秒，提高物理防御,魔法防御,命中力,回避力,攻击力"/>
-        <string name="h23" value="每6秒施展，持续100秒，提高物理防御,魔法防御,命中力,回避力,攻击力"/>
-        <string name="h24" value="每5秒施展，持续100秒，提高物理防御,魔法防御,命中力,回避力,攻击力"/>
-        <string name="h25" value="每4秒施展，持续99秒，提高物理防御,魔法防御,命中力,回避力,攻击力"/>
-        <string name="h3" value="每44秒施展，持续20秒，提高物理防御力状态"/>
-        <string name="h4" value="每42秒施展，持续20秒，提高物理防御力状态"/>
-        <string name="h5" value="每40秒施展，持续20秒，提高物理防御力状态"/>
-        <string name="h6" value="每38秒施展，持续40秒，提高物理防御,魔法防御状态"/>
-        <string name="h7" value="每36秒施展，持续40秒，提高物理防御,魔法防御状态"/>
-        <string name="h8" value="每34秒施展，持续40秒，提高物理防御,魔法防御状态"/>
-        <string name="h9" value="每32秒施展，持续40秒，提高物理防御,魔法防御状态"/>
-        <string name="desc" value="灵魂祝福在每一定时间使用状态. 根据技能\n等级不同发动物理防御力，魔法防御力，\n回避率，命中率，物理攻击力上升的状态.\n必要技能 : #c灵魂助力 1级 以上#"/>
+        <string name="desc" value="[最高等级：25]\n灵魂助力召唤期间，灵魂会周期性为黑骑士施加增益，增益种类随技能等级提升而增加。"/>
+        <string name="h1" value="每48秒施加增益，持续20秒，物理防御力 +20"/>
+        <string name="h2" value="每46秒施加增益，持续20秒，物理防御力 +20"/>
+        <string name="h3" value="每44秒施加增益，持续20秒，物理防御力 +20"/>
+        <string name="h4" value="每42秒施加增益，持续20秒，物理防御力 +20"/>
+        <string name="h5" value="每40秒施加增益，持续20秒，物理防御力 +20"/>
+        <string name="h6" value="每38秒施加增益，持续40秒，物理防御力 +40，魔法防御力 +25"/>
+        <string name="h7" value="每36秒施加增益，持续40秒，物理防御力 +40，魔法防御力 +25"/>
+        <string name="h8" value="每34秒施加增益，持续40秒，物理防御力 +40，魔法防御力 +25"/>
+        <string name="h9" value="每32秒施加增益，持续40秒，物理防御力 +40，魔法防御力 +25"/>
+        <string name="h10" value="每30秒施加增益，持续40秒，物理防御力 +40，魔法防御力 +25"/>
+        <string name="h11" value="每28秒施加增益，持续60秒，物理防御力 +60，魔法防御力 +50，命中率 +10"/>
+        <string name="h12" value="每26秒施加增益，持续60秒，物理防御力 +60，魔法防御力 +50，命中率 +10"/>
+        <string name="h13" value="每24秒施加增益，持续60秒，物理防御力 +60，魔法防御力 +50，命中率 +10"/>
+        <string name="h14" value="每22秒施加增益，持续60秒，物理防御力 +60，魔法防御力 +50，命中率 +10"/>
+        <string name="h15" value="每20秒施加增益，持续60秒，物理防御力 +60，魔法防御力 +50，命中率 +10"/>
+        <string name="h16" value="每18秒施加增益，持续80秒，物理防御力 +80，魔法防御力 +75，命中率 +20，回避率 +30"/>
+        <string name="h17" value="每16秒施加增益，持续80秒，物理防御力 +80，魔法防御力 +75，命中率 +20，回避率 +30"/>
+        <string name="h18" value="每14秒施加增益，持续80秒，物理防御力 +80，魔法防御力 +75，命中率 +20，回避率 +30"/>
+        <string name="h19" value="每12秒施加增益，持续80秒，物理防御力 +80，魔法防御力 +75，命中率 +20，回避率 +30"/>
+        <string name="h20" value="每10秒施加增益，持续80秒，物理防御力 +80，魔法防御力 +75，命中率 +20，回避率 +30"/>
+        <string name="h21" value="每8秒施加增益，持续100秒，物理防御力 +100，魔法防御力 +100，命中率 +25，回避率 +50，物理攻击力 +3"/>
+        <string name="h22" value="每7秒施加增益，持续100秒，物理防御力 +100，魔法防御力 +100，命中率 +25，回避率 +50，物理攻击力 +6"/>
+        <string name="h23" value="每6秒施加增益，持续100秒，物理防御力 +100，魔法防御力 +100，命中率 +25，回避率 +50，物理攻击力 +9"/>
+        <string name="h24" value="每5秒施加增益，持续100秒，物理防御力 +100，魔法防御力 +100，命中率 +25，回避率 +50，物理攻击力 +12"/>
+        <string name="h25" value="每4秒施加增益，持续99秒，物理防御力 +100，魔法防御力 +100，命中率 +25，回避率 +50，物理攻击力 +15"/>
     </imgdir>
     <imgdir name="1321000">
         <string name="name" value="冒险岛勇士"/>
-        <string name="h1" value="消耗MP 10，30秒内所有的属性点提高 1%"/>
-        <string name="h10" value="消耗MP 20，300秒内所有的属性点提高 5%"/>
-        <string name="h11" value="消耗MP 30，330秒内所有的属性点提高 6%"/>
-        <string name="h12" value="消耗MP 30，360秒内所有的属性点提高 6%"/>
-        <string name="h13" value="消耗MP 30，390秒内所有的属性点提高 7%"/>
-        <string name="h14" value="消耗MP 30，420秒内所有的属性点提高 7%"/>
-        <string name="h15" value="消耗MP 30，450秒内所有的属性点提高 8%"/>
-        <string name="h16" value="消耗MP 40，480秒内所有的属性点提高 8%"/>
-        <string name="h17" value="消耗MP 40，510秒内所有的属性点提高 9%"/>
-        <string name="h18" value="消耗MP 40，540秒内所有的属性点提高 9%"/>
-        <string name="h19" value="消耗MP 40，570秒内所有的属性点提高 10%"/>
-        <string name="h2" value="消耗MP 10，60秒内所有的属性点提高 1%"/>
-        <string name="h20" value="消耗MP 40，600秒内所有的属性点提高 10%"/>
-        <string name="h21" value="消耗MP 50，630秒内所有的属性点提高 11%"/>
-        <string name="h22" value="消耗MP 50，660秒内所有的属性点提高 11%"/>
-        <string name="h23" value="消耗MP 50，690秒内所有的属性点提高 12%"/>
-        <string name="h24" value="消耗MP 50，720秒内所有的属性点提高 12%"/>
-        <string name="h25" value="消耗MP 50，750秒内所有的属性点提高 13%"/>
-        <string name="h26" value="消耗MP 60，780秒内所有的属性点提高 13%"/>
-        <string name="h27" value="消耗MP 60，810秒内所有的属性点提高 14%"/>
-        <string name="h28" value="消耗MP 50，840秒内所有的属性点提高 14%"/>
-        <string name="h29" value="消耗MP 50，870秒内所有的属性点提高 15%"/>
-        <string name="h3" value="消耗MP 10，90秒内所有的属性点提高 2%"/>
-        <string name="h30" value="消耗MP 50，900秒内所有的属性点提高 15%"/>
-        <string name="h4" value="消耗MP 10，120秒内所有的属性点提高 2%"/>
-        <string name="h5" value="消耗MP 10，150秒内所有的属性点提高 3%"/>
-        <string name="h6" value="消耗MP 20，180秒内所有的属性点提高 3%"/>
-        <string name="h7" value="消耗MP 20，210秒内所有的属性点提高 4%"/>
-        <string name="h8" value="消耗MP 20，240秒内所有的属性点提高 4%"/>
-        <string name="h9" value="消耗MP 20，270秒内所有的属性点提高 5%"/>
-        <string name="desc" value="一定时间内把组队成员的所有属性点提高\n一定的百分比"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内按百分比提高自身及周围队员的所有属性。"/>
+        <string name="h1" value="消耗MP 10，所有属性 +1%，持续30秒"/>
+        <string name="h2" value="消耗MP 10，所有属性 +1%，持续60秒"/>
+        <string name="h3" value="消耗MP 10，所有属性 +2%，持续90秒"/>
+        <string name="h4" value="消耗MP 10，所有属性 +2%，持续120秒"/>
+        <string name="h5" value="消耗MP 10，所有属性 +3%，持续150秒"/>
+        <string name="h6" value="消耗MP 20，所有属性 +3%，持续180秒"/>
+        <string name="h7" value="消耗MP 20，所有属性 +4%，持续210秒"/>
+        <string name="h8" value="消耗MP 20，所有属性 +4%，持续240秒"/>
+        <string name="h9" value="消耗MP 20，所有属性 +5%，持续270秒"/>
+        <string name="h10" value="消耗MP 20，所有属性 +5%，持续300秒"/>
+        <string name="h11" value="消耗MP 30，所有属性 +6%，持续330秒"/>
+        <string name="h12" value="消耗MP 30，所有属性 +6%，持续360秒"/>
+        <string name="h13" value="消耗MP 30，所有属性 +7%，持续390秒"/>
+        <string name="h14" value="消耗MP 30，所有属性 +7%，持续420秒"/>
+        <string name="h15" value="消耗MP 30，所有属性 +8%，持续450秒"/>
+        <string name="h16" value="消耗MP 40，所有属性 +8%，持续480秒"/>
+        <string name="h17" value="消耗MP 40，所有属性 +9%，持续510秒"/>
+        <string name="h18" value="消耗MP 40，所有属性 +9%，持续540秒"/>
+        <string name="h19" value="消耗MP 40，所有属性 +10%，持续570秒"/>
+        <string name="h20" value="消耗MP 40，所有属性 +10%，持续600秒"/>
+        <string name="h21" value="消耗MP 50，所有属性 +11%，持续630秒"/>
+        <string name="h22" value="消耗MP 50，所有属性 +11%，持续660秒"/>
+        <string name="h23" value="消耗MP 50，所有属性 +12%，持续690秒"/>
+        <string name="h24" value="消耗MP 50，所有属性 +12%，持续720秒"/>
+        <string name="h25" value="消耗MP 50，所有属性 +13%，持续750秒"/>
+        <string name="h26" value="消耗MP 60，所有属性 +13%，持续780秒"/>
+        <string name="h27" value="消耗MP 60，所有属性 +14%，持续810秒"/>
+        <string name="h28" value="消耗MP 60，所有属性 +14%，持续840秒"/>
+        <string name="h29" value="消耗MP 60，所有属性 +15%，持续870秒"/>
+        <string name="h30" value="消耗MP 60，所有属性 +15%，持续900秒"/>
     </imgdir>
     <imgdir name="1321001">
         <string name="name" value="磁石"/>
-        <string name="h1" value="消耗MP 10，范围 100%，成功率 42%"/>
-        <string name="h10" value="消耗MP 13，范围 100%，成功率 60%"/>
-        <string name="h11" value="消耗MP 18，范围 150%，成功率 62%"/>
-        <string name="h12" value="消耗MP 18，范围 150%，成功率 64%"/>
-        <string name="h13" value="消耗MP 18，范围 150%，成功率 66%"/>
-        <string name="h14" value="消耗MP 18，范围 150%，成功率 68%"/>
-        <string name="h15" value="消耗MP 18，范围 150%，成功率 70%"/>
-        <string name="h16" value="消耗MP 21，范围 150%，成功率 72%"/>
-        <string name="h17" value="消耗MP 21，范围 150%，成功率 74%"/>
-        <string name="h18" value="消耗MP 21，范围 150%，成功率 76%"/>
-        <string name="h19" value="消耗MP 21，范围 150%，成功率 78%"/>
-        <string name="h2" value="消耗MP 10，范围 100%，成功率 44%"/>
-        <string name="h20" value="消耗MP 21，范围 150%，成功率 80%"/>
-        <string name="h21" value="消耗MP 26，范围 200%，成功率 82%"/>
-        <string name="h22" value="消耗MP 26，范围 200%，成功率 84%"/>
-        <string name="h23" value="消耗MP 26，范围 200%，成功率 86%"/>
-        <string name="h24" value="消耗MP 26，范围 200%，成功率 88%"/>
-        <string name="h25" value="消耗MP 26，范围 200%，成功率 90%"/>
-        <string name="h26" value="消耗MP 25，范围 200%，成功率 91%"/>
-        <string name="h27" value="消耗MP 24，范围 200%，成功率 92%"/>
-        <string name="h28" value="消耗MP 23，范围 200%，成功率 93%"/>
-        <string name="h29" value="消耗MP 22，范围 200%，成功率 94%"/>
-        <string name="h3" value="消耗MP 10，范围 100%，成功率 46%"/>
-        <string name="h30" value="消耗MP 21，范围 200%，成功率 95%"/>
-        <string name="h4" value="消耗MP 10，范围 100%，成功率 48%"/>
-        <string name="h5" value="消耗MP 10，范围 100%，成功率 50%"/>
-        <string name="h6" value="消耗MP 13，范围 100%，成功率 52%"/>
-        <string name="h7" value="消耗MP 13，范围 100%，成功率 54%"/>
-        <string name="h8" value="消耗MP 13，范围 100%，成功率 56%"/>
-        <string name="h9" value="消耗MP 13，范围 100%，成功率 58%"/>
-        <string name="desc" value="把远处的敌人吸到自己面前"/>
+        <string name="desc" value="[最高等级：30]\n以一定概率将远处的怪物拉到自己面前。"/>
+        <string name="h1" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h2" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h3" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h4" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h5" value="消耗MP 10，最多牵引3个敌人，成功率 100%"/>
+        <string name="h6" value="消耗MP 13，最多牵引3个敌人，成功率 100%"/>
+        <string name="h7" value="消耗MP 13，最多牵引3个敌人，成功率 100%"/>
+        <string name="h8" value="消耗MP 13，最多牵引4个敌人，成功率 100%"/>
+        <string name="h9" value="消耗MP 13，最多牵引4个敌人，成功率 100%"/>
+        <string name="h10" value="消耗MP 13，最多牵引4个敌人，成功率 100%"/>
+        <string name="h11" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h12" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h13" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h14" value="消耗MP 18，最多牵引4个敌人，成功率 100%"/>
+        <string name="h15" value="消耗MP 18，最多牵引5个敌人，成功率 100%"/>
+        <string name="h16" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h17" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h18" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h19" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h20" value="消耗MP 21，最多牵引5个敌人，成功率 100%"/>
+        <string name="h21" value="消耗MP 26，最多牵引5个敌人，成功率 100%"/>
+        <string name="h22" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h23" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h24" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h25" value="消耗MP 26，最多牵引6个敌人，成功率 100%"/>
+        <string name="h26" value="消耗MP 25，最多牵引6个敌人，成功率 100%"/>
+        <string name="h27" value="消耗MP 24，最多牵引6个敌人，成功率 100%"/>
+        <string name="h28" value="消耗MP 23，最多牵引6个敌人，成功率 100%"/>
+        <string name="h29" value="消耗MP 22，最多牵引7个敌人，成功率 100%"/>
+        <string name="h30" value="消耗MP 21，最多牵引7个敌人，成功率 100%"/>
     </imgdir>
     <imgdir name="1321002">
         <string name="name" value="稳如泰山"/>
-        <string name="h1" value="消耗MP 30，10秒内有42%的几率不会出现退后现象"/>
-        <string name="h10" value="消耗MP 36，100秒内有60%的几率不会出现退后现象"/>
-        <string name="h11" value="消耗MP 42，110秒内有62%的几率不会出现退后现象"/>
-        <string name="h12" value="消耗MP 42，120秒内有64%的几率不会出现退后现象"/>
-        <string name="h13" value="消耗MP 42，130秒内有66%的几率不会出现退后现象"/>
-        <string name="h14" value="消耗MP 42，140秒内有68%的几率不会出现退后现象"/>
-        <string name="h15" value="消耗MP 42，150秒内有70%的几率不会出现退后现象"/>
-        <string name="h16" value="消耗MP 48，160秒内有72%的几率不会出现退后现象"/>
-        <string name="h17" value="消耗MP 48，170秒内有74%的几率不会出现退后现象"/>
-        <string name="h18" value="消耗MP 48，180秒内有76%的几率不会出现退后现象"/>
-        <string name="h19" value="消耗MP 48，190秒内有78%的几率不会出现退后现象"/>
-        <string name="h2" value="消耗MP 30，20秒内有44%的几率不会出现退后现象"/>
-        <string name="h20" value="消耗MP 48，200秒内有80%的几率不会出现退后现象"/>
-        <string name="h21" value="消耗MP 54，210秒内有81%的几率不会出现退后现象"/>
-        <string name="h22" value="消耗MP 54，220秒内有82%的几率不会出现退后现象"/>
-        <string name="h23" value="消耗MP 54，230秒内有83%的几率不会出现退后现象"/>
-        <string name="h24" value="消耗MP 54，240秒内有84%的几率不会出现退后现象"/>
-        <string name="h25" value="消耗MP 54，250秒内有85%的几率不会出现退后现象"/>
-        <string name="h26" value="消耗MP 53，260秒内有86%的几率不会出现退后现象"/>
-        <string name="h27" value="消耗MP 52，270秒内有87%的几率不会出现退后现象"/>
-        <string name="h28" value="消耗MP 51，280秒内有88%的几率不会出现退后现象"/>
-        <string name="h29" value="消耗MP 50，290秒内有89%的几率不会出现退后现象"/>
-        <string name="h3" value="消耗MP 30，30秒内有46%的几率不会出现退后现象"/>
-        <string name="h30" value="消耗MP 50，300秒内有90%的几率不会出现退后现象"/>
-        <string name="h4" value="消耗MP 30，40秒内有48%的几率不会出现退后现象"/>
-        <string name="h5" value="消耗MP 30，50秒内有50%的几率不会出现退后现象"/>
-        <string name="h6" value="消耗MP 36，60秒内有52%的几率不会出现退后现象"/>
-        <string name="h7" value="消耗MP 36，70秒内有54%的几率不会出现退后现象"/>
-        <string name="h8" value="消耗MP 36，80秒内有56%的几率不会出现退后现象"/>
-        <string name="h9" value="消耗MP 36，90秒内有58%的几率不会出现退后现象"/>
-        <string name="desc" value="凭借着强韧的精神，\n受到敌人的攻击仍不会后退"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内以一定概率抵抗敌人攻击造成的击退。"/>
+        <string name="h1" value="消耗MP 30，42%概率抵抗击退，持续10秒"/>
+        <string name="h2" value="消耗MP 30，44%概率抵抗击退，持续20秒"/>
+        <string name="h3" value="消耗MP 30，46%概率抵抗击退，持续30秒"/>
+        <string name="h4" value="消耗MP 30，48%概率抵抗击退，持续40秒"/>
+        <string name="h5" value="消耗MP 30，50%概率抵抗击退，持续50秒"/>
+        <string name="h6" value="消耗MP 36，52%概率抵抗击退，持续60秒"/>
+        <string name="h7" value="消耗MP 36，54%概率抵抗击退，持续70秒"/>
+        <string name="h8" value="消耗MP 36，56%概率抵抗击退，持续80秒"/>
+        <string name="h9" value="消耗MP 36，58%概率抵抗击退，持续90秒"/>
+        <string name="h10" value="消耗MP 36，60%概率抵抗击退，持续100秒"/>
+        <string name="h11" value="消耗MP 42，62%概率抵抗击退，持续110秒"/>
+        <string name="h12" value="消耗MP 42，64%概率抵抗击退，持续120秒"/>
+        <string name="h13" value="消耗MP 42，66%概率抵抗击退，持续130秒"/>
+        <string name="h14" value="消耗MP 42，68%概率抵抗击退，持续140秒"/>
+        <string name="h15" value="消耗MP 42，70%概率抵抗击退，持续150秒"/>
+        <string name="h16" value="消耗MP 48，72%概率抵抗击退，持续160秒"/>
+        <string name="h17" value="消耗MP 48，74%概率抵抗击退，持续170秒"/>
+        <string name="h18" value="消耗MP 48，76%概率抵抗击退，持续180秒"/>
+        <string name="h19" value="消耗MP 48，78%概率抵抗击退，持续190秒"/>
+        <string name="h20" value="消耗MP 48，80%概率抵抗击退，持续200秒"/>
+        <string name="h21" value="消耗MP 54，81%概率抵抗击退，持续210秒"/>
+        <string name="h22" value="消耗MP 54，82%概率抵抗击退，持续220秒"/>
+        <string name="h23" value="消耗MP 54，83%概率抵抗击退，持续230秒"/>
+        <string name="h24" value="消耗MP 54，84%概率抵抗击退，持续240秒"/>
+        <string name="h25" value="消耗MP 54，85%概率抵抗击退，持续250秒"/>
+        <string name="h26" value="消耗MP 53，86%概率抵抗击退，持续260秒"/>
+        <string name="h27" value="消耗MP 52，87%概率抵抗击退，持续270秒"/>
+        <string name="h28" value="消耗MP 51，88%概率抵抗击退，持续280秒"/>
+        <string name="h29" value="消耗MP 50，89%概率抵抗击退，持续290秒"/>
+        <string name="h30" value="消耗MP 50，90%概率抵抗击退，持续300秒"/>
     </imgdir>
     <imgdir name="1321003">
         <string name="name" value="突进"/>
-        <string name="h1" value="消耗MP 22，伤害 72%，范围 80%"/>
-        <string name="h10" value="消耗MP 40，伤害 90%，范围 90%"/>
-        <string name="h11" value="消耗MP 42，伤害 92%，范围 95%"/>
-        <string name="h12" value="消耗MP 44，伤害 94%，范围 95%"/>
-        <string name="h13" value="消耗MP 46，伤害 96%，范围 95%"/>
-        <string name="h14" value="消耗MP 48，伤害 98%，范围 100%"/>
-        <string name="h15" value="消耗MP 50，伤害 100%，范围 100%"/>
-        <string name="h16" value="消耗MP 52，伤害 102%，范围 100%"/>
-        <string name="h17" value="消耗MP 54，伤害 104%，范围 105%"/>
-        <string name="h18" value="消耗MP 56，伤害 106%，范围 105%"/>
-        <string name="h19" value="消耗MP 58，伤害 108%，范围 105%"/>
-        <string name="h2" value="消耗MP 24，伤害 74%，范围 80%"/>
-        <string name="h20" value="消耗MP 60，伤害 110%，范围 110%"/>
-        <string name="h21" value="消耗MP 59，伤害 112%，范围 110%"/>
-        <string name="h22" value="消耗MP 58，伤害 114%，范围 115%"/>
-        <string name="h23" value="消耗MP 57，伤害 116%，范围 115%"/>
-        <string name="h24" value="消耗MP 56，伤害 118%，范围 115%"/>
-        <string name="h25" value="消耗MP 55，伤害 120%，范围 120%"/>
-        <string name="h26" value="消耗MP 54，伤害 122%，范围 120%"/>
-        <string name="h27" value="消耗MP 53，伤害 124%，范围 120%"/>
-        <string name="h28" value="消耗MP 52，伤害 126%，范围 125%"/>
-        <string name="h29" value="消耗MP 51，伤害 128%，范围 125%"/>
-        <string name="h3" value="消耗MP 26，伤害 76%，范围 80%"/>
-        <string name="h30" value="消耗MP 50，伤害 130%，范围 125%"/>
-        <string name="h4" value="消耗MP 28，伤害 78%，范围 85%"/>
-        <string name="h5" value="消耗MP 30，伤害 80%，范围 85%"/>
-        <string name="h6" value="消耗MP 32，伤害 82%，范围 85%"/>
-        <string name="h7" value="消耗MP 34，伤害 84%，范围 85%"/>
-        <string name="h8" value="消耗MP 36，伤害 86%，范围 90%"/>
-        <string name="h9" value="消耗MP 38，伤害 88%，范围 90%"/>
-        <string name="desc" value="向前方猛烈刺击，推开阻挡在面前的敌人"/>
+        <string name="desc" value="[最高等级：30]\n向前突进，攻击并推动最多15只怪物。"/>
+        <string name="h1" value="消耗MP 22，伤害 72%，最多推动15个敌人"/>
+        <string name="h2" value="消耗MP 24，伤害 74%，最多推动15个敌人"/>
+        <string name="h3" value="消耗MP 26，伤害 76%，最多推动15个敌人"/>
+        <string name="h4" value="消耗MP 28，伤害 78%，最多推动15个敌人"/>
+        <string name="h5" value="消耗MP 30，伤害 80%，最多推动15个敌人"/>
+        <string name="h6" value="消耗MP 32，伤害 82%，最多推动15个敌人"/>
+        <string name="h7" value="消耗MP 34，伤害 84%，最多推动15个敌人"/>
+        <string name="h8" value="消耗MP 36，伤害 86%，最多推动15个敌人"/>
+        <string name="h9" value="消耗MP 38，伤害 88%，最多推动15个敌人"/>
+        <string name="h10" value="消耗MP 40，伤害 90%，最多推动15个敌人"/>
+        <string name="h11" value="消耗MP 42，伤害 92%，最多推动15个敌人"/>
+        <string name="h12" value="消耗MP 44，伤害 94%，最多推动15个敌人"/>
+        <string name="h13" value="消耗MP 46，伤害 96%，最多推动15个敌人"/>
+        <string name="h14" value="消耗MP 48，伤害 98%，最多推动15个敌人"/>
+        <string name="h15" value="消耗MP 50，伤害 100%，最多推动15个敌人"/>
+        <string name="h16" value="消耗MP 52，伤害 102%，最多推动15个敌人"/>
+        <string name="h17" value="消耗MP 54，伤害 104%，最多推动15个敌人"/>
+        <string name="h18" value="消耗MP 56，伤害 106%，最多推动15个敌人"/>
+        <string name="h19" value="消耗MP 58，伤害 108%，最多推动15个敌人"/>
+        <string name="h20" value="消耗MP 60，伤害 110%，最多推动15个敌人"/>
+        <string name="h21" value="消耗MP 59，伤害 112%，最多推动15个敌人"/>
+        <string name="h22" value="消耗MP 58，伤害 114%，最多推动15个敌人"/>
+        <string name="h23" value="消耗MP 57，伤害 116%，最多推动15个敌人"/>
+        <string name="h24" value="消耗MP 56，伤害 118%，最多推动15个敌人"/>
+        <string name="h25" value="消耗MP 55，伤害 120%，最多推动15个敌人"/>
+        <string name="h26" value="消耗MP 54，伤害 122%，最多推动15个敌人"/>
+        <string name="h27" value="消耗MP 53，伤害 124%，最多推动15个敌人"/>
+        <string name="h28" value="消耗MP 52，伤害 126%，最多推动15个敌人"/>
+        <string name="h29" value="消耗MP 51，伤害 128%，最多推动15个敌人"/>
+        <string name="h30" value="消耗MP 50，伤害 130%，最多推动15个敌人"/>
     </imgdir>
     <imgdir name="1321007">
         <string name="name" value="灵魂助力"/>
-        <string name="h1" value="消耗MP 114，11分内召唤黑灵魂，武器熟练度 5% 上升"/>
-        <string name="h10" value="消耗MP 60，20分内召唤黑灵魂，武器熟练度 20% 上升"/>
-        <string name="h2" value="消耗MP 108，12分内召唤黑灵魂，武器熟练度 5% 上升"/>
-        <string name="h3" value="消耗MP 102，13分内召唤黑灵魂，武器熟练度 5% 上升"/>
-        <string name="h4" value="消耗MP 96，14分内召唤黑灵魂，武器熟练度 10% 上升"/>
-        <string name="h5" value="消耗MP 90，15分内召唤黑灵魂，武器熟练度 10% 上升"/>
-        <string name="h6" value="消耗MP 84，16分内召唤黑灵魂，武器熟练度 10% 上升"/>
-        <string name="h7" value="消耗MP 78，17分内召唤黑灵魂，武器熟练度 15% 上升"/>
-        <string name="h8" value="消耗MP 72，18分内召唤黑灵魂，武器熟练度 15% 上升"/>
-        <string name="h9" value="消耗MP 66，19分内召唤黑灵魂，武器熟练度 15% 上升"/>
-        <string name="desc" value="召唤灵魂助力. \n用灵魂助力的力永久地提高武器熟练度"/>
+        <string name="desc" value="[最高等级：10]\n召唤灵魂助力。召唤期间，黑骑士的武器熟练度提高。"/>
+        <string name="h1" value="消耗MP 114，召唤灵魂助力，持续660秒"/>
+        <string name="h2" value="消耗MP 108，召唤灵魂助力，持续720秒"/>
+        <string name="h3" value="消耗MP 102，召唤灵魂助力，持续780秒"/>
+        <string name="h4" value="消耗MP 96，召唤灵魂助力，持续840秒"/>
+        <string name="h5" value="消耗MP 90，召唤灵魂助力，持续900秒"/>
+        <string name="h6" value="消耗MP 84，召唤灵魂助力，持续960秒"/>
+        <string name="h7" value="消耗MP 78，召唤灵魂助力，持续1020秒"/>
+        <string name="h8" value="消耗MP 72，召唤灵魂助力，持续1080秒"/>
+        <string name="h9" value="消耗MP 66，召唤灵魂助力，持续1140秒"/>
+        <string name="h10" value="消耗MP 60，召唤灵魂助力，持续1200秒"/>
     </imgdir>
     <imgdir name="1321010">
         <string name="name" value="勇士的意志"/>
-        <string name="h1" value="消耗MP 30，解除诱惑异常状态，冷却时间10分钟"/>
-        <string name="h2" value="消耗MP 30，解除诱惑异常状态，冷却时间9分钟"/>
-        <string name="h3" value="消耗MP 30，解除诱惑异常状态，冷却时间8分钟"/>
-        <string name="h4" value="消耗MP 30，解除诱惑异常状态，冷却时间7分钟"/>
-        <string name="h5" value="消耗MP 30，解除诱惑异常状态，冷却时间6分钟"/>
-        <string name="desc" value="从异常状态中恢复. \n随着等级的上升,冷却时间逐渐缩短"/>
+        <string name="desc" value="[最高等级：5]\n解除部分异常状态。技能等级越高，冷却时间越短。"/>
+        <string name="h1" value="消耗MP 30，解除异常状态，冷却时间 600秒"/>
+        <string name="h2" value="消耗MP 30，解除异常状态，冷却时间 540秒"/>
+        <string name="h3" value="消耗MP 30，解除异常状态，冷却时间 480秒"/>
+        <string name="h4" value="消耗MP 30，解除异常状态，冷却时间 420秒"/>
+        <string name="h5" value="消耗MP 30，解除异常状态，冷却时间 360秒"/>
     </imgdir>
     <imgdir name="1400">
         <string name="bookName" value="夜行者入门书"/>

--- a/gms-server/wz/String.wz/Skill.img.xml
+++ b/gms-server/wz/String.wz/Skill.img.xml
@@ -55,7 +55,7 @@
   </imgdir>
   <imgdir name="1000000">
     <string name="name" value="Improved HP Recovery"/>
-    <string name="desc" value="[Master Level : 16]\nRecover additional HP every 10 sec. while standing still."/>
+    <string name="desc" value="[Master Level: 16]\nRecover additional HP every 10 sec. while standing still."/>
     <string name="h1" value="Recover additional HP +3"/>
     <string name="h2" value="Recover additional HP +6"/>
     <string name="h3" value="Recover additional HP +9"/>
@@ -75,101 +75,101 @@
   </imgdir>
   <imgdir name="1000001">
     <string name="name" value="Improved MaxHP Increase"/>
-    <string name="desc" value="Master Level : 10] This skill boosts up the amount of increase on MaxHP after each Level UP, or AP used on MaxHP.\nRequired Skill : #cAt least Level 5 on Improving HP Recovery.#"/>
-    <string name="h1" value="If Level UP, +4 more; if AP applied, +3 more on top on MaxHP"/>
-    <string name="h2" value="If Level UP, +8 more; if AP applied, +6 more on top on MaxHP"/>
-    <string name="h3" value="If Level UP, +12 more; if AP applied, +9 more on top on MaxHP"/>
-    <string name="h4" value="If Level UP, +16 more; if AP applied, +12 more on top on MaxHP"/>
-    <string name="h5" value="If Level UP, +20 more; if AP applied, +15 more on top on MaxHP"/>
-    <string name="h6" value="If Level UP, +24 more; if AP applied, +18 more on top on MaxHP"/>
-    <string name="h7" value="If Level UP, +28 more; if AP applied, +21 more on top on MaxHP"/>
-    <string name="h8" value="If Level UP, +32 more; if AP applied, +24 more on top on MaxHP"/>
-    <string name="h9" value="If Level UP, +36 more; if AP applied, +27 more on top on MaxHP"/>
-    <string name="h10" value="If Level UP, +40 more; if AP applied, +30 more on top on MaxHP"/>
+    <string name="desc" value="[Master Level: 10]\nIncreases the amount of MaxHP gained when leveling up or when AP is assigned to MaxHP.\nRequired Skill: #cImproved HP Recovery Lv. 5 or higher#"/>
+    <string name="h1" value="Level up MaxHP +4; AP assigned to MaxHP +3"/>
+    <string name="h2" value="Level up MaxHP +8; AP assigned to MaxHP +6"/>
+    <string name="h3" value="Level up MaxHP +12; AP assigned to MaxHP +9"/>
+    <string name="h4" value="Level up MaxHP +16; AP assigned to MaxHP +12"/>
+    <string name="h5" value="Level up MaxHP +20; AP assigned to MaxHP +15"/>
+    <string name="h6" value="Level up MaxHP +24; AP assigned to MaxHP +18"/>
+    <string name="h7" value="Level up MaxHP +28; AP assigned to MaxHP +21"/>
+    <string name="h8" value="Level up MaxHP +32; AP assigned to MaxHP +24"/>
+    <string name="h9" value="Level up MaxHP +36; AP assigned to MaxHP +27"/>
+    <string name="h10" value="Level up MaxHP +40; AP assigned to MaxHP +30"/>
   </imgdir>
   <imgdir name="1000002">
     <string name="name" value="Endure"/>
-    <string name="desc" value="[Master Level : 8]\nEven when hanging on the rope or on a ladder, you&apos;ll be able to recover some HP after a certain amount of time.\nRequired Skill : #cAt least Level 3 on Improving MaxHP Increase.#"/>
-    <string name="h1" value="Recover HP every 31 sec."/>
-    <string name="h2" value="Recover HP every 28 sec."/>
-    <string name="h3" value="Recover HP every 25 sec."/>
-    <string name="h4" value="Recover HP every 22 sec."/>
-    <string name="h5" value="Recover HP every 19 sec."/>
-    <string name="h6" value="Recover HP every 16 sec."/>
-    <string name="h7" value="Recover HP every 13 sec."/>
-    <string name="h8" value="Recover HP every 10 sec."/>
+    <string name="desc" value="[Master Level: 8]\nAllows HP to recover even while hanging on a rope or ladder.\nRequired Skill: #cImproved MaxHP Increase Lv. 3 or higher#"/>
+    <string name="h1" value="Recover HP every 31 sec"/>
+    <string name="h2" value="Recover HP every 28 sec"/>
+    <string name="h3" value="Recover HP every 25 sec"/>
+    <string name="h4" value="Recover HP every 22 sec"/>
+    <string name="h5" value="Recover HP every 19 sec"/>
+    <string name="h6" value="Recover HP every 16 sec"/>
+    <string name="h7" value="Recover HP every 13 sec"/>
+    <string name="h8" value="Recover HP every 10 sec"/>
   </imgdir>
   <imgdir name="1001003">
     <string name="name" value="Iron Body"/>
-    <string name="desc" value="[Master Level : 20]\nTemporarily increases your weapon defense.\nRequired Skill : #cAt least Level 3 on Endure#"/>
-    <string name="h1" value="MP -8; weapon def. +2 for 75 sec."/>
-    <string name="h2" value="MP -8; weapon def. +4 for 85 sec."/>
-    <string name="h3" value="MP -8; weapon def. +6 for 95 sec."/>
-    <string name="h4" value="MP -8; weapon def. +8 for 105 sec."/>
-    <string name="h5" value="MP -9; weapon def. +10 for 120 sec."/>
-    <string name="h6" value="MP -9; weapon def. +12 for 130 sec."/>
-    <string name="h7" value="MP -9; weapon def. +14 for 140 sec."/>
-    <string name="h8" value="MP -10; weapon def. +16 for 155 sec."/>
-    <string name="h9" value="MP -10; weapon def. +18 for 165 sec."/>
-    <string name="h10" value="MP -10; weapon def. +20 for 175 sec."/>
-    <string name="h11" value="MP -11; weapon def. +22 for 190 sec."/>
-    <string name="h12" value="MP -11; weapon def. +24 for 200 sec."/>
-    <string name="h13" value="MP -12; weapon def. +26 for 215 sec."/>
-    <string name="h14" value="MP -12; weapon def. +28 for 225 sec."/>
-    <string name="h15" value="MP -13; weapon def. +30 for 240 sec."/>
-    <string name="h16" value="MP -13; weapon def. +32 for 250 sec."/>
-    <string name="h17" value="MP -14; weapon def. +34 for 265 sec."/>
-    <string name="h18" value="MP -14; weapon def. +36 for 275 sec."/>
-    <string name="h19" value="MP -15; weapon def. +38 for 290 sec."/>
-    <string name="h20" value="MP -15; weapon def. +40 for 300 sec."/>
+    <string name="desc" value="[Master Level: 20]\nTemporarily increases weapon defense.\nRequired Skill: #cEndure Lv. 3 or higher#"/>
+    <string name="h1" value="MP -8; Weapon DEF +2 for 75 sec"/>
+    <string name="h2" value="MP -8; Weapon DEF +4 for 85 sec"/>
+    <string name="h3" value="MP -8; Weapon DEF +6 for 95 sec"/>
+    <string name="h4" value="MP -8; Weapon DEF +8 for 105 sec"/>
+    <string name="h5" value="MP -9; Weapon DEF +10 for 120 sec"/>
+    <string name="h6" value="MP -9; Weapon DEF +12 for 130 sec"/>
+    <string name="h7" value="MP -9; Weapon DEF +14 for 140 sec"/>
+    <string name="h8" value="MP -10; Weapon DEF +16 for 155 sec"/>
+    <string name="h9" value="MP -10; Weapon DEF +18 for 165 sec"/>
+    <string name="h10" value="MP -10; Weapon DEF +20 for 175 sec"/>
+    <string name="h11" value="MP -11; Weapon DEF +22 for 190 sec"/>
+    <string name="h12" value="MP -11; Weapon DEF +24 for 200 sec"/>
+    <string name="h13" value="MP -12; Weapon DEF +26 for 215 sec"/>
+    <string name="h14" value="MP -12; Weapon DEF +28 for 225 sec"/>
+    <string name="h15" value="MP -13; Weapon DEF +30 for 240 sec"/>
+    <string name="h16" value="MP -13; Weapon DEF +32 for 250 sec"/>
+    <string name="h17" value="MP -14; Weapon DEF +34 for 265 sec"/>
+    <string name="h18" value="MP -14; Weapon DEF +36 for 275 sec"/>
+    <string name="h19" value="MP -15; Weapon DEF +38 for 290 sec"/>
+    <string name="h20" value="MP -15; Weapon DEF +40 for 300 sec"/>
   </imgdir>
   <imgdir name="1001004">
     <string name="name" value="Power Strike"/>
-    <string name="desc" value="[Master Level : 20]\nUse MP to deliver a killer blow to the monsters with a sword."/>
-    <string name="h1" value="MP -4; sword damage 165%"/>
-    <string name="h2" value="MP -4; sword damage 170%"/>
-    <string name="h3" value="MP -4; sword damage 175%"/>
-    <string name="h4" value="MP -4; sword damage 180%"/>
-    <string name="h5" value="MP -5; sword damage 185%"/>
-    <string name="h6" value="MP -5; sword damage 190%"/>
-    <string name="h7" value="MP -5; sword damage 195%"/>
-    <string name="h8" value="MP -6; sword damage 200%"/>
-    <string name="h9" value="MP -6; sword damage 205%"/>
-    <string name="h10" value="MP -7; sword damage 210%"/>
-    <string name="h11" value="MP -7; sword damage 215%"/>
-    <string name="h12" value="MP -8; sword damage 220%"/>
-    <string name="h13" value="MP -8; sword damage 225%"/>
-    <string name="h14" value="MP -9; sword damage 230%"/>
-    <string name="h15" value="MP -9; sword damage 235%"/>
-    <string name="h16" value="MP -10; sword damage 240%"/>
-    <string name="h17" value="MP -10; sword damage 245%"/>
-    <string name="h18" value="MP -11; sword damage 250%"/>
-    <string name="h19" value="MP -11; sword damage 255%"/>
-    <string name="h20" value="MP -12; sword damage 260%"/>
+    <string name="desc" value="[Master Level: 20]\nUses MP to deliver a powerful attack with the equipped melee weapon."/>
+    <string name="h1" value="MP -4; Damage 165%"/>
+    <string name="h2" value="MP -4; Damage 170%"/>
+    <string name="h3" value="MP -4; Damage 175%"/>
+    <string name="h4" value="MP -4; Damage 180%"/>
+    <string name="h5" value="MP -5; Damage 185%"/>
+    <string name="h6" value="MP -5; Damage 190%"/>
+    <string name="h7" value="MP -5; Damage 195%"/>
+    <string name="h8" value="MP -6; Damage 200%"/>
+    <string name="h9" value="MP -6; Damage 205%"/>
+    <string name="h10" value="MP -7; Damage 210%"/>
+    <string name="h11" value="MP -7; Damage 215%"/>
+    <string name="h12" value="MP -8; Damage 220%"/>
+    <string name="h13" value="MP -8; Damage 225%"/>
+    <string name="h14" value="MP -9; Damage 230%"/>
+    <string name="h15" value="MP -9; Damage 235%"/>
+    <string name="h16" value="MP -10; Damage 240%"/>
+    <string name="h17" value="MP -10; Damage 245%"/>
+    <string name="h18" value="MP -11; Damage 250%"/>
+    <string name="h19" value="MP -11; Damage 255%"/>
+    <string name="h20" value="MP -12; Damage 260%"/>
   </imgdir>
   <imgdir name="1001005">
     <string name="name" value="Slash Blast"/>
-    <string name="desc" value="[Master Level : 20]\nUse HP and MP to attack every enemy around you with a sword.\nRequired Skill : #cAt least Level 1 on Power Strike#"/>
-    <string name="h1" value="HP -8, MP -6; damage 72%"/>
-    <string name="h2" value="HP -8, MP -6; damage 75%"/>
-    <string name="h3" value="HP -8, MP -6; damage 78%"/>
-    <string name="h4" value="HP -8, MP -6; damage 81%"/>
-    <string name="h5" value="HP -9, MP -7; damage 84%"/>
-    <string name="h6" value="HP -9, MP -7; damage 87%"/>
-    <string name="h7" value="HP -9, MP -7; damage 90%"/>
-    <string name="h8" value="HP -10, MP -8; damage 93%"/>
-    <string name="h9" value="HP -10, MP -8; damage 96%"/>
-    <string name="h10" value="HP -11, MP -9; damage 99%"/>
-    <string name="h11" value="HP -11, MP -9; damage 102%"/>
-    <string name="h12" value="HP -12, MP -10; damage 105%"/>
-    <string name="h13" value="HP -12, MP -10; damage 108%"/>
-    <string name="h14" value="HP -13, MP -11; damage 111%"/>
-    <string name="h15" value="HP -13, MP -11; damage 114%"/>
-    <string name="h16" value="HP -14, MP -12; damage 117%"/>
-    <string name="h17" value="HP -14, MP -12; damage 120%"/>
-    <string name="h18" value="HP -15, MP -13; damage 123%"/>
-    <string name="h19" value="HP -15, MP -13; damage 126%"/>
-    <string name="h20" value="HP -16, MP -14; damage 130%"/>
+    <string name="desc" value="[Master Level: 20]\nUses HP and MP to attack nearby enemies with the equipped melee weapon.\nRequired Skill: #cPower Strike Lv. 1 or higher#"/>
+    <string name="h1" value="HP -8; MP -6; Damage 72%; attacks up to 6 enemies"/>
+    <string name="h2" value="HP -8; MP -6; Damage 75%; attacks up to 6 enemies"/>
+    <string name="h3" value="HP -8; MP -6; Damage 78%; attacks up to 6 enemies"/>
+    <string name="h4" value="HP -8; MP -6; Damage 81%; attacks up to 6 enemies"/>
+    <string name="h5" value="HP -9; MP -7; Damage 84%; attacks up to 6 enemies"/>
+    <string name="h6" value="HP -9; MP -7; Damage 87%; attacks up to 6 enemies"/>
+    <string name="h7" value="HP -9; MP -7; Damage 90%; attacks up to 6 enemies"/>
+    <string name="h8" value="HP -10; MP -8; Damage 93%; attacks up to 6 enemies"/>
+    <string name="h9" value="HP -10; MP -8; Damage 96%; attacks up to 6 enemies"/>
+    <string name="h10" value="HP -11; MP -9; Damage 99%; attacks up to 6 enemies"/>
+    <string name="h11" value="HP -11; MP -9; Damage 102%; attacks up to 6 enemies"/>
+    <string name="h12" value="HP -12; MP -10; Damage 105%; attacks up to 6 enemies"/>
+    <string name="h13" value="HP -12; MP -10; Damage 108%; attacks up to 6 enemies"/>
+    <string name="h14" value="HP -13; MP -11; Damage 111%; attacks up to 6 enemies"/>
+    <string name="h15" value="HP -13; MP -11; Damage 114%; attacks up to 6 enemies"/>
+    <string name="h16" value="HP -14; MP -12; Damage 117%; attacks up to 6 enemies"/>
+    <string name="h17" value="HP -14; MP -12; Damage 120%; attacks up to 6 enemies"/>
+    <string name="h18" value="HP -15; MP -13; Damage 123%; attacks up to 6 enemies"/>
+    <string name="h19" value="HP -15; MP -13; Damage 126%; attacks up to 6 enemies"/>
+    <string name="h20" value="HP -16; MP -14; Damage 130%; attacks up to 6 enemies"/>
   </imgdir>
   <imgdir name="200">
     <string name="bookName" value="Intro. to Magic"/>
@@ -575,675 +575,675 @@
   </imgdir>
   <imgdir name="1100000">
     <string name="name" value="Sword Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the sword mastery and accuracy. It only applies when either a one-handed or a two-handed sword is in hand."/>
-    <string name="h1" value="Sword mastery 15%, accuracy +1"/>
-    <string name="h2" value="Sword mastery 15%, accuracy +2"/>
-    <string name="h3" value="Sword mastery 20%, accuracy +3"/>
-    <string name="h4" value="Sword mastery 20%, accuracy +4"/>
-    <string name="h5" value="Sword mastery 25%, accuracy +5"/>
-    <string name="h6" value="Sword mastery 25%, accuracy +6"/>
-    <string name="h7" value="Sword mastery 30%, accuracy +7"/>
-    <string name="h8" value="Sword mastery 30%, accuracy +8"/>
-    <string name="h9" value="Sword mastery 35%, accuracy +9"/>
-    <string name="h10" value="Sword mastery 35%, accuracy +10"/>
-    <string name="h11" value="Sword mastery 40%, accuracy +11"/>
-    <string name="h12" value="Sword mastery 40%, accuracy +12"/>
-    <string name="h13" value="Sword mastery 45%, accuracy +13"/>
-    <string name="h14" value="Sword mastery 45%, accuracy +14"/>
-    <string name="h15" value="Sword mastery 50%, accuracy +15"/>
-    <string name="h16" value="Sword mastery 50%, accuracy +16"/>
-    <string name="h17" value="Sword mastery 55%, accuracy +17"/>
-    <string name="h18" value="Sword mastery 55%, accuracy +18"/>
-    <string name="h19" value="Sword mastery 60%, accuracy +19"/>
-    <string name="h20" value="Sword mastery 60%, accuracy +20"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases sword mastery and accuracy. Applies only while the matching weapon is equipped."/>
+    <string name="h1" value="Sword mastery 51%; accuracy +1"/>
+    <string name="h2" value="Sword mastery 51%; accuracy +2"/>
+    <string name="h3" value="Sword mastery 52%; accuracy +3"/>
+    <string name="h4" value="Sword mastery 52%; accuracy +4"/>
+    <string name="h5" value="Sword mastery 53%; accuracy +5"/>
+    <string name="h6" value="Sword mastery 53%; accuracy +6"/>
+    <string name="h7" value="Sword mastery 54%; accuracy +7"/>
+    <string name="h8" value="Sword mastery 54%; accuracy +8"/>
+    <string name="h9" value="Sword mastery 55%; accuracy +9"/>
+    <string name="h10" value="Sword mastery 55%; accuracy +10"/>
+    <string name="h11" value="Sword mastery 56%; accuracy +11"/>
+    <string name="h12" value="Sword mastery 56%; accuracy +12"/>
+    <string name="h13" value="Sword mastery 57%; accuracy +13"/>
+    <string name="h14" value="Sword mastery 57%; accuracy +14"/>
+    <string name="h15" value="Sword mastery 58%; accuracy +15"/>
+    <string name="h16" value="Sword mastery 58%; accuracy +16"/>
+    <string name="h17" value="Sword mastery 59%; accuracy +17"/>
+    <string name="h18" value="Sword mastery 59%; accuracy +18"/>
+    <string name="h19" value="Sword mastery 60%; accuracy +19"/>
+    <string name="h20" value="Sword mastery 60%; accuracy +20"/>
   </imgdir>
   <imgdir name="1100001">
     <string name="name" value="Axe Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the axe mastery and accuracy. It only applies when either a one-handed or a two-handed axe is in hand."/>
-    <string name="h1" value="Axe mastery +15%, accuracy +1"/>
-    <string name="h2" value="Axe mastery +15%, accuracy +2"/>
-    <string name="h3" value="Axe mastery +20%, accuracy +3"/>
-    <string name="h4" value="Axe mastery +20%, accuracy +4"/>
-    <string name="h5" value="Axe mastery +25%, accuracy +5"/>
-    <string name="h6" value="Axe mastery +25%, accuracy +6"/>
-    <string name="h7" value="Axe mastery +30%, accuracy +7"/>
-    <string name="h8" value="Axe mastery +30%, accuracy +8"/>
-    <string name="h9" value="Axe mastery +35%, accuracy +9"/>
-    <string name="h10" value="Axe mastery +35%, accuracy +10"/>
-    <string name="h11" value="Axe mastery +40%, accuracy +11"/>
-    <string name="h12" value="Axe mastery +40%, accuracy +12"/>
-    <string name="h13" value="Axe mastery +45%, accuracy +13"/>
-    <string name="h14" value="Axe mastery +45%, accuracy +14"/>
-    <string name="h15" value="Axe mastery +50%, accuracy +15"/>
-    <string name="h16" value="Axe mastery +50%, accuracy +16"/>
-    <string name="h17" value="Axe mastery +55%, accuracy +17"/>
-    <string name="h18" value="Axe mastery +55%, accuracy +18"/>
-    <string name="h19" value="Axe mastery +60%, accuracy +19"/>
-    <string name="h20" value="Axe mastery +60%, accuracy +20"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases axe mastery and accuracy. Applies only while the matching weapon is equipped."/>
+    <string name="h1" value="Axe mastery 51%; accuracy +1"/>
+    <string name="h2" value="Axe mastery 51%; accuracy +2"/>
+    <string name="h3" value="Axe mastery 52%; accuracy +3"/>
+    <string name="h4" value="Axe mastery 52%; accuracy +4"/>
+    <string name="h5" value="Axe mastery 53%; accuracy +5"/>
+    <string name="h6" value="Axe mastery 53%; accuracy +6"/>
+    <string name="h7" value="Axe mastery 54%; accuracy +7"/>
+    <string name="h8" value="Axe mastery 54%; accuracy +8"/>
+    <string name="h9" value="Axe mastery 55%; accuracy +9"/>
+    <string name="h10" value="Axe mastery 55%; accuracy +10"/>
+    <string name="h11" value="Axe mastery 56%; accuracy +11"/>
+    <string name="h12" value="Axe mastery 56%; accuracy +12"/>
+    <string name="h13" value="Axe mastery 57%; accuracy +13"/>
+    <string name="h14" value="Axe mastery 57%; accuracy +14"/>
+    <string name="h15" value="Axe mastery 58%; accuracy +15"/>
+    <string name="h16" value="Axe mastery 58%; accuracy +16"/>
+    <string name="h17" value="Axe mastery 59%; accuracy +17"/>
+    <string name="h18" value="Axe mastery 59%; accuracy +18"/>
+    <string name="h19" value="Axe mastery 60%; accuracy +19"/>
+    <string name="h20" value="Axe mastery 60%; accuracy +20"/>
   </imgdir>
   <imgdir name="1100002">
     <string name="name" value="Final Attack : Sword"/>
-    <string name="desc" value="[Master Level : 30]\nStrikes an another, far deadlier blow following the initial attack with a given success rate. It works only when holding a one-hand or two-hand sword.\nRequired Skill : #cAt least Level 3 on Sword Mastery#"/>
-    <string name="h1" value="2% Success rate, final attack with sword damage 105% "/>
-    <string name="h2" value="4% Success rate, final attack with sword damage 110% "/>
-    <string name="h3" value="6% Success rate, final attack with sword damage 115% "/>
-    <string name="h4" value="8% Success rate, final attack with sword damage 120% "/>
-    <string name="h5" value="10% Success rate, final attack with sword damage 125% "/>
-    <string name="h6" value="12% Success rate, final attack with sword damage 130% "/>
-    <string name="h7" value="14% Success rate, final attack with sword damage 135% "/>
-    <string name="h8" value="16% Success rate, final attack with sword damage 140% "/>
-    <string name="h9" value="18% Success rate, final attack with sword damage 145% "/>
-    <string name="h10" value="20% Success rate, final attack with sword damage 150% "/>
-    <string name="h11" value="22% Success rate, final attack with sword damage 155% "/>
-    <string name="h12" value="24% Success rate, final attack with sword damage 160% "/>
-    <string name="h13" value="26% Success rate, final attack with sword damage 165% "/>
-    <string name="h14" value="28% Success rate, final attack with sword damage 170% "/>
-    <string name="h15" value="30% Success rate, final attack with sword damage 175% "/>
-    <string name="h16" value="32% Success rate, final attack with sword damage 180% "/>
-    <string name="h17" value="34% Success rate, final attack with sword damage 185% "/>
-    <string name="h18" value="36% Success rate, final attack with sword damage 190% "/>
-    <string name="h19" value="38% Success rate, final attack with sword damage 195% "/>
-    <string name="h20" value="40% Success rate, final attack with sword damage 200% "/>
-    <string name="h21" value="42% Success rate, final attack with sword damage 205% "/>
-    <string name="h22" value="44% Success rate, final attack with sword damage 210% "/>
-    <string name="h23" value="46% Success rate, final attack with sword damage 215% "/>
-    <string name="h24" value="48% Success rate, final attack with sword damage 220% "/>
-    <string name="h25" value="50% Success rate, final attack with sword damage 225% "/>
-    <string name="h26" value="52% Success rate, final attack with sword damage 230% "/>
-    <string name="h27" value="54% Success rate, final attack with sword damage 235% "/>
-    <string name="h28" value="56% Success rate, final attack with sword damage 240% "/>
-    <string name="h29" value="58% Success rate, final attack with sword damage 245% "/>
-    <string name="h30" value="60% Success rate, final attack with sword damage 250% "/>
+    <string name="desc" value="[Master Level: 30]\nAfter certain attacks, has a chance to perform an additional attack. Applies only while a sword is equipped.\nRequired Skill: #cMatching Mastery Lv. 3 or higher#"/>
+    <string name="h1" value="2% success rate; final attack damage 105%"/>
+    <string name="h2" value="4% success rate; final attack damage 110%"/>
+    <string name="h3" value="6% success rate; final attack damage 115%"/>
+    <string name="h4" value="8% success rate; final attack damage 120%"/>
+    <string name="h5" value="10% success rate; final attack damage 125%"/>
+    <string name="h6" value="12% success rate; final attack damage 130%"/>
+    <string name="h7" value="14% success rate; final attack damage 135%"/>
+    <string name="h8" value="16% success rate; final attack damage 140%"/>
+    <string name="h9" value="18% success rate; final attack damage 145%"/>
+    <string name="h10" value="20% success rate; final attack damage 150%"/>
+    <string name="h11" value="22% success rate; final attack damage 155%"/>
+    <string name="h12" value="24% success rate; final attack damage 160%"/>
+    <string name="h13" value="26% success rate; final attack damage 165%"/>
+    <string name="h14" value="28% success rate; final attack damage 170%"/>
+    <string name="h15" value="30% success rate; final attack damage 175%"/>
+    <string name="h16" value="32% success rate; final attack damage 180%"/>
+    <string name="h17" value="34% success rate; final attack damage 185%"/>
+    <string name="h18" value="36% success rate; final attack damage 190%"/>
+    <string name="h19" value="38% success rate; final attack damage 195%"/>
+    <string name="h20" value="40% success rate; final attack damage 200%"/>
+    <string name="h21" value="42% success rate; final attack damage 205%"/>
+    <string name="h22" value="44% success rate; final attack damage 210%"/>
+    <string name="h23" value="46% success rate; final attack damage 215%"/>
+    <string name="h24" value="48% success rate; final attack damage 220%"/>
+    <string name="h25" value="50% success rate; final attack damage 225%"/>
+    <string name="h26" value="52% success rate; final attack damage 230%"/>
+    <string name="h27" value="54% success rate; final attack damage 235%"/>
+    <string name="h28" value="56% success rate; final attack damage 240%"/>
+    <string name="h29" value="58% success rate; final attack damage 245%"/>
+    <string name="h30" value="60% success rate; final attack damage 250%"/>
   </imgdir>
   <imgdir name="1100003">
     <string name="name" value="Final Attack : Axe"/>
-    <string name="desc" value="[Master Level : 30]\nStrikes an another, far deadlier blow following the initial attack with a given success rate. It works only when holding a one-hand or two-hand axe.\nRequired Skill : #cAt least Level 3 on Axe Mastery#"/>
-    <string name="h1" value="2% Success rate, final attack with axe damage 105% "/>
-    <string name="h2" value="4% Success rate, final attack with axe damage 110% "/>
-    <string name="h3" value="6% Success rate, final attack with axe damage 115% "/>
-    <string name="h4" value="8% Success rate, final attack with axe damage 120% "/>
-    <string name="h5" value="10% Success rate, final attack with axe damage 125% "/>
-    <string name="h6" value="12% Success rate, final attack with axe damage 130% "/>
-    <string name="h7" value="14% Success rate, final attack with axe damage 135% "/>
-    <string name="h8" value="16% Success rate, final attack with axe damage 140% "/>
-    <string name="h9" value="18% Success rate, final attack with axe damage 145% "/>
-    <string name="h10" value="20% Success rate, final attack with axe damage 150% "/>
-    <string name="h11" value="22% Success rate, final attack with axe damage 155% "/>
-    <string name="h12" value="24% Success rate, final attack with axe damage 160% "/>
-    <string name="h13" value="26% Success rate, final attack with axe damage 165% "/>
-    <string name="h14" value="28% Success rate, final attack with axe damage 170% "/>
-    <string name="h15" value="30% Success rate, final attack with axe damage 175% "/>
-    <string name="h16" value="32% Success rate, final attack with axe damage 180% "/>
-    <string name="h17" value="34% Success rate, final attack with axe damage 185% "/>
-    <string name="h18" value="36% Success rate, final attack with axe damage 190% "/>
-    <string name="h19" value="38% Success rate, final attack with axe damage 195% "/>
-    <string name="h20" value="40% Success rate, final attack with axe damage 200% "/>
-    <string name="h21" value="42% Success rate, final attack with axe damage 205% "/>
-    <string name="h22" value="44% Success rate, final attack with axe damage 210% "/>
-    <string name="h23" value="46% Success rate, final attack with axe damage 215% "/>
-    <string name="h24" value="48% Success rate, final attack with axe damage 220% "/>
-    <string name="h25" value="50% Success rate, final attack with axe damage 225% "/>
-    <string name="h26" value="52% Success rate, final attack with axe damage 230% "/>
-    <string name="h27" value="54% Success rate, final attack with axe damage 235% "/>
-    <string name="h28" value="56% Success rate, final attack with axe damage 240% "/>
-    <string name="h29" value="58% Success rate, final attack with axe damage 245% "/>
-    <string name="h30" value="60% Success rate, final attack with axe damage 250% "/>
+    <string name="desc" value="[Master Level: 30]\nAfter certain attacks, has a chance to perform an additional attack. Applies only while a axe is equipped.\nRequired Skill: #cMatching Mastery Lv. 3 or higher#"/>
+    <string name="h1" value="2% success rate; final attack damage 105%"/>
+    <string name="h2" value="4% success rate; final attack damage 110%"/>
+    <string name="h3" value="6% success rate; final attack damage 115%"/>
+    <string name="h4" value="8% success rate; final attack damage 120%"/>
+    <string name="h5" value="10% success rate; final attack damage 125%"/>
+    <string name="h6" value="12% success rate; final attack damage 130%"/>
+    <string name="h7" value="14% success rate; final attack damage 135%"/>
+    <string name="h8" value="16% success rate; final attack damage 140%"/>
+    <string name="h9" value="18% success rate; final attack damage 145%"/>
+    <string name="h10" value="20% success rate; final attack damage 150%"/>
+    <string name="h11" value="22% success rate; final attack damage 155%"/>
+    <string name="h12" value="24% success rate; final attack damage 160%"/>
+    <string name="h13" value="26% success rate; final attack damage 165%"/>
+    <string name="h14" value="28% success rate; final attack damage 170%"/>
+    <string name="h15" value="30% success rate; final attack damage 175%"/>
+    <string name="h16" value="32% success rate; final attack damage 180%"/>
+    <string name="h17" value="34% success rate; final attack damage 185%"/>
+    <string name="h18" value="36% success rate; final attack damage 190%"/>
+    <string name="h19" value="38% success rate; final attack damage 195%"/>
+    <string name="h20" value="40% success rate; final attack damage 200%"/>
+    <string name="h21" value="42% success rate; final attack damage 205%"/>
+    <string name="h22" value="44% success rate; final attack damage 210%"/>
+    <string name="h23" value="46% success rate; final attack damage 215%"/>
+    <string name="h24" value="48% success rate; final attack damage 220%"/>
+    <string name="h25" value="50% success rate; final attack damage 225%"/>
+    <string name="h26" value="52% success rate; final attack damage 230%"/>
+    <string name="h27" value="54% success rate; final attack damage 235%"/>
+    <string name="h28" value="56% success rate; final attack damage 240%"/>
+    <string name="h29" value="58% success rate; final attack damage 245%"/>
+    <string name="h30" value="60% success rate; final attack damage 250%"/>
   </imgdir>
   <imgdir name="1101004">
     <string name="name" value="Sword Booster"/>
-    <string name="desc" value="[Master Level : 20]\nUses HP and MP to temporarily boost up the attacking speed of the equipped sword. It only applies when either a one-handed or a two-handed sword is in hand.\nRequired Skill : #cAt least Level 5 on Sword Mastery#"/>
-    <string name="h1" value="HP -29, MP -29; increase in sword speed for 10 sec. "/>
-    <string name="h2" value="HP -28, MP -28; increase in sword speed for 20 sec. "/>
-    <string name="h3" value="HP -27, MP -27; increase in sword speed for 30 sec. "/>
-    <string name="h4" value="HP -26, MP -26; increase in sword speed for 40 sec. "/>
-    <string name="h5" value="HP -25, MP -25; increase in sword speed for 50 sec. "/>
-    <string name="h6" value="HP -24, MP -24; increase in sword speed for 60 sec. "/>
-    <string name="h7" value="HP -23, MP -23; increase in sword speed for 70 sec. "/>
-    <string name="h8" value="HP -22, MP -22; increase in sword speed for 80 sec. "/>
-    <string name="h9" value="HP -21, MP -21; increase in sword speed for 90 sec. "/>
-    <string name="h10" value="HP -20, MP -20; increase in sword speed for 100 sec. "/>
-    <string name="h11" value="HP -19, MP -19; increase in sword speed for 110 sec. "/>
-    <string name="h12" value="HP -18, MP -18; increase in sword speed for 120 sec. "/>
-    <string name="h13" value="HP -17, MP -17; increase in sword speed for 130 sec. "/>
-    <string name="h14" value="HP -16, MP -16; increase in sword speed for 140 sec. "/>
-    <string name="h15" value="HP -15, MP -15; increase in sword speed for 150 sec. "/>
-    <string name="h16" value="HP -14, MP -14; increase in sword speed for 160 sec. "/>
-    <string name="h17" value="HP -13, MP -13; increase in sword speed for 170 sec. "/>
-    <string name="h18" value="HP -12, MP -12; increase in sword speed for 180 sec. "/>
-    <string name="h19" value="HP -11, MP -11; increase in sword speed for 190 sec. "/>
-    <string name="h20" value="HP -10, MP -10; increase in sword speed for 200 sec. "/>
+    <string name="desc" value="[Master Level: 20]\nUses HP and MP to temporarily increase the attack speed of the equipped sword.\nRequired Skill: #cMatching Mastery Lv. 5 or higher#"/>
+    <string name="h1" value="HP -29; MP -29; Increase sword attack speed for 10 sec"/>
+    <string name="h2" value="HP -28; MP -28; Increase sword attack speed for 20 sec"/>
+    <string name="h3" value="HP -27; MP -27; Increase sword attack speed for 30 sec"/>
+    <string name="h4" value="HP -26; MP -26; Increase sword attack speed for 40 sec"/>
+    <string name="h5" value="HP -25; MP -25; Increase sword attack speed for 50 sec"/>
+    <string name="h6" value="HP -24; MP -24; Increase sword attack speed for 60 sec"/>
+    <string name="h7" value="HP -23; MP -23; Increase sword attack speed for 70 sec"/>
+    <string name="h8" value="HP -22; MP -22; Increase sword attack speed for 80 sec"/>
+    <string name="h9" value="HP -21; MP -21; Increase sword attack speed for 90 sec"/>
+    <string name="h10" value="HP -20; MP -20; Increase sword attack speed for 100 sec"/>
+    <string name="h11" value="HP -19; MP -19; Increase sword attack speed for 110 sec"/>
+    <string name="h12" value="HP -18; MP -18; Increase sword attack speed for 120 sec"/>
+    <string name="h13" value="HP -17; MP -17; Increase sword attack speed for 130 sec"/>
+    <string name="h14" value="HP -16; MP -16; Increase sword attack speed for 140 sec"/>
+    <string name="h15" value="HP -15; MP -15; Increase sword attack speed for 150 sec"/>
+    <string name="h16" value="HP -14; MP -14; Increase sword attack speed for 160 sec"/>
+    <string name="h17" value="HP -13; MP -13; Increase sword attack speed for 170 sec"/>
+    <string name="h18" value="HP -12; MP -12; Increase sword attack speed for 180 sec"/>
+    <string name="h19" value="HP -11; MP -11; Increase sword attack speed for 190 sec"/>
+    <string name="h20" value="HP -10; MP -10; Increase sword attack speed for 200 sec"/>
   </imgdir>
   <imgdir name="1101005">
     <string name="name" value="Axe Booster"/>
-    <string name="desc" value="[Master Level : 20]\nUses HP and MP  to temporarily boost up the attacking speed of the equipped axe. It only applies when either a one-handed or a two-handed axe is in hand.\nRequired Skill : #cAt least Level 5 on Axe Mastery#"/>
-    <string name="h1" value="HP -29, MP -29; increase in axe speed for 10 sec."/>
-    <string name="h2" value="HP -28, MP -28; increase in axe speed for 20 sec."/>
-    <string name="h3" value="HP -27, MP -27; increase in axe speed for 30 sec."/>
-    <string name="h4" value="HP -26, MP -26; increase in axe speed for 40 sec."/>
-    <string name="h5" value="HP -25, MP -25; increase in axe speed for 50 sec."/>
-    <string name="h6" value="HP -24, MP -24; increase in axe speed for 60 sec."/>
-    <string name="h7" value="HP -23, MP -23; increase in axe speed for 70 sec."/>
-    <string name="h8" value="HP -22, MP -22; increase in axe speed for 80 sec."/>
-    <string name="h9" value="HP -21, MP -21; increase in axe speed for 90 sec."/>
-    <string name="h10" value="HP -20, MP -20; increase in axe speed for 100 sec."/>
-    <string name="h11" value="HP -19, MP -19; increase in axe speed for 110 sec."/>
-    <string name="h12" value="HP -18, MP -18; increase in axe speed for 120 sec."/>
-    <string name="h13" value="HP -17, MP -17; increase in axe speed for 130 sec."/>
-    <string name="h14" value="HP -17, MP -17; increase in axe speed for 140 sec."/>
-    <string name="h15" value="HP -15, MP -15; increase in axe speed for 150 sec."/>
-    <string name="h16" value="HP -14, MP -14; increase in axe speed for 160 sec."/>
-    <string name="h17" value="HP -13, MP -13; increase in axe speed for 170 sec."/>
-    <string name="h18" value="HP -12, MP -12; increase in axe speed for 180 sec."/>
-    <string name="h19" value="HP -11, MP -11 increase in axe speed for 190 sec."/>
-    <string name="h20" value="HP -10, MP -10; increase in axe speed for 200 sec."/>
+    <string name="desc" value="[Master Level: 20]\nUses HP and MP to temporarily increase the attack speed of the equipped axe.\nRequired Skill: #cMatching Mastery Lv. 5 or higher#"/>
+    <string name="h1" value="HP -29; MP -29; Increase axe attack speed for 10 sec"/>
+    <string name="h2" value="HP -28; MP -28; Increase axe attack speed for 20 sec"/>
+    <string name="h3" value="HP -27; MP -27; Increase axe attack speed for 30 sec"/>
+    <string name="h4" value="HP -26; MP -26; Increase axe attack speed for 40 sec"/>
+    <string name="h5" value="HP -25; MP -25; Increase axe attack speed for 50 sec"/>
+    <string name="h6" value="HP -24; MP -24; Increase axe attack speed for 60 sec"/>
+    <string name="h7" value="HP -23; MP -23; Increase axe attack speed for 70 sec"/>
+    <string name="h8" value="HP -22; MP -22; Increase axe attack speed for 80 sec"/>
+    <string name="h9" value="HP -21; MP -21; Increase axe attack speed for 90 sec"/>
+    <string name="h10" value="HP -20; MP -20; Increase axe attack speed for 100 sec"/>
+    <string name="h11" value="HP -19; MP -19; Increase axe attack speed for 110 sec"/>
+    <string name="h12" value="HP -18; MP -18; Increase axe attack speed for 120 sec"/>
+    <string name="h13" value="HP -17; MP -17; Increase axe attack speed for 130 sec"/>
+    <string name="h14" value="HP -16; MP -16; Increase axe attack speed for 140 sec"/>
+    <string name="h15" value="HP -15; MP -15; Increase axe attack speed for 150 sec"/>
+    <string name="h16" value="HP -14; MP -14; Increase axe attack speed for 160 sec"/>
+    <string name="h17" value="HP -13; MP -13; Increase axe attack speed for 170 sec"/>
+    <string name="h18" value="HP -12; MP -12; Increase axe attack speed for 180 sec"/>
+    <string name="h19" value="HP -11; MP -11; Increase axe attack speed for 190 sec"/>
+    <string name="h20" value="HP -10; MP -10; Increase axe attack speed for 200 sec"/>
   </imgdir>
   <imgdir name="1101006">
     <string name="name" value="Rage"/>
-    <string name="desc" value="[Master Level : 20]\nTemporarily boosts the weapon attack level of everyone in the party around the area, but also decreases the level of weapon attack defense."/>
-    <string name="h1" value="MP -12; weapon attack +3, weapon def. -3 for 46 sec. "/>
-    <string name="h2" value="MP -12; weapon attack +3, weapon def. -3 for 52 sec. "/>
-    <string name="h3" value="MP -12; weapon attack +4, weapon def. -4 for 58 sec. "/>
-    <string name="h4" value="MP -12; weapon attack +4, weapon def. -4 for 64 sec. "/>
-    <string name="h5" value="MP -12; weapon attack +5, weapon def. -5 for 70 sec. "/>
-    <string name="h6" value="MP -12; weapon attack +5, weapon def. -5 for 76 sec. "/>
-    <string name="h7" value="MP -12; weapon attack +6, weapon def. -6 for 82 sec. "/>
-    <string name="h8" value="MP -12; weapon attack +6, weapon def. -6 for 88 sec. "/>
-    <string name="h9" value="MP -12; weapon attack +7, weapon def. -7 for 94 sec. "/>
-    <string name="h10" value="MP -12; weapon attack +7, weapon def. -7 for 100 sec. "/>
-    <string name="h11" value="MP -20; weapon attack +8, weapon def. -8 for 106 sec. "/>
-    <string name="h12" value="MP -20; weapon attack +8, weapon def. -8 for 112 sec. "/>
-    <string name="h13" value="MP -20; weapon attack +9, weapon def. -9 for 118 sec. "/>
-    <string name="h14" value="MP -20; weapon attack +9, weapon def. -9 for 124 sec. "/>
-    <string name="h15" value="MP -20; weapon attack +10, weapon def. -10 for 130 sec. "/>
-    <string name="h16" value="MP -20; weapon attack +10, weapon def. -10 for 136 sec. "/>
-    <string name="h17" value="MP -20; weapon attack +11, weapon def. -11 for 142 sec. "/>
-    <string name="h18" value="MP -20; weapon attack +11, weapon def. -11 for 148 sec. "/>
-    <string name="h19" value="MP -20; weapon attack +12, weapon def. -12 for 154 sec. "/>
-    <string name="h20" value="MP -20; weapon attack +12, weapon def. -12 for 160 sec. "/>
+    <string name="desc" value="[Master Level: 20]\nTemporarily increases nearby party members&#x27; weapon attack, but decreases weapon defense."/>
+    <string name="h1" value="MP -12; Weapon ATT +3; Weapon DEF -3 for 46 sec"/>
+    <string name="h2" value="MP -12; Weapon ATT +3; Weapon DEF -3 for 52 sec"/>
+    <string name="h3" value="MP -12; Weapon ATT +4; Weapon DEF -4 for 58 sec"/>
+    <string name="h4" value="MP -12; Weapon ATT +4; Weapon DEF -4 for 64 sec"/>
+    <string name="h5" value="MP -12; Weapon ATT +5; Weapon DEF -5 for 70 sec"/>
+    <string name="h6" value="MP -12; Weapon ATT +5; Weapon DEF -5 for 76 sec"/>
+    <string name="h7" value="MP -12; Weapon ATT +6; Weapon DEF -6 for 82 sec"/>
+    <string name="h8" value="MP -12; Weapon ATT +6; Weapon DEF -6 for 88 sec"/>
+    <string name="h9" value="MP -12; Weapon ATT +7; Weapon DEF -7 for 94 sec"/>
+    <string name="h10" value="MP -12; Weapon ATT +7; Weapon DEF -7 for 100 sec"/>
+    <string name="h11" value="MP -20; Weapon ATT +8; Weapon DEF -8 for 106 sec"/>
+    <string name="h12" value="MP -20; Weapon ATT +8; Weapon DEF -8 for 112 sec"/>
+    <string name="h13" value="MP -20; Weapon ATT +9; Weapon DEF -9 for 118 sec"/>
+    <string name="h14" value="MP -20; Weapon ATT +9; Weapon DEF -9 for 124 sec"/>
+    <string name="h15" value="MP -20; Weapon ATT +10; Weapon DEF -10 for 130 sec"/>
+    <string name="h16" value="MP -20; Weapon ATT +10; Weapon DEF -10 for 136 sec"/>
+    <string name="h17" value="MP -20; Weapon ATT +11; Weapon DEF -11 for 142 sec"/>
+    <string name="h18" value="MP -20; Weapon ATT +11; Weapon DEF -11 for 148 sec"/>
+    <string name="h19" value="MP -20; Weapon ATT +12; Weapon DEF -12 for 154 sec"/>
+    <string name="h20" value="MP -20; Weapon ATT +12; Weapon DEF -12 for 160 sec"/>
   </imgdir>
   <imgdir name="1101007">
     <string name="name" value="Power Guard"/>
-    <string name="desc" value="[Master Level : 30]\nReturns a portion of the damage received from the enemy. Can&apos;t return more than 10% of the enemy&apos;s Max HP at once, however.\nRequired Skill : #cAt least Level 3 on Rage#"/>
-    <string name="h1" value="MP -15; For 3 sec., return 11% of the damage received."/>
-    <string name="h2" value="MP -15; For 6 sec., return 12% of the damage received."/>
-    <string name="h3" value="MP -15; For 9 sec., return 13% of the damage received."/>
-    <string name="h4" value="MP -15; For 12 sec., return 14% of the damage received."/>
-    <string name="h5" value="MP -15; For 15 sec., return 15% of the damage received."/>
-    <string name="h6" value="MP -15; For 18 sec., return 16% of the damage received."/>
-    <string name="h7" value="MP -15; For 21 sec., return 17% of the damage received."/>
-    <string name="h8" value="MP -15; For 24 sec., return 18% of the damage received."/>
-    <string name="h9" value="MP -15; For 27 sec., return 19% of the damage received."/>
-    <string name="h10" value="MP -15; For 30 sec., return 20% of the damage received."/>
-    <string name="h11" value="MP -15; For 33 sec., return 21% of the damage received."/>
-    <string name="h12" value="MP -15; For 36 sec., return 22% of the damage received."/>
-    <string name="h13" value="MP -15; For 39 sec., return 23% of the damage received."/>
-    <string name="h14" value="MP -15; For 42 sec., return 24% of the damage received."/>
-    <string name="h15" value="MP -15; For 45 sec., return 25% of the damage received."/>
-    <string name="h16" value="MP -30; For 48 sec., return 26% of the damage received."/>
-    <string name="h17" value="MP -30; For 51 sec., return 27% of the damage received."/>
-    <string name="h18" value="MP -30; For 54 sec., return 28% of the damage received."/>
-    <string name="h19" value="MP -30; For 57 sec., return 29% of the damage received."/>
-    <string name="h20" value="MP -30; For 60 sec., return 30% of the damage received."/>
-    <string name="h21" value="MP -30; For 63 sec., return 31% of the damage received."/>
-    <string name="h22" value="MP -30; For 66 sec., return 32% of the damage received."/>
-    <string name="h23" value="MP -30; For 69 sec., return 33% of the damage received."/>
-    <string name="h24" value="MP -30; For 72 sec., return 34% of the damage received."/>
-    <string name="h25" value="MP -30; For 75 sec., return 35% of the damage received."/>
-    <string name="h26" value="MP -30; For 78 sec., return 36% of the damage received."/>
-    <string name="h27" value="MP -30; For 81 sec., return 37% of the damage received."/>
-    <string name="h28" value="MP -30; For 84 sec., return 38% of the damage received."/>
-    <string name="h29" value="MP -30; For 87 sec., return 39% of the damage received."/>
-    <string name="h30" value="MP -30; For 90 sec., return 40% of the damage received."/>
+    <string name="desc" value="[Master Level: 30]\nReturns a portion of received touch damage to the enemy. Reflected damage cannot exceed 10% of the monster&#x27;s MaxHP.\nRequired Skill: #cRage Lv. 3 or higher#"/>
+    <string name="h1" value="MP -15; Reflect 11% damage for 3 sec"/>
+    <string name="h2" value="MP -15; Reflect 12% damage for 6 sec"/>
+    <string name="h3" value="MP -15; Reflect 13% damage for 9 sec"/>
+    <string name="h4" value="MP -15; Reflect 14% damage for 12 sec"/>
+    <string name="h5" value="MP -15; Reflect 15% damage for 15 sec"/>
+    <string name="h6" value="MP -15; Reflect 16% damage for 18 sec"/>
+    <string name="h7" value="MP -15; Reflect 17% damage for 21 sec"/>
+    <string name="h8" value="MP -15; Reflect 18% damage for 24 sec"/>
+    <string name="h9" value="MP -15; Reflect 19% damage for 27 sec"/>
+    <string name="h10" value="MP -15; Reflect 20% damage for 30 sec"/>
+    <string name="h11" value="MP -15; Reflect 21% damage for 33 sec"/>
+    <string name="h12" value="MP -15; Reflect 22% damage for 36 sec"/>
+    <string name="h13" value="MP -15; Reflect 23% damage for 39 sec"/>
+    <string name="h14" value="MP -15; Reflect 24% damage for 42 sec"/>
+    <string name="h15" value="MP -15; Reflect 25% damage for 45 sec"/>
+    <string name="h16" value="MP -30; Reflect 26% damage for 48 sec"/>
+    <string name="h17" value="MP -30; Reflect 27% damage for 51 sec"/>
+    <string name="h18" value="MP -30; Reflect 28% damage for 54 sec"/>
+    <string name="h19" value="MP -30; Reflect 29% damage for 57 sec"/>
+    <string name="h20" value="MP -30; Reflect 30% damage for 60 sec"/>
+    <string name="h21" value="MP -30; Reflect 31% damage for 63 sec"/>
+    <string name="h22" value="MP -30; Reflect 32% damage for 66 sec"/>
+    <string name="h23" value="MP -30; Reflect 33% damage for 69 sec"/>
+    <string name="h24" value="MP -30; Reflect 34% damage for 72 sec"/>
+    <string name="h25" value="MP -30; Reflect 35% damage for 75 sec"/>
+    <string name="h26" value="MP -30; Reflect 36% damage for 78 sec"/>
+    <string name="h27" value="MP -30; Reflect 37% damage for 81 sec"/>
+    <string name="h28" value="MP -30; Reflect 38% damage for 84 sec"/>
+    <string name="h29" value="MP -30; Reflect 39% damage for 87 sec"/>
+    <string name="h30" value="MP -30; Reflect 40% damage for 90 sec"/>
   </imgdir>
   <imgdir name="120">
     <string name="bookName" value="Page&apos;s Path"/>
   </imgdir>
   <imgdir name="1200000">
     <string name="name" value="Sword Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the sword mastery and accuracy. It only applies when either a one-handed or a two-handed sword is in hand."/>
-    <string name="h1" value="Sword Mastery +15%, accuracy +1"/>
-    <string name="h2" value="Sword Mastery +15%, accuracy +2"/>
-    <string name="h3" value="Sword Mastery +20%, accuracy +3"/>
-    <string name="h4" value="Sword Mastery +20%, accuracy +4"/>
-    <string name="h5" value="Sword Mastery +25%, accuracy +5"/>
-    <string name="h6" value="Sword Mastery +25%, accuracy +6"/>
-    <string name="h7" value="Sword Mastery +30%, accuracy +7"/>
-    <string name="h8" value="Sword Mastery +30%, accuracy +8"/>
-    <string name="h9" value="Sword Mastery +35%, accuracy +9"/>
-    <string name="h10" value="Sword Mastery +35%, accuracy +10"/>
-    <string name="h11" value="Sword Mastery +40%, accuracy +11"/>
-    <string name="h12" value="Sword Mastery +40%, accuracy +12"/>
-    <string name="h13" value="Sword Mastery +45%, accuracy +13"/>
-    <string name="h14" value="Sword Mastery +45%, accuracy +14"/>
-    <string name="h15" value="Sword Mastery +50%, accuracy +15"/>
-    <string name="h16" value="Sword Mastery +50%, accuracy +16"/>
-    <string name="h17" value="Sword Mastery +55%, accuracy +17"/>
-    <string name="h18" value="Sword Mastery +55%, accuracy +18"/>
-    <string name="h19" value="Sword Mastery +60%, accuracy +19"/>
-    <string name="h20" value="Sword Mastery +60%, accuracy +20"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases sword mastery and accuracy. Applies only while the matching weapon is equipped."/>
+    <string name="h1" value="Sword mastery 51%; accuracy +1"/>
+    <string name="h2" value="Sword mastery 51%; accuracy +2"/>
+    <string name="h3" value="Sword mastery 52%; accuracy +3"/>
+    <string name="h4" value="Sword mastery 52%; accuracy +4"/>
+    <string name="h5" value="Sword mastery 53%; accuracy +5"/>
+    <string name="h6" value="Sword mastery 53%; accuracy +6"/>
+    <string name="h7" value="Sword mastery 54%; accuracy +7"/>
+    <string name="h8" value="Sword mastery 54%; accuracy +8"/>
+    <string name="h9" value="Sword mastery 55%; accuracy +9"/>
+    <string name="h10" value="Sword mastery 55%; accuracy +10"/>
+    <string name="h11" value="Sword mastery 56%; accuracy +11"/>
+    <string name="h12" value="Sword mastery 56%; accuracy +12"/>
+    <string name="h13" value="Sword mastery 57%; accuracy +13"/>
+    <string name="h14" value="Sword mastery 57%; accuracy +14"/>
+    <string name="h15" value="Sword mastery 58%; accuracy +15"/>
+    <string name="h16" value="Sword mastery 58%; accuracy +16"/>
+    <string name="h17" value="Sword mastery 59%; accuracy +17"/>
+    <string name="h18" value="Sword mastery 59%; accuracy +18"/>
+    <string name="h19" value="Sword mastery 60%; accuracy +19"/>
+    <string name="h20" value="Sword mastery 60%; accuracy +20"/>
   </imgdir>
   <imgdir name="1200001">
-    <string name="name" value="BW Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the mastery of blunt weapons and accuracy. It only applies when either a one-handed or a two-handed blunt weapon is in hand."/>
-    <string name="h1" value="Mace mastery +15%, accuracy +1"/>
-    <string name="h2" value="Mace mastery +15%, accuracy +2"/>
-    <string name="h3" value="Mace mastery +20%, accuracy +3"/>
-    <string name="h4" value="Mace mastery +20%, accuracy +4"/>
-    <string name="h5" value="Mace mastery +25%, accuracy +5"/>
-    <string name="h6" value="Mace mastery +25%, accuracy +6"/>
-    <string name="h7" value="Mace mastery +30%, accuracy +7"/>
-    <string name="h8" value="Mace mastery +30%, accuracy +8"/>
-    <string name="h9" value="Mace mastery +35%, accuracy +9"/>
-    <string name="h10" value="Mace mastery +35%, accuracy +10"/>
-    <string name="h11" value="Mace mastery +40%, accuracy +11"/>
-    <string name="h12" value="Mace mastery +40%, accuracy +12"/>
-    <string name="h13" value="Mace mastery +45%, accuracy +13"/>
-    <string name="h14" value="Mace mastery +45%, accuracy +14"/>
-    <string name="h15" value="Mace mastery +50%, accuracy +15"/>
-    <string name="h16" value="Mace mastery +50%, accuracy +16"/>
-    <string name="h17" value="Mace mastery +55%, accuracy +17"/>
-    <string name="h18" value="Mace mastery +55%, accuracy +18"/>
-    <string name="h19" value="Mace mastery +60%, accuracy +19"/>
-    <string name="h20" value="Mace mastery +60%, accuracy +20"/>
+    <string name="name" value="Blunt Weapon Mastery"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases blunt weapon mastery and accuracy. Applies only while the matching weapon is equipped."/>
+    <string name="h1" value="Blunt weapon mastery 51%; accuracy +1"/>
+    <string name="h2" value="Blunt weapon mastery 51%; accuracy +2"/>
+    <string name="h3" value="Blunt weapon mastery 52%; accuracy +3"/>
+    <string name="h4" value="Blunt weapon mastery 52%; accuracy +4"/>
+    <string name="h5" value="Blunt weapon mastery 53%; accuracy +5"/>
+    <string name="h6" value="Blunt weapon mastery 53%; accuracy +6"/>
+    <string name="h7" value="Blunt weapon mastery 54%; accuracy +7"/>
+    <string name="h8" value="Blunt weapon mastery 54%; accuracy +8"/>
+    <string name="h9" value="Blunt weapon mastery 55%; accuracy +9"/>
+    <string name="h10" value="Blunt weapon mastery 55%; accuracy +10"/>
+    <string name="h11" value="Blunt weapon mastery 56%; accuracy +11"/>
+    <string name="h12" value="Blunt weapon mastery 56%; accuracy +12"/>
+    <string name="h13" value="Blunt weapon mastery 57%; accuracy +13"/>
+    <string name="h14" value="Blunt weapon mastery 57%; accuracy +14"/>
+    <string name="h15" value="Blunt weapon mastery 58%; accuracy +15"/>
+    <string name="h16" value="Blunt weapon mastery 58%; accuracy +16"/>
+    <string name="h17" value="Blunt weapon mastery 59%; accuracy +17"/>
+    <string name="h18" value="Blunt weapon mastery 59%; accuracy +18"/>
+    <string name="h19" value="Blunt weapon mastery 60%; accuracy +19"/>
+    <string name="h20" value="Blunt weapon mastery 60%; accuracy +20"/>
   </imgdir>
   <imgdir name="1200002">
     <string name="name" value="Final Attack : Sword"/>
-    <string name="desc" value="[Master Level : 30]\nStrikes an another, far deadlier blow following the initial attack with a given success rate. It works only when holding a one-hand or two-hand sword.\nRequired Skill : #cAt least Level 3 on Sword Mastery#"/>
-    <string name="h1" value="2% Success rate, final attack with sword damage 105% "/>
-    <string name="h2" value="4% Success rate, final attack with sword damage 110% "/>
-    <string name="h3" value="6% Success rate, final attack with sword damage 115% "/>
-    <string name="h4" value="8% Success rate, final attack with sword damage 120% "/>
-    <string name="h5" value="10% Success rate, final attack with sword damage 125% "/>
-    <string name="h6" value="12% Success rate, final attack with sword damage 130% "/>
-    <string name="h7" value="14% Success rate, final attack with sword damage 135% "/>
-    <string name="h8" value="16% Success rate, final attack with sword damage 140% "/>
-    <string name="h9" value="18% Success rate, final attack with sword damage 145% "/>
-    <string name="h10" value="20% Success rate, final attack with sword damage 150% "/>
-    <string name="h11" value="22% Success rate, final attack with sword damage 155% "/>
-    <string name="h12" value="24% Success rate, final attack with sword damage 160% "/>
-    <string name="h13" value="26% Success rate, final attack with sword damage 165% "/>
-    <string name="h14" value="28% Success rate, final attack with sword damage 170% "/>
-    <string name="h15" value="30% Success rate, final attack with sword damage 175% "/>
-    <string name="h16" value="32% Success rate, final attack with sword damage 180% "/>
-    <string name="h17" value="34% Success rate, final attack with sword damage 185% "/>
-    <string name="h18" value="36% Success rate, final attack with sword damage 190% "/>
-    <string name="h19" value="38% Success rate, final attack with sword damage 195% "/>
-    <string name="h20" value="40% Success rate, final attack with sword damage 200% "/>
-    <string name="h21" value="42% Success rate, final attack with sword damage 205% "/>
-    <string name="h22" value="44% Success rate, final attack with sword damage 210% "/>
-    <string name="h23" value="46% Success rate, final attack with sword damage 215% "/>
-    <string name="h24" value="48% Success rate, final attack with sword damage 220% "/>
-    <string name="h25" value="50% Success rate, final attack with sword damage 225% "/>
-    <string name="h26" value="52% Success rate, final attack with sword damage 230% "/>
-    <string name="h27" value="54% Success rate, final attack with sword damage 235% "/>
-    <string name="h28" value="56% Success rate, final attack with sword damage 240% "/>
-    <string name="h29" value="58% Success rate, final attack with sword damage 245% "/>
-    <string name="h30" value="60% Success rate, final attack with sword damage 250% "/>
+    <string name="desc" value="[Master Level: 30]\nAfter certain attacks, has a chance to perform an additional attack. Applies only while a sword is equipped.\nRequired Skill: #cMatching Mastery Lv. 3 or higher#"/>
+    <string name="h1" value="2% success rate; final attack damage 105%"/>
+    <string name="h2" value="4% success rate; final attack damage 110%"/>
+    <string name="h3" value="6% success rate; final attack damage 115%"/>
+    <string name="h4" value="8% success rate; final attack damage 120%"/>
+    <string name="h5" value="10% success rate; final attack damage 125%"/>
+    <string name="h6" value="12% success rate; final attack damage 130%"/>
+    <string name="h7" value="14% success rate; final attack damage 135%"/>
+    <string name="h8" value="16% success rate; final attack damage 140%"/>
+    <string name="h9" value="18% success rate; final attack damage 145%"/>
+    <string name="h10" value="20% success rate; final attack damage 150%"/>
+    <string name="h11" value="22% success rate; final attack damage 155%"/>
+    <string name="h12" value="24% success rate; final attack damage 160%"/>
+    <string name="h13" value="26% success rate; final attack damage 165%"/>
+    <string name="h14" value="28% success rate; final attack damage 170%"/>
+    <string name="h15" value="30% success rate; final attack damage 175%"/>
+    <string name="h16" value="32% success rate; final attack damage 180%"/>
+    <string name="h17" value="34% success rate; final attack damage 185%"/>
+    <string name="h18" value="36% success rate; final attack damage 190%"/>
+    <string name="h19" value="38% success rate; final attack damage 195%"/>
+    <string name="h20" value="40% success rate; final attack damage 200%"/>
+    <string name="h21" value="42% success rate; final attack damage 205%"/>
+    <string name="h22" value="44% success rate; final attack damage 210%"/>
+    <string name="h23" value="46% success rate; final attack damage 215%"/>
+    <string name="h24" value="48% success rate; final attack damage 220%"/>
+    <string name="h25" value="50% success rate; final attack damage 225%"/>
+    <string name="h26" value="52% success rate; final attack damage 230%"/>
+    <string name="h27" value="54% success rate; final attack damage 235%"/>
+    <string name="h28" value="56% success rate; final attack damage 240%"/>
+    <string name="h29" value="58% success rate; final attack damage 245%"/>
+    <string name="h30" value="60% success rate; final attack damage 250%"/>
   </imgdir>
   <imgdir name="1200003">
-    <string name="name" value="Final Attack : BW"/>
-    <string name="desc" value="[Master Level : 30]\nStrikes an another, far deadlier blow following the initial attack with a given success rate. It works only when holding a one-hand or two-hand blunt weapon.\nRequired Skill : #cAt least Level 3 on BW Mastery#"/>
-    <string name="h1" value="2% Success rate, final attack with blunt weapon damage 105% "/>
-    <string name="h2" value="4% Success rate, final attack with blunt weapon damage 110% "/>
-    <string name="h3" value="6% Success rate, final attack with blunt weapon damage 115% "/>
-    <string name="h4" value="8% Success rate, final attack with blunt weapon damage 120% "/>
-    <string name="h5" value="10% Success rate, final attack with blunt weapon damage 125% "/>
-    <string name="h6" value="12% Success rate, final attack with blunt weapon damage 130% "/>
-    <string name="h7" value="14% Success rate, final attack with blunt weapon damage 135% "/>
-    <string name="h8" value="16% Success rate, final attack with blunt weapon damage 140% "/>
-    <string name="h9" value="18% Success rate, final attack with blunt weapon damage 145% "/>
-    <string name="h10" value="20% Success rate, final attack with blunt weapon damage 150% "/>
-    <string name="h11" value="22% Success rate, final attack with blunt weapon damage 155% "/>
-    <string name="h12" value="24% Success rate, final attack with blunt weapon damage 160% "/>
-    <string name="h13" value="26% Success rate, final attack with blunt weapon damage 165% "/>
-    <string name="h14" value="28% Success rate, final attack with blunt weapon damage 170% "/>
-    <string name="h15" value="30% Success rate, final attack with blunt weapon damage 175% "/>
-    <string name="h16" value="32% Success rate, final attack with blunt weapon damage 180% "/>
-    <string name="h17" value="34% Success rate, final attack with blunt weapon damage 185% "/>
-    <string name="h18" value="36% Success rate, final attack with blunt weapon damage 190% "/>
-    <string name="h19" value="38% Success rate, final attack with blunt weapon damage 195% "/>
-    <string name="h20" value="40% Success rate, final attack with blunt weapon damage 200% "/>
-    <string name="h21" value="42% Success rate, final attack with blunt weapon damage 205% "/>
-    <string name="h22" value="44% Success rate, final attack with blunt weapon damage 210% "/>
-    <string name="h23" value="46% Success rate, final attack with blunt weapon damage 215% "/>
-    <string name="h24" value="48% Success rate, final attack with blunt weapon damage 220% "/>
-    <string name="h25" value="50% Success rate, final attack with blunt weapon damage 225% "/>
-    <string name="h26" value="52% Success rate, final attack with blunt weapon damage 230% "/>
-    <string name="h27" value="54% Success rate, final attack with blunt weapon damage 235% "/>
-    <string name="h28" value="56% Success rate, final attack with blunt weapon damage 240% "/>
-    <string name="h29" value="58% Success rate, final attack with blunt weapon damage 245% "/>
-    <string name="h30" value="60% Success rate, final attack with blunt weapon damage 250% "/>
+    <string name="name" value="Final Attack: Blunt Weapon"/>
+    <string name="desc" value="[Master Level: 30]\nAfter certain attacks, has a chance to perform an additional attack. Applies only while a blunt weapon is equipped.\nRequired Skill: #cMatching Mastery Lv. 3 or higher#"/>
+    <string name="h1" value="2% success rate; final attack damage 105%"/>
+    <string name="h2" value="4% success rate; final attack damage 110%"/>
+    <string name="h3" value="6% success rate; final attack damage 115%"/>
+    <string name="h4" value="8% success rate; final attack damage 120%"/>
+    <string name="h5" value="10% success rate; final attack damage 125%"/>
+    <string name="h6" value="12% success rate; final attack damage 130%"/>
+    <string name="h7" value="14% success rate; final attack damage 135%"/>
+    <string name="h8" value="16% success rate; final attack damage 140%"/>
+    <string name="h9" value="18% success rate; final attack damage 145%"/>
+    <string name="h10" value="20% success rate; final attack damage 150%"/>
+    <string name="h11" value="22% success rate; final attack damage 155%"/>
+    <string name="h12" value="24% success rate; final attack damage 160%"/>
+    <string name="h13" value="26% success rate; final attack damage 165%"/>
+    <string name="h14" value="28% success rate; final attack damage 170%"/>
+    <string name="h15" value="30% success rate; final attack damage 175%"/>
+    <string name="h16" value="32% success rate; final attack damage 180%"/>
+    <string name="h17" value="34% success rate; final attack damage 185%"/>
+    <string name="h18" value="36% success rate; final attack damage 190%"/>
+    <string name="h19" value="38% success rate; final attack damage 195%"/>
+    <string name="h20" value="40% success rate; final attack damage 200%"/>
+    <string name="h21" value="42% success rate; final attack damage 205%"/>
+    <string name="h22" value="44% success rate; final attack damage 210%"/>
+    <string name="h23" value="46% success rate; final attack damage 215%"/>
+    <string name="h24" value="48% success rate; final attack damage 220%"/>
+    <string name="h25" value="50% success rate; final attack damage 225%"/>
+    <string name="h26" value="52% success rate; final attack damage 230%"/>
+    <string name="h27" value="54% success rate; final attack damage 235%"/>
+    <string name="h28" value="56% success rate; final attack damage 240%"/>
+    <string name="h29" value="58% success rate; final attack damage 245%"/>
+    <string name="h30" value="60% success rate; final attack damage 250%"/>
   </imgdir>
   <imgdir name="1201004">
     <string name="name" value="Sword Booster"/>
-    <string name="desc" value="[Master Level : 20]\nUses HP and MP to temporarily boost up the attacking speed of the equipped sword. It only applies when either a one-handed or a two-handed sword is in hand.\nRequired Skill : #cAt least Level 5 on Sword Mastery#"/>
-    <string name="h1" value="HP -29, MP -29; increase in sword speed for 10 sec. "/>
-    <string name="h2" value="HP -28, MP -28; increase in sword speed for 20 sec. "/>
-    <string name="h3" value="HP -27, MP -27; increase in sword speed for 30 sec. "/>
-    <string name="h4" value="HP -26, MP -26; increase in sword speed for 40 sec. "/>
-    <string name="h5" value="HP -25, MP -25; increase in sword speed for 50 sec. "/>
-    <string name="h6" value="HP -24, MP -24; increase in sword speed for 60 sec. "/>
-    <string name="h7" value="HP -23, MP -23; increase in sword speed for 70 sec. "/>
-    <string name="h8" value="HP -22, MP -22; increase in sword speed for 80 sec. "/>
-    <string name="h9" value="HP -21, MP -21; increase in sword speed for 90 sec. "/>
-    <string name="h10" value="HP -20, MP -20; increase in sword speed for 100 sec. "/>
-    <string name="h11" value="HP -19, MP -19; increase in sword speed for 110 sec. "/>
-    <string name="h12" value="HP -18, MP -18; increase in sword speed for 120 sec. "/>
-    <string name="h13" value="HP -17, MP -17; increase in sword speed for 130 sec. "/>
-    <string name="h14" value="HP -16, MP -16; increase in sword speed for 140 sec. "/>
-    <string name="h15" value="HP -15, MP -15; increase in sword speed for 150 sec. "/>
-    <string name="h16" value="HP -14, MP -14; increase in sword speed for 160 sec. "/>
-    <string name="h17" value="HP -13, MP -13; increase in sword speed for 170 sec. "/>
-    <string name="h18" value="HP -12, MP -12; increase in sword speed for 180 sec. "/>
-    <string name="h19" value="HP -11, MP -11; increase in sword speed for 190 sec. "/>
-    <string name="h20" value="HP -10, MP -10; increase in sword speed for 200 sec. "/>
+    <string name="desc" value="[Master Level: 20]\nUses HP and MP to temporarily increase the attack speed of the equipped sword.\nRequired Skill: #cMatching Mastery Lv. 5 or higher#"/>
+    <string name="h1" value="HP -29; MP -29; Increase sword attack speed for 10 sec"/>
+    <string name="h2" value="HP -28; MP -28; Increase sword attack speed for 20 sec"/>
+    <string name="h3" value="HP -27; MP -27; Increase sword attack speed for 30 sec"/>
+    <string name="h4" value="HP -26; MP -26; Increase sword attack speed for 40 sec"/>
+    <string name="h5" value="HP -25; MP -25; Increase sword attack speed for 50 sec"/>
+    <string name="h6" value="HP -24; MP -24; Increase sword attack speed for 60 sec"/>
+    <string name="h7" value="HP -23; MP -23; Increase sword attack speed for 70 sec"/>
+    <string name="h8" value="HP -22; MP -22; Increase sword attack speed for 80 sec"/>
+    <string name="h9" value="HP -21; MP -21; Increase sword attack speed for 90 sec"/>
+    <string name="h10" value="HP -20; MP -20; Increase sword attack speed for 100 sec"/>
+    <string name="h11" value="HP -19; MP -19; Increase sword attack speed for 110 sec"/>
+    <string name="h12" value="HP -18; MP -18; Increase sword attack speed for 120 sec"/>
+    <string name="h13" value="HP -17; MP -17; Increase sword attack speed for 130 sec"/>
+    <string name="h14" value="HP -16; MP -16; Increase sword attack speed for 140 sec"/>
+    <string name="h15" value="HP -15; MP -15; Increase sword attack speed for 150 sec"/>
+    <string name="h16" value="HP -14; MP -14; Increase sword attack speed for 160 sec"/>
+    <string name="h17" value="HP -13; MP -13; Increase sword attack speed for 170 sec"/>
+    <string name="h18" value="HP -12; MP -12; Increase sword attack speed for 180 sec"/>
+    <string name="h19" value="HP -11; MP -11; Increase sword attack speed for 190 sec"/>
+    <string name="h20" value="HP -10; MP -10; Increase sword attack speed for 200 sec"/>
   </imgdir>
   <imgdir name="1201005">
-    <string name="name" value="BW Booster"/>
-    <string name="desc" value="[Master Level: 20]\nUses HP and MP  to temporarily boost up the attacking speed of the equipped blunt weapon. It only applies when either a one-handed or a two-handed blunt weapon is in hand.\nRequired Skill : #cAt least Level 5 on Mace Mastery#"/>
-    <string name="h1" value="HP -29, MP -29; increase in mace speed for 10 sec. "/>
-    <string name="h2" value="HP -28, MP -28; increase in mace speed for 20 sec. "/>
-    <string name="h3" value="HP -27, MP -27; increase in mace speed for 30 sec. "/>
-    <string name="h4" value="HP -26, MP -26; increase in mace speed for 40 sec. "/>
-    <string name="h5" value="HP -25, MP -25; increase in mace speed for 50 sec. "/>
-    <string name="h6" value="HP -24, MP -24; increase in mace speed for 60 sec. "/>
-    <string name="h7" value="HP -23, MP -23; increase in mace speed for 70 sec. "/>
-    <string name="h8" value="HP -22, MP -22; increase in mace speed for 80 sec. "/>
-    <string name="h9" value="HP -21, MP -21; increase in mace speed for 90 sec. "/>
-    <string name="h10" value="HP -20, MP -20; increase in mace speed for 100 sec. "/>
-    <string name="h11" value="HP -19, MP -19; increase in mace speed for 110 sec. "/>
-    <string name="h12" value="HP -18, MP -18; increase in mace speed for 120 sec. "/>
-    <string name="h13" value="HP -17, MP -17; increase in mace speed for 130 sec. "/>
-    <string name="h14" value="HP -16, MP -16; increase in mace speed for 140 sec. "/>
-    <string name="h15" value="HP -15, MP -15; increase in mace speed for 150 sec. "/>
-    <string name="h16" value="HP -14, MP -14; increase in mace speed for 160 sec. "/>
-    <string name="h17" value="HP -13, MP -13; increase in mace speed for 170 sec. "/>
-    <string name="h18" value="HP -12, MP -12; increase in mace speed for 180 sec. "/>
-    <string name="h19" value="HP -11, MP -11; increase in mace speed for 190 sec. "/>
-    <string name="h20" value="HP -10, MP -10; increase in mace speed for 200 sec. "/>
+    <string name="name" value="Blunt Weapon Booster"/>
+    <string name="desc" value="[Master Level: 20]\nUses HP and MP to temporarily increase the attack speed of the equipped blunt weapon.\nRequired Skill: #cMatching Mastery Lv. 5 or higher#"/>
+    <string name="h1" value="HP -29; MP -29; Increase blunt weapon attack speed for 10 sec"/>
+    <string name="h2" value="HP -28; MP -28; Increase blunt weapon attack speed for 20 sec"/>
+    <string name="h3" value="HP -27; MP -27; Increase blunt weapon attack speed for 30 sec"/>
+    <string name="h4" value="HP -26; MP -26; Increase blunt weapon attack speed for 40 sec"/>
+    <string name="h5" value="HP -25; MP -25; Increase blunt weapon attack speed for 50 sec"/>
+    <string name="h6" value="HP -24; MP -24; Increase blunt weapon attack speed for 60 sec"/>
+    <string name="h7" value="HP -23; MP -23; Increase blunt weapon attack speed for 70 sec"/>
+    <string name="h8" value="HP -22; MP -22; Increase blunt weapon attack speed for 80 sec"/>
+    <string name="h9" value="HP -21; MP -21; Increase blunt weapon attack speed for 90 sec"/>
+    <string name="h10" value="HP -20; MP -20; Increase blunt weapon attack speed for 100 sec"/>
+    <string name="h11" value="HP -19; MP -19; Increase blunt weapon attack speed for 110 sec"/>
+    <string name="h12" value="HP -18; MP -18; Increase blunt weapon attack speed for 120 sec"/>
+    <string name="h13" value="HP -17; MP -17; Increase blunt weapon attack speed for 130 sec"/>
+    <string name="h14" value="HP -16; MP -16; Increase blunt weapon attack speed for 140 sec"/>
+    <string name="h15" value="HP -15; MP -15; Increase blunt weapon attack speed for 150 sec"/>
+    <string name="h16" value="HP -14; MP -14; Increase blunt weapon attack speed for 160 sec"/>
+    <string name="h17" value="HP -13; MP -13; Increase blunt weapon attack speed for 170 sec"/>
+    <string name="h18" value="HP -12; MP -12; Increase blunt weapon attack speed for 180 sec"/>
+    <string name="h19" value="HP -11; MP -11; Increase blunt weapon attack speed for 190 sec"/>
+    <string name="h20" value="HP -10; MP -10; Increase blunt weapon attack speed for 200 sec"/>
   </imgdir>
   <imgdir name="1201006">
     <string name="name" value="Threaten"/>
-    <string name="desc" value="[Master Level : 20]\nUse MP to temporarily threaten a monster. Decreases the level of weapon attack and weapon defense of every monster around the area."/>
-    <string name="h1" value="MP -12; enemy&apos;s weapon attack -1, weapon def. -1 for 44 sec."/>
-    <string name="h2" value="MP -12; enemy&apos;s weapon attack -2, weapon def. -2 for 48 sec."/>
-    <string name="h3" value="MP -12; enemy&apos;s weapon attack -3, weapon def. -3 for 52 sec."/>
-    <string name="h4" value="MP -12; enemy&apos;s weapon attack -4, weapon def. -4 for 56 sec."/>
-    <string name="h5" value="MP -12; enemy&apos;s weapon attack -5, weapon def. -5 for 60 sec."/>
-    <string name="h6" value="MP -12; enemy&apos;s weapon attack -6, weapon def. -6 for 64 sec."/>
-    <string name="h7" value="MP -12; enemy&apos;s weapon attack -7, weapon def. -7 for 68 sec."/>
-    <string name="h8" value="MP -12; enemy&apos;s weapon attack -8, weapon def. -8 for 72 sec."/>
-    <string name="h9" value="MP -12; enemy&apos;s weapon attack -9, weapon def. -9 for 76 sec."/>
-    <string name="h10" value="MP -12; enemy&apos;s weapon attack -10, weapon def. -10 for 80 sec."/>
-    <string name="h11" value="MP -20; enemy&apos;s weapon attack -11, weapon def. -11 for 84 sec."/>
-    <string name="h12" value="MP -20; enemy&apos;s weapon attack -12, weapon def. -12 for 88 sec."/>
-    <string name="h13" value="MP -20; enemy&apos;s weapon attack -13, weapon def. -13 for 92 sec."/>
-    <string name="h14" value="MP -20; enemy&apos;s weapon attack -14, weapon def. -14 for 96 sec."/>
-    <string name="h15" value="MP -20; enemy&apos;s weapon attack -15, weapon def. -15 for 100 sec."/>
-    <string name="h16" value="MP -20; enemy&apos;s weapon attack -16, weapon def. -16 for 104 sec."/>
-    <string name="h17" value="MP -20; enemy&apos;s weapon attack -17, weapon def. -17 for 108 sec."/>
-    <string name="h18" value="MP -20; enemy&apos;s weapon attack -18, weapon def. -18 for 112 sec."/>
-    <string name="h19" value="MP -20; enemy&apos;s weapon attack -19, weapon def. -19 for 116 sec."/>
-    <string name="h20" value="MP -20; enemy&apos;s weapon attack -20, weapon def. -20 for 120 sec."/>
+    <string name="desc" value="[Master Level: 20]\nThreatens nearby monsters, temporarily lowering their weapon attack and weapon defense."/>
+    <string name="h1" value="MP -12; Enemy weapon ATT -1; enemy weapon DEF -1 for 44 sec"/>
+    <string name="h2" value="MP -12; Enemy weapon ATT -2; enemy weapon DEF -2 for 48 sec"/>
+    <string name="h3" value="MP -12; Enemy weapon ATT -3; enemy weapon DEF -3 for 52 sec"/>
+    <string name="h4" value="MP -12; Enemy weapon ATT -4; enemy weapon DEF -4 for 56 sec"/>
+    <string name="h5" value="MP -12; Enemy weapon ATT -5; enemy weapon DEF -5 for 60 sec"/>
+    <string name="h6" value="MP -12; Enemy weapon ATT -6; enemy weapon DEF -6 for 64 sec"/>
+    <string name="h7" value="MP -12; Enemy weapon ATT -7; enemy weapon DEF -7 for 68 sec"/>
+    <string name="h8" value="MP -12; Enemy weapon ATT -8; enemy weapon DEF -8 for 72 sec"/>
+    <string name="h9" value="MP -12; Enemy weapon ATT -9; enemy weapon DEF -9 for 76 sec"/>
+    <string name="h10" value="MP -12; Enemy weapon ATT -10; enemy weapon DEF -10 for 80 sec"/>
+    <string name="h11" value="MP -20; Enemy weapon ATT -11; enemy weapon DEF -11 for 84 sec"/>
+    <string name="h12" value="MP -20; Enemy weapon ATT -12; enemy weapon DEF -12 for 88 sec"/>
+    <string name="h13" value="MP -20; Enemy weapon ATT -13; enemy weapon DEF -13 for 92 sec"/>
+    <string name="h14" value="MP -20; Enemy weapon ATT -14; enemy weapon DEF -14 for 96 sec"/>
+    <string name="h15" value="MP -20; Enemy weapon ATT -15; enemy weapon DEF -15 for 100 sec"/>
+    <string name="h16" value="MP -20; Enemy weapon ATT -16; enemy weapon DEF -16 for 104 sec"/>
+    <string name="h17" value="MP -20; Enemy weapon ATT -17; enemy weapon DEF -17 for 108 sec"/>
+    <string name="h18" value="MP -20; Enemy weapon ATT -18; enemy weapon DEF -18 for 112 sec"/>
+    <string name="h19" value="MP -20; Enemy weapon ATT -19; enemy weapon DEF -19 for 116 sec"/>
+    <string name="h20" value="MP -20; Enemy weapon ATT -20; enemy weapon DEF -20 for 120 sec"/>
   </imgdir>
   <imgdir name="1201007">
     <string name="name" value="Power Guard"/>
-    <string name="desc" value="[Master Level : 30]\nReturns a portion of the damage received from the enemy. Can&apos;t return more than 10% of the enemy&apos;s Max HP at once, however.\nRequired Skill : #cAt least Level 3 on Threaten#"/>
-    <string name="h1" value="MP -15 for 3 sec., return 11% of the damage received."/>
-    <string name="h2" value="MP -15 for 6 sec., return 12% of the damage received."/>
-    <string name="h3" value="MP -15 for 9 sec., return 13% of the damage received."/>
-    <string name="h4" value="MP -15 for 12sec., return 14% of the damage received."/>
-    <string name="h5" value="MP -15 for 15 sec., return 15% of the damage received."/>
-    <string name="h6" value="MP -15 for 18 sec., return 16% of the damage received."/>
-    <string name="h7" value="MP -15 for 21 sec., return 17% of the damage received."/>
-    <string name="h8" value="MP -15 for 24 sec., return 18% of the damage received."/>
-    <string name="h9" value="MP -15 for 27 sec., return 19% of the damage received."/>
-    <string name="h10" value="MP -15 for 30 sec., return 20% of the damage received."/>
-    <string name="h11" value="MP -15 for 33 sec., return 21% of the damage received."/>
-    <string name="h12" value="MP -15 for 36 sec., return 22% of the damage received."/>
-    <string name="h13" value="MP -15 for 39 sec., return 23% of the damage received."/>
-    <string name="h14" value="MP -15 for 42 sec., return 24% of the damage received."/>
-    <string name="h15" value="MP -15 for 45 sec., return 25% of the damage received."/>
-    <string name="h16" value="MP -30 for 48 sec., return 26% of the damage received."/>
-    <string name="h17" value="MP -30 for 51 sec., return 27% of the damage received."/>
-    <string name="h18" value="MP -30 for 54 sec., return 28% of the damage received."/>
-    <string name="h19" value="MP -30 for 57 sec., return 29% of the damage received."/>
-    <string name="h20" value="MP -30 for 60 sec., return 30% of the damage received."/>
-    <string name="h21" value="MP -30 for 63 sec., return 31% of the damage received."/>
-    <string name="h22" value="MP -30 for 66 sec., return 32% of the damage received."/>
-    <string name="h23" value="MP -30 for 69 sec., return 33% of the damage received."/>
-    <string name="h24" value="MP -30 for 72 sec., return 34% of the damage received."/>
-    <string name="h25" value="MP -30 for 75 sec., return 35% of the damage received."/>
-    <string name="h26" value="MP -30 for 78 sec., return 36% of the damage received."/>
-    <string name="h27" value="MP -30 for 81 sec., return 37% of the damage received."/>
-    <string name="h28" value="MP -30 for 84 sec., return 38% of the damage received."/>
-    <string name="h29" value="MP -30 for 87 sec., return 39% of the damage received."/>
-    <string name="h30" value="MP -30 for 90 sec., return 40% of the damage received."/>
+    <string name="desc" value="[Master Level: 30]\nReturns a portion of received touch damage to the enemy. Reflected damage cannot exceed 10% of the monster&#x27;s MaxHP.\nRequired Skill: #cThreaten Lv. 3 or higher#"/>
+    <string name="h1" value="MP -15; Reflect 11% damage for 3 sec"/>
+    <string name="h2" value="MP -15; Reflect 12% damage for 6 sec"/>
+    <string name="h3" value="MP -15; Reflect 13% damage for 9 sec"/>
+    <string name="h4" value="MP -15; Reflect 14% damage for 12 sec"/>
+    <string name="h5" value="MP -15; Reflect 15% damage for 15 sec"/>
+    <string name="h6" value="MP -15; Reflect 16% damage for 18 sec"/>
+    <string name="h7" value="MP -15; Reflect 17% damage for 21 sec"/>
+    <string name="h8" value="MP -15; Reflect 18% damage for 24 sec"/>
+    <string name="h9" value="MP -15; Reflect 19% damage for 27 sec"/>
+    <string name="h10" value="MP -15; Reflect 20% damage for 30 sec"/>
+    <string name="h11" value="MP -15; Reflect 21% damage for 33 sec"/>
+    <string name="h12" value="MP -15; Reflect 22% damage for 36 sec"/>
+    <string name="h13" value="MP -15; Reflect 23% damage for 39 sec"/>
+    <string name="h14" value="MP -15; Reflect 24% damage for 42 sec"/>
+    <string name="h15" value="MP -15; Reflect 25% damage for 45 sec"/>
+    <string name="h16" value="MP -30; Reflect 26% damage for 48 sec"/>
+    <string name="h17" value="MP -30; Reflect 27% damage for 51 sec"/>
+    <string name="h18" value="MP -30; Reflect 28% damage for 54 sec"/>
+    <string name="h19" value="MP -30; Reflect 29% damage for 57 sec"/>
+    <string name="h20" value="MP -30; Reflect 30% damage for 60 sec"/>
+    <string name="h21" value="MP -30; Reflect 31% damage for 63 sec"/>
+    <string name="h22" value="MP -30; Reflect 32% damage for 66 sec"/>
+    <string name="h23" value="MP -30; Reflect 33% damage for 69 sec"/>
+    <string name="h24" value="MP -30; Reflect 34% damage for 72 sec"/>
+    <string name="h25" value="MP -30; Reflect 35% damage for 75 sec"/>
+    <string name="h26" value="MP -30; Reflect 36% damage for 78 sec"/>
+    <string name="h27" value="MP -30; Reflect 37% damage for 81 sec"/>
+    <string name="h28" value="MP -30; Reflect 38% damage for 84 sec"/>
+    <string name="h29" value="MP -30; Reflect 39% damage for 87 sec"/>
+    <string name="h30" value="MP -30; Reflect 40% damage for 90 sec"/>
   </imgdir>
   <imgdir name="130">
     <string name="bookName" value="Spearman Techniques"/>
   </imgdir>
   <imgdir name="1300000">
     <string name="name" value="Spear Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the spear mastery and accuracy. It only applies when a spear is in hand."/>
-    <string name="h1" value="Spear mastery +15%, accuracy +1"/>
-    <string name="h2" value="Spear mastery +15%, accuracy +2"/>
-    <string name="h3" value="Spear mastery +20%, accuracy +3"/>
-    <string name="h4" value="Spear mastery +20%, accuracy +4"/>
-    <string name="h5" value="Spear mastery +25%, accuracy +5"/>
-    <string name="h6" value="Spear mastery +25%, accuracy +6"/>
-    <string name="h7" value="Spear mastery +30%, accuracy +7"/>
-    <string name="h8" value="Spear mastery +30%, accuracy +8"/>
-    <string name="h9" value="Spear mastery +35%, accuracy +9"/>
-    <string name="h10" value="Spear mastery +35%, accuracy +10"/>
-    <string name="h11" value="Spear mastery +40%, accuracy +11"/>
-    <string name="h12" value="Spear mastery +40%, accuracy +12"/>
-    <string name="h13" value="Spear mastery +45%, accuracy +13"/>
-    <string name="h14" value="Spear mastery +45%, accuracy +14"/>
-    <string name="h15" value="Spear mastery +50%, accuracy +15"/>
-    <string name="h16" value="Spear mastery +50%, accuracy +16"/>
-    <string name="h17" value="Spear mastery +55%, accuracy +17"/>
-    <string name="h18" value="Spear mastery +55%, accuracy +18"/>
-    <string name="h19" value="Spear mastery +60%, accuracy +19"/>
-    <string name="h20" value="Spear mastery +60%, accuracy +20"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases spear mastery and accuracy. Applies only while the matching weapon is equipped."/>
+    <string name="h1" value="Spear mastery 51%; accuracy +1"/>
+    <string name="h2" value="Spear mastery 51%; accuracy +2"/>
+    <string name="h3" value="Spear mastery 52%; accuracy +3"/>
+    <string name="h4" value="Spear mastery 52%; accuracy +4"/>
+    <string name="h5" value="Spear mastery 53%; accuracy +5"/>
+    <string name="h6" value="Spear mastery 53%; accuracy +6"/>
+    <string name="h7" value="Spear mastery 54%; accuracy +7"/>
+    <string name="h8" value="Spear mastery 54%; accuracy +8"/>
+    <string name="h9" value="Spear mastery 55%; accuracy +9"/>
+    <string name="h10" value="Spear mastery 55%; accuracy +10"/>
+    <string name="h11" value="Spear mastery 56%; accuracy +11"/>
+    <string name="h12" value="Spear mastery 56%; accuracy +12"/>
+    <string name="h13" value="Spear mastery 57%; accuracy +13"/>
+    <string name="h14" value="Spear mastery 57%; accuracy +14"/>
+    <string name="h15" value="Spear mastery 58%; accuracy +15"/>
+    <string name="h16" value="Spear mastery 58%; accuracy +16"/>
+    <string name="h17" value="Spear mastery 59%; accuracy +17"/>
+    <string name="h18" value="Spear mastery 59%; accuracy +18"/>
+    <string name="h19" value="Spear mastery 60%; accuracy +19"/>
+    <string name="h20" value="Spear mastery 60%; accuracy +20"/>
   </imgdir>
   <imgdir name="1300001">
     <string name="name" value="Pole Arm Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the mastery of pole arms and accuracy. It only applies when a pole arm is in hand."/>
-    <string name="h1" value="Pole Arm Mastery +15%, accuracy +1"/>
-    <string name="h2" value="Pole Arm Mastery +15%, accuracy +2"/>
-    <string name="h3" value="Pole Arm Mastery +20%, accuracy +3"/>
-    <string name="h4" value="Pole Arm Mastery +20%, accuracy +4"/>
-    <string name="h5" value="Pole Arm Mastery +25%, accuracy +5"/>
-    <string name="h6" value="Pole Arm Mastery +25%, accuracy +6"/>
-    <string name="h7" value="Pole Arm Mastery +30%, accuracy +7"/>
-    <string name="h8" value="Pole Arm Mastery +30%, accuracy +8"/>
-    <string name="h9" value="Pole Arm Mastery +35%, accuracy +9"/>
-    <string name="h10" value="Pole Arm Mastery +35%, accuracy +10"/>
-    <string name="h11" value="Pole Arm Mastery +40%, accuracy +11"/>
-    <string name="h12" value="Pole Arm Mastery +40%, accuracy +12"/>
-    <string name="h13" value="Pole Arm Mastery +45%, accuracy +13"/>
-    <string name="h14" value="Pole Arm Mastery +45%, accuracy +14"/>
-    <string name="h15" value="Pole Arm Mastery +50%, accuracy +15"/>
-    <string name="h16" value="Pole Arm Mastery +50%, accuracy +16"/>
-    <string name="h17" value="Pole Arm Mastery +55%, accuracy +17"/>
-    <string name="h18" value="Pole Arm Mastery +55%, accuracy +18"/>
-    <string name="h19" value="Pole Arm Mastery +60%, accuracy +19"/>
-    <string name="h20" value="Pole Arm Mastery +60%, accuracy +20"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases pole arm mastery and accuracy. Applies only while the matching weapon is equipped."/>
+    <string name="h1" value="Pole arm mastery 51%; accuracy +1"/>
+    <string name="h2" value="Pole arm mastery 51%; accuracy +2"/>
+    <string name="h3" value="Pole arm mastery 52%; accuracy +3"/>
+    <string name="h4" value="Pole arm mastery 52%; accuracy +4"/>
+    <string name="h5" value="Pole arm mastery 53%; accuracy +5"/>
+    <string name="h6" value="Pole arm mastery 53%; accuracy +6"/>
+    <string name="h7" value="Pole arm mastery 54%; accuracy +7"/>
+    <string name="h8" value="Pole arm mastery 54%; accuracy +8"/>
+    <string name="h9" value="Pole arm mastery 55%; accuracy +9"/>
+    <string name="h10" value="Pole arm mastery 55%; accuracy +10"/>
+    <string name="h11" value="Pole arm mastery 56%; accuracy +11"/>
+    <string name="h12" value="Pole arm mastery 56%; accuracy +12"/>
+    <string name="h13" value="Pole arm mastery 57%; accuracy +13"/>
+    <string name="h14" value="Pole arm mastery 57%; accuracy +14"/>
+    <string name="h15" value="Pole arm mastery 58%; accuracy +15"/>
+    <string name="h16" value="Pole arm mastery 58%; accuracy +16"/>
+    <string name="h17" value="Pole arm mastery 59%; accuracy +17"/>
+    <string name="h18" value="Pole arm mastery 59%; accuracy +18"/>
+    <string name="h19" value="Pole arm mastery 60%; accuracy +19"/>
+    <string name="h20" value="Pole arm mastery 60%; accuracy +20"/>
   </imgdir>
   <imgdir name="1300002">
     <string name="name" value="Final Attack : Spear"/>
-    <string name="desc" value="[Master Level : 30]\nStrikes an another, far deadlier blow following the initial attack with a given success rate. It works only when holding a one-hand or two-hand spear.\nRequired Skill : #cAt least Level 3 on Spear Mastery#"/>
-    <string name="h1" value="2% Success rate, final attack with spear damage 105% "/>
-    <string name="h2" value="4% Success rate, final attack with spear damage 110% "/>
-    <string name="h3" value="6% Success rate, final attack with spear damage 115% "/>
-    <string name="h4" value="8% Success rate, final attack with spear damage 120% "/>
-    <string name="h5" value="10% Success rate, final attack with spear damage 125% "/>
-    <string name="h6" value="12% Success rate, final attack with spear damage 130% "/>
-    <string name="h7" value="14% Success rate, final attack with spear damage 135% "/>
-    <string name="h8" value="16% Success rate, final attack with spear damage 140% "/>
-    <string name="h9" value="18% Success rate, final attack with spear damage 145% "/>
-    <string name="h10" value="20% Success rate, final attack with spear damage 150% "/>
-    <string name="h11" value="22% Success rate, final attack with spear damage 155% "/>
-    <string name="h12" value="24% Success rate, final attack with spear damage 160% "/>
-    <string name="h13" value="26% Success rate, final attack with spear damage 165% "/>
-    <string name="h14" value="28% Success rate, final attack with spear damage 170% "/>
-    <string name="h15" value="30% Success rate, final attack with spear damage 175% "/>
-    <string name="h16" value="32% Success rate, final attack with spear damage 180% "/>
-    <string name="h17" value="34% Success rate, final attack with spear damage 185% "/>
-    <string name="h18" value="36% Success rate, final attack with spear damage 190% "/>
-    <string name="h19" value="38% Success rate, final attack with spear damage 195% "/>
-    <string name="h20" value="40% Success rate, final attack with spear damage 200% "/>
-    <string name="h21" value="42% Success rate, final attack with spear damage 205% "/>
-    <string name="h22" value="44% Success rate, final attack with spear damage 210% "/>
-    <string name="h23" value="46% Success rate, final attack with spear damage 215% "/>
-    <string name="h24" value="48% Success rate, final attack with spear damage 220% "/>
-    <string name="h25" value="50% Success rate, final attack with spear damage 225% "/>
-    <string name="h26" value="52% Success rate, final attack with spear damage 230% "/>
-    <string name="h27" value="54% Success rate, final attack with spear damage 235% "/>
-    <string name="h28" value="56% Success rate, final attack with spear damage 240% "/>
-    <string name="h29" value="58% Success rate, final attack with spear damage 245% "/>
-    <string name="h30" value="60% Success rate, final attack with spear damage 250% "/>
+    <string name="desc" value="[Master Level: 30]\nAfter certain attacks, has a chance to perform an additional attack. Applies only while a spear is equipped.\nRequired Skill: #cMatching Mastery Lv. 3 or higher#"/>
+    <string name="h1" value="2% success rate; final attack damage 105%"/>
+    <string name="h2" value="4% success rate; final attack damage 110%"/>
+    <string name="h3" value="6% success rate; final attack damage 115%"/>
+    <string name="h4" value="8% success rate; final attack damage 120%"/>
+    <string name="h5" value="10% success rate; final attack damage 125%"/>
+    <string name="h6" value="12% success rate; final attack damage 130%"/>
+    <string name="h7" value="14% success rate; final attack damage 135%"/>
+    <string name="h8" value="16% success rate; final attack damage 140%"/>
+    <string name="h9" value="18% success rate; final attack damage 145%"/>
+    <string name="h10" value="20% success rate; final attack damage 150%"/>
+    <string name="h11" value="22% success rate; final attack damage 155%"/>
+    <string name="h12" value="24% success rate; final attack damage 160%"/>
+    <string name="h13" value="26% success rate; final attack damage 165%"/>
+    <string name="h14" value="28% success rate; final attack damage 170%"/>
+    <string name="h15" value="30% success rate; final attack damage 175%"/>
+    <string name="h16" value="32% success rate; final attack damage 180%"/>
+    <string name="h17" value="34% success rate; final attack damage 185%"/>
+    <string name="h18" value="36% success rate; final attack damage 190%"/>
+    <string name="h19" value="38% success rate; final attack damage 195%"/>
+    <string name="h20" value="40% success rate; final attack damage 200%"/>
+    <string name="h21" value="42% success rate; final attack damage 205%"/>
+    <string name="h22" value="44% success rate; final attack damage 210%"/>
+    <string name="h23" value="46% success rate; final attack damage 215%"/>
+    <string name="h24" value="48% success rate; final attack damage 220%"/>
+    <string name="h25" value="50% success rate; final attack damage 225%"/>
+    <string name="h26" value="52% success rate; final attack damage 230%"/>
+    <string name="h27" value="54% success rate; final attack damage 235%"/>
+    <string name="h28" value="56% success rate; final attack damage 240%"/>
+    <string name="h29" value="58% success rate; final attack damage 245%"/>
+    <string name="h30" value="60% success rate; final attack damage 250%"/>
   </imgdir>
   <imgdir name="1300003">
     <string name="name" value="Final Attack : Pole Arm"/>
-    <string name="desc" value="[Master Level : 30]\nStrikes an another, far deadlier blow following the initial attack with a given success rate. It works only when holding a one-hand or two-hand pole arm.\nRequired Skill : #cAt least Level 3 on Pole Arm Mastery#"/>
-    <string name="h1" value="2% Success rate, final attack with pole arm damage 105% "/>
-    <string name="h2" value="4% Success rate, final attack with pole arm damage 110% "/>
-    <string name="h3" value="6% Success rate, final attack with pole arm damage 115% "/>
-    <string name="h4" value="8% Success rate, final attack with pole arm damage 120% "/>
-    <string name="h5" value="10% Success rate, final attack with pole arm damage 125% "/>
-    <string name="h6" value="12% Success rate, final attack with pole arm damage 130% "/>
-    <string name="h7" value="14% Success rate, final attack with pole arm damage 135% "/>
-    <string name="h8" value="16% Success rate, final attack with pole arm damage 140% "/>
-    <string name="h9" value="18% Success rate, final attack with pole arm damage 145% "/>
-    <string name="h10" value="20% Success rate, final attack with pole arm damage 150% "/>
-    <string name="h11" value="22% Success rate, final attack with pole arm damage 155% "/>
-    <string name="h12" value="24% Success rate, final attack with pole arm damage 160% "/>
-    <string name="h13" value="26% Success rate, final attack with pole arm damage 165% "/>
-    <string name="h14" value="28% Success rate, final attack with pole arm damage 170% "/>
-    <string name="h15" value="30% Success rate, final attack with pole arm damage 175% "/>
-    <string name="h16" value="32% Success rate, final attack with pole arm damage 180% "/>
-    <string name="h17" value="34% Success rate, final attack with pole arm damage 185% "/>
-    <string name="h18" value="36% Success rate, final attack with pole arm damage 190% "/>
-    <string name="h19" value="38% Success rate, final attack with pole arm damage 195% "/>
-    <string name="h20" value="40% Success rate, final attack with pole arm damage 200% "/>
-    <string name="h21" value="42% Success rate, final attack with pole arm damage 205% "/>
-    <string name="h22" value="44% Success rate, final attack with pole arm damage 210% "/>
-    <string name="h23" value="46% Success rate, final attack with pole arm damage 215% "/>
-    <string name="h24" value="48% Success rate, final attack with pole arm damage 220% "/>
-    <string name="h25" value="50% Success rate, final attack with pole arm damage 225% "/>
-    <string name="h26" value="52% Success rate, final attack with pole arm damage 230% "/>
-    <string name="h27" value="54% Success rate, final attack with pole arm damage 235% "/>
-    <string name="h28" value="56% Success rate, final attack with pole arm damage 240% "/>
-    <string name="h29" value="58% Success rate, final attack with pole arm damage 245% "/>
-    <string name="h30" value="60% Success rate, final attack with pole arm damage 250% "/>
+    <string name="desc" value="[Master Level: 30]\nAfter certain attacks, has a chance to perform an additional attack. Applies only while a pole arm is equipped.\nRequired Skill: #cMatching Mastery Lv. 3 or higher#"/>
+    <string name="h1" value="2% success rate; final attack damage 105%"/>
+    <string name="h2" value="4% success rate; final attack damage 110%"/>
+    <string name="h3" value="6% success rate; final attack damage 115%"/>
+    <string name="h4" value="8% success rate; final attack damage 120%"/>
+    <string name="h5" value="10% success rate; final attack damage 125%"/>
+    <string name="h6" value="12% success rate; final attack damage 130%"/>
+    <string name="h7" value="14% success rate; final attack damage 135%"/>
+    <string name="h8" value="16% success rate; final attack damage 140%"/>
+    <string name="h9" value="18% success rate; final attack damage 145%"/>
+    <string name="h10" value="20% success rate; final attack damage 150%"/>
+    <string name="h11" value="22% success rate; final attack damage 155%"/>
+    <string name="h12" value="24% success rate; final attack damage 160%"/>
+    <string name="h13" value="26% success rate; final attack damage 165%"/>
+    <string name="h14" value="28% success rate; final attack damage 170%"/>
+    <string name="h15" value="30% success rate; final attack damage 175%"/>
+    <string name="h16" value="32% success rate; final attack damage 180%"/>
+    <string name="h17" value="34% success rate; final attack damage 185%"/>
+    <string name="h18" value="36% success rate; final attack damage 190%"/>
+    <string name="h19" value="38% success rate; final attack damage 195%"/>
+    <string name="h20" value="40% success rate; final attack damage 200%"/>
+    <string name="h21" value="42% success rate; final attack damage 205%"/>
+    <string name="h22" value="44% success rate; final attack damage 210%"/>
+    <string name="h23" value="46% success rate; final attack damage 215%"/>
+    <string name="h24" value="48% success rate; final attack damage 220%"/>
+    <string name="h25" value="50% success rate; final attack damage 225%"/>
+    <string name="h26" value="52% success rate; final attack damage 230%"/>
+    <string name="h27" value="54% success rate; final attack damage 235%"/>
+    <string name="h28" value="56% success rate; final attack damage 240%"/>
+    <string name="h29" value="58% success rate; final attack damage 245%"/>
+    <string name="h30" value="60% success rate; final attack damage 250%"/>
   </imgdir>
   <imgdir name="1301004">
     <string name="name" value="Spear Booster"/>
-    <string name="desc" value="[Master Level : 20]\nUses HP and MP to temporarily boost up the attacking speed of the equipped spear. It only applies when a spear is in hand.\nRequired Skill : #cAt least Level 5 on Spear Mastery#"/>
-    <string name="h1" value="HP -29, MP -29; increase in spear speed for 10 sec."/>
-    <string name="h2" value="HP -28, MP -28; increase in spear speed for 20 sec."/>
-    <string name="h3" value="HP -27, MP -27; increase in spear speed for 30 sec."/>
-    <string name="h4" value="HP -26, MP -26; increase in spear speed for 40 sec."/>
-    <string name="h5" value="HP -25, MP -25; increase in spear speed for 50 sec."/>
-    <string name="h6" value="HP -24, MP -24; increase in spear speed for 60 sec."/>
-    <string name="h7" value="HP -23, MP -23; increase in spear speed for 70 sec."/>
-    <string name="h8" value="HP -22, MP -22; increase in spear speed for 80 sec."/>
-    <string name="h9" value="HP -21, MP -21; increase in spear speed for 90 sec."/>
-    <string name="h10" value="HP -20, MP -20; increase in spear speed for 100 sec."/>
-    <string name="h11" value="HP -19, MP -19; increase in spear speed for 110 sec."/>
-    <string name="h12" value="HP -18, MP -18; increase in spear speed for 120 sec."/>
-    <string name="h13" value="HP -17, MP -17; increase in spear speed for 130 sec."/>
-    <string name="h14" value="HP -16, MP -16; increase in spear speed for 140 sec."/>
-    <string name="h15" value="HP -15, MP -15; increase in spear speed for 150 sec."/>
-    <string name="h16" value="HP -14, MP -14; increase in spear speed for 160 sec."/>
-    <string name="h17" value="HP -13, MP -13; increase in spear speed for 170 sec."/>
-    <string name="h18" value="HP -12, MP -12; increase in spear speed for 180 sec."/>
-    <string name="h19" value="HP -11, MP -11; increase in spear speed for 190 sec."/>
-    <string name="h20" value="HP -10, MP -10; increase in spear speed for 200 sec."/>
+    <string name="desc" value="[Master Level: 20]\nUses HP and MP to temporarily increase the attack speed of the equipped spear.\nRequired Skill: #cMatching Mastery Lv. 5 or higher#"/>
+    <string name="h1" value="HP -29; MP -29; Increase spear attack speed for 10 sec"/>
+    <string name="h2" value="HP -28; MP -28; Increase spear attack speed for 20 sec"/>
+    <string name="h3" value="HP -27; MP -27; Increase spear attack speed for 30 sec"/>
+    <string name="h4" value="HP -26; MP -26; Increase spear attack speed for 40 sec"/>
+    <string name="h5" value="HP -25; MP -25; Increase spear attack speed for 50 sec"/>
+    <string name="h6" value="HP -24; MP -24; Increase spear attack speed for 60 sec"/>
+    <string name="h7" value="HP -23; MP -23; Increase spear attack speed for 70 sec"/>
+    <string name="h8" value="HP -22; MP -22; Increase spear attack speed for 80 sec"/>
+    <string name="h9" value="HP -21; MP -21; Increase spear attack speed for 90 sec"/>
+    <string name="h10" value="HP -20; MP -20; Increase spear attack speed for 100 sec"/>
+    <string name="h11" value="HP -19; MP -19; Increase spear attack speed for 110 sec"/>
+    <string name="h12" value="HP -18; MP -18; Increase spear attack speed for 120 sec"/>
+    <string name="h13" value="HP -17; MP -17; Increase spear attack speed for 130 sec"/>
+    <string name="h14" value="HP -16; MP -16; Increase spear attack speed for 140 sec"/>
+    <string name="h15" value="HP -15; MP -15; Increase spear attack speed for 150 sec"/>
+    <string name="h16" value="HP -14; MP -14; Increase spear attack speed for 160 sec"/>
+    <string name="h17" value="HP -13; MP -13; Increase spear attack speed for 170 sec"/>
+    <string name="h18" value="HP -12; MP -12; Increase spear attack speed for 180 sec"/>
+    <string name="h19" value="HP -11; MP -11; Increase spear attack speed for 190 sec"/>
+    <string name="h20" value="HP -10; MP -10; Increase spear attack speed for 200 sec"/>
   </imgdir>
   <imgdir name="1301005">
     <string name="name" value="Pole Arm Booster"/>
-    <string name="desc" value="[Master Level : 20]\nUses HP and MP to temporarily boost up the attacking speed of the equipped pole arm. It only applies when a pole arm is in hand.\nRequired Skill : #cAt least Level 5 on Pole Arm Mastery#"/>
-    <string name="h1" value="HP -29, MP -29; increase in pole arm speed for 10 sec."/>
-    <string name="h2" value="HP -28, MP -28; increase in pole arm speed for 20 sec."/>
-    <string name="h3" value="HP -27, MP -27; increase in pole arm speed for 30 sec."/>
-    <string name="h4" value="HP -26, MP -26; increase in pole arm speed for 40 sec."/>
-    <string name="h5" value="HP -25, MP -25; increase in pole arm speed for 50 sec."/>
-    <string name="h6" value="HP -24, MP -24; increase in pole arm speed for 60 sec."/>
-    <string name="h7" value="HP -23, MP -23; increase in pole arm speed for 70 sec."/>
-    <string name="h8" value="HP -22, MP -22; increase in pole arm speed for 80 sec."/>
-    <string name="h9" value="HP -21, MP -21; increase in pole arm speed for 90 sec."/>
-    <string name="h10" value="HP -20, MP -20; increase in pole arm speed for 100 sec."/>
-    <string name="h11" value="HP -19, MP -19; increase in pole arm speed for 110 sec."/>
-    <string name="h12" value="HP -18, MP -18; increase in pole arm speed for 120 sec."/>
-    <string name="h13" value="HP -17, MP -17; increase in pole arm speed for 130 sec."/>
-    <string name="h14" value="HP -16, MP -16; increase in pole arm speed for 140 sec."/>
-    <string name="h15" value="HP -15, MP -15; increase in pole arm speed for 150 sec."/>
-    <string name="h16" value="HP -14, MP -14; increase in pole arm speed for 160 sec."/>
-    <string name="h17" value="HP -13, MP -13; increase in pole arm speed for 170 sec."/>
-    <string name="h18" value="HP -12, MP -12; increase in pole arm speed for 180 sec."/>
-    <string name="h19" value="HP -11, MP -11; increase in pole arm speed for 190 sec."/>
-    <string name="h20" value="HP -10, MP -10; increase in pole arm speed for 200 sec."/>
+    <string name="desc" value="[Master Level: 20]\nUses HP and MP to temporarily increase the attack speed of the equipped pole arm.\nRequired Skill: #cMatching Mastery Lv. 5 or higher#"/>
+    <string name="h1" value="HP -29; MP -29; Increase pole arm attack speed for 10 sec"/>
+    <string name="h2" value="HP -28; MP -28; Increase pole arm attack speed for 20 sec"/>
+    <string name="h3" value="HP -27; MP -27; Increase pole arm attack speed for 30 sec"/>
+    <string name="h4" value="HP -26; MP -26; Increase pole arm attack speed for 40 sec"/>
+    <string name="h5" value="HP -25; MP -25; Increase pole arm attack speed for 50 sec"/>
+    <string name="h6" value="HP -24; MP -24; Increase pole arm attack speed for 60 sec"/>
+    <string name="h7" value="HP -23; MP -23; Increase pole arm attack speed for 70 sec"/>
+    <string name="h8" value="HP -22; MP -22; Increase pole arm attack speed for 80 sec"/>
+    <string name="h9" value="HP -21; MP -21; Increase pole arm attack speed for 90 sec"/>
+    <string name="h10" value="HP -20; MP -20; Increase pole arm attack speed for 100 sec"/>
+    <string name="h11" value="HP -19; MP -19; Increase pole arm attack speed for 110 sec"/>
+    <string name="h12" value="HP -18; MP -18; Increase pole arm attack speed for 120 sec"/>
+    <string name="h13" value="HP -17; MP -17; Increase pole arm attack speed for 130 sec"/>
+    <string name="h14" value="HP -16; MP -16; Increase pole arm attack speed for 140 sec"/>
+    <string name="h15" value="HP -15; MP -15; Increase pole arm attack speed for 150 sec"/>
+    <string name="h16" value="HP -14; MP -14; Increase pole arm attack speed for 160 sec"/>
+    <string name="h17" value="HP -13; MP -13; Increase pole arm attack speed for 170 sec"/>
+    <string name="h18" value="HP -12; MP -12; Increase pole arm attack speed for 180 sec"/>
+    <string name="h19" value="HP -11; MP -11; Increase pole arm attack speed for 190 sec"/>
+    <string name="h20" value="HP -10; MP -10; Increase pole arm attack speed for 200 sec"/>
   </imgdir>
   <imgdir name="1301006">
     <string name="name" value="Iron Will"/>
-    <string name="desc" value="[Master Level : 20]\nTemporarily increases the level of weapon and magic defense on every member of the party around the area."/>
-    <string name="h1" value="MP -12; weapon def. +1, magic def. +1 for 15 sec."/>
-    <string name="h2" value="MP -12; weapon def. +2, magic def. +2 for 30 sec."/>
-    <string name="h3" value="MP -12; weapon def. +3, magic def. +3 for 45 sec."/>
-    <string name="h4" value="MP -12; weapon def. +4, magic def. +4 for 60 sec."/>
-    <string name="h5" value="MP -12; weapon def. +5, magic def. +5 for 75 sec."/>
-    <string name="h6" value="MP -12; weapon def. +6, magic def. +6 for 90 sec."/>
-    <string name="h7" value="MP -12; weapon def. +7, magic def. +7 for 105 sec."/>
-    <string name="h8" value="MP -12; weapon def. +8, magic def. +8 for 120 sec."/>
-    <string name="h9" value="MP -12; weapon def. +9, magic def. +9 for 135 sec."/>
-    <string name="h10" value="MP -12; weapon def. +10, magic def. +10 for 150 sec."/>
-    <string name="h11" value="MP -24; weapon def. +11, magic def. +11 for 165 sec."/>
-    <string name="h12" value="MP -24; weapon def. +12, magic def. +12 for 180 sec."/>
-    <string name="h13" value="MP -24; weapon def. +13, magic def. +13 for 195 sec."/>
-    <string name="h14" value="MP -24; weapon def. +14, magic def. +14 for 210 sec."/>
-    <string name="h15" value="MP -24; weapon def. +15, magic def. +15 for 225 sec."/>
-    <string name="h16" value="MP -24; weapon def. +16, magic def. +16 for 240 sec."/>
-    <string name="h17" value="MP -24; weapon def. +17, magic def. +17 for 255 sec."/>
-    <string name="h18" value="MP -24; weapon def. +18, magic def. +18 for 270 sec."/>
-    <string name="h19" value="MP -24; weapon def. +19, magic def. +19 for 285 sec."/>
-    <string name="h20" value="MP -24; weapon def. +20, magic def. +20 for 300 sec."/>
+    <string name="desc" value="[Master Level: 20]\nTemporarily increases nearby party members&#x27; weapon and magic defense."/>
+    <string name="h1" value="MP -12; Weapon DEF +1; Magic DEF +1 for 15 sec"/>
+    <string name="h2" value="MP -12; Weapon DEF +2; Magic DEF +2 for 30 sec"/>
+    <string name="h3" value="MP -12; Weapon DEF +3; Magic DEF +3 for 45 sec"/>
+    <string name="h4" value="MP -12; Weapon DEF +4; Magic DEF +4 for 60 sec"/>
+    <string name="h5" value="MP -12; Weapon DEF +5; Magic DEF +5 for 75 sec"/>
+    <string name="h6" value="MP -12; Weapon DEF +6; Magic DEF +6 for 90 sec"/>
+    <string name="h7" value="MP -12; Weapon DEF +7; Magic DEF +7 for 105 sec"/>
+    <string name="h8" value="MP -12; Weapon DEF +8; Magic DEF +8 for 120 sec"/>
+    <string name="h9" value="MP -12; Weapon DEF +9; Magic DEF +9 for 135 sec"/>
+    <string name="h10" value="MP -12; Weapon DEF +10; Magic DEF +10 for 150 sec"/>
+    <string name="h11" value="MP -24; Weapon DEF +11; Magic DEF +11 for 165 sec"/>
+    <string name="h12" value="MP -24; Weapon DEF +12; Magic DEF +12 for 180 sec"/>
+    <string name="h13" value="MP -24; Weapon DEF +13; Magic DEF +13 for 195 sec"/>
+    <string name="h14" value="MP -24; Weapon DEF +14; Magic DEF +14 for 210 sec"/>
+    <string name="h15" value="MP -24; Weapon DEF +15; Magic DEF +15 for 225 sec"/>
+    <string name="h16" value="MP -24; Weapon DEF +16; Magic DEF +16 for 240 sec"/>
+    <string name="h17" value="MP -24; Weapon DEF +17; Magic DEF +17 for 255 sec"/>
+    <string name="h18" value="MP -24; Weapon DEF +18; Magic DEF +18 for 270 sec"/>
+    <string name="h19" value="MP -24; Weapon DEF +19; Magic DEF +19 for 285 sec"/>
+    <string name="h20" value="MP -24; Weapon DEF +20; Magic DEF +20 for 300 sec"/>
   </imgdir>
   <imgdir name="1301007">
     <string name="name" value="Hyper Body"/>
-    <string name="desc" value="[Master Level : 30]\nTemporarily increases the Max HP and Max MP of all members of the party around the area.\nRequired Skill : #cAt least Level 3 on Iron Will#"/>
-    <string name="h1" value="MP -20; +2% on Max HP and Max MP for 10 sec."/>
-    <string name="h2" value="MP -20; +4% on Max HP and Max MP for 20 sec."/>
-    <string name="h3" value="MP -20; +6% on Max HP and Max MP for 30 sec."/>
-    <string name="h4" value="MP -20; +8% on Max HP and Max MP for 40 sec."/>
-    <string name="h5" value="MP -20; +10% on Max HP and Max MP for 50 sec."/>
-    <string name="h6" value="MP -20; +12% on Max HP and Max MP for 60 sec."/>
-    <string name="h7" value="MP -20; +14% on Max HP and Max MP for 70 sec."/>
-    <string name="h8" value="MP -20; +16% on Max HP and Max MP for 80 sec."/>
-    <string name="h9" value="MP -20; +18% on Max HP and Max MP for 90 sec."/>
-    <string name="h10" value="MP -20; +20% on Max HP and Max MP for 100 sec."/>
-    <string name="h11" value="MP -40; +22% on Max HP and Max MP for 110 sec."/>
-    <string name="h12" value="MP -40; +24% on Max HP and Max MP for 120 sec."/>
-    <string name="h13" value="MP -40; +26% on Max HP and Max MP for 130 sec."/>
-    <string name="h14" value="MP -40; +28% on Max HP and Max MP for 140 sec."/>
-    <string name="h15" value="MP -40; +30% on Max HP and Max MP for 150 sec."/>
-    <string name="h16" value="MP -40; +32% on Max HP and Max MP for 160 sec."/>
-    <string name="h17" value="MP -40; +34% on Max HP and Max MP for 170 sec."/>
-    <string name="h18" value="MP -40; +36% on Max HP and Max MP for 180 sec."/>
-    <string name="h19" value="MP -40; +38% on Max HP and Max MP for 190 sec."/>
-    <string name="h20" value="MP -40; +40% on Max HP and Max MP for 200 sec."/>
-    <string name="h21" value="MP -60; +42% on Max HP and Max MP for 210 sec."/>
-    <string name="h22" value="MP -60; +44% on Max HP and Max MP for 220 sec."/>
-    <string name="h23" value="MP -60; +46% on Max HP and Max MP for 230 sec."/>
-    <string name="h24" value="MP -60; +48% on Max HP and Max MP for 240 sec."/>
-    <string name="h25" value="MP -50; +50% on Max HP and Max MP for 250 sec."/>
-    <string name="h26" value="MP -60; +52% on Max HP and Max MP for 260 sec."/>
-    <string name="h27" value="MP -60; +54% on Max HP and Max MP for 270 sec."/>
-    <string name="h28" value="MP -60; +56% on Max HP and Max MP for 280 sec."/>
-    <string name="h29" value="MP -60; +58% on Max HP and Max MP for 290 sec."/>
-    <string name="h30" value="MP -60; +60% on Max HP and Max MP for 300 sec."/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily increases nearby party members&#x27; MaxHP and MaxMP.\nRequired Skill: #cIron Will Lv. 3 or higher#"/>
+    <string name="h1" value="MP -20; MaxHP +2%; MaxMP +2% for 10 sec"/>
+    <string name="h2" value="MP -20; MaxHP +4%; MaxMP +4% for 20 sec"/>
+    <string name="h3" value="MP -20; MaxHP +6%; MaxMP +6% for 30 sec"/>
+    <string name="h4" value="MP -20; MaxHP +8%; MaxMP +8% for 40 sec"/>
+    <string name="h5" value="MP -20; MaxHP +10%; MaxMP +10% for 50 sec"/>
+    <string name="h6" value="MP -20; MaxHP +12%; MaxMP +12% for 60 sec"/>
+    <string name="h7" value="MP -20; MaxHP +14%; MaxMP +14% for 70 sec"/>
+    <string name="h8" value="MP -20; MaxHP +16%; MaxMP +16% for 80 sec"/>
+    <string name="h9" value="MP -20; MaxHP +18%; MaxMP +18% for 90 sec"/>
+    <string name="h10" value="MP -20; MaxHP +20%; MaxMP +20% for 100 sec"/>
+    <string name="h11" value="MP -40; MaxHP +22%; MaxMP +22% for 110 sec"/>
+    <string name="h12" value="MP -40; MaxHP +24%; MaxMP +24% for 120 sec"/>
+    <string name="h13" value="MP -40; MaxHP +26%; MaxMP +26% for 130 sec"/>
+    <string name="h14" value="MP -40; MaxHP +28%; MaxMP +28% for 140 sec"/>
+    <string name="h15" value="MP -40; MaxHP +30%; MaxMP +30% for 150 sec"/>
+    <string name="h16" value="MP -40; MaxHP +32%; MaxMP +32% for 160 sec"/>
+    <string name="h17" value="MP -40; MaxHP +34%; MaxMP +34% for 170 sec"/>
+    <string name="h18" value="MP -40; MaxHP +36%; MaxMP +36% for 180 sec"/>
+    <string name="h19" value="MP -40; MaxHP +38%; MaxMP +38% for 190 sec"/>
+    <string name="h20" value="MP -40; MaxHP +40%; MaxMP +40% for 200 sec"/>
+    <string name="h21" value="MP -60; MaxHP +42%; MaxMP +42% for 210 sec"/>
+    <string name="h22" value="MP -60; MaxHP +44%; MaxMP +44% for 220 sec"/>
+    <string name="h23" value="MP -60; MaxHP +46%; MaxMP +46% for 230 sec"/>
+    <string name="h24" value="MP -60; MaxHP +48%; MaxMP +48% for 240 sec"/>
+    <string name="h25" value="MP -50; MaxHP +50%; MaxMP +50% for 250 sec"/>
+    <string name="h26" value="MP -60; MaxHP +52%; MaxMP +52% for 260 sec"/>
+    <string name="h27" value="MP -60; MaxHP +54%; MaxMP +54% for 270 sec"/>
+    <string name="h28" value="MP -60; MaxHP +56%; MaxMP +56% for 280 sec"/>
+    <string name="h29" value="MP -60; MaxHP +58%; MaxMP +58% for 290 sec"/>
+    <string name="h30" value="MP -60; MaxHP +60%; MaxMP +60% for 300 sec"/>
   </imgdir>
   <imgdir name="210">
     <string name="bookName" value="Fire &amp; Poison Basics"/>
@@ -2419,871 +2419,871 @@
   </imgdir>
   <imgdir name="1110000">
     <string name="name" value="Improving MP Recovery"/>
-    <string name="desc" value="[Master Level : 20]\nRecovers MP at a faster rate than the norm every 10 seconds by standing still."/>
-    <string name="h1" value="Constant additional recovery of MP +2"/>
-    <string name="h2" value="Constant additional recovery of MP +4"/>
-    <string name="h3" value="Constant additional recovery of MP +6"/>
-    <string name="h4" value="Constant additional recovery of MP +8"/>
-    <string name="h5" value="Constant additional recovery of MP +10"/>
-    <string name="h6" value="Constant additional recovery of MP +12"/>
-    <string name="h7" value="Constant additional recovery of MP +14"/>
-    <string name="h8" value="Constant additional recovery of MP +16"/>
-    <string name="h9" value="Constant additional recovery of MP +18"/>
-    <string name="h10" value="Constant additional recovery of MP +20"/>
-    <string name="h11" value="Constant additional recovery of MP +21"/>
-    <string name="h12" value="Constant additional recovery of MP +22"/>
-    <string name="h13" value="Constant additional recovery of MP +23"/>
-    <string name="h14" value="Constant additional recovery of MP +24"/>
-    <string name="h15" value="Constant additional recovery of MP +25"/>
-    <string name="h16" value="Constant additional recovery of MP +26"/>
-    <string name="h17" value="Constant additional recovery of MP +27"/>
-    <string name="h18" value="Constant additional recovery of MP +28"/>
-    <string name="h19" value="Constant additional recovery of MP +29"/>
-    <string name="h20" value="Constant additional recovery of MP +30"/>
+    <string name="desc" value="[Master Level: 20]\nRecover additional MP every 10 sec. while standing still."/>
+    <string name="h1" value="Recover additional MP +2"/>
+    <string name="h2" value="Recover additional MP +4"/>
+    <string name="h3" value="Recover additional MP +6"/>
+    <string name="h4" value="Recover additional MP +8"/>
+    <string name="h5" value="Recover additional MP +10"/>
+    <string name="h6" value="Recover additional MP +12"/>
+    <string name="h7" value="Recover additional MP +14"/>
+    <string name="h8" value="Recover additional MP +16"/>
+    <string name="h9" value="Recover additional MP +18"/>
+    <string name="h10" value="Recover additional MP +20"/>
+    <string name="h11" value="Recover additional MP +21"/>
+    <string name="h12" value="Recover additional MP +22"/>
+    <string name="h13" value="Recover additional MP +23"/>
+    <string name="h14" value="Recover additional MP +24"/>
+    <string name="h15" value="Recover additional MP +25"/>
+    <string name="h16" value="Recover additional MP +26"/>
+    <string name="h17" value="Recover additional MP +27"/>
+    <string name="h18" value="Recover additional MP +28"/>
+    <string name="h19" value="Recover additional MP +29"/>
+    <string name="h20" value="Recover additional MP +30"/>
   </imgdir>
   <imgdir name="1110001">
     <string name="name" value="Shield Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases shield defense. However, it does not affect if the character does not equip the shield."/>
-    <string name="h1" value="5% Increased Shield Defense"/>
-    <string name="h2" value="10% Increased Shield Defense"/>
-    <string name="h3" value="15% Increased Shield Defense"/>
-    <string name="h4" value="20% Increased Shield Defense"/>
-    <string name="h5" value="25% Increased Shield Defense"/>
-    <string name="h6" value="30% Increased Shield Defense"/>
-    <string name="h7" value="35% Increased Shield Defense"/>
-    <string name="h8" value="40% Increased Shield Defense"/>
-    <string name="h9" value="45% Increased Shield Defense"/>
-    <string name="h10" value="50% Increased Shield Defense"/>
-    <string name="h11" value="55% Increased Shield Defense"/>
-    <string name="h12" value="60% Increased Shield Defense"/>
-    <string name="h13" value="65% Increased Shield Defense"/>
-    <string name="h14" value="70% Increased Shield Defense"/>
-    <string name="h15" value="75% Increased Shield Defense"/>
-    <string name="h16" value="80% Increased Shield Defense"/>
-    <string name="h17" value="85% Increased Shield Defense"/>
-    <string name="h18" value="90% Increased Shield Defense"/>
-    <string name="h19" value="95% Increased Shield Defense"/>
-    <string name="h20" value="100% Increased Shield Defense"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases shield defense while a shield is equipped."/>
+    <string name="h1" value="Shield defense becomes 105%"/>
+    <string name="h2" value="Shield defense becomes 110%"/>
+    <string name="h3" value="Shield defense becomes 115%"/>
+    <string name="h4" value="Shield defense becomes 120%"/>
+    <string name="h5" value="Shield defense becomes 125%"/>
+    <string name="h6" value="Shield defense becomes 130%"/>
+    <string name="h7" value="Shield defense becomes 135%"/>
+    <string name="h8" value="Shield defense becomes 140%"/>
+    <string name="h9" value="Shield defense becomes 145%"/>
+    <string name="h10" value="Shield defense becomes 150%"/>
+    <string name="h11" value="Shield defense becomes 155%"/>
+    <string name="h12" value="Shield defense becomes 160%"/>
+    <string name="h13" value="Shield defense becomes 165%"/>
+    <string name="h14" value="Shield defense becomes 170%"/>
+    <string name="h15" value="Shield defense becomes 175%"/>
+    <string name="h16" value="Shield defense becomes 180%"/>
+    <string name="h17" value="Shield defense becomes 185%"/>
+    <string name="h18" value="Shield defense becomes 190%"/>
+    <string name="h19" value="Shield defense becomes 195%"/>
+    <string name="h20" value="Shield defense becomes 200%"/>
   </imgdir>
   <imgdir name="1111002">
     <string name="name" value="Combo Attack"/>
-    <string name="desc" value="[Master Level : 30]\nPrepares for combo attack.  Combo counter can be used to strike a deadly blow to the monster.  Max. for combo counter is 5 and midpoint is 3."/>
-    <string name="h1" value="Use 25 MP, For 100 Seconds, Damage 104%, The Max Combo Counter 3"/>
-    <string name="h2" value="Use 25 MP, For 100 Seconds, Damage 108%, The Max Combo Counter 3"/>
-    <string name="h3" value="Use 25 MP, For 100 Seconds, Damage 112%, The Max Combo Counter 3"/>
-    <string name="h4" value="Use 25 MP, For 100 Seconds, Damage 116%, The Max Combo Counter 3"/>
-    <string name="h5" value="Use 25 MP, For 100 Seconds, Damage 120%, The Max Combo Counter 3"/>
-    <string name="h6" value="Use 25 MP, For 120 Seconds, Damage 124%, The Max Combo Counter 3"/>
-    <string name="h7" value="Use 25 MP, For 120 Seconds, Damage 128%, The Max Combo Counter 3"/>
-    <string name="h8" value="Use 25 MP, For 120 Seconds, Damage 132%, The Max Combo Counter 3"/>
-    <string name="h9" value="Use 25 MP, For 120 Seconds, Damage 136%, The Max Combo Counter 3"/>
-    <string name="h10" value="Use 25 MP, For 120 Seconds, Damage 140%, The Max Combo Counter 3"/>
-    <string name="h11" value="Use 30 MP, For 140 Seconds, Damage 144%, The Max Combo Counter 4"/>
-    <string name="h12" value="Use 30 MP, For 140 Seconds, Damage 148%, The Max Combo Counter 4"/>
-    <string name="h13" value="Use 30 MP, For 140 Seconds, Damage 152%, The Max Combo Counter 4"/>
-    <string name="h14" value="Use 30 MP, For 140 Seconds, Damage 156%, The Max Combo Counter 4"/>
-    <string name="h15" value="Use 30 MP, For 140 Seconds, Damage 160%, The Max Combo Counter 4"/>
-    <string name="h16" value="Use 30 MP, For 160 Seconds, Damage 164%, The Max Combo Counter 4"/>
-    <string name="h17" value="Use 30 MP, For 160 Seconds, Damage 168%, The Max Combo Counter 4"/>
-    <string name="h18" value="Use 30 MP, For 160 Seconds, Damage 172%, The Max Combo Counter 4"/>
-    <string name="h19" value="Use 30 MP, For 160 Seconds, Damage 176%, The Max Combo Counter 4"/>
-    <string name="h20" value="Use 30 MP, For 160 Seconds, Damage 180%, The Max Combo Counter 4"/>
-    <string name="h21" value="Use 35 MP, For 180 Seconds, Damage 184%, The Max Combo Counter 5"/>
-    <string name="h22" value="Use 35 MP, For 180 Seconds, Damage 188%, The Max Combo Counter 5"/>
-    <string name="h23" value="Use 35 MP, For 180 Seconds, Damage 192%, The Max Combo Counter 5"/>
-    <string name="h24" value="Use 35 MP, For 180 Seconds, Damage 196%, The Max Combo Counter 5"/>
-    <string name="h25" value="Use 35 MP, For 180 Seconds, Damage 200%, The Max Combo Counter 5"/>
-    <string name="h26" value="Use 35 MP, For 200 Seconds, Damage 204%, The Max Combo Counter 5"/>
-    <string name="h27" value="Use 35 MP, For 200 Seconds, Damage 208%, The Max Combo Counter 5"/>
-    <string name="h28" value="Use 35 MP, For 200 Seconds, Damage 212%, The Max Combo Counter 5"/>
-    <string name="h29" value="Use 35 MP, For 200 Seconds, Damage 216%, The Max Combo Counter 5"/>
-    <string name="h30" value="Use 35 MP, For 200 Seconds, Damage 220%, The Max Combo Counter 5"/>
+    <string name="desc" value="[Master Level: 30]\nEnters the Combo Attack state. Each attack can charge a combo orb, up to the maximum shown by the skill."/>
+    <string name="h1" value="MP -25; Damage 100%; max combo count 3 for 100 sec"/>
+    <string name="h2" value="MP -25; Damage 104%; max combo count 3 for 100 sec"/>
+    <string name="h3" value="MP -25; Damage 105%; max combo count 3 for 100 sec"/>
+    <string name="h4" value="MP -25; Damage 106%; max combo count 3 for 100 sec"/>
+    <string name="h5" value="MP -25; Damage 107%; max combo count 3 for 100 sec"/>
+    <string name="h6" value="MP -25; Damage 108%; max combo count 3 for 120 sec"/>
+    <string name="h7" value="MP -25; Damage 109%; max combo count 3 for 120 sec"/>
+    <string name="h8" value="MP -25; Damage 110%; max combo count 3 for 120 sec"/>
+    <string name="h9" value="MP -25; Damage 111%; max combo count 3 for 120 sec"/>
+    <string name="h10" value="MP -25; Damage 111%; max combo count 3 for 120 sec"/>
+    <string name="h11" value="MP -30; Damage 112%; max combo count 4 for 140 sec"/>
+    <string name="h12" value="MP -30; Damage 112%; max combo count 4 for 140 sec"/>
+    <string name="h13" value="MP -30; Damage 113%; max combo count 4 for 140 sec"/>
+    <string name="h14" value="MP -30; Damage 113%; max combo count 4 for 140 sec"/>
+    <string name="h15" value="MP -30; Damage 114%; max combo count 4 for 140 sec"/>
+    <string name="h16" value="MP -30; Damage 114%; max combo count 4 for 160 sec"/>
+    <string name="h17" value="MP -30; Damage 115%; max combo count 4 for 160 sec"/>
+    <string name="h18" value="MP -30; Damage 115%; max combo count 4 for 160 sec"/>
+    <string name="h19" value="MP -30; Damage 116%; max combo count 4 for 160 sec"/>
+    <string name="h20" value="MP -30; Damage 116%; max combo count 4 for 160 sec"/>
+    <string name="h21" value="MP -35; Damage 117%; max combo count 5 for 180 sec"/>
+    <string name="h22" value="MP -35; Damage 117%; max combo count 5 for 180 sec"/>
+    <string name="h23" value="MP -35; Damage 117%; max combo count 5 for 180 sec"/>
+    <string name="h24" value="MP -35; Damage 118%; max combo count 5 for 180 sec"/>
+    <string name="h25" value="MP -35; Damage 118%; max combo count 5 for 180 sec"/>
+    <string name="h26" value="MP -35; Damage 118%; max combo count 5 for 200 sec"/>
+    <string name="h27" value="MP -35; Damage 119%; max combo count 5 for 200 sec"/>
+    <string name="h28" value="MP -35; Damage 119%; max combo count 5 for 200 sec"/>
+    <string name="h29" value="MP -35; Damage 119%; max combo count 5 for 200 sec"/>
+    <string name="h30" value="MP -35; Damage 120%; max combo count 5 for 200 sec"/>
   </imgdir>
   <imgdir name="1111003">
     <string name="name" value="Panic : Sword"/>
-    <string name="desc" value="[Master Level : 30]\n Attack a single monster using dark powers. This skill can only be used when equipped with a sword and the combo all charged up.\nRequired Skill : #cAt least Level 1 on Combo Attack#"/>
-    <string name="h1" value="Use 10 MP, Damage 150%, Attack with Dark Power 32%"/>
-    <string name="h2" value="Use 10 MP, Damage 171%, Attack with Dark Power 34%"/>
-    <string name="h3" value="Use 10 MP, Damage 184%, Attack with Dark Power 36%"/>
-    <string name="h4" value="Use 10 MP, Damage 194%, Attack with Dark Power 38%"/>
-    <string name="h5" value="Use 10 MP, Damage 203%, Attack with Dark Power 40%"/>
-    <string name="h6" value="Use 10 MP, Damage 212%, Attack with Dark Power 42%"/>
-    <string name="h7" value="Use 10 MP, Damage 220%, Attack with Dark Power 44%"/>
-    <string name="h8" value="Use 10 MP, Damage 228%, Attack with Dark Power 46%"/>
-    <string name="h9" value="Use 10 MP, Damage 235%, Attack with Dark Power 48%"/>
-    <string name="h10" value="Use 10 MP, Damage 242%, Attack with Dark Power 50%"/>
-    <string name="h11" value="Use 17 MP, Damage 248%, Attack with Dark Power 52%"/>
-    <string name="h12" value="Use 17 MP, Damage 255%, Attack with Dark Power 54%"/>
-    <string name="h13" value="Use 17 MP, Damage 261%, Attack with Dark Power 54%"/>
-    <string name="h14" value="Use 17 MP, Damage 267%, Attack with Dark Power 58%"/>
-    <string name="h15" value="Use 17 MP, Damage 273%, Attack with Dark Power 60%"/>
-    <string name="h16" value="Use 17 MP, Damage 279%, Attack with Dark Power 62%"/>
-    <string name="h17" value="Use 17 MP, Damage 285%, Attack with Dark Power 64%"/>
-    <string name="h18" value="Use 17 MP, Damage 290%, Attack with Dark Power 66%"/>
-    <string name="h19" value="Use 17 MP, Damage 296%, Attack with Dark Power 68%"/>
-    <string name="h20" value="Use 17 MP, Damage 301%, Attack with Dark Power 70%"/>
-    <string name="h21" value="Use 24 MP, Damage 306%, Attack with Dark Power 72%"/>
-    <string name="h22" value="Use 24 MP, Damage 311%, Attack with Dark Power 74%"/>
-    <string name="h23" value="Use 24 MP, Damage 316%, Attack with Dark Power 76%"/>
-    <string name="h24" value="Use 24 MP, Damage 321%, Attack with Dark Power 78%"/>
-    <string name="h25" value="Use 24 MP, Damage 326%, Attack with Dark Power 80%"/>
-    <string name="h26" value="Use 24 MP, Damage 331%, Attack with Dark Power 82%"/>
-    <string name="h27" value="Use 24 MP, Damage 336%, Attack with Dark Power 84%"/>
-    <string name="h28" value="Use 24 MP, Damage 341%, Attack with Dark Power 86%"/>
-    <string name="h29" value="Use 24 MP, Damage 345%, Attack with Dark Power 88%"/>
-    <string name="h30" value="Use 24 MP, Damage 350%, Attack with Dark Power 90%"/>
+    <string name="desc" value="[Master Level: 30]\nConsumes combo orbs to attack one monster with dark power. Applies only while a sword is equipped.\nRequired Skill: #cCombo Attack Lv. 1 or higher#"/>
+    <string name="h1" value="MP -10; Damage 150%; 32% dark effect for 5 sec"/>
+    <string name="h2" value="MP -10; Damage 171%; 34% dark effect for 5 sec"/>
+    <string name="h3" value="MP -10; Damage 184%; 36% dark effect for 5 sec"/>
+    <string name="h4" value="MP -10; Damage 194%; 38% dark effect for 5 sec"/>
+    <string name="h5" value="MP -10; Damage 203%; 40% dark effect for 5 sec"/>
+    <string name="h6" value="MP -10; Damage 212%; 42% dark effect for 5 sec"/>
+    <string name="h7" value="MP -10; Damage 220%; 44% dark effect for 5 sec"/>
+    <string name="h8" value="MP -10; Damage 228%; 46% dark effect for 5 sec"/>
+    <string name="h9" value="MP -10; Damage 235%; 48% dark effect for 5 sec"/>
+    <string name="h10" value="MP -10; Damage 242%; 50% dark effect for 5 sec"/>
+    <string name="h11" value="MP -17; Damage 248%; 52% dark effect for 7 sec"/>
+    <string name="h12" value="MP -17; Damage 255%; 54% dark effect for 7 sec"/>
+    <string name="h13" value="MP -17; Damage 261%; 56% dark effect for 7 sec"/>
+    <string name="h14" value="MP -17; Damage 267%; 58% dark effect for 7 sec"/>
+    <string name="h15" value="MP -17; Damage 273%; 60% dark effect for 7 sec"/>
+    <string name="h16" value="MP -17; Damage 279%; 62% dark effect for 7 sec"/>
+    <string name="h17" value="MP -17; Damage 285%; 64% dark effect for 7 sec"/>
+    <string name="h18" value="MP -17; Damage 290%; 66% dark effect for 7 sec"/>
+    <string name="h19" value="MP -17; Damage 296%; 68% dark effect for 7 sec"/>
+    <string name="h20" value="MP -17; Damage 301%; 70% dark effect for 7 sec"/>
+    <string name="h21" value="MP -24; Damage 306%; 72% dark effect for 9 sec"/>
+    <string name="h22" value="MP -24; Damage 311%; 74% dark effect for 9 sec"/>
+    <string name="h23" value="MP -24; Damage 316%; 76% dark effect for 9 sec"/>
+    <string name="h24" value="MP -24; Damage 321%; 78% dark effect for 9 sec"/>
+    <string name="h25" value="MP -24; Damage 326%; 80% dark effect for 9 sec"/>
+    <string name="h26" value="MP -24; Damage 331%; 82% dark effect for 9 sec"/>
+    <string name="h27" value="MP -24; Damage 336%; 84% dark effect for 9 sec"/>
+    <string name="h28" value="MP -24; Damage 341%; 86% dark effect for 9 sec"/>
+    <string name="h29" value="MP -24; Damage 345%; 88% dark effect for 9 sec"/>
+    <string name="h30" value="MP -24; Damage 350%; 90% dark effect for 9 sec"/>
   </imgdir>
   <imgdir name="1111004">
     <string name="name" value="Panic : Axe"/>
-    <string name="desc" value="[Master Level : 30]\n Attack a single monster using dark powers. This skill can only be used when equipped with an axe and the combo all charged up.\nRequired Skill : #cAt least Level 1 on Combo Attack#"/>
-    <string name="h1" value="Use 10 MP, Damage 150%, Attack with Dark Power 32%"/>
-    <string name="h2" value="Use 10 MP, Damage 171%, Attack with Dark Power 34%"/>
-    <string name="h3" value="Use 10 MP, Damage 184%, Attack with Dark Power 36%"/>
-    <string name="h4" value="Use 10 MP, Damage 164%, Attack with Dark Power 38%"/>
-    <string name="h5" value="Use 10 MP, Damage 203%, Attack with Dark Power 40%"/>
-    <string name="h6" value="Use 10 MP, Damage 212%, Attack with Dark Power 42%"/>
-    <string name="h7" value="Use 10 MP, Damage 220%, Attack with Dark Power 44%"/>
-    <string name="h8" value="Use 10 MP, Damage 228%, Attack with Dark Power 46%"/>
-    <string name="h9" value="Use 10 MP, Damage 235%, Attack with Dark Power 48%"/>
-    <string name="h10" value="Use 10 MP, Damage 242%, Attack with Dark Power 50%"/>
-    <string name="h11" value="Use 17 MP, Damage 248%, Attack with Dark Power 52%"/>
-    <string name="h12" value="Use 17 MP, Damage 255%, Attack with Dark Power 54%"/>
-    <string name="h13" value="Use 17 MP, Damage 261%, Attack with Dark Power 54%"/>
-    <string name="h14" value="Use 17 MP, Damage 267%, Attack with Dark Power 58%"/>
-    <string name="h15" value="Use 17 MP, Damage 273%, Attack with Dark Power 60%"/>
-    <string name="h16" value="Use 17 MP, Damage 279%, Attack with Dark Power 62%"/>
-    <string name="h17" value="Use 17 MP, Damage 285%, Attack with Dark Power 64%"/>
-    <string name="h18" value="Use 17 MP, Damage 290%, Attack with Dark Power 66%"/>
-    <string name="h19" value="Use 17 MP, Damage 296%, Attack with Dark Power 68%"/>
-    <string name="h20" value="Use 17 MP, Damage 301%, Attack with Dark Power 70%"/>
-    <string name="h21" value="Use 24 MP, Damage 306%, Attack with Dark Power 72%"/>
-    <string name="h22" value="Use 24 MP, Damage 311%, Attack with Dark Power 74%"/>
-    <string name="h23" value="Use 24 MP, Damage 316%, Attack with Dark Power 76%"/>
-    <string name="h24" value="Use 24 MP, Damage 321%, Attack with Dark Power 78%"/>
-    <string name="h25" value="Use 24 MP, Damage 326%, Attack with Dark Power 80%"/>
-    <string name="h26" value="Use 24 MP, Damage 331%, Attack with Dark Power 82%"/>
-    <string name="h27" value="Use 24 MP, Damage 336%, Attack with Dark Power 84%"/>
-    <string name="h28" value="Use 24 MP, Damage 341%, Attack with Dark Power 86%"/>
-    <string name="h29" value="Use 24 MP, Damage 345%, Attack with Dark Power 88%"/>
-    <string name="h30" value="Use 24 MP, Damage 350%, Attack with Dark Power 90%"/>
+    <string name="desc" value="[Master Level: 30]\nConsumes combo orbs to attack one monster with dark power. Applies only while a axe is equipped.\nRequired Skill: #cCombo Attack Lv. 1 or higher#"/>
+    <string name="h1" value="MP -10; Damage 150%; 32% dark effect for 5 sec"/>
+    <string name="h2" value="MP -10; Damage 171%; 34% dark effect for 5 sec"/>
+    <string name="h3" value="MP -10; Damage 184%; 36% dark effect for 5 sec"/>
+    <string name="h4" value="MP -10; Damage 194%; 38% dark effect for 5 sec"/>
+    <string name="h5" value="MP -10; Damage 203%; 40% dark effect for 5 sec"/>
+    <string name="h6" value="MP -10; Damage 212%; 42% dark effect for 5 sec"/>
+    <string name="h7" value="MP -10; Damage 220%; 44% dark effect for 5 sec"/>
+    <string name="h8" value="MP -10; Damage 228%; 46% dark effect for 5 sec"/>
+    <string name="h9" value="MP -10; Damage 235%; 48% dark effect for 5 sec"/>
+    <string name="h10" value="MP -10; Damage 242%; 50% dark effect for 5 sec"/>
+    <string name="h11" value="MP -17; Damage 248%; 52% dark effect for 7 sec"/>
+    <string name="h12" value="MP -17; Damage 255%; 54% dark effect for 7 sec"/>
+    <string name="h13" value="MP -17; Damage 261%; 56% dark effect for 7 sec"/>
+    <string name="h14" value="MP -17; Damage 267%; 58% dark effect for 7 sec"/>
+    <string name="h15" value="MP -17; Damage 273%; 60% dark effect for 7 sec"/>
+    <string name="h16" value="MP -17; Damage 279%; 62% dark effect for 7 sec"/>
+    <string name="h17" value="MP -17; Damage 285%; 64% dark effect for 7 sec"/>
+    <string name="h18" value="MP -17; Damage 290%; 66% dark effect for 7 sec"/>
+    <string name="h19" value="MP -17; Damage 296%; 68% dark effect for 7 sec"/>
+    <string name="h20" value="MP -17; Damage 301%; 70% dark effect for 7 sec"/>
+    <string name="h21" value="MP -24; Damage 306%; 72% dark effect for 9 sec"/>
+    <string name="h22" value="MP -24; Damage 311%; 74% dark effect for 9 sec"/>
+    <string name="h23" value="MP -24; Damage 316%; 76% dark effect for 9 sec"/>
+    <string name="h24" value="MP -24; Damage 321%; 78% dark effect for 9 sec"/>
+    <string name="h25" value="MP -24; Damage 326%; 80% dark effect for 9 sec"/>
+    <string name="h26" value="MP -24; Damage 331%; 82% dark effect for 9 sec"/>
+    <string name="h27" value="MP -24; Damage 336%; 84% dark effect for 9 sec"/>
+    <string name="h28" value="MP -24; Damage 341%; 86% dark effect for 9 sec"/>
+    <string name="h29" value="MP -24; Damage 345%; 88% dark effect for 9 sec"/>
+    <string name="h30" value="MP -24; Damage 350%; 90% dark effect for 9 sec"/>
   </imgdir>
   <imgdir name="1111005">
     <string name="name" value="Coma: Sword"/>
-    <string name="desc" value="[Master Level : 30]\n If struck cleanly, the monster becomes panicked. This skill can only be used when equipped with a sword and the combo all charged up.\nRequired Skill : #cAt least Level 1 on Combo Attack#"/>
-    <string name="h1" value="Use 15 HP, 12 MP, Damage 84%, Stun Attack 32%"/>
-    <string name="h2" value="Use 15 HP, 12 MP, Damage 88%, Stun Attack 34%"/>
-    <string name="h3" value="Use 15 HP, 12 MP, Damage 92%, Stun Attack 36%"/>
-    <string name="h4" value="Use 15 HP, 12 MP, Damage 96%, Stun Attack 38%"/>
-    <string name="h5" value="Use 15 HP, 12 MP, Damage 100%, Stun Attack 40%"/>
-    <string name="h6" value="Use 15 HP, 12 MP, Damage 104%, Stun Attack 42%"/>
-    <string name="h7" value="Use 15 HP, 12 MP, Damage 108%, Stun Attack 44%"/>
-    <string name="h8" value="Use 15 HP, 12 MP, Damage 112%, Stun Attack 46%"/>
-    <string name="h9" value="Use 15 HP, 12 MP, Damage 116%, Stun Attack 48%"/>
-    <string name="h10" value="Use 15 HP, 12 MP, Damage 120%, Stun Attack 50%"/>
-    <string name="h11" value="Use 20 HP, 19 MP, Damage 124%, Stun Attack 52%"/>
-    <string name="h12" value="Use 20 HP, 19 MP, Damage 128%, Stun Attack 54%"/>
-    <string name="h13" value="Use 20 HP, 19 MP, Damage 132%, Stun Attack 56%"/>
-    <string name="h14" value="Use 20 HP, 19 MP, Damage 136%, Stun Attack 58%"/>
-    <string name="h15" value="Use 20 HP, 19 MP, Damage 140%, Stun Attack 60%"/>
-    <string name="h16" value="Use 20 HP, 19 MP, Damage 144%, Stun Attack 62%"/>
-    <string name="h17" value="Use 20 HP, 19 MP, Damage 148%, Stun Attack 64%"/>
-    <string name="h18" value="Use 20 HP, 19 MP, Damage 152%, Stun Attack 66%"/>
-    <string name="h19" value="Use 20 HP, 19 MP, Damage 156%, Stun Attack 68%"/>
-    <string name="h20" value="Use 20 HP, 19 MP, Damage 160%, Stun Attack 70%"/>
-    <string name="h21" value="Use 25 HP, 26 MP, Damage 164%, Stun Attack 72%"/>
-    <string name="h22" value="Use 25 HP, 26 MP, Damage 168%, Stun Attack 74%"/>
-    <string name="h23" value="Use 25 HP, 26 MP, Damage 172%, Stun Attack 76%"/>
-    <string name="h24" value="Use 25 HP, 26 MP, Damage 176%, Stun Attack 78%"/>
-    <string name="h25" value="Use 25 HP, 26 MP, Damage 180%, Stun Attack 80%"/>
-    <string name="h26" value="Use 25 HP, 26 MP, Damage 184%, Stun Attack 82%"/>
-    <string name="h27" value="Use 25 HP, 26 MP, Damage 188%, Stun Attack 84%"/>
-    <string name="h28" value="Use 25 HP, 26 MP, Damage 192%, Stun Attack 86%"/>
-    <string name="h29" value="Use 25 HP, 26 MP, Damage 196%, Stun Attack 88%"/>
-    <string name="h30" value="Use 25 HP, 26 MP, Damage 200%, Stun Attack 90%"/>
+    <string name="desc" value="[Master Level: 30]\nConsumes combo orbs to attack nearby monsters and stun them. Applies only while a sword is equipped.\nRequired Skill: #cCombo Attack Lv. 1 or higher#"/>
+    <string name="h1" value="HP -15; MP -12; Damage 84%; attacks up to 6 enemies; 32% stun for 2 sec"/>
+    <string name="h2" value="HP -15; MP -12; Damage 88%; attacks up to 6 enemies; 34% stun for 2 sec"/>
+    <string name="h3" value="HP -15; MP -12; Damage 92%; attacks up to 6 enemies; 36% stun for 2 sec"/>
+    <string name="h4" value="HP -15; MP -12; Damage 96%; attacks up to 6 enemies; 38% stun for 2 sec"/>
+    <string name="h5" value="HP -15; MP -12; Damage 100%; attacks up to 6 enemies; 40% stun for 2 sec"/>
+    <string name="h6" value="HP -15; MP -12; Damage 104%; attacks up to 6 enemies; 42% stun for 2 sec"/>
+    <string name="h7" value="HP -15; MP -12; Damage 108%; attacks up to 6 enemies; 44% stun for 2 sec"/>
+    <string name="h8" value="HP -15; MP -12; Damage 112%; attacks up to 6 enemies; 46% stun for 2 sec"/>
+    <string name="h9" value="HP -15; MP -12; Damage 116%; attacks up to 6 enemies; 48% stun for 2 sec"/>
+    <string name="h10" value="HP -15; MP -12; Damage 120%; attacks up to 6 enemies; 50% stun for 2 sec"/>
+    <string name="h11" value="HP -20; MP -19; Damage 124%; attacks up to 6 enemies; 52% stun for 3 sec"/>
+    <string name="h12" value="HP -20; MP -19; Damage 128%; attacks up to 6 enemies; 54% stun for 3 sec"/>
+    <string name="h13" value="HP -20; MP -19; Damage 132%; attacks up to 6 enemies; 56% stun for 3 sec"/>
+    <string name="h14" value="HP -20; MP -19; Damage 136%; attacks up to 6 enemies; 58% stun for 3 sec"/>
+    <string name="h15" value="HP -20; MP -19; Damage 140%; attacks up to 6 enemies; 60% stun for 3 sec"/>
+    <string name="h16" value="HP -20; MP -19; Damage 144%; attacks up to 6 enemies; 62% stun for 3 sec"/>
+    <string name="h17" value="HP -20; MP -19; Damage 148%; attacks up to 6 enemies; 64% stun for 3 sec"/>
+    <string name="h18" value="HP -20; MP -19; Damage 152%; attacks up to 6 enemies; 66% stun for 3 sec"/>
+    <string name="h19" value="HP -20; MP -19; Damage 156%; attacks up to 6 enemies; 68% stun for 3 sec"/>
+    <string name="h20" value="HP -20; MP -19; Damage 160%; attacks up to 6 enemies; 70% stun for 3 sec"/>
+    <string name="h21" value="HP -25; MP -26; Damage 164%; attacks up to 6 enemies; 72% stun for 4 sec"/>
+    <string name="h22" value="HP -25; MP -26; Damage 168%; attacks up to 6 enemies; 74% stun for 4 sec"/>
+    <string name="h23" value="HP -25; MP -26; Damage 172%; attacks up to 6 enemies; 76% stun for 4 sec"/>
+    <string name="h24" value="HP -25; MP -26; Damage 176%; attacks up to 6 enemies; 78% stun for 4 sec"/>
+    <string name="h25" value="HP -25; MP -26; Damage 180%; attacks up to 6 enemies; 80% stun for 4 sec"/>
+    <string name="h26" value="HP -25; MP -26; Damage 184%; attacks up to 6 enemies; 82% stun for 4 sec"/>
+    <string name="h27" value="HP -25; MP -26; Damage 188%; attacks up to 6 enemies; 84% stun for 4 sec"/>
+    <string name="h28" value="HP -25; MP -26; Damage 192%; attacks up to 6 enemies; 86% stun for 4 sec"/>
+    <string name="h29" value="HP -25; MP -26; Damage 196%; attacks up to 6 enemies; 88% stun for 4 sec"/>
+    <string name="h30" value="HP -25; MP -26; Damage 200%; attacks up to 6 enemies; 90% stun for 4 sec"/>
   </imgdir>
   <imgdir name="1111006">
     <string name="name" value="Coma: Axe"/>
-    <string name="desc" value="[Master Level : 30]\n If struck cleanly, the monster becomes panicked. This skill can only be used when equipped with an axe and the combo all charged up.\nRequired Skill : #cAt least Level 1 on Combo Attack#"/>
-    <string name="h1" value="Use 15 HP, 12 MP, Damage 84%, Stun Attack 32%"/>
-    <string name="h2" value="Use 15 HP, 12 MP, Damage 88%, Stun Attack 34%"/>
-    <string name="h3" value="Use 15 HP, 12 MP, Damage 92%, Stun Attack 36%"/>
-    <string name="h4" value="Use 15 HP, 12 MP, Damage 96%, Stun Attack 38%"/>
-    <string name="h5" value="Use 15 HP, 12 MP, Damage 100%, Stun Attack 40%"/>
-    <string name="h6" value="Use 15 HP, 12 MP, Damage 104%, Stun Attack 42%"/>
-    <string name="h7" value="Use 15 HP, 12 MP, Damage 108%, Stun Attack 44%"/>
-    <string name="h8" value="Use 15 HP, 12 MP, Damage 112%, Stun Attack 46%"/>
-    <string name="h9" value="Use 15 HP, 12 MP, Damage 116%, Stun Attack 48%"/>
-    <string name="h10" value="Use 15 HP, 12 MP, Damage 120%, Stun Attack 50%"/>
-    <string name="h11" value="Use 20 HP, 19 MP, Damage 124%, Stun Attack 52%"/>
-    <string name="h12" value="Use 20 HP, 19 MP, Damage 128%, Stun Attack 54%"/>
-    <string name="h13" value="Use 20 HP, 19 MP, Damage 132%, Stun Attack 56%"/>
-    <string name="h14" value="Use 20 HP, 19 MP, Damage 136%, Stun Attack 58%"/>
-    <string name="h15" value="Use 20 HP, 19 MP, Damage 140%, Stun Attack 60%"/>
-    <string name="h16" value="Use 20 HP, 19 MP, Damage 144%, Stun Attack 62%"/>
-    <string name="h17" value="Use 20 HP, 19 MP, Damage 148%, Stun Attack 64%"/>
-    <string name="h18" value="Use 20 HP, 19 MP, Damage 152%, Stun Attack 66%"/>
-    <string name="h19" value="Use 20 HP, 19 MP, Damage 156%, Stun Attack 68%"/>
-    <string name="h20" value="Use 20 HP, 19 MP, Damage 160%, Stun Attack 70%"/>
-    <string name="h21" value="Use 25 HP, 26 MP, Damage 164%, Stun Attack 72%"/>
-    <string name="h22" value="Use 25 HP, 26 MP, Damage 168%, Stun Attack 74%"/>
-    <string name="h23" value="Use 25 HP, 26 MP, Damage 172%, Stun Attack 76%"/>
-    <string name="h24" value="Use 25 HP, 26 MP, Damage 176%, Stun Attack 78%"/>
-    <string name="h25" value="Use 25 HP, 26 MP, Damage 180%, Stun Attack 80%"/>
-    <string name="h26" value="Use 25 HP, 26 MP, Damage 184%, Stun Attack 82%"/>
-    <string name="h27" value="Use 25 HP, 26 MP, Damage 188%, Stun Attack 84%"/>
-    <string name="h28" value="Use 25 HP, 26 MP, Damage 192%, Stun Attack 86%"/>
-    <string name="h29" value="Use 25 HP, 26 MP, Damage 196%, Stun Attack 88%"/>
-    <string name="h30" value="Use 25 HP, 26 MP, Damage 200%, Stun Attack 90%"/>
+    <string name="desc" value="[Master Level: 30]\nConsumes combo orbs to attack nearby monsters and stun them. Applies only while a axe is equipped.\nRequired Skill: #cCombo Attack Lv. 1 or higher#"/>
+    <string name="h1" value="HP -15; MP -12; Damage 84%; attacks up to 6 enemies; 32% stun for 2 sec"/>
+    <string name="h2" value="HP -15; MP -12; Damage 88%; attacks up to 6 enemies; 34% stun for 2 sec"/>
+    <string name="h3" value="HP -15; MP -12; Damage 92%; attacks up to 6 enemies; 36% stun for 2 sec"/>
+    <string name="h4" value="HP -15; MP -12; Damage 96%; attacks up to 6 enemies; 38% stun for 2 sec"/>
+    <string name="h5" value="HP -15; MP -12; Damage 100%; attacks up to 6 enemies; 40% stun for 2 sec"/>
+    <string name="h6" value="HP -15; MP -12; Damage 104%; attacks up to 6 enemies; 42% stun for 2 sec"/>
+    <string name="h7" value="HP -15; MP -12; Damage 108%; attacks up to 6 enemies; 44% stun for 2 sec"/>
+    <string name="h8" value="HP -15; MP -12; Damage 112%; attacks up to 6 enemies; 46% stun for 2 sec"/>
+    <string name="h9" value="HP -15; MP -12; Damage 116%; attacks up to 6 enemies; 48% stun for 2 sec"/>
+    <string name="h10" value="HP -15; MP -12; Damage 120%; attacks up to 6 enemies; 50% stun for 2 sec"/>
+    <string name="h11" value="HP -20; MP -19; Damage 124%; attacks up to 6 enemies; 52% stun for 3 sec"/>
+    <string name="h12" value="HP -20; MP -19; Damage 128%; attacks up to 6 enemies; 54% stun for 3 sec"/>
+    <string name="h13" value="HP -20; MP -19; Damage 132%; attacks up to 6 enemies; 56% stun for 3 sec"/>
+    <string name="h14" value="HP -20; MP -19; Damage 136%; attacks up to 6 enemies; 58% stun for 3 sec"/>
+    <string name="h15" value="HP -20; MP -19; Damage 140%; attacks up to 6 enemies; 60% stun for 3 sec"/>
+    <string name="h16" value="HP -20; MP -19; Damage 144%; attacks up to 6 enemies; 62% stun for 3 sec"/>
+    <string name="h17" value="HP -20; MP -19; Damage 148%; attacks up to 6 enemies; 64% stun for 3 sec"/>
+    <string name="h18" value="HP -20; MP -19; Damage 152%; attacks up to 6 enemies; 66% stun for 3 sec"/>
+    <string name="h19" value="HP -20; MP -19; Damage 156%; attacks up to 6 enemies; 68% stun for 3 sec"/>
+    <string name="h20" value="HP -20; MP -19; Damage 160%; attacks up to 6 enemies; 70% stun for 3 sec"/>
+    <string name="h21" value="HP -25; MP -26; Damage 164%; attacks up to 6 enemies; 72% stun for 4 sec"/>
+    <string name="h22" value="HP -25; MP -26; Damage 168%; attacks up to 6 enemies; 74% stun for 4 sec"/>
+    <string name="h23" value="HP -25; MP -26; Damage 172%; attacks up to 6 enemies; 76% stun for 4 sec"/>
+    <string name="h24" value="HP -25; MP -26; Damage 176%; attacks up to 6 enemies; 78% stun for 4 sec"/>
+    <string name="h25" value="HP -25; MP -26; Damage 180%; attacks up to 6 enemies; 80% stun for 4 sec"/>
+    <string name="h26" value="HP -25; MP -26; Damage 184%; attacks up to 6 enemies; 82% stun for 4 sec"/>
+    <string name="h27" value="HP -25; MP -26; Damage 188%; attacks up to 6 enemies; 84% stun for 4 sec"/>
+    <string name="h28" value="HP -25; MP -26; Damage 192%; attacks up to 6 enemies; 86% stun for 4 sec"/>
+    <string name="h29" value="HP -25; MP -26; Damage 196%; attacks up to 6 enemies; 88% stun for 4 sec"/>
+    <string name="h30" value="HP -25; MP -26; Damage 200%; attacks up to 6 enemies; 90% stun for 4 sec"/>
   </imgdir>
   <imgdir name="1111007">
     <string name="name" value="Armor Crash"/>
-    <string name="desc" value="[Master Level : 20]\n Nullifies the defense buff used by the monster with a given success rate.\nRequired Skill : #cAt least Level 3 on Shout#"/>
-    <string name="h1" value="Use 35 MP, 24 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h2" value="Use 33 MP, 28 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h3" value="Use 31 MP, 32 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h4" value="Use 29 MP, 36 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h5" value="Use 27 MP, 40 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h6" value="Use 25 MP, 44 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h7" value="Use 23 MP, 48 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h8" value="Use 21 MP, 52 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h9" value="Use 19 MP, 56 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h10" value="Use 17 MP, 60 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h11" value="Use 16 MP, 64 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h12" value="Use 15 MP, 68 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h13" value="Use 14 MP, 72 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h14" value="Use 13 MP, 76 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h15" value="Use 12 MP, 80 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h16" value="Use 11 MP, 84 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h17" value="Use 10 MP, 88 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h18" value="Use 9 MP, 92 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h19" value="Use 8 MP, 96 % Cancel out Enemy&apos;s Physical Defense-Up"/>
-    <string name="h20" value="Use 7 MP, 100 % Cancel out Enemy&apos;s Physical Defense-Up"/>
+    <string name="desc" value="[Master Level: 20]\nCancels the physical defense-up buff on nearby monsters with a given success rate.\nRequired Skill: #cShout Lv. 3 or higher#"/>
+    <string name="h1" value="MP -35; Cancels up to 6 enemies&#x27; buff at 24% success rate"/>
+    <string name="h2" value="MP -33; Cancels up to 6 enemies&#x27; buff at 28% success rate"/>
+    <string name="h3" value="MP -31; Cancels up to 6 enemies&#x27; buff at 32% success rate"/>
+    <string name="h4" value="MP -29; Cancels up to 6 enemies&#x27; buff at 36% success rate"/>
+    <string name="h5" value="MP -27; Cancels up to 6 enemies&#x27; buff at 40% success rate"/>
+    <string name="h6" value="MP -25; Cancels up to 6 enemies&#x27; buff at 44% success rate"/>
+    <string name="h7" value="MP -23; Cancels up to 6 enemies&#x27; buff at 48% success rate"/>
+    <string name="h8" value="MP -21; Cancels up to 6 enemies&#x27; buff at 52% success rate"/>
+    <string name="h9" value="MP -19; Cancels up to 6 enemies&#x27; buff at 56% success rate"/>
+    <string name="h10" value="MP -17; Cancels up to 6 enemies&#x27; buff at 60% success rate"/>
+    <string name="h11" value="MP -16; Cancels up to 6 enemies&#x27; buff at 64% success rate"/>
+    <string name="h12" value="MP -15; Cancels up to 6 enemies&#x27; buff at 68% success rate"/>
+    <string name="h13" value="MP -14; Cancels up to 6 enemies&#x27; buff at 72% success rate"/>
+    <string name="h14" value="MP -13; Cancels up to 6 enemies&#x27; buff at 76% success rate"/>
+    <string name="h15" value="MP -12; Cancels up to 6 enemies&#x27; buff at 80% success rate"/>
+    <string name="h16" value="MP -11; Cancels up to 6 enemies&#x27; buff at 84% success rate"/>
+    <string name="h17" value="MP -10; Cancels up to 6 enemies&#x27; buff at 88% success rate"/>
+    <string name="h18" value="MP -9; Cancels up to 6 enemies&#x27; buff at 92% success rate"/>
+    <string name="h19" value="MP -8; Cancels up to 6 enemies&#x27; buff at 96% success rate"/>
+    <string name="h20" value="MP -7; Cancels up to 6 enemies&#x27; buff at 100% success rate"/>
   </imgdir>
   <imgdir name="1111008">
     <string name="name" value="Shout"/>
-    <string name="desc" value="[Master Level : 30]\nTemporarily stuns up to 6 monsters nearby with damage."/>
-    <string name="h1" value="Use 8 MP, Damage 11%, Attack Range 110%, 52% Stun for 5 Sec"/>
-    <string name="h2" value="Use 8 MP, Damage 12%, Attack Range 110%, 54% Stun for 5 Sec"/>
-    <string name="h3" value="Use 8 MP, Damage 13%, Attack Range 110%, 56% Stun for 5 Sec"/>
-    <string name="h4" value="Use 8 MP, Damage 14%, Attack Range 120%, 58% Stun for 5 Sec"/>
-    <string name="h5" value="Use 8 MP, Damage 15%, Attack Range 120%, 60% Stun for 5 Sec"/>
-    <string name="h6" value="Use 8 MP, Damage 16%, Attack Range 120%, 62% Stun for 6 Sec"/>
-    <string name="h7" value="Use 8 MP, Damage 17%, Attack Range 130%, 64% Stun for 6 Sec"/>
-    <string name="h8" value="Use 8 MP, Damage 18%, Attack Range 130%, 66% Stun for 6 Sec"/>
-    <string name="h9" value="Use 8 MP, Damage 19%, Attack Range 130%, 68% Stun for 6 Sec"/>
-    <string name="h10" value="Use 8 MP, Damage 20%, Attack Range 140%, 70% Stun for 6 Sec"/>
-    <string name="h11" value="Use 12 MP, Damage 20%, Attack Range 140%, 72% Stun for 7 Sec"/>
-    <string name="h12" value="Use 12 MP, Damage 21%, Attack Range 140%, 74% Stun for 7 Sec"/>
-    <string name="h13" value="Use 12 MP, Damage 21%, Attack Range 150%, 76% Stun for 7 Sec"/>
-    <string name="h14" value="Use 12 MP, Damage 22%, Attack Range 150%, 78% Stun for 7 Sec"/>
-    <string name="h15" value="Use 12 MP, Damage 22%, Attack Range 150%, 80% Stun for 7 Sec"/>
-    <string name="h16" value="Use 12 MP, Damage 23%, Attack Range 160%, 81% Stun for 8 Sec"/>
-    <string name="h17" value="Use 12 MP, Damage 23%, Attack Range 160%, 82% Stun for 8 Sec"/>
-    <string name="h18" value="Use 12 MP, Damage 24%, Attack Range 160%, 83% Stun for 8 Sec"/>
-    <string name="h19" value="Use 12 MP, Damage 24%, Attack Range 170%, 84% Stun for 8 Sec"/>
-    <string name="h20" value="Use 12 MP, Damage 25%, Attack Range 170%, 85% Stun for 8 Sec"/>
-    <string name="h21" value="Use 16 MP, Damage 25%, Attack Range 170%, 86% Stun for 9 Sec"/>
-    <string name="h22" value="Use 16 MP, Damage 26%, Attack Range 180%, 87% Stun for 9 Sec"/>
-    <string name="h23" value="Use 16 MP, Damage 26%, Attack Range 180%, 88% Stun for 9 Sec"/>
-    <string name="h24" value="Use 16 MP, Damage 27%, Attack Range 180%, 89% Stun for 9 Sec"/>
-    <string name="h25" value="Use 16 MP, Damage 27%, Attack Range 190%, 90% Stun for 9 Sec"/>
-    <string name="h26" value="Use 16 MP, Damage 28%, Attack Range 190%, 91% Stun for 10 Sec"/>
-    <string name="h27" value="Use 16 MP, Damage 28%, Attack Range 190%, 92% Stun for 10 Sec"/>
-    <string name="h28" value="Use 16 MP, Damage 29%, Attack Range 200%, 93% Stun for 10 Sec"/>
-    <string name="h29" value="Use 16 MP, Damage 29%, Attack Range 200%, 94% Stun for 10 Sec"/>
-    <string name="h30" value="Use 16 MP, Damage 30%, Attack Range 200%, 95% Stun for 10 Sec"/>
+    <string name="desc" value="[Master Level: 30]\nDamages nearby monsters and stuns them with a given success rate."/>
+    <string name="h1" value="MP -8; Damage 11%; attacks up to 6 enemies; 52% stun for 5 sec"/>
+    <string name="h2" value="MP -8; Damage 12%; attacks up to 6 enemies; 54% stun for 5 sec"/>
+    <string name="h3" value="MP -8; Damage 13%; attacks up to 6 enemies; 56% stun for 5 sec"/>
+    <string name="h4" value="MP -8; Damage 14%; attacks up to 6 enemies; % stun for 5 sec"/>
+    <string name="h5" value="MP -8; Damage 15%; attacks up to 6 enemies; 60% stun for 5 sec"/>
+    <string name="h6" value="MP -8; Damage 16%; attacks up to 6 enemies; 62% stun for 6 sec"/>
+    <string name="h7" value="MP -8; Damage 17%; attacks up to 6 enemies; 64% stun for 6 sec"/>
+    <string name="h8" value="MP -8; Damage 18%; attacks up to 6 enemies; 66% stun for 6 sec"/>
+    <string name="h9" value="MP -8; Damage 19%; attacks up to 6 enemies; 68% stun for 6 sec"/>
+    <string name="h10" value="MP -8; Damage 20%; attacks up to 6 enemies; 70% stun for 6 sec"/>
+    <string name="h11" value="MP -12; Damage 20%; attacks up to 6 enemies; 72% stun for 7 sec"/>
+    <string name="h12" value="MP -12; Damage 21%; attacks up to 6 enemies; 74% stun for 7 sec"/>
+    <string name="h13" value="MP -12; Damage 21%; attacks up to 6 enemies; 76% stun for 7 sec"/>
+    <string name="h14" value="MP -12; Damage 22%; attacks up to 6 enemies; 78% stun for 7 sec"/>
+    <string name="h15" value="MP -12; Damage 22%; attacks up to 6 enemies; 80% stun for 7 sec"/>
+    <string name="h16" value="MP -12; Damage 23%; attacks up to 6 enemies; 81% stun for 8 sec"/>
+    <string name="h17" value="MP -12; Damage 23%; attacks up to 6 enemies; 82% stun for 8 sec"/>
+    <string name="h18" value="MP -12; Damage 24%; attacks up to 6 enemies; 83% stun for 8 sec"/>
+    <string name="h19" value="MP -12; Damage 24%; attacks up to 6 enemies; 84% stun for 8 sec"/>
+    <string name="h20" value="MP -12; Damage 25%; attacks up to 6 enemies; 85% stun for 8 sec"/>
+    <string name="h21" value="MP -16; Damage 25%; attacks up to 6 enemies; 86% stun for 9 sec"/>
+    <string name="h22" value="MP -16; Damage 26%; attacks up to 6 enemies; 87% stun for 9 sec"/>
+    <string name="h23" value="MP -16; Damage 26%; attacks up to 6 enemies; 88% stun for 9 sec"/>
+    <string name="h24" value="MP -16; Damage 27%; attacks up to 6 enemies; 89% stun for 9 sec"/>
+    <string name="h25" value="MP -16; Damage 27%; attacks up to 6 enemies; 90% stun for 9 sec"/>
+    <string name="h26" value="MP -16; Damage 28%; attacks up to 6 enemies; 91% stun for 10 sec"/>
+    <string name="h27" value="MP -16; Damage 28%; attacks up to 6 enemies; 92% stun for 10 sec"/>
+    <string name="h28" value="MP -16; Damage 29%; attacks up to 6 enemies; 93% stun for 10 sec"/>
+    <string name="h29" value="MP -16; Damage 29%; attacks up to 6 enemies; 94% stun for 10 sec"/>
+    <string name="h30" value="MP -16; Damage 30%; attacks up to 6 enemies; 95% stun for 10 sec"/>
   </imgdir>
   <imgdir name="121">
     <string name="bookName" value="White Knight&apos;s Code"/>
   </imgdir>
   <imgdir name="1210000">
     <string name="name" value="Improving MP Recovery"/>
-    <string name="desc" value="[Master Level : 20]\nRecovering even more MP every 10 sec. "/>
-    <string name="h1" value="Constant additional recovery of MP +2"/>
-    <string name="h2" value="Constant additional recovery of MP +4"/>
-    <string name="h3" value="Constant additional recovery of MP +6"/>
-    <string name="h4" value="Constant additional recovery of MP +8"/>
-    <string name="h5" value="Constant additional recovery of MP +10"/>
-    <string name="h6" value="Constant additional recovery of MP +12"/>
-    <string name="h7" value="Constant additional recovery of MP +14"/>
-    <string name="h8" value="Constant additional recovery of MP +16"/>
-    <string name="h9" value="Constant additional recovery of MP +18"/>
-    <string name="h10" value="Constant additional recovery of MP +20"/>
-    <string name="h11" value="Constant additional recovery of MP +21"/>
-    <string name="h12" value="Constant additional recovery of MP +22"/>
-    <string name="h13" value="Constant additional recovery of MP +23"/>
-    <string name="h14" value="Constant additional recovery of MP +24"/>
-    <string name="h15" value="Constant additional recovery of MP +25"/>
-    <string name="h16" value="Constant additional recovery of MP +26"/>
-    <string name="h17" value="Constant additional recovery of MP +27"/>
-    <string name="h18" value="Constant additional recovery of MP +28"/>
-    <string name="h19" value="Constant additional recovery of MP +29"/>
-    <string name="h20" value="Constant additional recovery of MP +30"/>
+    <string name="desc" value="[Master Level: 20]\nRecover additional MP every 10 sec. while standing still."/>
+    <string name="h1" value="Recover additional MP +2"/>
+    <string name="h2" value="Recover additional MP +4"/>
+    <string name="h3" value="Recover additional MP +6"/>
+    <string name="h4" value="Recover additional MP +8"/>
+    <string name="h5" value="Recover additional MP +10"/>
+    <string name="h6" value="Recover additional MP +12"/>
+    <string name="h7" value="Recover additional MP +14"/>
+    <string name="h8" value="Recover additional MP +16"/>
+    <string name="h9" value="Recover additional MP +18"/>
+    <string name="h10" value="Recover additional MP +20"/>
+    <string name="h11" value="Recover additional MP +21"/>
+    <string name="h12" value="Recover additional MP +22"/>
+    <string name="h13" value="Recover additional MP +23"/>
+    <string name="h14" value="Recover additional MP +24"/>
+    <string name="h15" value="Recover additional MP +25"/>
+    <string name="h16" value="Recover additional MP +26"/>
+    <string name="h17" value="Recover additional MP +27"/>
+    <string name="h18" value="Recover additional MP +28"/>
+    <string name="h19" value="Recover additional MP +29"/>
+    <string name="h20" value="Recover additional MP +30"/>
   </imgdir>
   <imgdir name="1210001">
     <string name="name" value="Shield Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nShield Defense increases. However, it does not affect if the character does not equip the shield."/>
-    <string name="h1" value="5% Increased Shield Defense"/>
-    <string name="h2" value="10% Increased Shield Defense"/>
-    <string name="h3" value="15% Increased Shield Defense"/>
-    <string name="h4" value="20% Increased Shield Defense"/>
-    <string name="h5" value="25% Increased Shield Defense"/>
-    <string name="h6" value="30% Increased Shield Defense"/>
-    <string name="h7" value="35% Increased Shield Defense"/>
-    <string name="h8" value="40% Increased Shield Defense"/>
-    <string name="h9" value="45% Increased Shield Defense"/>
-    <string name="h10" value="50% Increased Shield Defense"/>
-    <string name="h11" value="55% Increased Shield Defense"/>
-    <string name="h12" value="60% Increased Shield Defense"/>
-    <string name="h13" value="65% Increased Shield Defense"/>
-    <string name="h14" value="70% Increased Shield Defense"/>
-    <string name="h15" value="75% Increased Shield Defense"/>
-    <string name="h16" value="80% Increased Shield Defense"/>
-    <string name="h17" value="85% Increased Shield Defense"/>
-    <string name="h18" value="90% Increased Shield Defense"/>
-    <string name="h19" value="95% Increased Shield Defense"/>
-    <string name="h20" value="100% Increased Shield Defense"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases shield defense while a shield is equipped."/>
+    <string name="h1" value="Shield defense becomes 105%"/>
+    <string name="h2" value="Shield defense becomes 110%"/>
+    <string name="h3" value="Shield defense becomes 115%"/>
+    <string name="h4" value="Shield defense becomes 120%"/>
+    <string name="h5" value="Shield defense becomes 125%"/>
+    <string name="h6" value="Shield defense becomes 130%"/>
+    <string name="h7" value="Shield defense becomes 135%"/>
+    <string name="h8" value="Shield defense becomes 140%"/>
+    <string name="h9" value="Shield defense becomes 145%"/>
+    <string name="h10" value="Shield defense becomes 150%"/>
+    <string name="h11" value="Shield defense becomes 155%"/>
+    <string name="h12" value="Shield defense becomes 160%"/>
+    <string name="h13" value="Shield defense becomes 165%"/>
+    <string name="h14" value="Shield defense becomes 170%"/>
+    <string name="h15" value="Shield defense becomes 175%"/>
+    <string name="h16" value="Shield defense becomes 180%"/>
+    <string name="h17" value="Shield defense becomes 185%"/>
+    <string name="h18" value="Shield defense becomes 190%"/>
+    <string name="h19" value="Shield defense becomes 195%"/>
+    <string name="h20" value="Shield defense becomes 200%"/>
   </imgdir>
   <imgdir name="1211002">
     <string name="name" value="Charged Blow"/>
-    <string name="desc" value="[Master Level : 30]\n Make the enemy stun. You can use this skill only when your combo is charged up."/>
-    <string name="h1" value="Use 15 HP, 12 MP, Damage 162%, Stun 32%"/>
-    <string name="h2" value="Use 15 HP, 12 MP, Damage 164%, Stun 34%"/>
-    <string name="h3" value="Use 15 HP, 12 MP, Damage 166%, Stun 36%"/>
-    <string name="h4" value="Use 15 HP, 12 MP, Damage 168%, Stun 38%"/>
-    <string name="h5" value="Use 15 HP, 12 MP, Damage 170%, Stun 40%"/>
-    <string name="h6" value="Use 15 HP, 12 MP, Damage 172%, Stun 42%"/>
-    <string name="h7" value="Use 15 HP, 12 MP, Damage 174%, Stun 44%"/>
-    <string name="h8" value="Use 15 HP, 12 MP, Damage 176%, Stun 46%"/>
-    <string name="h9" value="Use 15 HP, 12 MP, Damage 178%, Stun 48%"/>
-    <string name="h10" value="Use 15 HP, 12 MP, Damage 180%, Stun 50%"/>
-    <string name="h11" value="Use 20 HP, 19 MP, Damage 183%, Stun 52%"/>
-    <string name="h12" value="Use 20 HP, 19 MP, Damage 186%, Stun 54%"/>
-    <string name="h13" value="Use 20 HP, 19 MP, Damage 189%, Stun 56%"/>
-    <string name="h14" value="Use 20 HP, 19 MP, Damage 192%, Stun 58%"/>
-    <string name="h15" value="Use 20 HP, 19 MP, Damage 195%, Stun 60%"/>
-    <string name="h16" value="Use 20 HP, 19 MP, Damage 198%, Stun 62%"/>
-    <string name="h17" value="Use 20 HP, 19 MP, Damage 201%, Stun 64%"/>
-    <string name="h18" value="Use 20 HP, 19 MP, Damage 204%, Stun 66%"/>
-    <string name="h19" value="Use 20 HP, 19 MP, Damage 207%, Stun 68%"/>
-    <string name="h20" value="Use 20 HP, 19 MP, Damage 210%, Stun 70%"/>
-    <string name="h21" value="Use 25 HP, 26 MP, Damage 214%, Stun 72%"/>
-    <string name="h22" value="Use 25 HP, 26 MP, Damage 218%, Stun 74%"/>
-    <string name="h23" value="Use 25 HP, 26 MP, Damage 222%, Stun 76%"/>
-    <string name="h24" value="Use 25 HP, 26 MP, Damage 226%, Stun 78%"/>
-    <string name="h25" value="Use 25 HP, 26 MP, Damage 230%, Stun 80%"/>
-    <string name="h26" value="Use 25 HP, 26 MP, Damage 234%, Stun 82%"/>
-    <string name="h27" value="Use 25 HP, 26 MP, Damage 238%, Stun 84%"/>
-    <string name="h28" value="Use 25 HP, 26 MP, Damage 242%, Stun 86%"/>
-    <string name="h29" value="Use 25 HP, 26 MP, Damage 246%, Stun 88%"/>
-    <string name="h30" value="Use 25 HP, 26 MP, Damage 250%, Stun 90%"/>
+    <string name="desc" value="[Master Level: 30]\nUses the active elemental charge to attack nearby monsters and stun them with a given success rate."/>
+    <string name="h1" value="HP -15; MP -12; Damage 162%; attacks up to 6 enemies; 32% stun for 2 sec"/>
+    <string name="h2" value="HP -15; MP -12; Damage 164%; attacks up to 6 enemies; 34% stun for 2 sec"/>
+    <string name="h3" value="HP -15; MP -12; Damage 166%; attacks up to 6 enemies; 36% stun for 2 sec"/>
+    <string name="h4" value="HP -15; MP -12; Damage 168%; attacks up to 6 enemies; 38% stun for 2 sec"/>
+    <string name="h5" value="HP -15; MP -12; Damage 170%; attacks up to 6 enemies; 40% stun for 2 sec"/>
+    <string name="h6" value="HP -15; MP -12; Damage 172%; attacks up to 6 enemies; 42% stun for 2 sec"/>
+    <string name="h7" value="HP -15; MP -12; Damage 174%; attacks up to 6 enemies; 44% stun for 2 sec"/>
+    <string name="h8" value="HP -15; MP -12; Damage 176%; attacks up to 6 enemies; 46% stun for 2 sec"/>
+    <string name="h9" value="HP -15; MP -12; Damage 178%; attacks up to 6 enemies; 48% stun for 2 sec"/>
+    <string name="h10" value="HP -15; MP -12; Damage 180%; attacks up to 6 enemies; 50% stun for 2 sec"/>
+    <string name="h11" value="HP -20; MP -19; Damage 183%; attacks up to 6 enemies; 52% stun for 3 sec"/>
+    <string name="h12" value="HP -20; MP -19; Damage 186%; attacks up to 6 enemies; 54% stun for 3 sec"/>
+    <string name="h13" value="HP -20; MP -19; Damage 189%; attacks up to 6 enemies; 56% stun for 3 sec"/>
+    <string name="h14" value="HP -20; MP -19; Damage 192%; attacks up to 6 enemies; 58% stun for 3 sec"/>
+    <string name="h15" value="HP -20; MP -19; Damage 195%; attacks up to 6 enemies; 60% stun for 3 sec"/>
+    <string name="h16" value="HP -20; MP -19; Damage 198%; attacks up to 6 enemies; 62% stun for 3 sec"/>
+    <string name="h17" value="HP -20; MP -19; Damage 201%; attacks up to 6 enemies; 64% stun for 3 sec"/>
+    <string name="h18" value="HP -20; MP -19; Damage 204%; attacks up to 6 enemies; 66% stun for 3 sec"/>
+    <string name="h19" value="HP -20; MP -19; Damage 207%; attacks up to 6 enemies; 68% stun for 3 sec"/>
+    <string name="h20" value="HP -20; MP -19; Damage 210%; attacks up to 6 enemies; 70% stun for 3 sec"/>
+    <string name="h21" value="HP -25; MP -26; Damage 214%; attacks up to 6 enemies; 72% stun for 4 sec"/>
+    <string name="h22" value="HP -25; MP -26; Damage 218%; attacks up to 6 enemies; 74% stun for 4 sec"/>
+    <string name="h23" value="HP -25; MP -26; Damage 222%; attacks up to 6 enemies; 76% stun for 4 sec"/>
+    <string name="h24" value="HP -25; MP -26; Damage 226%; attacks up to 6 enemies; 78% stun for 4 sec"/>
+    <string name="h25" value="HP -25; MP -26; Damage 230%; attacks up to 6 enemies; 80% stun for 4 sec"/>
+    <string name="h26" value="HP -25; MP -26; Damage 234%; attacks up to 6 enemies; 82% stun for 4 sec"/>
+    <string name="h27" value="HP -25; MP -26; Damage 238%; attacks up to 6 enemies; 84% stun for 4 sec"/>
+    <string name="h28" value="HP -25; MP -26; Damage 242%; attacks up to 6 enemies; 86% stun for 4 sec"/>
+    <string name="h29" value="HP -25; MP -26; Damage 246%; attacks up to 6 enemies; 88% stun for 4 sec"/>
+    <string name="h30" value="HP -25; MP -26; Damage 250%; attacks up to 6 enemies; 90% stun for 4 sec"/>
   </imgdir>
   <imgdir name="1211003">
     <string name="name" value="Fire Charge: Sword"/>
-    <string name="desc" value="[Master Level: 30]\n Temporarily adds an element of fire into the sword.  It gets cancelled when the charge blow is used or it simply expires."/>
-    <string name="h1" value="Use 25 MP, Damage 102%, For 12 Seconds"/>
-    <string name="h2" value="Use 25 MP, Damage 103%, For 19 Seconds"/>
-    <string name="h3" value="Use 25 MP, Damage 104%, For 26 Seconds"/>
-    <string name="h4" value="Use 25 MP, Damage 105%, For 33 Seconds"/>
-    <string name="h5" value="Use 25 MP, Damage 106%, For 40 Seconds"/>
-    <string name="h6" value="Use 25 MP, Damage 107%, For 47 Seconds"/>
-    <string name="h7" value="Use 25 MP, Damage 108%, For 54 Seconds"/>
-    <string name="h8" value="Use 25 MP, Damage 109%, For 61 Seconds"/>
-    <string name="h9" value="Use 25 MP, Damage 109%, For 68 Seconds"/>
-    <string name="h10" value="Use 25 MP, Damage 110%, For 75 Seconds"/>
-    <string name="h11" value="Use 30 MP, Damage 110%, For 82 Seconds"/>
-    <string name="h12" value="Use 30 MP, Damage 111%, For 89 Seconds"/>
-    <string name="h13" value="Use 30 MP, Damage 111%, For 96 Seconds"/>
-    <string name="h14" value="Use 30 MP, Damage 112%, For 103 Seconds"/>
-    <string name="h15" value="Use 30 MP, Damage 112%, For 110 Seconds"/>
-    <string name="h16" value="Use 30 MP, Damage 113%, For 116 Seconds"/>
-    <string name="h17" value="Use 30 MP, Damage 113%, For 122 Seconds"/>
-    <string name="h18" value="Use 30 MP, Damage 114%, For 128 Seconds"/>
-    <string name="h19" value="Use 30 MP, Damage 114%, For 134 Seconds"/>
-    <string name="h20" value="Use 35 MP, Damage 115%, For 140 Seconds"/>
-    <string name="h21" value="Use 35 MP, Damage 115%, For 146 Seconds"/>
-    <string name="h22" value="Use 35 MP, Damage 116%, For 152 Seconds"/>
-    <string name="h23" value="Use 35 MP, Damage 116%, For 158 Seconds"/>
-    <string name="h24" value="Use 35 MP, Damage 117%, For 164 Seconds"/>
-    <string name="h25" value="Use 35 MP, Damage 117%, For 170 Seconds"/>
-    <string name="h26" value="Use 35 MP, Damage 118%, For 176 Seconds"/>
-    <string name="h27" value="Use 35 MP, Damage 118%, For 182 Seconds"/>
-    <string name="h28" value="Use 35 MP, Damage 119%, For 188 Seconds"/>
-    <string name="h29" value="Use 35 MP, Damage 119%, For 194 Seconds"/>
-    <string name="h30" value="Use 35 MP, Damage 120%, For 200 Seconds"/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily adds fire element to the equipped sword. The charge can be consumed by Charged Blow or expire naturally."/>
+    <string name="h1" value="MP -25; Damage 102%; duration 12 sec"/>
+    <string name="h2" value="MP -25; Damage 103%; duration 19 sec"/>
+    <string name="h3" value="MP -25; Damage 104%; duration 26 sec"/>
+    <string name="h4" value="MP -25; Damage 105%; duration 33 sec"/>
+    <string name="h5" value="MP -25; Damage 106%; duration 40 sec"/>
+    <string name="h6" value="MP -25; Damage 107%; duration 47 sec"/>
+    <string name="h7" value="MP -25; Damage 108%; duration 54 sec"/>
+    <string name="h8" value="MP -25; Damage 109%; duration 61 sec"/>
+    <string name="h9" value="MP -25; Damage 109%; duration 68 sec"/>
+    <string name="h10" value="MP -25; Damage 110%; duration 75 sec"/>
+    <string name="h11" value="MP -30; Damage 110%; duration 82 sec"/>
+    <string name="h12" value="MP -30; Damage 111%; duration 89 sec"/>
+    <string name="h13" value="MP -30; Damage 111%; duration 96 sec"/>
+    <string name="h14" value="MP -30; Damage 112%; duration 103 sec"/>
+    <string name="h15" value="MP -30; Damage 112%; duration 110 sec"/>
+    <string name="h16" value="MP -30; Damage 113%; duration 116 sec"/>
+    <string name="h17" value="MP -30; Damage 113%; duration 122 sec"/>
+    <string name="h18" value="MP -30; Damage 114%; duration 128 sec"/>
+    <string name="h19" value="MP -30; Damage 114%; duration 134 sec"/>
+    <string name="h20" value="MP -30; Damage 115%; duration 140 sec"/>
+    <string name="h21" value="MP -35; Damage 115%; duration 146 sec"/>
+    <string name="h22" value="MP -35; Damage 116%; duration 152 sec"/>
+    <string name="h23" value="MP -35; Damage 116%; duration 158 sec"/>
+    <string name="h24" value="MP -35; Damage 117%; duration 164 sec"/>
+    <string name="h25" value="MP -35; Damage 117%; duration 170 sec"/>
+    <string name="h26" value="MP -35; Damage 118%; duration 176 sec"/>
+    <string name="h27" value="MP -35; Damage 118%; duration 182 sec"/>
+    <string name="h28" value="MP -35; Damage 119%; duration 188 sec"/>
+    <string name="h29" value="MP -35; Damage 119%; duration 194 sec"/>
+    <string name="h30" value="MP -35; Damage 120%; duration 200 sec"/>
   </imgdir>
   <imgdir name="1211004">
-    <string name="name" value="Flame Charge: BW"/>
-    <string name="desc" value="[Master Level: 30]\n Temporarily adds an element of fire into the blunt weapon.  It gets cancelled when the charge blow is used or it simply expires."/>
-    <string name="h1" value="Use 25 MP, Damage 102%, For 12 Seconds"/>
-    <string name="h2" value="Use 25 MP, Damage 103%, For 19 Seconds"/>
-    <string name="h3" value="Use 25 MP, Damage 104%, For 26 Seconds"/>
-    <string name="h4" value="Use 25 MP, Damage 105%, For 33 Seconds"/>
-    <string name="h5" value="Use 25 MP, Damage 106%, For 40 Seconds"/>
-    <string name="h6" value="Use 25 MP, Damage 107%, For 47 Seconds"/>
-    <string name="h7" value="Use 25 MP, Damage 108%, For 54 Seconds"/>
-    <string name="h8" value="Use 25 MP, Damage 109%, For 61 Seconds"/>
-    <string name="h9" value="Use 25 MP, Damage 109%, For 68 Seconds"/>
-    <string name="h10" value="Use 25 MP, Damage 110%, For 75 Seconds"/>
-    <string name="h11" value="Use 30 MP, Damage 110%, For 82 Seconds"/>
-    <string name="h12" value="Use 30 MP, Damage 111%, For 89 Seconds"/>
-    <string name="h13" value="Use 30 MP, Damage 111%, For 96 Seconds"/>
-    <string name="h14" value="Use 30 MP, Damage 112%, For 103 Seconds"/>
-    <string name="h15" value="Use 30 MP, Damage 112%, For 110 Seconds"/>
-    <string name="h16" value="Use 30 MP, Damage 113%, For 116 Seconds"/>
-    <string name="h17" value="Use 30 MP, Damage 113%, For 122 Seconds"/>
-    <string name="h18" value="Use 30 MP, Damage 114%, For 128 Seconds"/>
-    <string name="h19" value="Use 30 MP, Damage 114%, For 134 Seconds"/>
-    <string name="h20" value="Use 35 MP, Damage 115%, For 140 Seconds"/>
-    <string name="h21" value="Use 35 MP, Damage 115%, For 146 Seconds"/>
-    <string name="h22" value="Use 35 MP, Damage 116%, For 152 Seconds"/>
-    <string name="h23" value="Use 35 MP, Damage 116%, For 158 Seconds"/>
-    <string name="h24" value="Use 35 MP, Damage 117%, For 164 Seconds"/>
-    <string name="h25" value="Use 35 MP, Damage 117%, For 170 Seconds"/>
-    <string name="h26" value="Use 35 MP, Damage 118%, For 176 Seconds"/>
-    <string name="h27" value="Use 35 MP, Damage 118%, For 182 Seconds"/>
-    <string name="h28" value="Use 35 MP, Damage 119%, For 188 Seconds"/>
-    <string name="h29" value="Use 35 MP, Damage 119%, For 194 Seconds"/>
-    <string name="h30" value="Use 35 MP, Damage 120%, For 200 Seconds"/>
+    <string name="name" value="Fire Charge: Blunt Weapon"/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily adds fire element to the equipped blunt weapon. The charge can be consumed by Charged Blow or expire naturally."/>
+    <string name="h1" value="MP -25; Damage 102%; duration 12 sec"/>
+    <string name="h2" value="MP -25; Damage 103%; duration 19 sec"/>
+    <string name="h3" value="MP -25; Damage 104%; duration 26 sec"/>
+    <string name="h4" value="MP -25; Damage 105%; duration 33 sec"/>
+    <string name="h5" value="MP -25; Damage 106%; duration 40 sec"/>
+    <string name="h6" value="MP -25; Damage 107%; duration 47 sec"/>
+    <string name="h7" value="MP -25; Damage 108%; duration 54 sec"/>
+    <string name="h8" value="MP -25; Damage 109%; duration 61 sec"/>
+    <string name="h9" value="MP -25; Damage 109%; duration 68 sec"/>
+    <string name="h10" value="MP -25; Damage 110%; duration 75 sec"/>
+    <string name="h11" value="MP -30; Damage 110%; duration 82 sec"/>
+    <string name="h12" value="MP -30; Damage 111%; duration 89 sec"/>
+    <string name="h13" value="MP -30; Damage 111%; duration 96 sec"/>
+    <string name="h14" value="MP -30; Damage 112%; duration 103 sec"/>
+    <string name="h15" value="MP -30; Damage 112%; duration 110 sec"/>
+    <string name="h16" value="MP -30; Damage 113%; duration 116 sec"/>
+    <string name="h17" value="MP -30; Damage 113%; duration 122 sec"/>
+    <string name="h18" value="MP -30; Damage 114%; duration 128 sec"/>
+    <string name="h19" value="MP -30; Damage 114%; duration 134 sec"/>
+    <string name="h20" value="MP -30; Damage 115%; duration 140 sec"/>
+    <string name="h21" value="MP -35; Damage 115%; duration 146 sec"/>
+    <string name="h22" value="MP -35; Damage 116%; duration 152 sec"/>
+    <string name="h23" value="MP -35; Damage 116%; duration 158 sec"/>
+    <string name="h24" value="MP -35; Damage 117%; duration 164 sec"/>
+    <string name="h25" value="MP -35; Damage 117%; duration 170 sec"/>
+    <string name="h26" value="MP -35; Damage 118%; duration 176 sec"/>
+    <string name="h27" value="MP -35; Damage 118%; duration 182 sec"/>
+    <string name="h28" value="MP -35; Damage 119%; duration 188 sec"/>
+    <string name="h29" value="MP -35; Damage 119%; duration 194 sec"/>
+    <string name="h30" value="MP -35; Damage 120%; duration 200 sec"/>
   </imgdir>
   <imgdir name="1211005">
     <string name="name" value="Ice Charge: Sword"/>
-    <string name="desc" value="[Master Level: 30]\n You can attack with ice power. The skill get canceled if you use Charge Blow or if the time runs out."/>
-    <string name="h1" value="Use MP 25, Damage 100%, For 12 Seconds"/>
-    <string name="h2" value="Use MP 25, Damage 101%, For 19 Seconds"/>
-    <string name="h3" value="Use MP 25, Damage 101%, For 26 Seconds"/>
-    <string name="h4" value="Use MP 25, Damage 102%, For 33 Seconds"/>
-    <string name="h5" value="Use MP 25, Damage 102%, For 40 Seconds"/>
-    <string name="h6" value="Use MP 25, Damage 102%, For 47 Seconds"/>
-    <string name="h7" value="Use MP 25, Damage 103%, For 54 Seconds"/>
-    <string name="h8" value="Use MP 25, Damage 103%, For 61 Seconds"/>
-    <string name="h9" value="Use MP 25, Damage 103%, For 68 Seconds"/>
-    <string name="h10" value="Use MP 25, Damage 104%, For 75 Seconds"/>
-    <string name="h11" value="Use MP 30, Damage 104%, For 82 Seconds"/>
-    <string name="h12" value="Use MP 30, Damage 104%, For 89 Seconds"/>
-    <string name="h13" value="Use MP 30, Damage 105%, For 96 Seconds"/>
-    <string name="h14" value="Use MP 30, Damage 105%, For 103 Seconds"/>
-    <string name="h15" value="Use MP 30, Damage 105%, For 110 Seconds"/>
-    <string name="h16" value="Use MP 30, Damage 106%, For 116 Seconds"/>
-    <string name="h17" value="Use MP 30, Damage 106%, For 122 Seconds"/>
-    <string name="h18" value="Use MP 30, Damage 106%, For 128 Seconds"/>
-    <string name="h19" value="Use MP 30, Damage 107%, For 134 Seconds"/>
-    <string name="h20" value="Use MP 35, Damage 107%, For 140 Seconds"/>
-    <string name="h21" value="Use MP 35, Damage 107%, For 146 Seconds"/>
-    <string name="h22" value="Use MP 35, Damage 108%, For 152 Seconds"/>
-    <string name="h23" value="Use MP 35, Damage 108%, For 158 Seconds"/>
-    <string name="h24" value="Use MP 35, Damage 108%, For 164 Seconds"/>
-    <string name="h25" value="Use MP 35, Damage 108%, For 170 Seconds"/>
-    <string name="h26" value="Use MP 35, Damage 109%, For 176 Seconds"/>
-    <string name="h27" value="Use MP 35, Damage 109%, For 182 Seconds"/>
-    <string name="h28" value="Use MP 35, Damage 109%, For 188 Seconds"/>
-    <string name="h29" value="Use MP 35, Damage 109%, For 194 Seconds"/>
-    <string name="h30" value="Use MP 35, Damage 110%, For 200 Seconds"/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily adds ice element to the equipped sword. The charge can be consumed by Charged Blow or expire naturally."/>
+    <string name="h1" value="MP -25; Damage 100%; duration 12 sec"/>
+    <string name="h2" value="MP -25; Damage 101%; duration 19 sec"/>
+    <string name="h3" value="MP -25; Damage 101%; duration 26 sec"/>
+    <string name="h4" value="MP -25; Damage 102%; duration 33 sec"/>
+    <string name="h5" value="MP -25; Damage 102%; duration 40 sec"/>
+    <string name="h6" value="MP -25; Damage 102%; duration 47 sec"/>
+    <string name="h7" value="MP -25; Damage 103%; duration 54 sec"/>
+    <string name="h8" value="MP -25; Damage 103%; duration 61 sec"/>
+    <string name="h9" value="MP -25; Damage 103%; duration 68 sec"/>
+    <string name="h10" value="MP -25; Damage 104%; duration 75 sec"/>
+    <string name="h11" value="MP -30; Damage 104%; duration 82 sec"/>
+    <string name="h12" value="MP -30; Damage 104%; duration 89 sec"/>
+    <string name="h13" value="MP -30; Damage 105%; duration 96 sec"/>
+    <string name="h14" value="MP -30; Damage 105%; duration 103 sec"/>
+    <string name="h15" value="MP -30; Damage 105%; duration 110 sec"/>
+    <string name="h16" value="MP -30; Damage 106%; duration 116 sec"/>
+    <string name="h17" value="MP -30; Damage 106%; duration 122 sec"/>
+    <string name="h18" value="MP -30; Damage 106%; duration 128 sec"/>
+    <string name="h19" value="MP -30; Damage 107%; duration 134 sec"/>
+    <string name="h20" value="MP -30; Damage 107%; duration 140 sec"/>
+    <string name="h21" value="MP -35; Damage 107%; duration 146 sec"/>
+    <string name="h22" value="MP -35; Damage 108%; duration 152 sec"/>
+    <string name="h23" value="MP -35; Damage 108%; duration 158 sec"/>
+    <string name="h24" value="MP -35; Damage 108%; duration 164 sec"/>
+    <string name="h25" value="MP -35; Damage 108%; duration 170 sec"/>
+    <string name="h26" value="MP -35; Damage 109%; duration 176 sec"/>
+    <string name="h27" value="MP -35; Damage 109%; duration 182 sec"/>
+    <string name="h28" value="MP -35; Damage 109%; duration 188 sec"/>
+    <string name="h29" value="MP -35; Damage 109%; duration 194 sec"/>
+    <string name="h30" value="MP -35; Damage 110%; duration 200 sec"/>
   </imgdir>
   <imgdir name="1211006">
-    <string name="name" value="Blizzard Charge: BW"/>
-    <string name="desc" value="[Master Level: 30]\n Temporarily adds an element of blizzard into the blunt weapon.  It gets cancelled when the charge blow is used or it simply expires."/>
-    <string name="h1" value="Use MP 25, Damage 100%, For 12 Seconds"/>
-    <string name="h2" value="Use MP 25, Damage 101%, For 19 Seconds"/>
-    <string name="h3" value="Use MP 25, Damage 101%, For 26 Seconds"/>
-    <string name="h4" value="Use MP 25, Damage 102%, For 33 Seconds"/>
-    <string name="h5" value="Use MP 25, Damage 102%, For 40 Seconds"/>
-    <string name="h6" value="Use MP 25, Damage 102%, For 47 Seconds"/>
-    <string name="h7" value="Use MP 25, Damage 103%, For 54 Seconds"/>
-    <string name="h8" value="Use MP 25, Damage 103%, For 61 Seconds"/>
-    <string name="h9" value="Use MP 25, Damage 103%, For 68 Seconds"/>
-    <string name="h10" value="Use MP 25, Damage 104%, For 75 Seconds"/>
-    <string name="h11" value="Use MP 30, Damage 104%, For 82 Seconds"/>
-    <string name="h12" value="Use MP 30, Damage 104%, For 89 Seconds"/>
-    <string name="h13" value="Use MP 30, Damage 105%, For 96 Seconds"/>
-    <string name="h14" value="Use MP 30, Damage 105%, For 103 Seconds"/>
-    <string name="h15" value="Use MP 30, Damage 105%, For 110 Seconds"/>
-    <string name="h16" value="Use MP 30, Damage 106%, For 116 Seconds"/>
-    <string name="h17" value="Use MP 30, Damage 106%, For 122 Seconds"/>
-    <string name="h18" value="Use MP 30, Damage 106%, For 128 Seconds"/>
-    <string name="h19" value="Use MP 30, Damage 107%, For 134 Seconds"/>
-    <string name="h20" value="Use MP 30, Damage 107%, For 140 Seconds"/>
-    <string name="h21" value="Use MP 35, Damage 107%, For 146 Seconds"/>
-    <string name="h22" value="Use MP 35, Damage 108%, For 152 Seconds"/>
-    <string name="h23" value="Use MP 35, Damage 108%, For 158 Seconds"/>
-    <string name="h24" value="Use MP 35, Damage 108%, For 164 Seconds"/>
-    <string name="h25" value="Use MP 35, Damage 108%, For 170 Seconds"/>
-    <string name="h26" value="Use MP 35, Damage 109%, For 176 Seconds"/>
-    <string name="h27" value="Use MP 35, Damage 109%, For 182 Seconds"/>
-    <string name="h28" value="Use MP 35, Damage 109%, For 188 Seconds"/>
-    <string name="h29" value="Use MP 35, Damage 109%, For 194 Seconds"/>
-    <string name="h30" value="Use MP 35, Damage 110%, For 200 Seconds"/>
+    <string name="name" value="Ice Charge: Blunt Weapon"/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily adds ice element to the equipped blunt weapon. The charge can be consumed by Charged Blow or expire naturally."/>
+    <string name="h1" value="MP -25; Damage 100%; duration 12 sec"/>
+    <string name="h2" value="MP -25; Damage 101%; duration 19 sec"/>
+    <string name="h3" value="MP -25; Damage 101%; duration 26 sec"/>
+    <string name="h4" value="MP -25; Damage 102%; duration 33 sec"/>
+    <string name="h5" value="MP -25; Damage 102%; duration 40 sec"/>
+    <string name="h6" value="MP -25; Damage 102%; duration 47 sec"/>
+    <string name="h7" value="MP -25; Damage 103%; duration 54 sec"/>
+    <string name="h8" value="MP -25; Damage 103%; duration 61 sec"/>
+    <string name="h9" value="MP -25; Damage 103%; duration 68 sec"/>
+    <string name="h10" value="MP -25; Damage 104%; duration 75 sec"/>
+    <string name="h11" value="MP -30; Damage 104%; duration 82 sec"/>
+    <string name="h12" value="MP -30; Damage 104%; duration 89 sec"/>
+    <string name="h13" value="MP -30; Damage 105%; duration 96 sec"/>
+    <string name="h14" value="MP -30; Damage 105%; duration 103 sec"/>
+    <string name="h15" value="MP -30; Damage 105%; duration 110 sec"/>
+    <string name="h16" value="MP -30; Damage 106%; duration 116 sec"/>
+    <string name="h17" value="MP -30; Damage 106%; duration 122 sec"/>
+    <string name="h18" value="MP -30; Damage 106%; duration 128 sec"/>
+    <string name="h19" value="MP -30; Damage 107%; duration 134 sec"/>
+    <string name="h20" value="MP -30; Damage 107%; duration 140 sec"/>
+    <string name="h21" value="MP -35; Damage 107%; duration 146 sec"/>
+    <string name="h22" value="MP -35; Damage 108%; duration 152 sec"/>
+    <string name="h23" value="MP -35; Damage 108%; duration 158 sec"/>
+    <string name="h24" value="MP -35; Damage 108%; duration 164 sec"/>
+    <string name="h25" value="MP -35; Damage 108%; duration 170 sec"/>
+    <string name="h26" value="MP -35; Damage 109%; duration 176 sec"/>
+    <string name="h27" value="MP -35; Damage 109%; duration 182 sec"/>
+    <string name="h28" value="MP -35; Damage 109%; duration 188 sec"/>
+    <string name="h29" value="MP -35; Damage 109%; duration 194 sec"/>
+    <string name="h30" value="MP -35; Damage 110%; duration 200 sec"/>
   </imgdir>
   <imgdir name="1211007">
     <string name="name" value="Thunder Charge: Sword"/>
-    <string name="desc" value="[Master Level: 30]\n Temporarily adds an element of thunder into the sword.  It gets cancelled when the charge blow is used or it simply expires."/>
-    <string name="h1" value="Use 25 MP, Damage 102%, For 12 Seconds"/>
-    <string name="h2" value="Use 25 MP, Damage 104%, For 19 Seconds"/>
-    <string name="h3" value="Use 25 MP, Damage 106%, For 26 Seconds"/>
-    <string name="h4" value="Use 25 MP, Damage 107%, For 33 Seconds"/>
-    <string name="h5" value="Use 25 MP, Damage 108%, For 40 Seconds"/>
-    <string name="h6" value="Use 25 MP, Damage 109%, For 47 Seconds"/>
-    <string name="h7" value="Use 25 MP, Damage 110%, For 54 Seconds"/>
-    <string name="h8" value="Use 25 MP, Damage 111%, For 61 Seconds"/>
-    <string name="h9" value="Use 25 MP, Damage 112%, For 68 Seconds"/>
-    <string name="h10" value="Use 25 MP, Damage 113%, For 75 Seconds"/>
-    <string name="h11" value="Use 30 MP, Damage 114%, For 82 Seconds"/>
-    <string name="h12" value="Use 30 MP, Damage 115%, For 89 Seconds"/>
-    <string name="h13" value="Use 30 MP, Damage 116%, For 96 Seconds"/>
-    <string name="h14" value="Use 30 MP, Damage 117%, For 103 Seconds"/>
-    <string name="h15" value="Use 30 MP, Damage 117%, For 110 Seconds"/>
-    <string name="h16" value="Use 30 MP, Damage 118%, For 116 Seconds"/>
-    <string name="h17" value="Use 30 MP, Damage 118%, For 122 Seconds"/>
-    <string name="h18" value="Use 30 MP, Damage 119%, For 128 Seconds"/>
-    <string name="h19" value="Use 30 MP, Damage 119%, For 134 Seconds"/>
-    <string name="h20" value="Use 35 MP, Damage 120%, For 140 Seconds"/>
-    <string name="h21" value="Use 35 MP, Damage 120%, For 146 Seconds"/>
-    <string name="h22" value="Use 35 MP, Damage 121%, For 152 Seconds"/>
-    <string name="h23" value="Use 35 MP, Damage 121%, For 158 Seconds"/>
-    <string name="h24" value="Use 35 MP, Damage 122%, For 164 Seconds"/>
-    <string name="h25" value="Use 35 MP, Damage 122%, For 170 Seconds"/>
-    <string name="h26" value="Use 35 MP, Damage 123%, For 176 Seconds"/>
-    <string name="h27" value="Use 35 MP, Damage 123%, For 182 Seconds"/>
-    <string name="h28" value="Use 35 MP, Damage 124%, For 188 Seconds"/>
-    <string name="h29" value="Use 35 MP, Damage 124%, For 194 Seconds"/>
-    <string name="h30" value="Use 35 MP, Damage 125%, For 200 Seconds"/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily adds lightning element to the equipped sword. The charge can be consumed by Charged Blow or expire naturally."/>
+    <string name="h1" value="MP -25; Damage 102%; duration 12 sec"/>
+    <string name="h2" value="MP -25; Damage 104%; duration 19 sec"/>
+    <string name="h3" value="MP -25; Damage 106%; duration 26 sec"/>
+    <string name="h4" value="MP -25; Damage 107%; duration 33 sec"/>
+    <string name="h5" value="MP -25; Damage 108%; duration 40 sec"/>
+    <string name="h6" value="MP -25; Damage 109%; duration 47 sec"/>
+    <string name="h7" value="MP -25; Damage 110%; duration 54 sec"/>
+    <string name="h8" value="MP -25; Damage 111%; duration 61 sec"/>
+    <string name="h9" value="MP -25; Damage 112%; duration 68 sec"/>
+    <string name="h10" value="MP -25; Damage 113%; duration 75 sec"/>
+    <string name="h11" value="MP -30; Damage 114%; duration 82 sec"/>
+    <string name="h12" value="MP -30; Damage 115%; duration 89 sec"/>
+    <string name="h13" value="MP -30; Damage 116%; duration 96 sec"/>
+    <string name="h14" value="MP -30; Damage 117%; duration 103 sec"/>
+    <string name="h15" value="MP -30; Damage 117%; duration 110 sec"/>
+    <string name="h16" value="MP -30; Damage 118%; duration 116 sec"/>
+    <string name="h17" value="MP -30; Damage 118%; duration 122 sec"/>
+    <string name="h18" value="MP -30; Damage 119%; duration 128 sec"/>
+    <string name="h19" value="MP -30; Damage 119%; duration 134 sec"/>
+    <string name="h20" value="MP -30; Damage 120%; duration 140 sec"/>
+    <string name="h21" value="MP -35; Damage 120%; duration 146 sec"/>
+    <string name="h22" value="MP -35; Damage 121%; duration 152 sec"/>
+    <string name="h23" value="MP -35; Damage 121%; duration 158 sec"/>
+    <string name="h24" value="MP -35; Damage 122%; duration 164 sec"/>
+    <string name="h25" value="MP -35; Damage 122%; duration 170 sec"/>
+    <string name="h26" value="MP -35; Damage 123%; duration 176 sec"/>
+    <string name="h27" value="MP -35; Damage 123%; duration 182 sec"/>
+    <string name="h28" value="MP -35; Damage 124%; duration 188 sec"/>
+    <string name="h29" value="MP -35; Damage 124%; duration 194 sec"/>
+    <string name="h30" value="MP -35; Damage 125%; duration 200 sec"/>
   </imgdir>
   <imgdir name="1211008">
-    <string name="name" value="Lightning Charge: BW"/>
-    <string name="desc" value="[Master Level: 30]\n Temporarily adds an element of lightning into the blunt weapon.  It gets cancelled when the charge blow is used or it simply expires."/>
-    <string name="h1" value="Use 25 MP, Damage 102%, For 12 Seconds"/>
-    <string name="h2" value="Use 25 MP, Damage 104%, For 19 Seconds"/>
-    <string name="h3" value="Use 25 MP, Damage 106%, For 26 Seconds"/>
-    <string name="h4" value="Use 25 MP, Damage 107%, For 33 Seconds"/>
-    <string name="h5" value="Use 25 MP, Damage 108%, For 40 Seconds"/>
-    <string name="h6" value="Use 25 MP, Damage 109%, For 47 Seconds"/>
-    <string name="h7" value="Use 25 MP, Damage 110%, For 54 Seconds"/>
-    <string name="h8" value="Use 25 MP, Damage 111%, For 61 Seconds"/>
-    <string name="h9" value="Use 25 MP, Damage 112%, For 68 Seconds"/>
-    <string name="h10" value="Use 25 MP, Damage 113%, For 75 Seconds"/>
-    <string name="h11" value="Use 30 MP, Damage 114%, For 82 Seconds"/>
-    <string name="h12" value="Use 30 MP, Damage 115%, For 89 Seconds"/>
-    <string name="h13" value="Use 30 MP, Damage 116%, For 96 Seconds"/>
-    <string name="h14" value="Use 30 MP, Damage 117%, For 103 Seconds"/>
-    <string name="h15" value="Use 30 MP, Damage 117%, For 110 Seconds"/>
-    <string name="h16" value="Use 30 MP, Damage 118%, For 116 Seconds"/>
-    <string name="h17" value="Use 30 MP, Damage 118%, For 122 Seconds"/>
-    <string name="h18" value="Use 30 MP, Damage 119%, For 128 Seconds"/>
-    <string name="h19" value="Use 30 MP, Damage 119%, For 134 Seconds"/>
-    <string name="h20" value="Use 35 MP, Damage 120%, For 140 Seconds"/>
-    <string name="h21" value="Use 35 MP, Damage 120%, For 146 Seconds"/>
-    <string name="h22" value="Use 35 MP, Damage 121%, For 152 Seconds"/>
-    <string name="h23" value="Use 35 MP, Damage 121%, For 158 Seconds"/>
-    <string name="h24" value="Use 35 MP, Damage 122%, For 164 Seconds"/>
-    <string name="h25" value="Use 35 MP, Damage 122%, For 170 Seconds"/>
-    <string name="h26" value="Use 35 MP, Damage 123%, For 176 Seconds"/>
-    <string name="h27" value="Use 35 MP, Damage 123%, For 182 Seconds"/>
-    <string name="h28" value="Use 35 MP, Damage 124%, For 188 Seconds"/>
-    <string name="h29" value="Use 35 MP, Damage 124%, For 194 Seconds"/>
-    <string name="h30" value="Use 35 MP, Damage 125%, For 200 Seconds"/>
+    <string name="name" value="Lightning Charge: Blunt Weapon"/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily adds lightning element to the equipped blunt weapon. The charge can be consumed by Charged Blow or expire naturally."/>
+    <string name="h1" value="MP -25; Damage 102%; duration 12 sec"/>
+    <string name="h2" value="MP -25; Damage 104%; duration 19 sec"/>
+    <string name="h3" value="MP -25; Damage 106%; duration 26 sec"/>
+    <string name="h4" value="MP -25; Damage 107%; duration 33 sec"/>
+    <string name="h5" value="MP -25; Damage 108%; duration 40 sec"/>
+    <string name="h6" value="MP -25; Damage 109%; duration 47 sec"/>
+    <string name="h7" value="MP -25; Damage 110%; duration 54 sec"/>
+    <string name="h8" value="MP -25; Damage 111%; duration 61 sec"/>
+    <string name="h9" value="MP -25; Damage 112%; duration 68 sec"/>
+    <string name="h10" value="MP -25; Damage 113%; duration 75 sec"/>
+    <string name="h11" value="MP -30; Damage 114%; duration 82 sec"/>
+    <string name="h12" value="MP -30; Damage 115%; duration 89 sec"/>
+    <string name="h13" value="MP -30; Damage 116%; duration 96 sec"/>
+    <string name="h14" value="MP -30; Damage 117%; duration 103 sec"/>
+    <string name="h15" value="MP -30; Damage 117%; duration 110 sec"/>
+    <string name="h16" value="MP -30; Damage 118%; duration 116 sec"/>
+    <string name="h17" value="MP -30; Damage 118%; duration 122 sec"/>
+    <string name="h18" value="MP -30; Damage 119%; duration 128 sec"/>
+    <string name="h19" value="MP -30; Damage 119%; duration 134 sec"/>
+    <string name="h20" value="MP -30; Damage 120%; duration 140 sec"/>
+    <string name="h21" value="MP -35; Damage 120%; duration 146 sec"/>
+    <string name="h22" value="MP -35; Damage 121%; duration 152 sec"/>
+    <string name="h23" value="MP -35; Damage 121%; duration 158 sec"/>
+    <string name="h24" value="MP -35; Damage 122%; duration 164 sec"/>
+    <string name="h25" value="MP -35; Damage 122%; duration 170 sec"/>
+    <string name="h26" value="MP -35; Damage 123%; duration 176 sec"/>
+    <string name="h27" value="MP -35; Damage 123%; duration 182 sec"/>
+    <string name="h28" value="MP -35; Damage 124%; duration 188 sec"/>
+    <string name="h29" value="MP -35; Damage 124%; duration 194 sec"/>
+    <string name="h30" value="MP -35; Damage 125%; duration 200 sec"/>
   </imgdir>
   <imgdir name="1211009">
     <string name="name" value="Magic Crash"/>
-    <string name="desc" value="[Master Level : 20]\n Nullifies the magic defense buff used by the monster with a given success rate.\nRequired Skill : #cAt least Level 3 on Charged Blow#"/>
-    <string name="h1" value="Use 35 MP, 24 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h2" value="Use 33 MP, 28 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h3" value="Use 31 MP, 32 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h4" value="Use 29 MP, 36 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h5" value="Use 27 MP, 40 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h6" value="Use 25 MP, 44 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h7" value="Use 23 MP, 48 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h8" value="Use 21 MP, 52 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h9" value="Use 19 MP, 56 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h10" value="Use 17 MP, 60 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h11" value="Use 16 MP, 64 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h12" value="Use 15 MP, 68 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h13" value="Use 14 MP, 72 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h14" value="Use 13 MP, 76 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h15" value="Use 12 MP, 80 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h16" value="Use 11 MP, 84 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h17" value="Use 10 MP, 88 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h18" value="Use 9 MP, 92 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h19" value="Use 8 MP, 96 % Cancel out Enemy&apos;s Magical Defense-Up"/>
-    <string name="h20" value="Use 7 MP, 100 % Cancel out Enemy&apos;s Magical Defense-Up"/>
+    <string name="desc" value="[Master Level: 20]\nCancels the magic defense-up buff on nearby monsters with a given success rate.\nRequired Skill: #cCharged Blow Lv. 3 or higher#"/>
+    <string name="h1" value="MP -35; Cancels up to 6 enemies&#x27; buff at 24% success rate"/>
+    <string name="h2" value="MP -33; Cancels up to 6 enemies&#x27; buff at 28% success rate"/>
+    <string name="h3" value="MP -31; Cancels up to 6 enemies&#x27; buff at 32% success rate"/>
+    <string name="h4" value="MP -29; Cancels up to 6 enemies&#x27; buff at 36% success rate"/>
+    <string name="h5" value="MP -27; Cancels up to 6 enemies&#x27; buff at 40% success rate"/>
+    <string name="h6" value="MP -25; Cancels up to 6 enemies&#x27; buff at 44% success rate"/>
+    <string name="h7" value="MP -23; Cancels up to 6 enemies&#x27; buff at 48% success rate"/>
+    <string name="h8" value="MP -21; Cancels up to 6 enemies&#x27; buff at 52% success rate"/>
+    <string name="h9" value="MP -19; Cancels up to 6 enemies&#x27; buff at 56% success rate"/>
+    <string name="h10" value="MP -17; Cancels up to 6 enemies&#x27; buff at 60% success rate"/>
+    <string name="h11" value="MP -16; Cancels up to 6 enemies&#x27; buff at 64% success rate"/>
+    <string name="h12" value="MP -15; Cancels up to 6 enemies&#x27; buff at 68% success rate"/>
+    <string name="h13" value="MP -14; Cancels up to 6 enemies&#x27; buff at 72% success rate"/>
+    <string name="h14" value="MP -13; Cancels up to 6 enemies&#x27; buff at 76% success rate"/>
+    <string name="h15" value="MP -12; Cancels up to 6 enemies&#x27; buff at 80% success rate"/>
+    <string name="h16" value="MP -11; Cancels up to 6 enemies&#x27; buff at 84% success rate"/>
+    <string name="h17" value="MP -10; Cancels up to 6 enemies&#x27; buff at 88% success rate"/>
+    <string name="h18" value="MP -9; Cancels up to 6 enemies&#x27; buff at 92% success rate"/>
+    <string name="h19" value="MP -8; Cancels up to 6 enemies&#x27; buff at 96% success rate"/>
+    <string name="h20" value="MP -7; Cancels up to 6 enemies&#x27; buff at 100% success rate"/>
   </imgdir>
   <imgdir name="131">
     <string name="bookName" value="Dragon Knight&apos;s Path"/>
   </imgdir>
   <imgdir name="1310000">
     <string name="name" value="Elemental Resistance"/>
-    <string name="desc" value="[Master Level : 20]\n Gains resistance against all Magic attacks (Fire, Cold, Lightning &amp; Poison.)"/>
-    <string name="h1" value="12% Increased resistance on every element type"/>
-    <string name="h2" value="14% Increased resistance on every element type"/>
-    <string name="h3" value="16% Increased resistance on every element type"/>
-    <string name="h4" value="18% Increased resistance on every element type"/>
-    <string name="h5" value="20% Increased resistance on every element type"/>
-    <string name="h6" value="22% Increased resistance on every element type"/>
-    <string name="h7" value="24% Increased resistance on every element type"/>
-    <string name="h8" value="26% Increased resistance on every element type"/>
-    <string name="h9" value="28% Increased resistance on every element type"/>
-    <string name="h10" value="30% Increased resistance on every element type"/>
-    <string name="h11" value="31% Increased resistance on every element type"/>
-    <string name="h12" value="32% Increased resistance on every element type"/>
-    <string name="h13" value="33% Increased resistance on every element type"/>
-    <string name="h14" value="34% Increased resistance on every element type"/>
-    <string name="h15" value="35% Increased resistance on every element type"/>
-    <string name="h16" value="36% Increased resistance on every element type"/>
-    <string name="h17" value="37% Increased resistance on every element type"/>
-    <string name="h18" value="38% Increased resistance on every element type"/>
-    <string name="h19" value="39% Increased resistance on every element type"/>
-    <string name="h20" value="40% Increased resistance on every element type"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases resistance against elemental magic attacks."/>
+    <string name="h1" value="Elemental magic resistance +12%"/>
+    <string name="h2" value="Elemental magic resistance +14%"/>
+    <string name="h3" value="Elemental magic resistance +16%"/>
+    <string name="h4" value="Elemental magic resistance +18%"/>
+    <string name="h5" value="Elemental magic resistance +20%"/>
+    <string name="h6" value="Elemental magic resistance +22%"/>
+    <string name="h7" value="Elemental magic resistance +24%"/>
+    <string name="h8" value="Elemental magic resistance +26%"/>
+    <string name="h9" value="Elemental magic resistance +28%"/>
+    <string name="h10" value="Elemental magic resistance +30%"/>
+    <string name="h11" value="Elemental magic resistance +31%"/>
+    <string name="h12" value="Elemental magic resistance +32%"/>
+    <string name="h13" value="Elemental magic resistance +33%"/>
+    <string name="h14" value="Elemental magic resistance +34%"/>
+    <string name="h15" value="Elemental magic resistance +35%"/>
+    <string name="h16" value="Elemental magic resistance +36%"/>
+    <string name="h17" value="Elemental magic resistance +37%"/>
+    <string name="h18" value="Elemental magic resistance +38%"/>
+    <string name="h19" value="Elemental magic resistance +39%"/>
+    <string name="h20" value="Elemental magic resistance +40%"/>
   </imgdir>
   <imgdir name="1311001">
     <string name="name" value="Spear Crusher"/>
-    <string name="desc" value="[Master Level : 30]\nAttacks multiple monsters several times by thrusting the spear."/>
-    <string name="h1" value="Use 10 MP, Damage 55%, Attack 1 Enemy 2 Times"/>
-    <string name="h2" value="Use 10 MP, Damage 60%, Attack 1 Enemy 2 Times"/>
-    <string name="h3" value="Use 10 MP, Damage 65%, Attack 1 Enemy 2 Times"/>
-    <string name="h4" value="Use 10 MP, Damage 70%, Attack 1 Enemy 2 Times"/>
-    <string name="h5" value="Use 10 MP, Damage 75%, Attack 1 Enemy 2 Times"/>
-    <string name="h6" value="Use 13 MP, Damage 80%, Attack 2 Enemies 2 Times"/>
-    <string name="h7" value="Use 13 MP, Damage 85%, Attack 2 Enemies 2 Times"/>
-    <string name="h8" value="Use 13 MP, Damage 90%, Attack 2 Enemies 2 Times"/>
-    <string name="h9" value="Use 13 MP, Damage 95%, Attack 2 Enemies 2 Times"/>
-    <string name="h10" value="Use 13 MP, Damage 100%, Attack 2 Enemies 2 Times"/>
-    <string name="h11" value="Use 16 MP, Damage 104%, Attack 3 Enemies 2 Times"/>
-    <string name="h12" value="Use 16 MP, Damage 108%, Attack 3 Enemies 2 Times"/>
-    <string name="h13" value="Use 16 MP, Damage 112%, Attack 3 Enemies 2 Times"/>
-    <string name="h14" value="Use 16 MP, Damage 116%, Attack 3 Enemies 2 Times"/>
-    <string name="h15" value="Use 16 MP, Damage 120%, Attack 3 Enemies 2 Times"/>
-    <string name="h16" value="Use 19 MP, Damage 124%, Attack 1 Enemy 3 Times"/>
-    <string name="h17" value="Use 19 MP, Damage 128%, Attack 1 Enemy 3 Times"/>
-    <string name="h18" value="Use 19 MP, Damage 132%, Attack 1 Enemy 3 Times"/>
-    <string name="h19" value="Use 19 MP, Damage 136%, Attack 1 Enemy 3 Times"/>
-    <string name="h20" value="Use 19 MP, Damage 140%, Attack 1 Enemy 3 Times"/>
-    <string name="h21" value="Use 21 MP, Damage 144%, Attack 2 Enemies 3 Times"/>
-    <string name="h22" value="Use 21 MP, Damage 146%, Attack 2 Enemies 3 Times"/>
-    <string name="h23" value="Use 21 MP, Damage 149%, Attack 2 Enemies 3 Times"/>
-    <string name="h24" value="Use 21 MP, Damage 152%, Attack 2 Enemies 3 Times"/>
-    <string name="h25" value="Use 21 MP, Damage 155%, Attack 2 Enemies 3 Times"/>
-    <string name="h26" value="Use 24 MP, Damage 158%, Attack 3 Enemies 3 Times"/>
-    <string name="h27" value="Use 24 MP, Damage 161%, Attack 3 Enemies 3 Times"/>
-    <string name="h28" value="Use 24 MP, Damage 164%, Attack 3 Enemies 3 Times"/>
-    <string name="h29" value="Use 24 MP, Damage 167%, Attack 3 Enemies 3 Times"/>
-    <string name="h30" value="Use 24 MP, Damage 170%, Attack 3 Enemies 3 Times"/>
+    <string name="desc" value="[Master Level: 30]\nThrusts the spear to attack multiple monsters several times."/>
+    <string name="h1" value="MP -10; Damage 55%; attacks 2 times; up to 1 enemies"/>
+    <string name="h2" value="MP -10; Damage 60%; attacks 2 times; up to 1 enemies"/>
+    <string name="h3" value="MP -10; Damage 65%; attacks 2 times; up to 1 enemies"/>
+    <string name="h4" value="MP -10; Damage 70%; attacks 2 times; up to 1 enemies"/>
+    <string name="h5" value="MP -10; Damage 75%; attacks 2 times; up to 1 enemies"/>
+    <string name="h6" value="MP -13; Damage 80%; attacks 2 times; up to 2 enemies"/>
+    <string name="h7" value="MP -13; Damage 85%; attacks 2 times; up to 2 enemies"/>
+    <string name="h8" value="MP -13; Damage 90%; attacks 2 times; up to 2 enemies"/>
+    <string name="h9" value="MP -13; Damage 95%; attacks 2 times; up to 2 enemies"/>
+    <string name="h10" value="MP -13; Damage 100%; attacks 2 times; up to 2 enemies"/>
+    <string name="h11" value="MP -16; Damage 104%; attacks 2 times; up to 3 enemies"/>
+    <string name="h12" value="MP -16; Damage 108%; attacks 2 times; up to 3 enemies"/>
+    <string name="h13" value="MP -16; Damage 112%; attacks 2 times; up to 3 enemies"/>
+    <string name="h14" value="MP -16; Damage 116%; attacks 2 times; up to 3 enemies"/>
+    <string name="h15" value="MP -16; Damage 120%; attacks 2 times; up to 3 enemies"/>
+    <string name="h16" value="MP -19; Damage 124%; attacks 3 times; up to 1 enemies"/>
+    <string name="h17" value="MP -19; Damage 128%; attacks 3 times; up to 1 enemies"/>
+    <string name="h18" value="MP -19; Damage 132%; attacks 3 times; up to 1 enemies"/>
+    <string name="h19" value="MP -19; Damage 136%; attacks 3 times; up to 1 enemies"/>
+    <string name="h20" value="MP -19; Damage 140%; attacks 3 times; up to 1 enemies"/>
+    <string name="h21" value="MP -21; Damage 144%; attacks 3 times; up to 2 enemies"/>
+    <string name="h22" value="MP -21; Damage 146%; attacks 3 times; up to 2 enemies"/>
+    <string name="h23" value="MP -21; Damage 149%; attacks 3 times; up to 2 enemies"/>
+    <string name="h24" value="MP -21; Damage 152%; attacks 3 times; up to 2 enemies"/>
+    <string name="h25" value="MP -21; Damage 155%; attacks 3 times; up to 2 enemies"/>
+    <string name="h26" value="MP -24; Damage 158%; attacks 3 times; up to 3 enemies"/>
+    <string name="h27" value="MP -24; Damage 161%; attacks 3 times; up to 3 enemies"/>
+    <string name="h28" value="MP -24; Damage 164%; attacks 3 times; up to 3 enemies"/>
+    <string name="h29" value="MP -24; Damage 167%; attacks 3 times; up to 3 enemies"/>
+    <string name="h30" value="MP -24; Damage 170%; attacks 3 times; up to 3 enemies"/>
   </imgdir>
   <imgdir name="1311002">
     <string name="name" value="Pole Arm Crusher"/>
-    <string name="desc" value="[Master Level : 30]\nAttacks multiple monsters several times by thrusting the pole arm."/>
-    <string name="h1" value="Use 10 MP, Damage 55%, Attack 1 Enemy 2 Times"/>
-    <string name="h2" value="Use 10 MP, Damage 60%, Attack 1 Enemy 2 Times"/>
-    <string name="h3" value="Use 10 MP, Damage 65%, Attack 1 Enemy 2 Times"/>
-    <string name="h4" value="Use 10 MP, Damage 70%, Attack 1 Enemy 2 Times"/>
-    <string name="h5" value="Use 10 MP, Damage 75%, Attack 1 Enemy 2 Times"/>
-    <string name="h6" value="Use 13 MP, Damage 80%, Attack 2 Enemies 2 Times"/>
-    <string name="h7" value="Use 13 MP, Damage 85%, Attack 2 Enemies 2 Times"/>
-    <string name="h8" value="Use 13 MP, Damage 90%, Attack 2 Enemies 2 Times"/>
-    <string name="h9" value="Use 13 MP, Damage 95%, Attack 2 Enemies 2 Times"/>
-    <string name="h10" value="Use 16 MP, Damage 100%, Attack 3 Enemies 2 Times"/>
-    <string name="h11" value="Use 16 MP, Damage 104%, Attack 3 Enemies 2 Times"/>
-    <string name="h12" value="Use 16 MP, Damage 108%, Attack 3 Enemies 2 Times"/>
-    <string name="h13" value="Use 16 MP, Damage 112%, Attack 3 Enemies 2 Times"/>
-    <string name="h14" value="Use 16 MP, Damage 116%, Attack 3 Enemies 2 Times"/>
-    <string name="h15" value="Use 16 MP, Damage 120%, Attack 3 Enemies 2 Times"/>
-    <string name="h16" value="Use 19 MP, Damage 124%, Attack 1 Enemy 3 Times"/>
-    <string name="h17" value="Use 19 MP, Damage 128%, Attack 1 Enemy 3 Times"/>
-    <string name="h18" value="Use 19 MP, Damage 132%, Attack 1 Enemy 3 Times"/>
-    <string name="h19" value="Use 19 MP, Damage 136%, Attack 1 Enemy 3 Times"/>
-    <string name="h20" value="Use 19 MP, Damage 140%, Attack 1 Enemy 3 Times"/>
-    <string name="h21" value="Use 21 MP, Damage 143%, Attack 2 Enemies 3 Times"/>
-    <string name="h22" value="Use 21 MP, Damage 146%, Attack 2 Enemies 3 Times"/>
-    <string name="h23" value="Use 21 MP, Damage 149%, Attack 2 Enemies 3 Times"/>
-    <string name="h24" value="Use 21 MP, Damage 152%, Attack 2 Enemies 3 Times"/>
-    <string name="h25" value="Use 21 MP, Damage 155%, Attack 2 Enemies 3 Times"/>
-    <string name="h26" value="Use 24 MP, Damage 158%, Attack 3 Enemies 3 Times"/>
-    <string name="h27" value="Use 24 MP, Damage 161%, Attack 3 Enemies 3 Times"/>
-    <string name="h28" value="Use 24 MP, Damage 164%, Attack 3 Enemies 3 Times"/>
-    <string name="h29" value="Use 24 MP, Damage 167%, Attack 3 Enemies 3 Times"/>
-    <string name="h30" value="Use 24 MP, Damage 170%, Attack 3 Enemies 3 Times"/>
+    <string name="desc" value="[Master Level: 30]\nThrusts the pole arm to attack multiple monsters several times."/>
+    <string name="h1" value="MP -10; Damage 55%; attacks 2 times; up to 1 enemies"/>
+    <string name="h2" value="MP -10; Damage 60%; attacks 2 times; up to 1 enemies"/>
+    <string name="h3" value="MP -10; Damage 65%; attacks 2 times; up to 1 enemies"/>
+    <string name="h4" value="MP -10; Damage 70%; attacks 2 times; up to 1 enemies"/>
+    <string name="h5" value="MP -10; Damage 75%; attacks 2 times; up to 1 enemies"/>
+    <string name="h6" value="MP -13; Damage 80%; attacks 2 times; up to 2 enemies"/>
+    <string name="h7" value="MP -13; Damage 85%; attacks 2 times; up to 2 enemies"/>
+    <string name="h8" value="MP -13; Damage 90%; attacks 2 times; up to 2 enemies"/>
+    <string name="h9" value="MP -13; Damage 95%; attacks 2 times; up to 2 enemies"/>
+    <string name="h10" value="MP -13; Damage 100%; attacks 2 times; up to 2 enemies"/>
+    <string name="h11" value="MP -16; Damage 104%; attacks 2 times; up to 3 enemies"/>
+    <string name="h12" value="MP -16; Damage 108%; attacks 2 times; up to 3 enemies"/>
+    <string name="h13" value="MP -16; Damage 112%; attacks 2 times; up to 3 enemies"/>
+    <string name="h14" value="MP -16; Damage 116%; attacks 2 times; up to 3 enemies"/>
+    <string name="h15" value="MP -16; Damage 120%; attacks 2 times; up to 3 enemies"/>
+    <string name="h16" value="MP -19; Damage 124%; attacks 3 times; up to 1 enemies"/>
+    <string name="h17" value="MP -19; Damage 128%; attacks 3 times; up to 1 enemies"/>
+    <string name="h18" value="MP -19; Damage 132%; attacks 3 times; up to 1 enemies"/>
+    <string name="h19" value="MP -19; Damage 136%; attacks 3 times; up to 1 enemies"/>
+    <string name="h20" value="MP -19; Damage 140%; attacks 3 times; up to 1 enemies"/>
+    <string name="h21" value="MP -21; Damage 144%; attacks 3 times; up to 2 enemies"/>
+    <string name="h22" value="MP -21; Damage 146%; attacks 3 times; up to 2 enemies"/>
+    <string name="h23" value="MP -21; Damage 149%; attacks 3 times; up to 2 enemies"/>
+    <string name="h24" value="MP -21; Damage 152%; attacks 3 times; up to 2 enemies"/>
+    <string name="h25" value="MP -21; Damage 155%; attacks 3 times; up to 2 enemies"/>
+    <string name="h26" value="MP -24; Damage 158%; attacks 3 times; up to 3 enemies"/>
+    <string name="h27" value="MP -24; Damage 161%; attacks 3 times; up to 3 enemies"/>
+    <string name="h28" value="MP -24; Damage 164%; attacks 3 times; up to 3 enemies"/>
+    <string name="h29" value="MP -24; Damage 167%; attacks 3 times; up to 3 enemies"/>
+    <string name="h30" value="MP -24; Damage 170%; attacks 3 times; up to 3 enemies"/>
   </imgdir>
   <imgdir name="1311003">
     <string name="name" value="Dragon Fury: Spear"/>
-    <string name="desc" value="[Master Level : 30]\n Attacks up to 6 monsters nearby in relatively distant range by swinging the Spear."/>
-    <string name="h1" value="Use 20 HP, 10 MP, Damage 80%"/>
-    <string name="h2" value="Use 20 HP, 10 MP, Damage 90%"/>
-    <string name="h3" value="Use 20 HP, 10 MP, Damage 100%"/>
-    <string name="h4" value="Use 20 HP, 10 MP, Damage 110%"/>
-    <string name="h5" value="Use 20 HP, 10 MP, Damage 120%"/>
-    <string name="h6" value="Use 20 HP, 10 MP, Damage 130%"/>
-    <string name="h7" value="Use 20 HP, 10 MP, Damage 140%"/>
-    <string name="h8" value="Use 20 HP, 10 MP, Damage 150%"/>
-    <string name="h9" value="Use 20 HP, 10 MP, Damage 160%"/>
-    <string name="h10" value="Use 20 HP, 10 MP, Damage 170%"/>
-    <string name="h11" value="Use 25 HP, 15 MP, Damage 175%"/>
-    <string name="h12" value="Use 25 HP, 15 MP, Damage 180%"/>
-    <string name="h13" value="Use 25 HP, 15 MP, Damage 185%"/>
-    <string name="h14" value="Use 25 HP, 15 MP, Damage 190%"/>
-    <string name="h15" value="Use 25 HP, 15 MP, Damage 195%"/>
-    <string name="h16" value="Use 25 HP, 15 MP, Damage 200%"/>
-    <string name="h17" value="Use 25 HP, 15 MP, Damage 205%"/>
-    <string name="h18" value="Use 25 HP, 15 MP, Damage 210%"/>
-    <string name="h19" value="Use 25 HP, 15 MP, Damage 215%"/>
-    <string name="h20" value="Use 25 HP, 15 MP, Damage 220%"/>
-    <string name="h21" value="Use 30 HP, 20 MP, Damage 223%"/>
-    <string name="h22" value="Use 30 HP, 20 MP, Damage 226%"/>
-    <string name="h23" value="Use 30 HP, 20 MP, Damage 229%"/>
-    <string name="h24" value="Use 30 HP, 20 MP, Damage 232%"/>
-    <string name="h25" value="Use 30 HP, 20 MP, Damage 235%"/>
-    <string name="h26" value="Use 30 HP, 20 MP, Damage 238%"/>
-    <string name="h27" value="Use 30 HP, 20 MP, Damage 241%"/>
-    <string name="h28" value="Use 30 HP, 20 MP, Damage 244%"/>
-    <string name="h29" value="Use 30 HP, 20 MP, Damage 247%"/>
-    <string name="h30" value="Use 30 HP, 20 MP, Damage 250%"/>
+    <string name="desc" value="[Master Level: 30]\nSwings the spear to attack up to 6 nearby monsters."/>
+    <string name="h1" value="HP -20; MP -10; HP -20; MP -10; Damage 80%; attacks up to 6 enemies"/>
+    <string name="h2" value="HP -20; MP -10; HP -20; MP -10; Damage 90%; attacks up to 6 enemies"/>
+    <string name="h3" value="HP -20; MP -10; HP -20; MP -10; Damage 100%; attacks up to 6 enemies"/>
+    <string name="h4" value="HP -20; MP -10; HP -20; MP -10; Damage 110%; attacks up to 6 enemies"/>
+    <string name="h5" value="HP -20; MP -10; HP -20; MP -10; Damage 120%; attacks up to 6 enemies"/>
+    <string name="h6" value="HP -20; MP -10; HP -20; MP -10; Damage 130%; attacks up to 6 enemies"/>
+    <string name="h7" value="HP -20; MP -10; HP -20; MP -10; Damage 140%; attacks up to 6 enemies"/>
+    <string name="h8" value="HP -20; MP -10; HP -20; MP -10; Damage 150%; attacks up to 6 enemies"/>
+    <string name="h9" value="HP -20; MP -10; HP -20; MP -10; Damage 160%; attacks up to 6 enemies"/>
+    <string name="h10" value="HP -20; MP -10; HP -20; MP -10; Damage 170%; attacks up to 6 enemies"/>
+    <string name="h11" value="HP -25; MP -15; HP -25; MP -15; Damage 175%; attacks up to 6 enemies"/>
+    <string name="h12" value="HP -25; MP -15; HP -25; MP -15; Damage 180%; attacks up to 6 enemies"/>
+    <string name="h13" value="HP -25; MP -15; HP -25; MP -15; Damage 185%; attacks up to 6 enemies"/>
+    <string name="h14" value="HP -25; MP -15; HP -25; MP -15; Damage 190%; attacks up to 6 enemies"/>
+    <string name="h15" value="HP -25; MP -15; HP -25; MP -15; Damage 195%; attacks up to 6 enemies"/>
+    <string name="h16" value="HP -25; MP -15; HP -25; MP -15; Damage 200%; attacks up to 6 enemies"/>
+    <string name="h17" value="HP -25; MP -15; HP -25; MP -15; Damage 205%; attacks up to 6 enemies"/>
+    <string name="h18" value="HP -25; MP -15; HP -25; MP -15; Damage 210%; attacks up to 6 enemies"/>
+    <string name="h19" value="HP -25; MP -15; HP -25; MP -15; Damage 215%; attacks up to 6 enemies"/>
+    <string name="h20" value="HP -25; MP -15; HP -25; MP -15; Damage 220%; attacks up to 6 enemies"/>
+    <string name="h21" value="HP -30; MP -20; HP -30; MP -20; Damage 223%; attacks up to 6 enemies"/>
+    <string name="h22" value="HP -30; MP -20; HP -30; MP -20; Damage 226%; attacks up to 6 enemies"/>
+    <string name="h23" value="HP -30; MP -20; HP -30; MP -20; Damage 229%; attacks up to 6 enemies"/>
+    <string name="h24" value="HP -30; MP -20; HP -30; MP -20; Damage 232%; attacks up to 6 enemies"/>
+    <string name="h25" value="HP -30; MP -20; HP -30; MP -20; Damage 235%; attacks up to 6 enemies"/>
+    <string name="h26" value="HP -30; MP -20; HP -30; MP -20; Damage 238%; attacks up to 6 enemies"/>
+    <string name="h27" value="HP -30; MP -20; HP -30; MP -20; Damage 241%; attacks up to 6 enemies"/>
+    <string name="h28" value="HP -30; MP -20; HP -30; MP -20; Damage 244%; attacks up to 6 enemies"/>
+    <string name="h29" value="HP -30; MP -20; HP -30; MP -20; Damage 247%; attacks up to 6 enemies"/>
+    <string name="h30" value="HP -30; MP -20; HP -30; MP -20; Damage 250%; attacks up to 6 enemies"/>
   </imgdir>
   <imgdir name="1311004">
     <string name="name" value="Dragon Fury: Pole Arm"/>
-    <string name="desc" value="[Master Level : 30]\n Attacks up to 6 monsters nearby in relatively distant range by swinging the pole arm."/>
-    <string name="h1" value="Use 20 HP, 10 MP, Damage 80%"/>
-    <string name="h2" value="Use 20 HP, 10 MP, Damage 90%"/>
-    <string name="h3" value="Use 20 HP, 10 MP, Damage 100%"/>
-    <string name="h4" value="Use 20 HP, 10 MP, Damage 110%"/>
-    <string name="h5" value="Use 20 HP, 10 MP, Damage 120%"/>
-    <string name="h6" value="Use 20 HP, 10 MP, Damage 130%"/>
-    <string name="h7" value="Use 20 HP, 10 MP, Damage 140%"/>
-    <string name="h8" value="Use 20 HP, 10 MP, Damage 150%"/>
-    <string name="h9" value="Use 20 HP, 10 MP, Damage 160%"/>
-    <string name="h10" value="Use 20 HP, 10 MP, Damage 170%"/>
-    <string name="h11" value="Use 25 HP, 15 MP, Damage 175%"/>
-    <string name="h12" value="Use 25 HP, 15 MP, Damage 180%"/>
-    <string name="h13" value="Use 25 HP, 15 MP, Damage 185%"/>
-    <string name="h14" value="Use 25 HP, 15 MP, Damage 190%"/>
-    <string name="h15" value="Use 25 HP, 15 MP, Damage 195%"/>
-    <string name="h16" value="Use 25 HP, 15 MP, Damage 200%"/>
-    <string name="h17" value="Use 25 HP, 15 MP, Damage 205%"/>
-    <string name="h18" value="Use 25 HP, 15 MP, Damage 210%"/>
-    <string name="h19" value="Use 25 HP, 15 MP, Damage 215%"/>
-    <string name="h20" value="Use 25 HP, 15 MP, Damage 220%"/>
-    <string name="h21" value="Use 30 HP, 20 MP, Damage 223%"/>
-    <string name="h22" value="Use 30 HP, 20 MP, Damage 226%"/>
-    <string name="h23" value="Use 30 HP, 20 MP, Damage 229%"/>
-    <string name="h24" value="Use 30 HP, 20 MP, Damage 232%"/>
-    <string name="h25" value="Use 30 HP, 20 MP, Damage 235%"/>
-    <string name="h26" value="Use 30 HP, 20 MP, Damage 238%"/>
-    <string name="h27" value="Use 30 HP, 20 MP, Damage 241%"/>
-    <string name="h28" value="Use 30 HP, 20 MP, Damage 244%"/>
-    <string name="h29" value="Use 30 HP, 20 MP, Damage 247%"/>
-    <string name="h30" value="Use 30 HP, 20 MP, Damage 250%"/>
+    <string name="desc" value="[Master Level: 30]\nSwings the pole arm to attack up to 6 nearby monsters."/>
+    <string name="h1" value="HP -20; MP -10; HP -20; MP -10; Damage 80%; attacks up to 6 enemies"/>
+    <string name="h2" value="HP -20; MP -10; HP -20; MP -10; Damage 90%; attacks up to 6 enemies"/>
+    <string name="h3" value="HP -20; MP -10; HP -20; MP -10; Damage 100%; attacks up to 6 enemies"/>
+    <string name="h4" value="HP -20; MP -10; HP -20; MP -10; Damage 110%; attacks up to 6 enemies"/>
+    <string name="h5" value="HP -20; MP -10; HP -20; MP -10; Damage 120%; attacks up to 6 enemies"/>
+    <string name="h6" value="HP -20; MP -10; HP -20; MP -10; Damage 130%; attacks up to 6 enemies"/>
+    <string name="h7" value="HP -20; MP -10; HP -20; MP -10; Damage 140%; attacks up to 6 enemies"/>
+    <string name="h8" value="HP -20; MP -10; HP -20; MP -10; Damage 150%; attacks up to 6 enemies"/>
+    <string name="h9" value="HP -20; MP -10; HP -20; MP -10; Damage 160%; attacks up to 6 enemies"/>
+    <string name="h10" value="HP -20; MP -10; HP -20; MP -10; Damage 170%; attacks up to 6 enemies"/>
+    <string name="h11" value="HP -25; MP -15; HP -25; MP -15; Damage 175%; attacks up to 6 enemies"/>
+    <string name="h12" value="HP -25; MP -15; HP -25; MP -15; Damage 180%; attacks up to 6 enemies"/>
+    <string name="h13" value="HP -25; MP -15; HP -25; MP -15; Damage 185%; attacks up to 6 enemies"/>
+    <string name="h14" value="HP -25; MP -15; HP -25; MP -15; Damage 190%; attacks up to 6 enemies"/>
+    <string name="h15" value="HP -25; MP -15; HP -25; MP -15; Damage 195%; attacks up to 6 enemies"/>
+    <string name="h16" value="HP -25; MP -15; HP -25; MP -15; Damage 200%; attacks up to 6 enemies"/>
+    <string name="h17" value="HP -25; MP -15; HP -25; MP -15; Damage 205%; attacks up to 6 enemies"/>
+    <string name="h18" value="HP -25; MP -15; HP -25; MP -15; Damage 210%; attacks up to 6 enemies"/>
+    <string name="h19" value="HP -25; MP -15; HP -25; MP -15; Damage 215%; attacks up to 6 enemies"/>
+    <string name="h20" value="HP -25; MP -15; HP -25; MP -15; Damage 220%; attacks up to 6 enemies"/>
+    <string name="h21" value="HP -30; MP -20; HP -30; MP -20; Damage 223%; attacks up to 6 enemies"/>
+    <string name="h22" value="HP -30; MP -20; HP -30; MP -20; Damage 226%; attacks up to 6 enemies"/>
+    <string name="h23" value="HP -30; MP -20; HP -30; MP -20; Damage 229%; attacks up to 6 enemies"/>
+    <string name="h24" value="HP -30; MP -20; HP -30; MP -20; Damage 232%; attacks up to 6 enemies"/>
+    <string name="h25" value="HP -30; MP -20; HP -30; MP -20; Damage 235%; attacks up to 6 enemies"/>
+    <string name="h26" value="HP -30; MP -20; HP -30; MP -20; Damage 238%; attacks up to 6 enemies"/>
+    <string name="h27" value="HP -30; MP -20; HP -30; MP -20; Damage 241%; attacks up to 6 enemies"/>
+    <string name="h28" value="HP -30; MP -20; HP -30; MP -20; Damage 244%; attacks up to 6 enemies"/>
+    <string name="h29" value="HP -30; MP -20; HP -30; MP -20; Damage 247%; attacks up to 6 enemies"/>
+    <string name="h30" value="HP -30; MP -20; HP -30; MP -20; Damage 250%; attacks up to 6 enemies"/>
   </imgdir>
   <imgdir name="1311005">
     <string name="name" value="Sacrifice"/>
-    <string name="desc" value="[Master Level: 30]\n Attacks a single monster while disabling the monster&apos;s defending capacity. However, some damage will be done to the attacker him/herself. "/>
-    <string name="h1" value="Use 12 MP, Damage 205%, Sacrifice HP by 20% of Damage"/>
-    <string name="h2" value="Use 12 MP, Damage 210%, Sacrifice HP by 19% of Damage"/>
-    <string name="h3" value="Use 12 MP, Damage 215%, Sacrifice HP by 19% of Damage"/>
-    <string name="h4" value="Use 12 MP, Damage 220%, Sacrifice HP by 18% of Damage"/>
-    <string name="h5" value="Use 12 MP, Damage 225%, Sacrifice HP by 18% of Damage"/>
-    <string name="h6" value="Use 12 MP, Damage 230%, Sacrifice HP by 17% of Damage"/>
-    <string name="h7" value="Use 12 MP, Damage 235%, Sacrifice HP by 17% of Damage"/>
-    <string name="h8" value="Use 12 MP, Damage 240%, Sacrifice HP by 16% of Damage"/>
-    <string name="h9" value="Use 12 MP, Damage 245%, Sacrifice HP by 16% of Damage"/>
-    <string name="h10" value="Use 12 MP, Damage 250%, Sacrifice HP by 15% of Damage"/>
-    <string name="h11" value="Use 15 MP, Damage 255%, Sacrifice HP by 15% of Damage"/>
-    <string name="h12" value="Use 15 MP, Damage 260%, Sacrifice HP by 14% of Damage"/>
-    <string name="h13" value="Use 15 MP, Damage 265%, Sacrifice HP by 14% of Damage"/>
-    <string name="h14" value="Use 15 MP, Damage 270%, Sacrifice HP by 13% of Damage"/>
-    <string name="h15" value="Use 15 MP, Damage 275%, Sacrifice HP by 13% of Damage"/>
-    <string name="h16" value="Use 15 MP, Damage 280%, Sacrifice HP by 12% of Damage"/>
-    <string name="h17" value="Use 15 MP, Damage 285%, Sacrifice HP by 12% of Damage"/>
-    <string name="h18" value="Use 15 MP, Damage 290%, Sacrifice HP by 11% of Damage"/>
-    <string name="h19" value="Use 15 MP, Damage 295%, Sacrifice HP by 11% of Damage"/>
-    <string name="h20" value="Use 15 MP, Damage 300%, Sacrifice HP by 10% of Damage"/>
-    <string name="h21" value="Use 18 MP, Damage 305%, Sacrifice HP by 10% of Damage"/>
-    <string name="h22" value="Use 18 MP, Damage 310%, Sacrifice HP by 9% of Damage"/>
-    <string name="h23" value="Use 18 MP, Damage 315%, Sacrifice HP by 9% of Damage"/>
-    <string name="h24" value="Use 18 MP, Damage 320%, Sacrifice HP by 8% of Damage"/>
-    <string name="h25" value="Use 18 MP, Damage 325%, Sacrifice HP by 8% of Damage"/>
-    <string name="h26" value="Use 18 MP, Damage 330%, Sacrifice HP by 7% of Damage"/>
-    <string name="h27" value="Use 18 MP, Damage 335%, Sacrifice HP by7% of Damage"/>
-    <string name="h28" value="Use 18 MP, Damage 340%, Sacrifice HP by 6% of Damage"/>
-    <string name="h29" value="Use 18 MP, Damage 345%, Sacrifice HP by 6% of Damage"/>
-    <string name="h30" value="Use 18 MP, Damage 350%, Sacrifice HP by 5% of Damage"/>
+    <string name="desc" value="[Master Level: 30]\nAttacks one monster while ignoring its defense, but sacrifices a portion of the damage as HP."/>
+    <string name="h1" value="MP -12; Damage 205%; lose HP equal to 20% of damage dealt"/>
+    <string name="h2" value="MP -12; Damage 210%; lose HP equal to 19% of damage dealt"/>
+    <string name="h3" value="MP -12; Damage 215%; lose HP equal to 19% of damage dealt"/>
+    <string name="h4" value="MP -12; Damage 220%; lose HP equal to 18% of damage dealt"/>
+    <string name="h5" value="MP -12; Damage 225%; lose HP equal to 18% of damage dealt"/>
+    <string name="h6" value="MP -12; Damage 230%; lose HP equal to 17% of damage dealt"/>
+    <string name="h7" value="MP -12; Damage 235%; lose HP equal to 17% of damage dealt"/>
+    <string name="h8" value="MP -12; Damage 240%; lose HP equal to 16% of damage dealt"/>
+    <string name="h9" value="MP -12; Damage 245%; lose HP equal to 16% of damage dealt"/>
+    <string name="h10" value="MP -12; Damage 250%; lose HP equal to 15% of damage dealt"/>
+    <string name="h11" value="MP -15; Damage 255%; lose HP equal to 15% of damage dealt"/>
+    <string name="h12" value="MP -15; Damage 260%; lose HP equal to 14% of damage dealt"/>
+    <string name="h13" value="MP -15; Damage 265%; lose HP equal to 14% of damage dealt"/>
+    <string name="h14" value="MP -15; Damage 270%; lose HP equal to 13% of damage dealt"/>
+    <string name="h15" value="MP -15; Damage 275%; lose HP equal to 13% of damage dealt"/>
+    <string name="h16" value="MP -15; Damage 280%; lose HP equal to 12% of damage dealt"/>
+    <string name="h17" value="MP -15; Damage 285%; lose HP equal to 12% of damage dealt"/>
+    <string name="h18" value="MP -15; Damage 290%; lose HP equal to 11% of damage dealt"/>
+    <string name="h19" value="MP -15; Damage 295%; lose HP equal to 11% of damage dealt"/>
+    <string name="h20" value="MP -15; Damage 300%; lose HP equal to 10% of damage dealt"/>
+    <string name="h21" value="MP -18; Damage 305%; lose HP equal to 10% of damage dealt"/>
+    <string name="h22" value="MP -18; Damage 310%; lose HP equal to 9% of damage dealt"/>
+    <string name="h23" value="MP -18; Damage 315%; lose HP equal to 9% of damage dealt"/>
+    <string name="h24" value="MP -18; Damage 320%; lose HP equal to 8% of damage dealt"/>
+    <string name="h25" value="MP -18; Damage 325%; lose HP equal to 8% of damage dealt"/>
+    <string name="h26" value="MP -18; Damage 330%; lose HP equal to 7% of damage dealt"/>
+    <string name="h27" value="MP -18; Damage 335%; lose HP equal to 7% of damage dealt"/>
+    <string name="h28" value="MP -18; Damage 340%; lose HP equal to 6% of damage dealt"/>
+    <string name="h29" value="MP -18; Damage 345%; lose HP equal to 6% of damage dealt"/>
+    <string name="h30" value="MP -18; Damage 350%; lose HP equal to 5% of damage dealt"/>
   </imgdir>
   <imgdir name="1311006">
     <string name="name" value="Dragon Roar"/>
-    <string name="desc" value="[Master Level : 30]\n Attacks up to 15 monsters at once by temporarily stunning them.  It works only when more than 50% of HP is left.\nRequired Skill : #cAt least Level 3 on Sacrifice#"/>
-    <string name="h1" value="Use 16 MP, 59% HP, Damage 96%, Attack Range 110%, Stun for 4 Seconds"/>
-    <string name="h2" value="Use 16 MP, 58% HP, Damage 102%, Attack Range 120%, Stun for 4 Seconds"/>
-    <string name="h3" value="Use 16 MP, 57% HP, Damage 108%, Attack Range 130%, Stun for 4 Seconds"/>
-    <string name="h4" value="Use 16 MP, 56% HP, Damage 114%, Attack Range 140%, Stun for 4 Seconds"/>
-    <string name="h5" value="Use 16 MP, 55% HP, Damage 120%, Attack Range 150%, Stun for 4 Seconds"/>
-    <string name="h6" value="Use 16 MP, 54% HP, Damage 126%, Attack Range 160%, Stun for 4 Seconds"/>
-    <string name="h7" value="Use 16 MP, 53% HP, Damage 132%, Attack Range 170%, Stun for 4 Seconds"/>
-    <string name="h8" value="Use 16 MP, 52% HP, Damage 138%, Attack Range 180%, Stun for 4 Seconds"/>
-    <string name="h9" value="Use 16 MP, 51% HP, Damage 144%, Attack Range 190%, Stun for 4 Seconds"/>
-    <string name="h10" value="Use 24 MP, 50% HP, Damage 150%, Attack Range 200%, Stun for 4 Seconds"/>
-    <string name="h11" value="Use 24 MP, 49% HP, Damage 155%, Attack Range 210%, Stun for 3 Seconds"/>
-    <string name="h12" value="Use 24 MP, 48% HP, Damage 160%, Attack Range 220%, Stun for 3 Seconds"/>
-    <string name="h13" value="Use 24 MP, 47% HP, Damage 165%, Attack Range 230%, Stun for 3 Seconds"/>
-    <string name="h14" value="Use 24 MP, 46% HP, Damage 170%, Attack Range 240%, Stun for 3 Seconds"/>
-    <string name="h15" value="Use 24 MP, 45% HP, Damage 175%, Attack Range 250%, Stun for 3 Seconds"/>
-    <string name="h16" value="Use 24 MP, 44% HP, Damage 180%, Attack Range 260%, Stun for 3 Seconds"/>
-    <string name="h17" value="Use 24 MP, 43% HP, Damage 185%, Attack Range 270%, Stun for 3 Seconds"/>
-    <string name="h18" value="Use 24 MP, 42% HP, Damage 190%, Attack Range 190%, Stun for 3 Seconds"/>
-    <string name="h19" value="Use 24 MP, 41% HP, Damage 195%, Attack Range 290%, Stun for 3 Seconds"/>
-    <string name="h20" value="Use 24 MP, 40% HP, Damage 200%, Attack Range 300%, Stun for 3 Seconds"/>
-    <string name="h21" value="Use 30 MP, 39% HP, Damage 204%, Attack Range 310%, Stun for 2 Seconds"/>
-    <string name="h22" value="Use 30 MP, 38% HP, Damage 208%, Attack Range 320%, Stun for 2 Seconds"/>
-    <string name="h23" value="Use 30 MP, 37% HP, Damage 212%, Attack Range 330%, Stun for 2 Seconds"/>
-    <string name="h24" value="Use 30 MP, 36% HP, Damage 216%, Attack Range 340%, Stun for 2 Seconds"/>
-    <string name="h25" value="Use 30 MP, 35% HP, Damage 220%, Attack Range 350%, Stun for 2 Seconds"/>
-    <string name="h26" value="Use 30 MP, 34% HP, Damage 224%, Attack Range 360%, Stun for 2 Seconds"/>
-    <string name="h27" value="Use 30 MP, 33% HP, Damage 228%, Attack Range 370%, Stun for 2 Seconds"/>
-    <string name="h28" value="Use 30 MP, 32% HP, Damage 232%, Attack Range 380%, Stun for 2 Seconds"/>
-    <string name="h29" value="Use 30 MP, 31% HP, Damage 236%, Attack Range 390%, Stun for 2 Seconds"/>
-    <string name="h30" value="Use 30 MP, 30% HP, Damage 240%, Attack Range 400%, Stun for 2 Seconds"/>
+    <string name="desc" value="[Master Level: 30]\nConsumes HP to roar, damaging and stunning up to 15 monsters. Can only be used when HP is above 50%.\nRequired Skill: #cSacrifice Lv. 3 or higher#"/>
+    <string name="h1" value="MP -16; Consumes 59% HP; Damage 96%; attacks up to 15 enemies; stun for 4 sec"/>
+    <string name="h2" value="MP -16; Consumes 58% HP; Damage 102%; attacks up to 15 enemies; stun for 4 sec"/>
+    <string name="h3" value="MP -16; Consumes 57% HP; Damage 108%; attacks up to 15 enemies; stun for 4 sec"/>
+    <string name="h4" value="MP -16; Consumes 56% HP; Damage 114%; attacks up to 15 enemies; stun for 4 sec"/>
+    <string name="h5" value="MP -16; Consumes 55% HP; Damage 120%; attacks up to 15 enemies; stun for 4 sec"/>
+    <string name="h6" value="MP -16; Consumes 54% HP; Damage 126%; attacks up to 15 enemies; stun for 4 sec"/>
+    <string name="h7" value="MP -16; Consumes 53% HP; Damage 132%; attacks up to 15 enemies; stun for 4 sec"/>
+    <string name="h8" value="MP -16; Consumes 52% HP; Damage 138%; attacks up to 15 enemies; stun for 4 sec"/>
+    <string name="h9" value="MP -16; Consumes 51% HP; Damage 144%; attacks up to 15 enemies; stun for 4 sec"/>
+    <string name="h10" value="MP -16; Consumes 50% HP; Damage 150%; attacks up to 15 enemies; stun for 4 sec"/>
+    <string name="h11" value="MP -24; Consumes 49% HP; Damage 155%; attacks up to 15 enemies; stun for 3 sec"/>
+    <string name="h12" value="MP -24; Consumes 48% HP; Damage 160%; attacks up to 15 enemies; stun for 3 sec"/>
+    <string name="h13" value="MP -24; Consumes 47% HP; Damage 165%; attacks up to 15 enemies; stun for 3 sec"/>
+    <string name="h14" value="MP -24; Consumes 46% HP; Damage 170%; attacks up to 15 enemies; stun for 3 sec"/>
+    <string name="h15" value="MP -24; Consumes 45% HP; Damage 175%; attacks up to 15 enemies; stun for 3 sec"/>
+    <string name="h16" value="MP -24; Consumes 44% HP; Damage 180%; attacks up to 15 enemies; stun for 3 sec"/>
+    <string name="h17" value="MP -24; Consumes 43% HP; Damage 185%; attacks up to 15 enemies; stun for 3 sec"/>
+    <string name="h18" value="MP -24; Consumes 42% HP; Damage 190%; attacks up to 15 enemies; stun for 3 sec"/>
+    <string name="h19" value="MP -24; Consumes 41% HP; Damage 195%; attacks up to 15 enemies; stun for 3 sec"/>
+    <string name="h20" value="MP -24; Consumes 40% HP; Damage 200%; attacks up to 15 enemies; stun for 3 sec"/>
+    <string name="h21" value="MP -30; Consumes 39% HP; Damage 204%; attacks up to 15 enemies; stun for 2 sec"/>
+    <string name="h22" value="MP -30; Consumes 38% HP; Damage 208%; attacks up to 15 enemies; stun for 2 sec"/>
+    <string name="h23" value="MP -30; Consumes 37% HP; Damage 212%; attacks up to 15 enemies; stun for 2 sec"/>
+    <string name="h24" value="MP -30; Consumes 36% HP; Damage 216%; attacks up to 15 enemies; stun for 2 sec"/>
+    <string name="h25" value="MP -30; Consumes 35% HP; Damage 220%; attacks up to 15 enemies; stun for 2 sec"/>
+    <string name="h26" value="MP -30; Consumes 34% HP; Damage 224%; attacks up to 15 enemies; stun for 2 sec"/>
+    <string name="h27" value="MP -30; Consumes 33% HP; Damage 228%; attacks up to 15 enemies; stun for 2 sec"/>
+    <string name="h28" value="MP -30; Consumes 32% HP; Damage 232%; attacks up to 15 enemies; stun for 2 sec"/>
+    <string name="h29" value="MP -30; Consumes 31% HP; Damage 236%; attacks up to 15 enemies; stun for 2 sec"/>
+    <string name="h30" value="MP -30; Consumes 30% HP; Damage 240%; attacks up to 15 enemies; stun for 2 sec"/>
   </imgdir>
   <imgdir name="1311007">
     <string name="name" value="Power Crash"/>
-    <string name="desc" value="[Master Level : 20]\n Nullifies &quot;power-up&quot; skills of multiple monsters with a given success rate.\nRequired Skill : #cAt least Level 3 on Dragon Blood#"/>
-    <string name="h1" value="Use 35 MP, Cancels out Power-Up Skill in a chance of 24%"/>
-    <string name="h2" value="Use 33 MP, Cancels out Power-Up Skill in a chance of 28%"/>
-    <string name="h3" value="Use 31 MP, Cancels out Power-Up Skill in a chance of 32%"/>
-    <string name="h4" value="Use 29 MP, Cancels out Power-Up Skill in a chance of 36%"/>
-    <string name="h5" value="Use 27 MP, Cancels out Power-Up Skill in a chance of 40%"/>
-    <string name="h6" value="Use 25 MP, Cancels out Power-Up Skill in a chance of 44%"/>
-    <string name="h7" value="Use 23 MP, Cancels out Power-Up Skill in a chance of 48%"/>
-    <string name="h8" value="Use 21 MP, Cancels out Power-Up Skill in a chance of 52%"/>
-    <string name="h9" value="Use 19 MP, Cancels out Power-Up Skill in a chance of 56%"/>
-    <string name="h10" value="Use 17 MP, Cancels out Power-Up Skill in a chance of 60%"/>
-    <string name="h11" value="Use 16 MP, Cancels out Power-Up Skill in a chance of 64%"/>
-    <string name="h12" value="Use 15 MP, Cancels out Power-Up Skill in a chance of 68%"/>
-    <string name="h13" value="Use 14 MP, Cancels out Power-Up Skill in a chance of 72%"/>
-    <string name="h14" value="Use 13 MP, Cancels out Power-Up Skill in a chance of 76%"/>
-    <string name="h15" value="Use 12 MP, Cancels out Power-Up Skill in a chance of 80%"/>
-    <string name="h16" value="Use 11 MP, Cancels out Power-Up Skill in a chance of 84%"/>
-    <string name="h17" value="Use 10 MP, Cancels out Power-Up Skill in a chance of 88%"/>
-    <string name="h18" value="Use 9 MP, Cancels out Power-Up Skill in a chance of 92%"/>
-    <string name="h19" value="Use 8 MP, Cancels out Power-Up Skill in a chance of 96%"/>
-    <string name="h20" value="Use 7 MP, Cancels out Power-Up Skill in a chance of 100%"/>
+    <string name="desc" value="[Master Level: 20]\nCancels the power-up buff on nearby monsters with a given success rate.\nRequired Skill: #cDragon Blood Lv. 3 or higher#"/>
+    <string name="h1" value="MP -35; Cancels up to 6 enemies&#x27; buff at 24% success rate"/>
+    <string name="h2" value="MP -33; Cancels up to 6 enemies&#x27; buff at 28% success rate"/>
+    <string name="h3" value="MP -31; Cancels up to 6 enemies&#x27; buff at 32% success rate"/>
+    <string name="h4" value="MP -29; Cancels up to 6 enemies&#x27; buff at 36% success rate"/>
+    <string name="h5" value="MP -27; Cancels up to 6 enemies&#x27; buff at 40% success rate"/>
+    <string name="h6" value="MP -25; Cancels up to 6 enemies&#x27; buff at 44% success rate"/>
+    <string name="h7" value="MP -23; Cancels up to 6 enemies&#x27; buff at 48% success rate"/>
+    <string name="h8" value="MP -21; Cancels up to 6 enemies&#x27; buff at 52% success rate"/>
+    <string name="h9" value="MP -19; Cancels up to 6 enemies&#x27; buff at 56% success rate"/>
+    <string name="h10" value="MP -17; Cancels up to 6 enemies&#x27; buff at 60% success rate"/>
+    <string name="h11" value="MP -16; Cancels up to 6 enemies&#x27; buff at 64% success rate"/>
+    <string name="h12" value="MP -15; Cancels up to 6 enemies&#x27; buff at 68% success rate"/>
+    <string name="h13" value="MP -14; Cancels up to 6 enemies&#x27; buff at 72% success rate"/>
+    <string name="h14" value="MP -13; Cancels up to 6 enemies&#x27; buff at 76% success rate"/>
+    <string name="h15" value="MP -12; Cancels up to 6 enemies&#x27; buff at 80% success rate"/>
+    <string name="h16" value="MP -11; Cancels up to 6 enemies&#x27; buff at 84% success rate"/>
+    <string name="h17" value="MP -10; Cancels up to 6 enemies&#x27; buff at 88% success rate"/>
+    <string name="h18" value="MP -9; Cancels up to 6 enemies&#x27; buff at 92% success rate"/>
+    <string name="h19" value="MP -8; Cancels up to 6 enemies&#x27; buff at 96% success rate"/>
+    <string name="h20" value="MP -7; Cancels up to 6 enemies&#x27; buff at 100% success rate"/>
   </imgdir>
   <imgdir name="1311008">
     <string name="name" value="Dragon Blood"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the attacking capacity, but decreases HP steadily until 4 seconds before the remaining HP exhausts."/>
-    <string name="h1" value="Use 12 MP, 48 HP in every 4 seconds,  Attack + 1 in 8 Seconds"/>
-    <string name="h2" value="Use 12 MP, 46 HP in every 4 seconds,  Attack + 2 in 16 Seconds"/>
-    <string name="h3" value="Use 12 MP, 44 HP in every 4 seconds,  Attack + 3 in 24 Seconds"/>
-    <string name="h4" value="Use 12 MP, 42 HP in every 4 seconds,  Attack + 4 in 32 Seconds"/>
-    <string name="h5" value="Use 12 MP, 40 HP in every 4 seconds,  Attack + 4 in 40 Seconds"/>
-    <string name="h6" value="Use 12 MP, 38 HP in every 4 seconds,  Attack + 5 in 48 Seconds"/>
-    <string name="h7" value="Use 12 MP, 36 HP in every 4 seconds,  Attack + 5 in 56 Seconds"/>
-    <string name="h8" value="Use 12 MP, 34 HP in every 4 seconds,  Attack + 6 in 64 Seconds"/>
-    <string name="h9" value="Use 12 MP, 32 HP in every 4 seconds,  Attack + 6 in 72 Seconds"/>
-    <string name="h10" value="Use 12 MP, 30 HP in every 4 seconds,  Attack + 7 in 80 Seconds"/>
-    <string name="h11" value="Use 24 MP, 29 HP in every 4 seconds,  Attack + 7 in 88 Seconds"/>
-    <string name="h12" value="Use 24 MP, 28 HP in every 4 seconds,  Attack + 8 in 96 Seconds"/>
-    <string name="h13" value="Use 24 MP, 27 HP in every 4 seconds,  Attack + 8 in 104 Seconds"/>
-    <string name="h14" value="Use 24 MP, 26 HP in every 4 seconds,  Attack + 9 in 112 Seconds"/>
-    <string name="h15" value="Use 24 MP, 25 HP in every 4 seconds,  Attack + 9 in 120 Seconds"/>
-    <string name="h16" value="Use 24 MP, 24 HP in every 4 seconds,  Attack + 10 in 128 Seconds"/>
-    <string name="h17" value="Use 24 MP, 23 HP in every 4 seconds,  Attack + 10 in 136 Seconds"/>
-    <string name="h18" value="Use 24 MP, 22 HP in every 4 seconds,  Attack + 11 in 144 Seconds"/>
-    <string name="h19" value="Use 24 MP, 21 HP in every 4 seconds,  Attack + 11 in 152 Seconds"/>
-    <string name="h20" value="Use 24 MP, 20 HP in every 4 seconds,  Attack + 12 in 160 Seconds"/>
+    <string name="desc" value="[Master Level: 20]\nTemporarily increases weapon attack while steadily consuming HP."/>
+    <string name="h1" value="MP -12; Weapon ATT +1 for 8 sec; HP -48 every 4 sec"/>
+    <string name="h2" value="MP -12; Weapon ATT +2 for 16 sec; HP -46 every 4 sec"/>
+    <string name="h3" value="MP -12; Weapon ATT +3 for 24 sec; HP -44 every 4 sec"/>
+    <string name="h4" value="MP -12; Weapon ATT +4 for 32 sec; HP -42 every 4 sec"/>
+    <string name="h5" value="MP -12; Weapon ATT +4 for 40 sec; HP -40 every 4 sec"/>
+    <string name="h6" value="MP -12; Weapon ATT +5 for 48 sec; HP -38 every 4 sec"/>
+    <string name="h7" value="MP -12; Weapon ATT +5 for 56 sec; HP -36 every 4 sec"/>
+    <string name="h8" value="MP -12; Weapon ATT +6 for 64 sec; HP -34 every 4 sec"/>
+    <string name="h9" value="MP -12; Weapon ATT +6 for 72 sec; HP -32 every 4 sec"/>
+    <string name="h10" value="MP -12; Weapon ATT +7 for 80 sec; HP -30 every 4 sec"/>
+    <string name="h11" value="MP -24; Weapon ATT +7 for 88 sec; HP -29 every 4 sec"/>
+    <string name="h12" value="MP -24; Weapon ATT +8 for 96 sec; HP -28 every 4 sec"/>
+    <string name="h13" value="MP -24; Weapon ATT +8 for 104 sec; HP -27 every 4 sec"/>
+    <string name="h14" value="MP -24; Weapon ATT +9 for 112 sec; HP -26 every 4 sec"/>
+    <string name="h15" value="MP -24; Weapon ATT +9 for 120 sec; HP -25 every 4 sec"/>
+    <string name="h16" value="MP -24; Weapon ATT +10 for 128 sec; HP -24 every 4 sec"/>
+    <string name="h17" value="MP -24; Weapon ATT +10 for 136 sec; HP -23 every 4 sec"/>
+    <string name="h18" value="MP -24; Weapon ATT +11 for 144 sec; HP -22 every 4 sec"/>
+    <string name="h19" value="MP -24; Weapon ATT +11 for 152 sec; HP -21 every 4 sec"/>
+    <string name="h20" value="MP -24; Weapon ATT +12 for 160 sec; HP -20 every 4 sec"/>
   </imgdir>
   <imgdir name="211">
     <string name="bookName" value="Adv. Fire &amp; Poison"/>
@@ -4818,952 +4818,952 @@
   </imgdir>
   <imgdir name="1121000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
-    <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
-    <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
-    <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
-    <string name="h4" value="MP - 10 ,  For 120Secs, all stats + 2% "/>
-    <string name="h5" value="MP - 10 ,  For 150Secs, all stats + 3% "/>
-    <string name="h6" value="MP - 20 ,  For 180Secs, all stats + 3% "/>
-    <string name="h7" value="MP - 20 ,  For 210Secs, all stats + 4% "/>
-    <string name="h8" value="MP - 20 ,  For 240Secs, all stats + 4% "/>
-    <string name="h9" value="MP - 20 ,  For 270Secs, all stats + 5% "/>
-    <string name="h10" value="MP - 20 ,  For 300Secs, all stats + 5% "/>
-    <string name="h11" value="MP - 30 ,  For 330Secs, all stats + 6% "/>
-    <string name="h12" value="MP - 30 ,  For 360Secs, all stats + 6% "/>
-    <string name="h13" value="MP - 30 ,  For 390Secs, all stats + 7% "/>
-    <string name="h14" value="MP - 30 ,  For 420Secs, all stats + 7% "/>
-    <string name="h15" value="MP - 30 ,  For 450Secs, all stats + 8% "/>
-    <string name="h16" value="MP - 40 ,  For 480Secs, all stats + 8% "/>
-    <string name="h17" value="MP - 40 ,  For 510Secs, all stats + 9% "/>
-    <string name="h18" value="MP - 40 ,  For 540Secs, all stats + 9% "/>
-    <string name="h19" value="MP - 40 ,  For 570Secs, all stats + 10% "/>
-    <string name="h20" value="MP - 40 ,  For 600Secs, all stats + 10% "/>
-    <string name="h21" value="MP - 50 ,  For 630Secs, all stats + 11% "/>
-    <string name="h22" value="MP - 50 ,  For 660Secs, all stats + 11% "/>
-    <string name="h23" value="MP - 50 ,  For 690Secs, all stats + 12% "/>
-    <string name="h24" value="MP - 50 ,  For 720Secs, all stats + 12% "/>
-    <string name="h25" value="MP - 50 ,  For 750Secs, all stats + 13% "/>
-    <string name="h26" value="MP - 60 ,  For 780Secs, all stats + 13% "/>
-    <string name="h27" value="MP - 60 ,  For 810Secs, all stats + 14% "/>
-    <string name="h28" value="MP - 60 ,  For 840Secs, all stats + 14% "/>
-    <string name="h29" value="MP - 60 ,  For 870Secs, all stats + 15% "/>
-    <string name="h30" value="MP - 60 ,  For 900Secs, all stats + 15% "/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily increases all stats of yourself and nearby party members by a percentage."/>
+    <string name="h1" value="MP -10; All stats +1% for 30 sec"/>
+    <string name="h2" value="MP -10; All stats +1% for 60 sec"/>
+    <string name="h3" value="MP -10; All stats +2% for 90 sec"/>
+    <string name="h4" value="MP -10; All stats +2% for 120 sec"/>
+    <string name="h5" value="MP -10; All stats +3% for 150 sec"/>
+    <string name="h6" value="MP -20; All stats +3% for 180 sec"/>
+    <string name="h7" value="MP -20; All stats +4% for 210 sec"/>
+    <string name="h8" value="MP -20; All stats +4% for 240 sec"/>
+    <string name="h9" value="MP -20; All stats +5% for 270 sec"/>
+    <string name="h10" value="MP -20; All stats +5% for 300 sec"/>
+    <string name="h11" value="MP -30; All stats +6% for 330 sec"/>
+    <string name="h12" value="MP -30; All stats +6% for 360 sec"/>
+    <string name="h13" value="MP -30; All stats +7% for 390 sec"/>
+    <string name="h14" value="MP -30; All stats +7% for 420 sec"/>
+    <string name="h15" value="MP -30; All stats +8% for 450 sec"/>
+    <string name="h16" value="MP -40; All stats +8% for 480 sec"/>
+    <string name="h17" value="MP -40; All stats +9% for 510 sec"/>
+    <string name="h18" value="MP -40; All stats +9% for 540 sec"/>
+    <string name="h19" value="MP -40; All stats +10% for 570 sec"/>
+    <string name="h20" value="MP -40; All stats +10% for 600 sec"/>
+    <string name="h21" value="MP -50; All stats +11% for 630 sec"/>
+    <string name="h22" value="MP -50; All stats +11% for 660 sec"/>
+    <string name="h23" value="MP -50; All stats +12% for 690 sec"/>
+    <string name="h24" value="MP -50; All stats +12% for 720 sec"/>
+    <string name="h25" value="MP -50; All stats +13% for 750 sec"/>
+    <string name="h26" value="MP -60; All stats +13% for 780 sec"/>
+    <string name="h27" value="MP -60; All stats +14% for 810 sec"/>
+    <string name="h28" value="MP -60; All stats +14% for 840 sec"/>
+    <string name="h29" value="MP -60; All stats +15% for 870 sec"/>
+    <string name="h30" value="MP -60; All stats +15% for 900 sec"/>
   </imgdir>
   <imgdir name="1121001">
     <string name="name" value="Monster Magnet"/>
-    <string name="desc" value="Pulls a monster from afar up close."/>
-    <string name="h1" value="MP - 10, Range 100%, pulls up to 3 enemies."/>
-    <string name="h2" value="MP - 10, Range 105%, pulls up to 3 enemies."/>
-    <string name="h3" value="MP - 10, Range 110%, pulls up to 3 enemies."/>
-    <string name="h4" value="MP - 10, Range 115%, pulls up to 3 enemies."/>
-    <string name="h5" value="MP - 10, Range 120%, pulls up to 3 enemies."/>
-    <string name="h6" value="MP - 13, Range 125%, pulls up to 3 enemies."/>
-    <string name="h7" value="MP - 13, Range 130%, pulls up to 3 enemies."/>
-    <string name="h8" value="MP - 13, Range 135%, pulls up to 4 enemies."/>
-    <string name="h9" value="MP - 13, Range 140%, pulls up to 4 enemies."/>
-    <string name="h10" value="MP - 13, Range 145%, pulls up to 4 enemies."/>
-    <string name="h11" value="MP - 18, Range 150%, pulls up to 4 enemies."/>
-    <string name="h12" value="MP - 18, Range 155%, pulls up to 4 enemies."/>
-    <string name="h13" value="MP - 18, Range 160%, pulls up to 4 enemies."/>
-    <string name="h14" value="MP - 18, Range 165%, pulls up to 4 enemies."/>
-    <string name="h15" value="MP - 18, Range 170%, pulls up to 5 enemies."/>
-    <string name="h16" value="MP - 21, Range 175%, pulls up to 5 enemies."/>
-    <string name="h17" value="MP - 21, Range 180%, pulls up to 5 enemies."/>
-    <string name="h18" value="MP - 21, Range 185%, pulls up to 5 enemies."/>
-    <string name="h19" value="MP - 21, Range 190%, pulls up to 5 enemies."/>
-    <string name="h20" value="MP - 21, Range 195%, pulls up to 5 enemies."/>
-    <string name="h21" value="MP - 26, Range 200%, pulls up to 5 enemies."/>
-    <string name="h22" value="MP - 26, Range 205%, pulls up to 6 enemies."/>
-    <string name="h23" value="MP - 26, Range 210%, pulls up to 6 enemies."/>
-    <string name="h24" value="MP - 26, Range 215%, pulls up to 6 enemies."/>
-    <string name="h25" value="MP - 26, Range 220%, pulls up to 6 enemies."/>
-    <string name="h26" value="MP - 25, Range 225%, pulls up to 6 enemies."/>
-    <string name="h27" value="MP - 24, Range 225%, pulls up to 6 enemies."/>
-    <string name="h28" value="MP - 23, Range 225%, pulls up to 6 enemies."/>
-    <string name="h29" value="MP - 22, Range 225%, pulls up to 7 enemies."/>
-    <string name="h30" value="MP - 21, Range 225%, pulls up to 7 enemies."/>
+    <string name="desc" value="[Master Level: 30]\nPulls distant monsters toward you with a given success rate."/>
+    <string name="h1" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h2" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h3" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h4" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h5" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h6" value="MP -13; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h7" value="MP -13; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h8" value="MP -13; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h9" value="MP -13; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h10" value="MP -13; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h11" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h12" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h13" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h14" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h15" value="MP -18; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h16" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h17" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h18" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h19" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h20" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h21" value="MP -26; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h22" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h23" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h24" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h25" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h26" value="MP -25; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h27" value="MP -24; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h28" value="MP -23; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h29" value="MP -22; Pulls up to 7 enemies at 100% success rate"/>
+    <string name="h30" value="MP -21; Pulls up to 7 enemies at 100% success rate"/>
   </imgdir>
   <imgdir name="1121002">
     <string name="name" value="Power Stance"/>
-    <string name="desc" value="Enables one to stay at the same spot after being struck, resisting knock-back effects."/>
-    <string name="h1" value="MP - 30 ,For 10secs, prevent from getting knock-backed  with success rate  42%."/>
-    <string name="h2" value="MP - 30 ,For 20Secs, prevent from getting Knock-backed with success rate 44%."/>
-    <string name="h3" value="MP - 30 ,For 30Secs, prevent from getting Knock-backed with success rate 46%."/>
-    <string name="h4" value="MP - 30 ,For 40Secs, prevent from getting Knock-backed with success rate 48%."/>
-    <string name="h5" value="MP - 30 ,For 50Secs, prevent from getting Knock-backed with success rate 50%."/>
-    <string name="h6" value="MP - 36 ,For 60Secs, prevent from getting Knock-backed with success rate 52%."/>
-    <string name="h7" value="MP - 36 ,For 70Secs, prevent from getting Knock-backed with success rate 54%."/>
-    <string name="h8" value="MP - 36 ,For 80Secs, prevent from getting Knock-backed with success rate 56%."/>
-    <string name="h9" value="MP - 36 ,For 90Secs, prevent from getting Knock-backed with success rate 58%."/>
-    <string name="h10" value="MP - 36 ,For 100Secs, prevent from getting Knock-backed with success rate 60%."/>
-    <string name="h11" value="MP - 42 ,For 110Secs, prevent from getting Knock-backed with success rate 62%."/>
-    <string name="h12" value="MP - 42 ,For 120Secs, prevent from getting Knock-backed with success rate 64%."/>
-    <string name="h13" value="MP - 42 ,For 130Secs, prevent from getting Knock-backed with success rate 66%."/>
-    <string name="h14" value="MP - 42 ,For 140Secs, prevent from getting Knock-backed with success rate 68%."/>
-    <string name="h15" value="MP - 42 ,For 150Secs, prevent from getting Knock-backed with success rate 70%."/>
-    <string name="h16" value="MP - 48 ,For 160Secs, prevent from getting Knock-backed with success rate 72%."/>
-    <string name="h17" value="MP - 48 ,For 170Secs, prevent from getting Knock-backed with success rate 74%."/>
-    <string name="h18" value="MP - 48 ,For 180Secs, prevent from getting Knock-backed with success rate 76%."/>
-    <string name="h19" value="MP - 48 ,For 190Secs, prevent from getting Knock-backed with success rate 78%."/>
-    <string name="h20" value="MP - 48 ,For 200Secs, prevent from getting Knock-backed with success rate 80%."/>
-    <string name="h21" value="MP - 54 ,For 210Secs, prevent from getting Knock-backed with success rate 81%."/>
-    <string name="h22" value="MP - 54 ,For 220Secs, prevent from getting Knock-backed with success rate 82%."/>
-    <string name="h23" value="MP - 54 ,For 230Secs, prevent from getting Knock-backed with success rate 83%."/>
-    <string name="h24" value="MP - 54 ,For 240Secs, prevent from getting Knock-backed with success rate 84%."/>
-    <string name="h25" value="MP - 54 ,For 250Secs, prevent from getting Knock-backed with success rate 85%."/>
-    <string name="h26" value="MP - 53 ,For 260Secs, prevent from getting Knock-backed with success rate 86%."/>
-    <string name="h27" value="MP - 52 ,For 270Secs, prevent from getting Knock-backed with success rate 87%."/>
-    <string name="h28" value="MP - 51 ,For 280Secs, prevent from getting Knock-backed with success rate 88%."/>
-    <string name="h29" value="MP - 50 ,For 290Secs, prevent from getting Knock-backed with success rate 89%."/>
-    <string name="h30" value="MP - 50 ,For 300Secs, prevent from getting Knock-backed with success rate 90%."/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily resists knockback from enemy attacks with a given success rate."/>
+    <string name="h1" value="MP -30; 42% knockback resistance for 10 sec"/>
+    <string name="h2" value="MP -30; 44% knockback resistance for 20 sec"/>
+    <string name="h3" value="MP -30; 46% knockback resistance for 30 sec"/>
+    <string name="h4" value="MP -30; 48% knockback resistance for 40 sec"/>
+    <string name="h5" value="MP -30; 50% knockback resistance for 50 sec"/>
+    <string name="h6" value="MP -36; 52% knockback resistance for 60 sec"/>
+    <string name="h7" value="MP -36; 54% knockback resistance for 70 sec"/>
+    <string name="h8" value="MP -36; 56% knockback resistance for 80 sec"/>
+    <string name="h9" value="MP -36; 58% knockback resistance for 90 sec"/>
+    <string name="h10" value="MP -36; 60% knockback resistance for 100 sec"/>
+    <string name="h11" value="MP -42; 62% knockback resistance for 110 sec"/>
+    <string name="h12" value="MP -42; 64% knockback resistance for 120 sec"/>
+    <string name="h13" value="MP -42; 66% knockback resistance for 130 sec"/>
+    <string name="h14" value="MP -42; 68% knockback resistance for 140 sec"/>
+    <string name="h15" value="MP -42; 70% knockback resistance for 150 sec"/>
+    <string name="h16" value="MP -48; 72% knockback resistance for 160 sec"/>
+    <string name="h17" value="MP -48; 74% knockback resistance for 170 sec"/>
+    <string name="h18" value="MP -48; 76% knockback resistance for 180 sec"/>
+    <string name="h19" value="MP -48; 78% knockback resistance for 190 sec"/>
+    <string name="h20" value="MP -48; 80% knockback resistance for 200 sec"/>
+    <string name="h21" value="MP -54; 81% knockback resistance for 210 sec"/>
+    <string name="h22" value="MP -54; 82% knockback resistance for 220 sec"/>
+    <string name="h23" value="MP -54; 83% knockback resistance for 230 sec"/>
+    <string name="h24" value="MP -54; 84% knockback resistance for 240 sec"/>
+    <string name="h25" value="MP -54; 85% knockback resistance for 250 sec"/>
+    <string name="h26" value="MP -53; 86% knockback resistance for 260 sec"/>
+    <string name="h27" value="MP -52; 87% knockback resistance for 270 sec"/>
+    <string name="h28" value="MP -51; 88% knockback resistance for 280 sec"/>
+    <string name="h29" value="MP -50; 89% knockback resistance for 290 sec"/>
+    <string name="h30" value="MP -50; 90% knockback resistance for 300 sec"/>
   </imgdir>
   <imgdir name="1120003">
     <string name="name" value="Advanced Combo Attack"/>
-    <string name="desc" value="By maximizing the potential of the combo attack, it enables one to charge up the combo counter up to 10, and with a given success rate, the combo counter gets charged twice as fast. The Skill can only be obtained by fully mastered Combo Attack. \nRequired skill : #cCombo attack level 30#"/>
-    <string name="h1" value="Damage + 1% , Max Combo counter 1 , Recharge 2 combo counter with success rate  31%."/>
-    <string name="h2" value="Damage + 2% , Max Combo counter 1 , Recharge 2 combo counter with success rate  32%."/>
-    <string name="h3" value="Damage + 3% , Max Combo counter 1 , Recharge 2 combo counter with success rate  33%."/>
-    <string name="h4" value="Damage + 4% , Max Combo counter 1 , Recharge 2 combo counter with success rate  34%."/>
-    <string name="h5" value="Damage + 5% , Max Combo counter 1 , Recharge 2 combo counter with success rate  35%."/>
-    <string name="h6" value="Damage + 6% , Max Combo counter 1 , Recharge 2 combo counter with success rate  36%."/>
-    <string name="h7" value="Damage + 7% , Max Combo counter 2 , Recharge 2 combo counter with success rate  37%."/>
-    <string name="h8" value="Damage + 8% , Max Combo counter 2 , Recharge 2 combo counter with success rate  38%."/>
-    <string name="h9" value="Damage + 9% , Max Combo counter 2 , Recharge 2 combo counter with success rate  39%."/>
-    <string name="h10" value="Damage + 10% , Max Combo counter 2 , Recharge 2 combo counter with success rate  40%."/>
-    <string name="h11" value="Damage + 11% , Max Combo counter 2 , Recharge 2 combo counter with success rate  41%."/>
-    <string name="h12" value="Damage + 12% , Max Combo counter 2 , Recharge 2 combo counter with success rate  42%."/>
-    <string name="h13" value="Damage + 13% , Max Combo counter 3 , Recharge 2 combo counter with success rate  43%."/>
-    <string name="h14" value="Damage + 14% , Max Combo counter 3 , Recharge 2 combo counter with success rate  44%."/>
-    <string name="h15" value="Damage + 15% , Max Combo counter 3 , Recharge 2 combo counter with success rate  45%."/>
-    <string name="h16" value="Damage + 16% , Max Combo counter 3 , Recharge 2 combo counter with success rate  46%."/>
-    <string name="h17" value="Damage + 17% , Max Combo counter 3 , Recharge 2 combo counter with success rate  47%."/>
-    <string name="h18" value="Damage + 18% , Max Combo counter 3 , Recharge 2 combo counter with success rate  48%."/>
-    <string name="h19" value="Damage + 19% , Max Combo counter 4 , Recharge 2 combo counter with success rate  49%."/>
-    <string name="h20" value="Damage + 20% , Max Combo counter 4 , Recharge 2 combo counter with success rate  50%."/>
-    <string name="h21" value="Damage + 21% , Max Combo counter 4 , Recharge 2 combo counter with success rate  51%."/>
-    <string name="h22" value="Damage + 22% , Max Combo counter 4 , Recharge 2 combo counter with success rate  52%."/>
-    <string name="h23" value="Damage + 23% , Max Combo counter 4 , Recharge 2 combo counter with success rate  53%."/>
-    <string name="h24" value="Damage + 24% , Max Combo counter 4 , Recharge 2 combo counter with success rate  54%."/>
-    <string name="h25" value="Damage + 25% , Max Combo counter 5 , Recharge 2 combo counter with success rate  55%."/>
-    <string name="h26" value="Damage + 26% , Max Combo counter 5 , Recharge 2 combo counter with success rate  56%."/>
-    <string name="h27" value="Damage + 27% , Max Combo counter 5 , Recharge 2 combo counter with success rate  57%."/>
-    <string name="h28" value="Damage + 28% , Max Combo counter 5 , Recharge 2 combo counter with success rate  58%."/>
-    <string name="h29" value="Damage + 29% , Max Combo counter 5 , Recharge 2 combo counter with success rate  59%."/>
-    <string name="h30" value="Damage + 30% , Max Combo counter 5 , Recharge 2 combo counter with success rate  60%."/>
+    <string name="desc" value="[Master Level: 30]\nImproves Combo Attack, increasing the maximum combo count and allowing attacks to charge 2 combo orbs at a given success rate.\nRequired Skill: #cCombo Attack Lv. 30#"/>
+    <string name="h1" value="Damage +1%; max combo count 6; 31% chance to charge 2 combo orbs"/>
+    <string name="h2" value="Damage +2%; max combo count 6; 32% chance to charge 2 combo orbs"/>
+    <string name="h3" value="Damage +3%; max combo count 6; 33% chance to charge 2 combo orbs"/>
+    <string name="h4" value="Damage +4%; max combo count 6; 34% chance to charge 2 combo orbs"/>
+    <string name="h5" value="Damage +5%; max combo count 6; 35% chance to charge 2 combo orbs"/>
+    <string name="h6" value="Damage +6%; max combo count 6; 36% chance to charge 2 combo orbs"/>
+    <string name="h7" value="Damage +7%; max combo count 7; 37% chance to charge 2 combo orbs"/>
+    <string name="h8" value="Damage +8%; max combo count 7; 38% chance to charge 2 combo orbs"/>
+    <string name="h9" value="Damage +9%; max combo count 7; 39% chance to charge 2 combo orbs"/>
+    <string name="h10" value="Damage +10%; max combo count 7; 40% chance to charge 2 combo orbs"/>
+    <string name="h11" value="Damage +11%; max combo count 7; 41% chance to charge 2 combo orbs"/>
+    <string name="h12" value="Damage +12%; max combo count 7; 42% chance to charge 2 combo orbs"/>
+    <string name="h13" value="Damage +13%; max combo count 8; 43% chance to charge 2 combo orbs"/>
+    <string name="h14" value="Damage +14%; max combo count 8; 44% chance to charge 2 combo orbs"/>
+    <string name="h15" value="Damage +15%; max combo count 8; 45% chance to charge 2 combo orbs"/>
+    <string name="h16" value="Damage +16%; max combo count 8; 46% chance to charge 2 combo orbs"/>
+    <string name="h17" value="Damage +17%; max combo count 8; 47% chance to charge 2 combo orbs"/>
+    <string name="h18" value="Damage +18%; max combo count 8; 48% chance to charge 2 combo orbs"/>
+    <string name="h19" value="Damage +19%; max combo count 9; 49% chance to charge 2 combo orbs"/>
+    <string name="h20" value="Damage +20%; max combo count 9; 50% chance to charge 2 combo orbs"/>
+    <string name="h21" value="Damage +21%; max combo count 9; 51% chance to charge 2 combo orbs"/>
+    <string name="h22" value="Damage +22%; max combo count 9; 52% chance to charge 2 combo orbs"/>
+    <string name="h23" value="Damage +23%; max combo count 9; 53% chance to charge 2 combo orbs"/>
+    <string name="h24" value="Damage +24%; max combo count 9; 54% chance to charge 2 combo orbs"/>
+    <string name="h25" value="Damage +25%; max combo count 10; 55% chance to charge 2 combo orbs"/>
+    <string name="h26" value="Damage +26%; max combo count 10; 56% chance to charge 2 combo orbs"/>
+    <string name="h27" value="Damage +27%; max combo count 10; 57% chance to charge 2 combo orbs"/>
+    <string name="h28" value="Damage +28%; max combo count 10; 58% chance to charge 2 combo orbs"/>
+    <string name="h29" value="Damage +29%; max combo count 10; 59% chance to charge 2 combo orbs"/>
+    <string name="h30" value="Damage +30%; max combo count 10; 60% chance to charge 2 combo orbs"/>
   </imgdir>
   <imgdir name="1120004">
     <string name="name" value="Achilles"/>
-    <string name="desc" value="Permanently increases the weapon defense of one&apos;s armor"/>
-    <string name="h1" value="  Damage taken from enemy - 0.5% ."/>
-    <string name="h2" value="  Damage taken from enemy - 1% ."/>
-    <string name="h3" value="  Damage taken from enemy - 1.5% ."/>
-    <string name="h4" value="  Damage taken from enemy - 2% ."/>
-    <string name="h5" value="  Damage taken from enemy - 2.5% ."/>
-    <string name="h6" value="  Damage taken from enemy - 3% ."/>
-    <string name="h7" value="  Damage taken from enemy - 3.5% ."/>
-    <string name="h8" value="  Damage taken from enemy - 4% ."/>
-    <string name="h9" value="  Damage taken from enemy - 4.5% ."/>
-    <string name="h10" value="  Damage taken from enemy - 5% ."/>
-    <string name="h11" value="  Damage taken from enemy - 5.5% ."/>
-    <string name="h12" value="  Damage taken from enemy - 6% ."/>
-    <string name="h13" value="  Damage taken from enemy - 6.5% ."/>
-    <string name="h14" value="  Damage taken from enemy - 7% ."/>
-    <string name="h15" value="  Damage taken from enemy - 7.5% ."/>
-    <string name="h16" value="  Damage taken from enemy - 8% ."/>
-    <string name="h17" value="  Damage taken from enemy - 8.5% ."/>
-    <string name="h18" value="  Damage taken from enemy - 9% ."/>
-    <string name="h19" value="  Damage taken from enemy - 9.5% ."/>
-    <string name="h20" value="  Damage taken from enemy - 10% ."/>
-    <string name="h21" value="  Damage taken from enemy - 10.5% ."/>
-    <string name="h22" value="  Damage taken from enemy - 11% ."/>
-    <string name="h23" value="  Damage taken from enemy - 11.5% ."/>
-    <string name="h24" value="  Damage taken from enemy - 12% ."/>
-    <string name="h25" value="  Damage taken from enemy - 12.5% ."/>
-    <string name="h26" value="  Damage taken from enemy - 13% ."/>
-    <string name="h27" value="  Damage taken from enemy - 13.5% ."/>
-    <string name="h28" value="  Damage taken from enemy - 14% ."/>
-    <string name="h29" value="  Damage taken from enemy - 14.5% ."/>
-    <string name="h30" value="  Damage taken from enemy - 15% ."/>
+    <string name="desc" value="[Master Level: 30]\nPermanently reduces damage received from enemies."/>
+    <string name="h1" value="Damage taken -0.5%"/>
+    <string name="h2" value="Damage taken -1%"/>
+    <string name="h3" value="Damage taken -1.5%"/>
+    <string name="h4" value="Damage taken -2%"/>
+    <string name="h5" value="Damage taken -2.5%"/>
+    <string name="h6" value="Damage taken -3%"/>
+    <string name="h7" value="Damage taken -3.5%"/>
+    <string name="h8" value="Damage taken -4%"/>
+    <string name="h9" value="Damage taken -4.5%"/>
+    <string name="h10" value="Damage taken -5%"/>
+    <string name="h11" value="Damage taken -5.5%"/>
+    <string name="h12" value="Damage taken -6%"/>
+    <string name="h13" value="Damage taken -6.5%"/>
+    <string name="h14" value="Damage taken -7%"/>
+    <string name="h15" value="Damage taken -7.5%"/>
+    <string name="h16" value="Damage taken -8%"/>
+    <string name="h17" value="Damage taken -8.5%"/>
+    <string name="h18" value="Damage taken -9%"/>
+    <string name="h19" value="Damage taken -9.5%"/>
+    <string name="h20" value="Damage taken -10%"/>
+    <string name="h21" value="Damage taken -10.5%"/>
+    <string name="h22" value="Damage taken -11%"/>
+    <string name="h23" value="Damage taken -11.5%"/>
+    <string name="h24" value="Damage taken -12%"/>
+    <string name="h25" value="Damage taken -12.5%"/>
+    <string name="h26" value="Damage taken -13%"/>
+    <string name="h27" value="Damage taken -13.5%"/>
+    <string name="h28" value="Damage taken -14%"/>
+    <string name="h29" value="Damage taken -14.5%"/>
+    <string name="h30" value="Damage taken -15%"/>
   </imgdir>
   <imgdir name="1120005">
     <string name="name" value="Guardian"/>
-    <string name="desc" value="Blocks the monster&apos;s attack by using the shield with a given success rate. Additionally, if the close-range attack is blocked, the attacking monster will be stunned for 2 seconds. The skill only works when equipped with a shield"/>
-    <string name="h1" value="Block against enemies attack with success rate 0.5%"/>
-    <string name="h2" value="Block against enemies attack with success rate 1%"/>
-    <string name="h3" value="Block against enemies attack with success rate 1.5%"/>
-    <string name="h4" value="Block against enemies attack with success rate 2%"/>
-    <string name="h5" value="Block against enemies attack with success rate 2.5%"/>
-    <string name="h6" value="Block against enemies attack with success rate 3%"/>
-    <string name="h7" value="Block against enemies attack with success rate 3.5%"/>
-    <string name="h8" value="Block against enemies attack with success rate 4%"/>
-    <string name="h9" value="Block against enemies attack with success rate 4.5%"/>
-    <string name="h10" value="Block against enemies attack with success rate 5%"/>
-    <string name="h11" value="Block against enemies attack with success rate 5.5%"/>
-    <string name="h12" value="Block against enemies attack with success rate 6%"/>
-    <string name="h13" value="Block against enemies attack with success rate 6.5%"/>
-    <string name="h14" value="Block against enemies attack with success rate 7%"/>
-    <string name="h15" value="Block against enemies attack with success rate 7.5%"/>
-    <string name="h16" value="Block against enemies attack with success rate 8%"/>
-    <string name="h17" value="Block against enemies attack with success rate 8.5%"/>
-    <string name="h18" value="Block against enemies attack with success rate 9%"/>
-    <string name="h19" value="Block against enemies attack with success rate 9.5%"/>
-    <string name="h20" value="Block against enemies attack with success rate 10%"/>
-    <string name="h21" value="Block against enemies attack with success rate 10.5%"/>
-    <string name="h22" value="Block against enemies attack with success rate 11%"/>
-    <string name="h23" value="Block against enemies attack with success rate 11.5%"/>
-    <string name="h24" value="Block against enemies attack with success rate 12%"/>
-    <string name="h25" value="Block against enemies attack with success rate 12.5%"/>
-    <string name="h26" value="Block against enemies attack with success rate 13%"/>
-    <string name="h27" value="Block against enemies attack with success rate 13.5%"/>
-    <string name="h28" value="Block against enemies attack with success rate 14%"/>
-    <string name="h29" value="Block against enemies attack with success rate 14.5%"/>
-    <string name="h30" value="Block against enemies attack with success rate 15%"/>
+    <string name="desc" value="[Master Level: 30]\nBlocks enemy attacks with a shield at a given success rate. If a close-range attack is blocked, the attacker is stunned for 2 sec. Requires a shield."/>
+    <string name="h1" value="0% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h2" value="1% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h3" value="1% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h4" value="2% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h5" value="2% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h6" value="3% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h7" value="3% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h8" value="4% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h9" value="4% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h10" value="5% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h11" value="5% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h12" value="6% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h13" value="6% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h14" value="7% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h15" value="7% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h16" value="8% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h17" value="8% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h18" value="9% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h19" value="9% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h20" value="10% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h21" value="10% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h22" value="11% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h23" value="11% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h24" value="12% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h25" value="12% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h26" value="13% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h27" value="13% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h28" value="14% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h29" value="14% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h30" value="15% block rate; stun blocked close-range attackers for 2 sec"/>
   </imgdir>
   <imgdir name="1121006">
     <string name="name" value="Rush"/>
-    <string name="desc" value="Makes a mad dash forward, pushing off up to 10 monsters."/>
-    <string name="h1" value="MP - 22 , Damage 72%, Range 80%"/>
-    <string name="h2" value="MP - 24 , Damage 74%, Range 80%"/>
-    <string name="h3" value="MP - 26 , Damage 76%, Range 80%"/>
-    <string name="h4" value="MP - 28 , Damage 78%, Range 85%"/>
-    <string name="h5" value="MP - 30 , Damage 80%, Range 85%"/>
-    <string name="h6" value="MP - 32 , Damage 82%, Range 85%"/>
-    <string name="h7" value="MP - 34 , Damage 84%, Range 85%"/>
-    <string name="h8" value="MP - 36 , Damage 86%, Range 90%"/>
-    <string name="h9" value="MP - 38 , Damage 88%, Range 90%"/>
-    <string name="h10" value="MP - 40 , Damage 90%, Range 90%"/>
-    <string name="h11" value="MP - 42 , Damage 92%, Range 95%"/>
-    <string name="h12" value="MP - 44 , Damage 94%, Range 95%"/>
-    <string name="h13" value="MP - 46 , Damage 96%, Range 95%"/>
-    <string name="h14" value="MP - 48 , Damage 98%, Range 100%"/>
-    <string name="h15" value="MP - 50 , Damage 100%, Range 100%"/>
-    <string name="h16" value="MP - 52 , Damage 102%, Range 100%"/>
-    <string name="h17" value="MP - 54 , Damage 104%, Range 105%"/>
-    <string name="h18" value="MP - 56 , Damage 106%, Range 105%"/>
-    <string name="h19" value="MP - 58 , Damage 108%, Range 105%"/>
-    <string name="h20" value="MP - 60 , Damage 110%, Range 110%"/>
-    <string name="h21" value="MP - 59 , Damage 112%, Range 110%"/>
-    <string name="h22" value="MP - 58 , Damage 114%, Range 115%"/>
-    <string name="h23" value="MP - 57 , Damage 116%, Range 115%"/>
-    <string name="h24" value="MP - 56 , Damage 118%, Range 115%"/>
-    <string name="h25" value="MP - 55 , Damage 120%, Range 120%"/>
-    <string name="h26" value="MP - 54 , Damage 122%, Range 120%"/>
-    <string name="h27" value="MP - 53 , Damage 124%, Range 120%"/>
-    <string name="h28" value="MP - 52 , Damage 126%, Range 125%"/>
-    <string name="h29" value="MP - 51 , Damage 128%, Range 125%"/>
-    <string name="h30" value="MP - 50 , Damage 130%, Range 125%"/>
+    <string name="desc" value="[Master Level: 30]\nRushes forward, damaging and pushing up to 15 monsters."/>
+    <string name="h1" value="MP -22; Damage 72%; pushes up to 15 enemies"/>
+    <string name="h2" value="MP -24; Damage 74%; pushes up to 15 enemies"/>
+    <string name="h3" value="MP -26; Damage 76%; pushes up to 15 enemies"/>
+    <string name="h4" value="MP -28; Damage 78%; pushes up to 15 enemies"/>
+    <string name="h5" value="MP -30; Damage 80%; pushes up to 15 enemies"/>
+    <string name="h6" value="MP -32; Damage 82%; pushes up to 15 enemies"/>
+    <string name="h7" value="MP -34; Damage 84%; pushes up to 15 enemies"/>
+    <string name="h8" value="MP -36; Damage 86%; pushes up to 15 enemies"/>
+    <string name="h9" value="MP -38; Damage 88%; pushes up to 15 enemies"/>
+    <string name="h10" value="MP -40; Damage 90%; pushes up to 15 enemies"/>
+    <string name="h11" value="MP -42; Damage 92%; pushes up to 15 enemies"/>
+    <string name="h12" value="MP -44; Damage 94%; pushes up to 15 enemies"/>
+    <string name="h13" value="MP -46; Damage 96%; pushes up to 15 enemies"/>
+    <string name="h14" value="MP -48; Damage 98%; pushes up to 15 enemies"/>
+    <string name="h15" value="MP -50; Damage 100%; pushes up to 15 enemies"/>
+    <string name="h16" value="MP -52; Damage 102%; pushes up to 15 enemies"/>
+    <string name="h17" value="MP -54; Damage 104%; pushes up to 15 enemies"/>
+    <string name="h18" value="MP -56; Damage 106%; pushes up to 15 enemies"/>
+    <string name="h19" value="MP -58; Damage 108%; pushes up to 15 enemies"/>
+    <string name="h20" value="MP -60; Damage 110%; pushes up to 15 enemies"/>
+    <string name="h21" value="MP -59; Damage 112%; pushes up to 15 enemies"/>
+    <string name="h22" value="MP -58; Damage 114%; pushes up to 15 enemies"/>
+    <string name="h23" value="MP -57; Damage 116%; pushes up to 15 enemies"/>
+    <string name="h24" value="MP -56; Damage 118%; pushes up to 15 enemies"/>
+    <string name="h25" value="MP -55; Damage 120%; pushes up to 15 enemies"/>
+    <string name="h26" value="MP -54; Damage 122%; pushes up to 15 enemies"/>
+    <string name="h27" value="MP -53; Damage 124%; pushes up to 15 enemies"/>
+    <string name="h28" value="MP -52; Damage 126%; pushes up to 15 enemies"/>
+    <string name="h29" value="MP -51; Damage 128%; pushes up to 15 enemies"/>
+    <string name="h30" value="MP -50; Damage 130%; pushes up to 15 enemies"/>
   </imgdir>
   <imgdir name="1121008">
     <string name="name" value="Brandish"/>
     <string name="desc" value="Enables one to attack multiple monsters forward twice"/>
-    <string name="h1" value="MP - 16 , Damage 135%, Attack 1 enemy."/>
-    <string name="h2" value="MP - 16 , Damage 140%, Attack 1 enemy."/>
-    <string name="h3" value="MP - 16 , Damage 145%, Attack 1 enemy."/>
-    <string name="h4" value="MP - 16 , Damage 150%, Attack 1 enemy."/>
-    <string name="h5" value="MP - 16 , Damage 155%, Attack 1 enemy."/>
-    <string name="h6" value="MP - 16 , Damage 160%, Attack 1 enemy."/>
-    <string name="h7" value="MP - 16 , Damage 165%, Attack 1 enemy."/>
-    <string name="h8" value="MP - 16 , Damage 170%, Attack 1 enemy."/>
-    <string name="h9" value="MP - 16 , Damage 175%, Attack 1 enemy."/>
-    <string name="h10" value="MP - 16 , Damage 180%, Attack 1 enemy."/>
-    <string name="h11" value="MP - 24 , Damage 184%, Attack up to 2 enemies."/>
-    <string name="h12" value="MP - 24 , Damage 188%, Attack up to 2 enemies."/>
-    <string name="h13" value="MP - 24 , Damage 192%, Attack up to 2 enemies."/>
-    <string name="h14" value="MP - 24 , Damage 196%, Attack up to 2 enemies."/>
-    <string name="h15" value="MP - 24 , Damage 200%, Attack up to 2 enemies."/>
-    <string name="h16" value="MP - 24 , Damage 204%, Attack up to 2 enemies."/>
-    <string name="h17" value="MP - 24 , Damage 208%, Attack up to 2 enemies."/>
-    <string name="h18" value="MP - 24 , Damage 212%, Attack up to 2 enemies."/>
-    <string name="h19" value="MP - 24 , Damage 216%, Attack up to 2 enemies."/>
-    <string name="h20" value="MP - 24 , Damage 220%, Attack up to 2 enemies."/>
-    <string name="h21" value="MP - 30 , Damage 224%, Attack up to 3 enemies."/>
-    <string name="h22" value="MP - 30 , Damage 228%, Attack up to 3 enemies."/>
-    <string name="h23" value="MP - 30 , Damage 232%, Attack up to 3 enemies."/>
-    <string name="h24" value="MP - 30 , Damage 236%, Attack up to 3 enemies."/>
-    <string name="h25" value="MP - 30 , Damage 240%, Attack up to 3 enemies."/>
-    <string name="h26" value="MP - 29 , Damage 244%, Attack up to 3 enemies."/>
-    <string name="h27" value="MP - 28 , Damage 248%, Attack up to 3 enemies."/>
-    <string name="h28" value="MP - 27 , Damage 252%, Attack up to 3 enemies."/>
-    <string name="h29" value="MP - 26 , Damage 256%, Attack up to 3 enemies."/>
-    <string name="h30" value="MP - 25 , Damage 260%, Attack up to 3 enemies."/>
+    <string name="h1" value="MP -16; Damage 135%; attacks 2 times; up to 1 enemies"/>
+    <string name="h2" value="MP -16; Damage 140%; attacks 2 times; up to 1 enemies"/>
+    <string name="h3" value="MP -16; Damage 145%; attacks 2 times; up to 1 enemies"/>
+    <string name="h4" value="MP -16; Damage 150%; attacks 2 times; up to 1 enemies"/>
+    <string name="h5" value="MP -16; Damage 155%; attacks 2 times; up to 1 enemies"/>
+    <string name="h6" value="MP -16; Damage 160%; attacks 2 times; up to 1 enemies"/>
+    <string name="h7" value="MP -16; Damage 165%; attacks 2 times; up to 1 enemies"/>
+    <string name="h8" value="MP -16; Damage 170%; attacks 2 times; up to 1 enemies"/>
+    <string name="h9" value="MP -16; Damage 175%; attacks 2 times; up to 1 enemies"/>
+    <string name="h10" value="MP -16; Damage 180%; attacks 2 times; up to 1 enemies"/>
+    <string name="h11" value="MP -24; Damage 184%; attacks 2 times; up to 2 enemies"/>
+    <string name="h12" value="MP -24; Damage 188%; attacks 2 times; up to 2 enemies"/>
+    <string name="h13" value="MP -24; Damage 192%; attacks 2 times; up to 2 enemies"/>
+    <string name="h14" value="MP -24; Damage 196%; attacks 2 times; up to 2 enemies"/>
+    <string name="h15" value="MP -24; Damage 200%; attacks 2 times; up to 2 enemies"/>
+    <string name="h16" value="MP -24; Damage 204%; attacks 2 times; up to 2 enemies"/>
+    <string name="h17" value="MP -24; Damage 208%; attacks 2 times; up to 2 enemies"/>
+    <string name="h18" value="MP -24; Damage 212%; attacks 2 times; up to 2 enemies"/>
+    <string name="h19" value="MP -24; Damage 216%; attacks 2 times; up to 2 enemies"/>
+    <string name="h20" value="MP -24; Damage 220%; attacks 2 times; up to 2 enemies"/>
+    <string name="h21" value="MP -30; Damage 224%; attacks 2 times; up to 3 enemies"/>
+    <string name="h22" value="MP -30; Damage 228%; attacks 2 times; up to 3 enemies"/>
+    <string name="h23" value="MP -30; Damage 232%; attacks 2 times; up to 3 enemies"/>
+    <string name="h24" value="MP -30; Damage 236%; attacks 2 times; up to 3 enemies"/>
+    <string name="h25" value="MP -30; Damage 240%; attacks 2 times; up to 3 enemies"/>
+    <string name="h26" value="MP -29; Damage 244%; attacks 2 times; up to 3 enemies"/>
+    <string name="h27" value="MP -28; Damage 248%; attacks 2 times; up to 3 enemies"/>
+    <string name="h28" value="MP -27; Damage 252%; attacks 2 times; up to 3 enemies"/>
+    <string name="h29" value="MP -26; Damage 256%; attacks 2 times; up to 3 enemies"/>
+    <string name="h30" value="MP -25; Damage 260%; attacks 2 times; up to 3 enemies"/>
   </imgdir>
   <imgdir name="1121010">
     <string name="name" value="Enrage"/>
-    <string name="desc" value="Temporarily increases the attacking ability by using up the 10 combo counters."/>
-    <string name="h1" value="MP - 11 , Weapon attack + 11 for 10secs"/>
-    <string name="h2" value="MP - 12 , Weapon attack + 12 for 20secs"/>
-    <string name="h3" value="MP - 13 , fWeapon attack + 12 for 30secs"/>
-    <string name="h4" value="MP - 14 , Weapon attack + 13 for 40secs"/>
-    <string name="h5" value="MP - 15 , Weapon attack + 13 for 50secs"/>
-    <string name="h6" value="MP - 16 , Weapon attack + 14 for 60secs"/>
-    <string name="h7" value="MP - 17 , Weapon attack + 14 for 70secs"/>
-    <string name="h8" value="MP - 18 , Weapon attack + 15 for 80secs"/>
-    <string name="h9" value="MP - 19 , Weapon attack + 15 for 90secs"/>
-    <string name="h10" value="MP - 20 , Weapon attack + 16 for 100secs"/>
-    <string name="h11" value="MP - 21 , Weapon attack + 16 for 110secs"/>
-    <string name="h12" value="MP - 22 , Weapon attack + 17 for 120secs"/>
-    <string name="h13" value="MP - 23 , Weapon attack + 17 for 130secs"/>
-    <string name="h14" value="MP - 24 , Weapon attack + 18 for 140secs"/>
-    <string name="h15" value="MP - 25 , Weapon attack + 18 for 150secs"/>
-    <string name="h16" value="MP - 26 , Weapon attack + 19 for 160secs"/>
-    <string name="h17" value="MP - 27 , Weapon attack + 19 for 170secs"/>
-    <string name="h18" value="MP - 28 , Weapon attack + 20 for 180secs"/>
-    <string name="h19" value="MP - 29 , Weapon attack + 20 for 190secs"/>
-    <string name="h20" value="MP - 30 , Weapon attack + 21 for 200secs"/>
-    <string name="h21" value="MP - 31 , Weapon attack + 21 for 205secs"/>
-    <string name="h22" value="MP - 32 , Weapon attack + 22 for 210secs"/>
-    <string name="h23" value="MP - 33 , fWeapon attack + 22 for 215secs"/>
-    <string name="h24" value="MP - 34 , Weapon attack + 23 for 220secs"/>
-    <string name="h25" value="MP - 35 , Weapon attack + 23 for 225secs"/>
-    <string name="h26" value="MP - 36 , Weapon attack + 24 for 230secs"/>
-    <string name="h27" value="MP - 37 , Weapon attack + 24 for 235secs"/>
-    <string name="h28" value="MP - 38 , Weapon attack + 25 for 240secs"/>
-    <string name="h29" value="MP - 39 , Weapon attack + 25 for 240secs"/>
-    <string name="h30" value="MP - 40 , Weapon attack + 26 for 240secs"/>
+    <string name="desc" value="[Master Level: 30]\nConsumes 10 combo orbs to temporarily increase weapon attack.\nRequired Skill: #cAdvanced Combo Attack Lv. 25 or higher#"/>
+    <string name="h1" value="MP -11; Weapon ATT +11 for 10 sec; cooldown 360 sec"/>
+    <string name="h2" value="MP -12; Weapon ATT +12 for 20 sec; cooldown 360 sec"/>
+    <string name="h3" value="MP -13; Weapon ATT +12 for 30 sec; cooldown 360 sec"/>
+    <string name="h4" value="MP -14; Weapon ATT +13 for 40 sec; cooldown 360 sec"/>
+    <string name="h5" value="MP -15; Weapon ATT +13 for 50 sec; cooldown 360 sec"/>
+    <string name="h6" value="MP -16; Weapon ATT +14 for 60 sec; cooldown 360 sec"/>
+    <string name="h7" value="MP -17; Weapon ATT +14 for 70 sec; cooldown 360 sec"/>
+    <string name="h8" value="MP -18; Weapon ATT +15 for 80 sec; cooldown 360 sec"/>
+    <string name="h9" value="MP -19; Weapon ATT +15 for 90 sec; cooldown 360 sec"/>
+    <string name="h10" value="MP -20; Weapon ATT +16 for 100 sec; cooldown 360 sec"/>
+    <string name="h11" value="MP -21; Weapon ATT +16 for 110 sec; cooldown 360 sec"/>
+    <string name="h12" value="MP -22; Weapon ATT +17 for 120 sec; cooldown 360 sec"/>
+    <string name="h13" value="MP -23; Weapon ATT +17 for 130 sec; cooldown 360 sec"/>
+    <string name="h14" value="MP -24; Weapon ATT +18 for 140 sec; cooldown 360 sec"/>
+    <string name="h15" value="MP -25; Weapon ATT +18 for 150 sec; cooldown 360 sec"/>
+    <string name="h16" value="MP -26; Weapon ATT +19 for 160 sec; cooldown 360 sec"/>
+    <string name="h17" value="MP -27; Weapon ATT +19 for 170 sec; cooldown 360 sec"/>
+    <string name="h18" value="MP -28; Weapon ATT +20 for 180 sec; cooldown 360 sec"/>
+    <string name="h19" value="MP -29; Weapon ATT +20 for 190 sec; cooldown 360 sec"/>
+    <string name="h20" value="MP -30; Weapon ATT +21 for 200 sec; cooldown 360 sec"/>
+    <string name="h21" value="MP -31; Weapon ATT +21 for 205 sec; cooldown 360 sec"/>
+    <string name="h22" value="MP -32; Weapon ATT +22 for 210 sec; cooldown 360 sec"/>
+    <string name="h23" value="MP -33; Weapon ATT +22 for 215 sec; cooldown 360 sec"/>
+    <string name="h24" value="MP -34; Weapon ATT +23 for 220 sec; cooldown 360 sec"/>
+    <string name="h25" value="MP -35; Weapon ATT +23 for 225 sec; cooldown 360 sec"/>
+    <string name="h26" value="MP -36; Weapon ATT +24 for 230 sec; cooldown 360 sec"/>
+    <string name="h27" value="MP -37; Weapon ATT +24 for 235 sec; cooldown 360 sec"/>
+    <string name="h28" value="MP -38; Weapon ATT +25 for 240 sec; cooldown 360 sec"/>
+    <string name="h29" value="MP -39; Weapon ATT +25 for 240 sec; cooldown 360 sec"/>
+    <string name="h30" value="MP -40; Weapon ATT +26 for 240 sec; cooldown 360 sec"/>
   </imgdir>
   <imgdir name="1121011">
-    <string name="name" value="Hero&apos;s Will"/>
-    <string name="desc" value="Enables one to shrug off abnormal conditions. The higher the skill level, the more types of abnormal conditions one can nullify."/>
-    <string name="h1" value="MP - 30 escape from abnormal condition, Terms between skills 600secs"/>
-    <string name="h2" value="MP - 30 escape from abnormal condition, Terms between skills 540secs"/>
-    <string name="h3" value="MP - 30 escape from abnormal condition, Terms between skills 480secs"/>
-    <string name="h4" value="MP - 30 escape from abnormal condition, Terms between skills 420secs"/>
-    <string name="h5" value="MP - 30 escape from abnormal condition, Terms between skills 360secs"/>
+    <string name="name" value="Hero&#x27;s Will"/>
+    <string name="desc" value="[Master Level: 5]\nRemoves certain abnormal status effects. Higher levels reduce the cooldown."/>
+    <string name="h1" value="MP -30; Removes abnormal status; cooldown 600 sec"/>
+    <string name="h2" value="MP -30; Removes abnormal status; cooldown 540 sec"/>
+    <string name="h3" value="MP -30; Removes abnormal status; cooldown 480 sec"/>
+    <string name="h4" value="MP -30; Removes abnormal status; cooldown 420 sec"/>
+    <string name="h5" value="MP -30; Removes abnormal status; cooldown 360 sec"/>
   </imgdir>
   <imgdir name="122">
     <string name="bookName" value="Paladin of Light"/>
   </imgdir>
   <imgdir name="1221000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
-    <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
-    <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
-    <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
-    <string name="h4" value="MP - 10 ,  For 120Secs, all stats + 2% "/>
-    <string name="h5" value="MP - 10 ,  For 150Secs, all stats + 3% "/>
-    <string name="h6" value="MP - 20 ,  For 180Secs, all stats + 3% "/>
-    <string name="h7" value="MP - 20 ,  For 210Secs, all stats + 4% "/>
-    <string name="h8" value="MP - 20 ,  For 240Secs, all stats + 4% "/>
-    <string name="h9" value="MP - 20 ,  For 270Secs, all stats + 5% "/>
-    <string name="h10" value="MP - 20 ,  For 300Secs, all stats + 5% "/>
-    <string name="h11" value="MP - 30 ,  For 330Secs, all stats + 6% "/>
-    <string name="h12" value="MP - 30 ,  For 360Secs, all stats + 6% "/>
-    <string name="h13" value="MP - 30 ,  For 390Secs, all stats + 7% "/>
-    <string name="h14" value="MP - 30 ,  For 420Secs, all stats + 7% "/>
-    <string name="h15" value="MP - 30 ,  For 450Secs, all stats + 8% "/>
-    <string name="h16" value="MP - 40 ,  For 480Secs, all stats + 8% "/>
-    <string name="h17" value="MP - 40 ,  For 510Secs, all stats + 9% "/>
-    <string name="h18" value="MP - 40 ,  For 540Secs, all stats + 9% "/>
-    <string name="h19" value="MP - 40 ,  For 570Secs, all stats + 10% "/>
-    <string name="h20" value="MP - 40 ,  For 600Secs, all stats + 10% "/>
-    <string name="h21" value="MP - 50 ,  For 630Secs, all stats + 11% "/>
-    <string name="h22" value="MP - 50 ,  For 660Secs, all stats + 11% "/>
-    <string name="h23" value="MP - 50 ,  For 690Secs, all stats + 12% "/>
-    <string name="h24" value="MP - 50 ,  For 720Secs, all stats + 12% "/>
-    <string name="h25" value="MP - 50 ,  For 750Secs, all stats + 13% "/>
-    <string name="h26" value="MP - 60 ,  For 780Secs, all stats + 13% "/>
-    <string name="h27" value="MP - 60 ,  For 810Secs, all stats + 14% "/>
-    <string name="h28" value="MP - 60 ,  For 840Secs, all stats + 14% "/>
-    <string name="h29" value="MP - 60 ,  For 870Secs, all stats + 15% "/>
-    <string name="h30" value="MP - 60 ,  For 900Secs, all stats + 15% "/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily increases all stats of yourself and nearby party members by a percentage."/>
+    <string name="h1" value="MP -10; All stats +1% for 30 sec"/>
+    <string name="h2" value="MP -10; All stats +1% for 60 sec"/>
+    <string name="h3" value="MP -10; All stats +2% for 90 sec"/>
+    <string name="h4" value="MP -10; All stats +2% for 120 sec"/>
+    <string name="h5" value="MP -10; All stats +3% for 150 sec"/>
+    <string name="h6" value="MP -20; All stats +3% for 180 sec"/>
+    <string name="h7" value="MP -20; All stats +4% for 210 sec"/>
+    <string name="h8" value="MP -20; All stats +4% for 240 sec"/>
+    <string name="h9" value="MP -20; All stats +5% for 270 sec"/>
+    <string name="h10" value="MP -20; All stats +5% for 300 sec"/>
+    <string name="h11" value="MP -30; All stats +6% for 330 sec"/>
+    <string name="h12" value="MP -30; All stats +6% for 360 sec"/>
+    <string name="h13" value="MP -30; All stats +7% for 390 sec"/>
+    <string name="h14" value="MP -30; All stats +7% for 420 sec"/>
+    <string name="h15" value="MP -30; All stats +8% for 450 sec"/>
+    <string name="h16" value="MP -40; All stats +8% for 480 sec"/>
+    <string name="h17" value="MP -40; All stats +9% for 510 sec"/>
+    <string name="h18" value="MP -40; All stats +9% for 540 sec"/>
+    <string name="h19" value="MP -40; All stats +10% for 570 sec"/>
+    <string name="h20" value="MP -40; All stats +10% for 600 sec"/>
+    <string name="h21" value="MP -50; All stats +11% for 630 sec"/>
+    <string name="h22" value="MP -50; All stats +11% for 660 sec"/>
+    <string name="h23" value="MP -50; All stats +12% for 690 sec"/>
+    <string name="h24" value="MP -50; All stats +12% for 720 sec"/>
+    <string name="h25" value="MP -50; All stats +13% for 750 sec"/>
+    <string name="h26" value="MP -60; All stats +13% for 780 sec"/>
+    <string name="h27" value="MP -60; All stats +14% for 810 sec"/>
+    <string name="h28" value="MP -60; All stats +14% for 840 sec"/>
+    <string name="h29" value="MP -60; All stats +15% for 870 sec"/>
+    <string name="h30" value="MP -60; All stats +15% for 900 sec"/>
   </imgdir>
   <imgdir name="1221001">
     <string name="name" value="Monster Magnet"/>
-    <string name="desc" value="Pulls a monster from afar up close."/>
-    <string name="h1" value="MP - 10, Range 100%, pulls up to 3 enemies."/>
-    <string name="h2" value="MP - 10, Range 105%, pulls up to 3 enemies."/>
-    <string name="h3" value="MP - 10, Range 110%, pulls up to 3 enemies."/>
-    <string name="h4" value="MP - 10, Range 115%, pulls up to 3 enemies."/>
-    <string name="h5" value="MP - 10, Range 120%, pulls up to 3 enemies."/>
-    <string name="h6" value="MP - 13, Range 125%, pulls up to 3 enemies."/>
-    <string name="h7" value="MP - 13, Range 130%, pulls up to 3 enemies."/>
-    <string name="h8" value="MP - 13, Range 135%, pulls up to 4 enemies."/>
-    <string name="h9" value="MP - 13, Range 140%, pulls up to 4 enemies."/>
-    <string name="h10" value="MP - 13, Range 145%, pulls up to 4 enemies."/>
-    <string name="h11" value="MP - 18, Range 150%, pulls up to 4 enemies."/>
-    <string name="h12" value="MP - 18, Range 155%, pulls up to 4 enemies."/>
-    <string name="h13" value="MP - 18, Range 160%, pulls up to 4 enemies."/>
-    <string name="h14" value="MP - 18, Range 165%, pulls up to 4 enemies."/>
-    <string name="h15" value="MP - 18, Range 170%, pulls up to 5 enemies."/>
-    <string name="h16" value="MP - 21, Range 175%, pulls up to 5 enemies."/>
-    <string name="h17" value="MP - 21, Range 180%, pulls up to 5 enemies."/>
-    <string name="h18" value="MP - 21, Range 185%, pulls up to 5 enemies."/>
-    <string name="h19" value="MP - 21, Range 190%, pulls up to 5 enemies."/>
-    <string name="h20" value="MP - 21, Range 195%, pulls up to 5 enemies."/>
-    <string name="h21" value="MP - 26, Range 200%, pulls up to 5 enemies."/>
-    <string name="h22" value="MP - 26, Range 205%, pulls up to 6 enemies."/>
-    <string name="h23" value="MP - 26, Range 210%, pulls up to 6 enemies."/>
-    <string name="h24" value="MP - 26, Range 215%, pulls up to 6 enemies."/>
-    <string name="h25" value="MP - 26, Range 220%, pulls up to 6 enemies."/>
-    <string name="h26" value="MP - 25, Range 225%, pulls up to 6 enemies."/>
-    <string name="h27" value="MP - 24, Range 225%, pulls up to 6 enemies."/>
-    <string name="h28" value="MP - 23, Range 225%, pulls up to 6 enemies."/>
-    <string name="h29" value="MP - 22, Range 225%, pulls up to 7 enemies."/>
-    <string name="h30" value="MP - 21, Range 225%, pulls up to 7 enemies."/>
+    <string name="desc" value="[Master Level: 30]\nPulls distant monsters toward you with a given success rate."/>
+    <string name="h1" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h2" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h3" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h4" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h5" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h6" value="MP -13; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h7" value="MP -13; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h8" value="MP -13; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h9" value="MP -13; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h10" value="MP -13; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h11" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h12" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h13" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h14" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h15" value="MP -18; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h16" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h17" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h18" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h19" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h20" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h21" value="MP -26; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h22" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h23" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h24" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h25" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h26" value="MP -25; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h27" value="MP -24; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h28" value="MP -23; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h29" value="MP -22; Pulls up to 7 enemies at 100% success rate"/>
+    <string name="h30" value="MP -21; Pulls up to 7 enemies at 100% success rate"/>
   </imgdir>
   <imgdir name="1221002">
     <string name="name" value="Power Stance"/>
-    <string name="desc" value="Enables one to stay at the same spot after being struck, resisting knock-back effects."/>
-    <string name="h1" value="MP - 30 ,For 10secs, prevent from getting knock-backed  with success rate  42%."/>
-    <string name="h2" value="MP - 30 ,For 20Secs, prevent from getting Knock-backed with success rate 44%."/>
-    <string name="h3" value="MP - 30 ,For 30Secs, prevent from getting Knock-backed with success rate 46%."/>
-    <string name="h4" value="MP - 30 ,For 40Secs, prevent from getting Knock-backed with success rate 48%."/>
-    <string name="h5" value="MP - 30 ,For 50Secs, prevent from getting Knock-backed with success rate 50%."/>
-    <string name="h6" value="MP - 36 ,For 60Secs, prevent from getting Knock-backed with success rate 52%."/>
-    <string name="h7" value="MP - 36 ,For 70Secs, prevent from getting Knock-backed with success rate 54%."/>
-    <string name="h8" value="MP - 36 ,For 80Secs, prevent from getting Knock-backed with success rate 56%."/>
-    <string name="h9" value="MP - 36 ,For 90Secs, prevent from getting Knock-backed with success rate 58%."/>
-    <string name="h10" value="MP - 36 ,For 100Secs, prevent from getting Knock-backed with success rate 60%."/>
-    <string name="h11" value="MP - 42 ,For 110Secs, prevent from getting Knock-backed with success rate 62%."/>
-    <string name="h12" value="MP - 42 ,For 120Secs, prevent from getting Knock-backed with success rate 64%."/>
-    <string name="h13" value="MP - 42 ,For 130Secs, prevent from getting Knock-backed with success rate 66%."/>
-    <string name="h14" value="MP - 42 ,For 140Secs, prevent from getting Knock-backed with success rate 68%."/>
-    <string name="h15" value="MP - 42 ,For 150Secs, prevent from getting Knock-backed with success rate 70%."/>
-    <string name="h16" value="MP - 48 ,For 160Secs, prevent from getting Knock-backed with success rate 72%."/>
-    <string name="h17" value="MP - 48 ,For 170Secs, prevent from getting Knock-backed with success rate 74%."/>
-    <string name="h18" value="MP - 48 ,For 180Secs, prevent from getting Knock-backed with success rate 76%."/>
-    <string name="h19" value="MP - 48 ,For 190Secs, prevent from getting Knock-backed with success rate 78%."/>
-    <string name="h20" value="MP - 48 ,For 200Secs, prevent from getting Knock-backed with success rate 80%."/>
-    <string name="h21" value="MP - 54 ,For 210Secs, prevent from getting Knock-backed with success rate 81%."/>
-    <string name="h22" value="MP - 54 ,For 220Secs, prevent from getting Knock-backed with success rate 82%."/>
-    <string name="h23" value="MP - 54 ,For 230Secs, prevent from getting Knock-backed with success rate 83%."/>
-    <string name="h24" value="MP - 54 ,For 240Secs, prevent from getting Knock-backed with success rate 84%."/>
-    <string name="h25" value="MP - 54 ,For 250Secs, prevent from getting Knock-backed with success rate 85%."/>
-    <string name="h26" value="MP - 53 ,For 260Secs, prevent from getting Knock-backed with success rate 86%."/>
-    <string name="h27" value="MP - 52 ,For 270Secs, prevent from getting Knock-backed with success rate 87%."/>
-    <string name="h28" value="MP - 51 ,For 280Secs, prevent from getting Knock-backed with success rate 88%."/>
-    <string name="h29" value="MP - 50 ,For 290Secs, prevent from getting Knock-backed with success rate 89%."/>
-    <string name="h30" value="MP - 50 ,For 300Secs, prevent from getting Knock-backed with success rate 90%."/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily resists knockback from enemy attacks with a given success rate."/>
+    <string name="h1" value="MP -30; 42% knockback resistance for 10 sec"/>
+    <string name="h2" value="MP -30; 44% knockback resistance for 20 sec"/>
+    <string name="h3" value="MP -30; 46% knockback resistance for 30 sec"/>
+    <string name="h4" value="MP -30; 48% knockback resistance for 40 sec"/>
+    <string name="h5" value="MP -30; 50% knockback resistance for 50 sec"/>
+    <string name="h6" value="MP -36; 52% knockback resistance for 60 sec"/>
+    <string name="h7" value="MP -36; 54% knockback resistance for 70 sec"/>
+    <string name="h8" value="MP -36; 56% knockback resistance for 80 sec"/>
+    <string name="h9" value="MP -36; 58% knockback resistance for 90 sec"/>
+    <string name="h10" value="MP -36; 60% knockback resistance for 100 sec"/>
+    <string name="h11" value="MP -42; 62% knockback resistance for 110 sec"/>
+    <string name="h12" value="MP -42; 64% knockback resistance for 120 sec"/>
+    <string name="h13" value="MP -42; 66% knockback resistance for 130 sec"/>
+    <string name="h14" value="MP -42; 68% knockback resistance for 140 sec"/>
+    <string name="h15" value="MP -42; 70% knockback resistance for 150 sec"/>
+    <string name="h16" value="MP -48; 72% knockback resistance for 160 sec"/>
+    <string name="h17" value="MP -48; 74% knockback resistance for 170 sec"/>
+    <string name="h18" value="MP -48; 76% knockback resistance for 180 sec"/>
+    <string name="h19" value="MP -48; 78% knockback resistance for 190 sec"/>
+    <string name="h20" value="MP -48; 80% knockback resistance for 200 sec"/>
+    <string name="h21" value="MP -54; 81% knockback resistance for 210 sec"/>
+    <string name="h22" value="MP -54; 82% knockback resistance for 220 sec"/>
+    <string name="h23" value="MP -54; 83% knockback resistance for 230 sec"/>
+    <string name="h24" value="MP -54; 84% knockback resistance for 240 sec"/>
+    <string name="h25" value="MP -54; 85% knockback resistance for 250 sec"/>
+    <string name="h26" value="MP -53; 86% knockback resistance for 260 sec"/>
+    <string name="h27" value="MP -52; 87% knockback resistance for 270 sec"/>
+    <string name="h28" value="MP -51; 88% knockback resistance for 280 sec"/>
+    <string name="h29" value="MP -50; 89% knockback resistance for 290 sec"/>
+    <string name="h30" value="MP -50; 90% knockback resistance for 300 sec"/>
   </imgdir>
   <imgdir name="1221003">
     <string name="name" value="Holy Charge : Sword"/>
-    <string name="desc" value="Temporarily adds a holy element to the sword. The skill gets cancelled when the charge blow is used or expires."/>
-    <string name="h1" value="MP - 20 , Damage increases by 102% for 15secs"/>
-    <string name="h2" value="MP - 20 , Damage increases by 104% for 30secs"/>
-    <string name="h3" value="MP - 20 , Damage increases by 106% for 45secs"/>
-    <string name="h4" value="MP - 20 , Damage increases by 108% for 60secs"/>
-    <string name="h5" value="MP - 20 , Damage increases by 110% for 75secs"/>
-    <string name="h6" value="MP - 20 , Damage increases by 112% for 90secs"/>
-    <string name="h7" value="MP - 20 , Damage increases by 114% for 105secs"/>
-    <string name="h8" value="MP - 20 , Damage increases by 116% for 120secs"/>
-    <string name="h9" value="MP - 20 , Damage increases by 118% for 135secs"/>
-    <string name="h10" value="MP - 20 , Damage increases by 120% for 150secs"/>
-    <string name="h11" value="MP - 30 , Damage increases by 122% for 165secs"/>
-    <string name="h12" value="MP - 30 , Damage increases by 124% for 180secs"/>
-    <string name="h13" value="MP - 30 , Damage increases by 126% for 195secs"/>
-    <string name="h14" value="MP - 30 , Damage increases by 128% for 210secs"/>
-    <string name="h15" value="MP - 30 , Damage increases by 130% for 225secs"/>
-    <string name="h16" value="MP - 30 , Damage increases by 132% for 240secs"/>
-    <string name="h17" value="MP - 30 , Damage increases by 134% for 255secs"/>
-    <string name="h18" value="MP - 30 , Damage increases by 136% for 270secs"/>
-    <string name="h19" value="MP - 30 , Damage increases by 138% for 285secs"/>
-    <string name="h20" value="MP - 30 , Damage increases by 140% for 300secs"/>
+    <string name="desc" value="[Master Level: 20]\nTemporarily adds holy element to the equipped sword. The charge can be consumed by Charged Blow or expire naturally."/>
+    <string name="h1" value="MP -20; Damage 102%; duration 15 sec"/>
+    <string name="h2" value="MP -20; Damage 104%; duration 30 sec"/>
+    <string name="h3" value="MP -20; Damage 106%; duration 45 sec"/>
+    <string name="h4" value="MP -20; Damage 108%; duration 60 sec"/>
+    <string name="h5" value="MP -20; Damage 110%; duration 75 sec"/>
+    <string name="h6" value="MP -20; Damage 112%; duration 90 sec"/>
+    <string name="h7" value="MP -20; Damage 114%; duration 105 sec"/>
+    <string name="h8" value="MP -20; Damage 116%; duration 120 sec"/>
+    <string name="h9" value="MP -20; Damage 118%; duration 135 sec"/>
+    <string name="h10" value="MP -20; Damage 120%; duration 150 sec"/>
+    <string name="h11" value="MP -30; Damage 122%; duration 165 sec"/>
+    <string name="h12" value="MP -30; Damage 124%; duration 180 sec"/>
+    <string name="h13" value="MP -30; Damage 126%; duration 195 sec"/>
+    <string name="h14" value="MP -30; Damage 128%; duration 210 sec"/>
+    <string name="h15" value="MP -30; Damage 130%; duration 225 sec"/>
+    <string name="h16" value="MP -30; Damage 132%; duration 240 sec"/>
+    <string name="h17" value="MP -30; Damage 134%; duration 255 sec"/>
+    <string name="h18" value="MP -30; Damage 136%; duration 270 sec"/>
+    <string name="h19" value="MP -30; Damage 138%; duration 285 sec"/>
+    <string name="h20" value="MP -30; Damage 140%; duration 300 sec"/>
   </imgdir>
   <imgdir name="1221004">
-    <string name="name" value="Divine Charge : BW"/>
-    <string name="desc" value="Temporarily adds a divine element to the blunt weapon. The skill gets cancelled when the charge blow is used or expires."/>
-    <string name="h1" value="MP - 20 , Damage increases by 102% for 15secs"/>
-    <string name="h2" value="MP - 20 , Damage increases by 104% for 30secs"/>
-    <string name="h3" value="MP - 20 , Damage increases by 106% for 45secs"/>
-    <string name="h4" value="MP - 20 , Damage increases by 108% for 60secs"/>
-    <string name="h5" value="MP - 20 , Damage increases by 110% for 75secs"/>
-    <string name="h6" value="MP - 20 , Damage increases by 112% for 90secs"/>
-    <string name="h7" value="MP - 20 , Damage increases by 114% for 105secs"/>
-    <string name="h8" value="MP - 20 , Damage increases by 116% for 120secs"/>
-    <string name="h9" value="MP - 20 , Damage increases by 118% for 135secs"/>
-    <string name="h10" value="MP - 20 , Damage increases by 120% for 150secs"/>
-    <string name="h11" value="MP - 30 , Damage increases by 122% for 165secs"/>
-    <string name="h12" value="MP - 30 , Damage increases by 124% for 180secs"/>
-    <string name="h13" value="MP - 30 , Damage increases by 126% for 195secs"/>
-    <string name="h14" value="MP - 30 , Damage increases by 128% for 210secs"/>
-    <string name="h15" value="MP - 30 , Damage increases by 130% for 225secs"/>
-    <string name="h16" value="MP - 30 , Damage increases by 132% for 240secs"/>
-    <string name="h17" value="MP - 30 , Damage increases by 134% for 255secs"/>
-    <string name="h18" value="MP - 30 , Damage increases by 136% for 270secs"/>
-    <string name="h19" value="MP - 30 , Damage increases by 138% for 285secs"/>
-    <string name="h20" value="MP - 30 , Damage increases by 140% for 300secs"/>
+    <string name="name" value="Holy Charge: Blunt Weapon"/>
+    <string name="desc" value="[Master Level: 20]\nTemporarily adds holy element to the equipped blunt weapon. The charge can be consumed by Charged Blow or expire naturally."/>
+    <string name="h1" value="MP -20; Damage 102%; duration 15 sec"/>
+    <string name="h2" value="MP -20; Damage 104%; duration 30 sec"/>
+    <string name="h3" value="MP -20; Damage 106%; duration 45 sec"/>
+    <string name="h4" value="MP -20; Damage 108%; duration 60 sec"/>
+    <string name="h5" value="MP -20; Damage 110%; duration 75 sec"/>
+    <string name="h6" value="MP -20; Damage 112%; duration 90 sec"/>
+    <string name="h7" value="MP -20; Damage 114%; duration 105 sec"/>
+    <string name="h8" value="MP -20; Damage 116%; duration 120 sec"/>
+    <string name="h9" value="MP -20; Damage 118%; duration 135 sec"/>
+    <string name="h10" value="MP -20; Damage 120%; duration 150 sec"/>
+    <string name="h11" value="MP -30; Damage 122%; duration 165 sec"/>
+    <string name="h12" value="MP -30; Damage 124%; duration 180 sec"/>
+    <string name="h13" value="MP -30; Damage 126%; duration 195 sec"/>
+    <string name="h14" value="MP -30; Damage 128%; duration 210 sec"/>
+    <string name="h15" value="MP -30; Damage 130%; duration 225 sec"/>
+    <string name="h16" value="MP -30; Damage 132%; duration 240 sec"/>
+    <string name="h17" value="MP -30; Damage 134%; duration 255 sec"/>
+    <string name="h18" value="MP -30; Damage 136%; duration 270 sec"/>
+    <string name="h19" value="MP -30; Damage 138%; duration 285 sec"/>
+    <string name="h20" value="MP -30; Damage 140%; duration 300 sec"/>
   </imgdir>
   <imgdir name="1220005">
     <string name="name" value="Achilles"/>
-    <string name="desc" value="Permanently increases the weapon defense of one&apos;s armor"/>
-    <string name="h1" value="  Damage taken from enemy - 0.5% ."/>
-    <string name="h2" value="  Damage taken from enemy - 1% ."/>
-    <string name="h3" value="  Damage taken from enemy - 1.5% ."/>
-    <string name="h4" value="  Damage taken from enemy - 2% ."/>
-    <string name="h5" value="  Damage taken from enemy - 2.5% ."/>
-    <string name="h6" value="  Damage taken from enemy - 3% ."/>
-    <string name="h7" value="  Damage taken from enemy - 3.5% ."/>
-    <string name="h8" value="  Damage taken from enemy - 4% ."/>
-    <string name="h9" value="  Damage taken from enemy - 4.5% ."/>
-    <string name="h10" value="  Damage taken from enemy - 5% ."/>
-    <string name="h11" value="  Damage taken from enemy - 5.5% ."/>
-    <string name="h12" value="  Damage taken from enemy - 6% ."/>
-    <string name="h13" value="  Damage taken from enemy - 6.5% ."/>
-    <string name="h14" value="  Damage taken from enemy - 7% ."/>
-    <string name="h15" value="  Damage taken from enemy - 7.5% ."/>
-    <string name="h16" value="  Damage taken from enemy - 8% ."/>
-    <string name="h17" value="  Damage taken from enemy - 8.5% ."/>
-    <string name="h18" value="  Damage taken from enemy - 9% ."/>
-    <string name="h19" value="  Damage taken from enemy - 9.5% ."/>
-    <string name="h20" value="  Damage taken from enemy - 10% ."/>
-    <string name="h21" value="  Damage taken from enemy - 10.5% ."/>
-    <string name="h22" value="  Damage taken from enemy - 11% ."/>
-    <string name="h23" value="  Damage taken from enemy - 11.5% ."/>
-    <string name="h24" value="  Damage taken from enemy - 12% ."/>
-    <string name="h25" value="  Damage taken from enemy - 12.5% ."/>
-    <string name="h26" value="  Damage taken from enemy - 13% ."/>
-    <string name="h27" value="  Damage taken from enemy - 13.5% ."/>
-    <string name="h28" value="  Damage taken from enemy - 14% ."/>
-    <string name="h29" value="  Damage taken from enemy - 14.5% ."/>
-    <string name="h30" value="  Damage taken from enemy - 15% ."/>
+    <string name="desc" value="[Master Level: 30]\nPermanently reduces damage received from enemies."/>
+    <string name="h1" value="Damage taken -0.5%"/>
+    <string name="h2" value="Damage taken -1%"/>
+    <string name="h3" value="Damage taken -1.5%"/>
+    <string name="h4" value="Damage taken -2%"/>
+    <string name="h5" value="Damage taken -2.5%"/>
+    <string name="h6" value="Damage taken -3%"/>
+    <string name="h7" value="Damage taken -3.5%"/>
+    <string name="h8" value="Damage taken -4%"/>
+    <string name="h9" value="Damage taken -4.5%"/>
+    <string name="h10" value="Damage taken -5%"/>
+    <string name="h11" value="Damage taken -5.5%"/>
+    <string name="h12" value="Damage taken -6%"/>
+    <string name="h13" value="Damage taken -6.5%"/>
+    <string name="h14" value="Damage taken -7%"/>
+    <string name="h15" value="Damage taken -7.5%"/>
+    <string name="h16" value="Damage taken -8%"/>
+    <string name="h17" value="Damage taken -8.5%"/>
+    <string name="h18" value="Damage taken -9%"/>
+    <string name="h19" value="Damage taken -9.5%"/>
+    <string name="h20" value="Damage taken -10%"/>
+    <string name="h21" value="Damage taken -10.5%"/>
+    <string name="h22" value="Damage taken -11%"/>
+    <string name="h23" value="Damage taken -11.5%"/>
+    <string name="h24" value="Damage taken -12%"/>
+    <string name="h25" value="Damage taken -12.5%"/>
+    <string name="h26" value="Damage taken -13%"/>
+    <string name="h27" value="Damage taken -13.5%"/>
+    <string name="h28" value="Damage taken -14%"/>
+    <string name="h29" value="Damage taken -14.5%"/>
+    <string name="h30" value="Damage taken -15%"/>
   </imgdir>
   <imgdir name="1220006">
     <string name="name" value="Guardian"/>
-    <string name="desc" value="Blocks the monster&apos;s attack by using the shield with a given success rate. Additionally, if the close-range attack is blocked, the attacking monster will be stunned for 2 seconds. The skill only works when equipped with a shield"/>
-    <string name="h1" value="Block against enemies attack with success rate 0.5%"/>
-    <string name="h2" value="Block against enemies attack with success rate 1%"/>
-    <string name="h3" value="Block against enemies attack with success rate 1.5%"/>
-    <string name="h4" value="Block against enemies attack with success rate 2%"/>
-    <string name="h5" value="Block against enemies attack with success rate 2.5%"/>
-    <string name="h6" value="Block against enemies attack with success rate 3%"/>
-    <string name="h7" value="Block against enemies attack with success rate 3.5%"/>
-    <string name="h8" value="Block against enemies attack with success rate 4%"/>
-    <string name="h9" value="Block against enemies attack with success rate 4.5%"/>
-    <string name="h10" value="Block against enemies attack with success rate 5%"/>
-    <string name="h11" value="Block against enemies attack with success rate 5.5%"/>
-    <string name="h12" value="Block against enemies attack with success rate 6%"/>
-    <string name="h13" value="Block against enemies attack with success rate 6.5%"/>
-    <string name="h14" value="Block against enemies attack with success rate 7%"/>
-    <string name="h15" value="Block against enemies attack with success rate 7.5%"/>
-    <string name="h16" value="Block against enemies attack with success rate 8%"/>
-    <string name="h17" value="Block against enemies attack with success rate 8.5%"/>
-    <string name="h18" value="Block against enemies attack with success rate 9%"/>
-    <string name="h19" value="Block against enemies attack with success rate 9.5%"/>
-    <string name="h20" value="Block against enemies attack with success rate 10%"/>
-    <string name="h21" value="Block against enemies attack with success rate 10.5%"/>
-    <string name="h22" value="Block against enemies attack with success rate 11%"/>
-    <string name="h23" value="Block against enemies attack with success rate 11.5%"/>
-    <string name="h24" value="Block against enemies attack with success rate 12%"/>
-    <string name="h25" value="Block against enemies attack with success rate 12.5%"/>
-    <string name="h26" value="Block against enemies attack with success rate 13%"/>
-    <string name="h27" value="Block against enemies attack with success rate 13.5%"/>
-    <string name="h28" value="Block against enemies attack with success rate 14%"/>
-    <string name="h29" value="Block against enemies attack with success rate 14.5%"/>
-    <string name="h30" value="Block against enemies attack with success rate 15%"/>
+    <string name="desc" value="[Master Level: 30]\nBlocks enemy attacks with a shield at a given success rate. If a close-range attack is blocked, the attacker is stunned for 2 sec. Requires a shield."/>
+    <string name="h1" value="0% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h2" value="1% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h3" value="1% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h4" value="2% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h5" value="2% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h6" value="3% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h7" value="3% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h8" value="4% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h9" value="4% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h10" value="5% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h11" value="5% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h12" value="6% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h13" value="6% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h14" value="7% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h15" value="7% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h16" value="8% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h17" value="8% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h18" value="9% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h19" value="9% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h20" value="10% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h21" value="10% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h22" value="11% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h23" value="11% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h24" value="12% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h25" value="12% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h26" value="13% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h27" value="13% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h28" value="14% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h29" value="14% block rate; stun blocked close-range attackers for 2 sec"/>
+    <string name="h30" value="15% block rate; stun blocked close-range attackers for 2 sec"/>
   </imgdir>
   <imgdir name="1221007">
     <string name="name" value="Rush"/>
-    <string name="desc" value="Makes a mad dash forward, pushing off up to 10 monsters."/>
-    <string name="h1" value="MP - 22 , Damage 72%, Range 80%"/>
-    <string name="h2" value="MP - 24 , Damage 74%, Range 80%"/>
-    <string name="h3" value="MP - 26 , Damage 76%, Range 80%"/>
-    <string name="h4" value="MP - 28 , Damage 78%, Range 85%"/>
-    <string name="h5" value="MP - 30 , Damage 80%, Range 85%"/>
-    <string name="h6" value="MP - 32 , Damage 82%, Range 85%"/>
-    <string name="h7" value="MP - 34 , Damage 84%, Range 85%"/>
-    <string name="h8" value="MP - 36 , Damage 86%, Range 90%"/>
-    <string name="h9" value="MP - 38 , Damage 88%, Range 90%"/>
-    <string name="h10" value="MP - 40 , Damage 90%, Range 90%"/>
-    <string name="h11" value="MP - 42 , Damage 92%, Range 95%"/>
-    <string name="h12" value="MP - 44 , Damage 94%, Range 95%"/>
-    <string name="h13" value="MP - 46 , Damage 96%, Range 95%"/>
-    <string name="h14" value="MP - 48 , Damage 98%, Range 100%"/>
-    <string name="h15" value="MP - 50 , Damage 100%, Range 100%"/>
-    <string name="h16" value="MP - 52 , Damage 102%, Range 100%"/>
-    <string name="h17" value="MP - 54 , Damage 104%, Range 105%"/>
-    <string name="h18" value="MP - 56 , Damage 106%, Range 105%"/>
-    <string name="h19" value="MP - 58 , Damage 108%, Range 105%"/>
-    <string name="h20" value="MP - 60 , Damage 110%, Range 110%"/>
-    <string name="h21" value="MP - 59 , Damage 112%, Range 110%"/>
-    <string name="h22" value="MP - 58 , Damage 114%, Range 115%"/>
-    <string name="h23" value="MP - 57 , Damage 116%, Range 115%"/>
-    <string name="h24" value="MP - 56 , Damage 118%, Range 115%"/>
-    <string name="h25" value="MP - 55 , Damage 120%, Range 120%"/>
-    <string name="h26" value="MP - 54 , Damage 122%, Range 120%"/>
-    <string name="h27" value="MP - 53 , Damage 124%, Range 120%"/>
-    <string name="h28" value="MP - 52 , Damage 126%, Range 125%"/>
-    <string name="h29" value="MP - 51 , Damage 128%, Range 125%"/>
-    <string name="h30" value="MP - 50 , Damage 130%, Range 125%"/>
+    <string name="desc" value="[Master Level: 30]\nRushes forward, damaging and pushing up to 15 monsters."/>
+    <string name="h1" value="MP -22; Damage 72%; pushes up to 15 enemies"/>
+    <string name="h2" value="MP -24; Damage 74%; pushes up to 15 enemies"/>
+    <string name="h3" value="MP -26; Damage 76%; pushes up to 15 enemies"/>
+    <string name="h4" value="MP -28; Damage 78%; pushes up to 15 enemies"/>
+    <string name="h5" value="MP -30; Damage 80%; pushes up to 15 enemies"/>
+    <string name="h6" value="MP -32; Damage 82%; pushes up to 15 enemies"/>
+    <string name="h7" value="MP -34; Damage 84%; pushes up to 15 enemies"/>
+    <string name="h8" value="MP -36; Damage 86%; pushes up to 15 enemies"/>
+    <string name="h9" value="MP -38; Damage 88%; pushes up to 15 enemies"/>
+    <string name="h10" value="MP -40; Damage 90%; pushes up to 15 enemies"/>
+    <string name="h11" value="MP -42; Damage 92%; pushes up to 15 enemies"/>
+    <string name="h12" value="MP -44; Damage 94%; pushes up to 15 enemies"/>
+    <string name="h13" value="MP -46; Damage 96%; pushes up to 15 enemies"/>
+    <string name="h14" value="MP -48; Damage 98%; pushes up to 15 enemies"/>
+    <string name="h15" value="MP -50; Damage 100%; pushes up to 15 enemies"/>
+    <string name="h16" value="MP -52; Damage 102%; pushes up to 15 enemies"/>
+    <string name="h17" value="MP -54; Damage 104%; pushes up to 15 enemies"/>
+    <string name="h18" value="MP -56; Damage 106%; pushes up to 15 enemies"/>
+    <string name="h19" value="MP -58; Damage 108%; pushes up to 15 enemies"/>
+    <string name="h20" value="MP -60; Damage 110%; pushes up to 15 enemies"/>
+    <string name="h21" value="MP -59; Damage 112%; pushes up to 15 enemies"/>
+    <string name="h22" value="MP -58; Damage 114%; pushes up to 15 enemies"/>
+    <string name="h23" value="MP -57; Damage 116%; pushes up to 15 enemies"/>
+    <string name="h24" value="MP -56; Damage 118%; pushes up to 15 enemies"/>
+    <string name="h25" value="MP -55; Damage 120%; pushes up to 15 enemies"/>
+    <string name="h26" value="MP -54; Damage 122%; pushes up to 15 enemies"/>
+    <string name="h27" value="MP -53; Damage 124%; pushes up to 15 enemies"/>
+    <string name="h28" value="MP -52; Damage 126%; pushes up to 15 enemies"/>
+    <string name="h29" value="MP -51; Damage 128%; pushes up to 15 enemies"/>
+    <string name="h30" value="MP -50; Damage 130%; pushes up to 15 enemies"/>
   </imgdir>
   <imgdir name="1221009">
     <string name="name" value="Blast"/>
-    <string name="desc" value="Strikes a single, tremendous blow to a single monster."/>
-    <string name="h1" value="MP - 17 , Damage 170%"/>
-    <string name="h2" value="MP - 17 , Damage 190%"/>
-    <string name="h3" value="MP - 17 , Damage 210%"/>
-    <string name="h4" value="MP - 17 , Damage 230%"/>
-    <string name="h5" value="MP - 17 , Damage 250%"/>
-    <string name="h6" value="MP - 20 , Damage 270%"/>
-    <string name="h7" value="MP - 20 , Damage 290%"/>
-    <string name="h8" value="MP - 20 , Damage 310%"/>
-    <string name="h9" value="MP - 20 , Damage 330%"/>
-    <string name="h10" value="MP - 20 , Damage 350%"/>
-    <string name="h11" value="MP - 23 , Damage 360%"/>
-    <string name="h12" value="MP - 23 , Damage 370%"/>
-    <string name="h13" value="MP - 23 , Damage 380%"/>
-    <string name="h14" value="MP - 23 , Damage 390%"/>
-    <string name="h15" value="MP - 23 , Damage 400%"/>
-    <string name="h16" value="MP - 26 , Damage 410%"/>
-    <string name="h17" value="MP - 26 , Damage 420%"/>
-    <string name="h18" value="MP - 26 , Damage 430%"/>
-    <string name="h19" value="MP - 26 , Damage 440%"/>
-    <string name="h20" value="MP - 26 , Damage 450%"/>
-    <string name="h21" value="MP - 29 , Damage 460%"/>
-    <string name="h22" value="MP - 29 , Damage 470%"/>
-    <string name="h23" value="MP - 29 , Damage 480%"/>
-    <string name="h24" value="MP - 29 , Damage 490%"/>
-    <string name="h25" value="MP - 29 , Damage 500%"/>
-    <string name="h26" value="MP - 28 , Damage 510%"/>
-    <string name="h27" value="MP - 27 , Damage 520%"/>
-    <string name="h28" value="MP - 26 , Damage 530%"/>
-    <string name="h29" value="MP - 25 , Damage 540%"/>
-    <string name="h30" value="MP - 24 , Damage 550%"/>
+    <string name="desc" value="[Master Level: 30]\nStrikes one monster with a powerful single blow."/>
+    <string name="h1" value="MP -17; Damage 170%"/>
+    <string name="h2" value="MP -17; Damage 190%"/>
+    <string name="h3" value="MP -17; Damage 210%"/>
+    <string name="h4" value="MP -17; Damage 230%"/>
+    <string name="h5" value="MP -17; Damage 250%"/>
+    <string name="h6" value="MP -20; Damage 270%"/>
+    <string name="h7" value="MP -20; Damage 290%"/>
+    <string name="h8" value="MP -20; Damage 310%"/>
+    <string name="h9" value="MP -20; Damage 330%"/>
+    <string name="h10" value="MP -20; Damage 350%"/>
+    <string name="h11" value="MP -23; Damage 360%"/>
+    <string name="h12" value="MP -23; Damage 370%"/>
+    <string name="h13" value="MP -23; Damage 380%"/>
+    <string name="h14" value="MP -23; Damage 390%"/>
+    <string name="h15" value="MP -23; Damage 400%"/>
+    <string name="h16" value="MP -26; Damage 410%"/>
+    <string name="h17" value="MP -26; Damage 420%"/>
+    <string name="h18" value="MP -26; Damage 430%"/>
+    <string name="h19" value="MP -26; Damage 440%"/>
+    <string name="h20" value="MP -26; Damage 450%"/>
+    <string name="h21" value="MP -29; Damage 460%"/>
+    <string name="h22" value="MP -29; Damage 470%"/>
+    <string name="h23" value="MP -29; Damage 480%"/>
+    <string name="h24" value="MP -29; Damage 490%"/>
+    <string name="h25" value="MP -29; Damage 500%"/>
+    <string name="h26" value="MP -28; Damage 510%"/>
+    <string name="h27" value="MP -27; Damage 520%"/>
+    <string name="h28" value="MP -26; Damage 530%"/>
+    <string name="h29" value="MP -25; Damage 540%"/>
+    <string name="h30" value="MP -24; Damage 550%"/>
   </imgdir>
   <imgdir name="1220010">
     <string name="name" value="Advanced Charge"/>
-    <string name="desc" value="Increases the damage incurred when using Charge Blow.  With a given success rate, the charge does not expire even after the initial Charge Blow."/>
-    <string name="h1" value="Damage 260%, Charge remains intact on a success rate 10%."/>
-    <string name="h2" value="Damage 270%, Charge remains intact on a success rate 20%."/>
-    <string name="h3" value="Damage 280%, Charge remains intact on a success rate 30%."/>
-    <string name="h4" value="Damage 290%, Charge remains intact on a success rate 40%."/>
-    <string name="h5" value="Damage 300%, Charge remains intact on a success rate 50%."/>
-    <string name="h6" value="Damage 310%, Charge remains intact on a success rate 60%."/>
-    <string name="h7" value="Damage 320%, Charge remains intact on a success rate 70%."/>
-    <string name="h8" value="Damage 330%, Charge remains intact on a success rate 80%."/>
-    <string name="h9" value="Damage 340%, Charge remains intact on a success rate 90%."/>
-    <string name="h10" value="Damage 350%, Charge remains intact on a success rate 100%."/>
+    <string name="desc" value="[Master Level: 10]\nIncreases Charged Blow damage and gives a chance for the active charge to remain after Charged Blow.\nRequired Skill: #cCharged Blow Lv. 30#"/>
+    <string name="h1" value="Charged Blow damage 260%; 10% chance to keep charge"/>
+    <string name="h2" value="Charged Blow damage 270%; 20% chance to keep charge"/>
+    <string name="h3" value="Charged Blow damage 280%; 30% chance to keep charge"/>
+    <string name="h4" value="Charged Blow damage 290%; 40% chance to keep charge"/>
+    <string name="h5" value="Charged Blow damage 300%; 50% chance to keep charge"/>
+    <string name="h6" value="Charged Blow damage 310%; 60% chance to keep charge"/>
+    <string name="h7" value="Charged Blow damage 320%; 70% chance to keep charge"/>
+    <string name="h8" value="Charged Blow damage 330%; 80% chance to keep charge"/>
+    <string name="h9" value="Charged Blow damage 340%; 90% chance to keep charge"/>
+    <string name="h10" value="Charged Blow damage 350%; 100% chance to keep charge"/>
   </imgdir>
   <imgdir name="1221011">
-    <string name="name" value="Heaven&apos;s Hammer"/>
-    <string name="desc" value="Strikes the ground with a huge hammer to attack up to 15 monsters. The skill works when charged up in a Holy Charge."/>
-    <string name="h1" value="MP - 31 , Damage 420%, Terms between skills 310secs"/>
-    <string name="h2" value="MP - 32 , Damage 440%, Terms between skills 300secs"/>
-    <string name="h3" value="MP - 33 , Damage 460%, Terms between skills 290secs"/>
-    <string name="h4" value="MP - 34 , Damage 480%, Terms between skills 280secs"/>
-    <string name="h5" value="MP - 35 , Damage 500%, Terms between skills 270secs"/>
-    <string name="h6" value="MP - 36 , Damage 520%, Terms between skills 260secs"/>
-    <string name="h7" value="MP - 37 , Damage 540%, Terms between skills 250secs"/>
-    <string name="h8" value="MP - 38 , Damage 560%, Terms between skills 240secs"/>
-    <string name="h9" value="MP - 39 , Damage 580%, Terms between skills 230secs"/>
-    <string name="h10" value="MP - 40 , Damage 600%, Terms between skills 220secs"/>
-    <string name="h11" value="MP - 41 , Damage 620%, Terms between skills 210secs"/>
-    <string name="h12" value="MP - 42 , Damage 640%, Terms between skills 200secs"/>
-    <string name="h13" value="MP - 43 , Damage 660%, Terms between skills 190secs"/>
-    <string name="h14" value="MP - 44 , Damage 680%, Terms between skills 180secs"/>
-    <string name="h15" value="MP - 45 , Damage 700%, Terms between skills 170secs"/>
-    <string name="h16" value="MP - 46 , Damage 720%, Terms between skills 160secs"/>
-    <string name="h17" value="MP - 47 , Damage 740%, Terms between skills 150secs"/>
-    <string name="h18" value="MP - 48 , Damage 760%, Terms between skills 140secs"/>
-    <string name="h19" value="MP - 49 , Damage 780%, Terms between skills 130secs"/>
-    <string name="h20" value="MP - 50 , Damage 800%, Terms between skills 120secs"/>
-    <string name="h21" value="MP - 51 , Damage 810%, Terms between skills 110secs"/>
-    <string name="h22" value="MP - 52 , Damage 820%, Terms between skills 100secs"/>
-    <string name="h23" value="MP - 53 , Damage 830%, Terms between skills 90secs"/>
-    <string name="h24" value="MP - 54 , Damage 840%, Terms between skills 80secs"/>
-    <string name="h25" value="MP - 55 , Damage 850%, Terms between skills 70secs"/>
-    <string name="h26" value="MP - 56 , Damage 860%, Terms between skills 60secs"/>
-    <string name="h27" value="MP - 57 , Damage 870%, Terms between skills 50secs"/>
-    <string name="h28" value="MP - 58 , Damage 880%, Terms between skills 40secs"/>
-    <string name="h29" value="MP - 59 , Damage 890%, Terms between skills 30secs"/>
-    <string name="h30" value="MP - 60 , Damage 900%, Terms between skills 20secs"/>
+    <string name="name" value="Heaven&#x27;s Hammer"/>
+    <string name="desc" value="[Master Level: 30]\nStrikes the ground to attack up to 15 monsters. Normal monsters hit by this skill are reduced to 1 HP."/>
+    <string name="h1" value="MP -31; Damage 420%; attacks up to 15 enemies; cooldown 310 sec"/>
+    <string name="h2" value="MP -32; Damage 440%; attacks up to 15 enemies; cooldown 300 sec"/>
+    <string name="h3" value="MP -33; Damage 460%; attacks up to 15 enemies; cooldown 290 sec"/>
+    <string name="h4" value="MP -34; Damage 480%; attacks up to 15 enemies; cooldown 280 sec"/>
+    <string name="h5" value="MP -35; Damage 500%; attacks up to 15 enemies; cooldown 270 sec"/>
+    <string name="h6" value="MP -36; Damage 520%; attacks up to 15 enemies; cooldown 260 sec"/>
+    <string name="h7" value="MP -37; Damage 540%; attacks up to 15 enemies; cooldown 250 sec"/>
+    <string name="h8" value="MP -38; Damage 560%; attacks up to 15 enemies; cooldown 240 sec"/>
+    <string name="h9" value="MP -39; Damage 580%; attacks up to 15 enemies; cooldown 230 sec"/>
+    <string name="h10" value="MP -40; Damage 600%; attacks up to 15 enemies; cooldown 220 sec"/>
+    <string name="h11" value="MP -41; Damage 620%; attacks up to 15 enemies; cooldown 210 sec"/>
+    <string name="h12" value="MP -42; Damage 640%; attacks up to 15 enemies; cooldown 200 sec"/>
+    <string name="h13" value="MP -43; Damage 660%; attacks up to 15 enemies; cooldown 190 sec"/>
+    <string name="h14" value="MP -44; Damage 680%; attacks up to 15 enemies; cooldown 180 sec"/>
+    <string name="h15" value="MP -45; Damage 700%; attacks up to 15 enemies; cooldown 170 sec"/>
+    <string name="h16" value="MP -46; Damage 720%; attacks up to 15 enemies; cooldown 160 sec"/>
+    <string name="h17" value="MP -47; Damage 740%; attacks up to 15 enemies; cooldown 150 sec"/>
+    <string name="h18" value="MP -48; Damage 760%; attacks up to 15 enemies; cooldown 140 sec"/>
+    <string name="h19" value="MP -49; Damage 780%; attacks up to 15 enemies; cooldown 130 sec"/>
+    <string name="h20" value="MP -50; Damage 800%; attacks up to 15 enemies; cooldown 120 sec"/>
+    <string name="h21" value="MP -51; Damage 810%; attacks up to 15 enemies; cooldown 110 sec"/>
+    <string name="h22" value="MP -52; Damage 820%; attacks up to 15 enemies; cooldown 100 sec"/>
+    <string name="h23" value="MP -53; Damage 830%; attacks up to 15 enemies; cooldown 90 sec"/>
+    <string name="h24" value="MP -54; Damage 840%; attacks up to 15 enemies; cooldown 80 sec"/>
+    <string name="h25" value="MP -55; Damage 850%; attacks up to 15 enemies; cooldown 70 sec"/>
+    <string name="h26" value="MP -56; Damage 860%; attacks up to 15 enemies; cooldown 60 sec"/>
+    <string name="h27" value="MP -57; Damage 870%; attacks up to 15 enemies; cooldown 50 sec"/>
+    <string name="h28" value="MP -58; Damage 880%; attacks up to 15 enemies; cooldown 40 sec"/>
+    <string name="h29" value="MP -59; Damage 890%; attacks up to 15 enemies; cooldown 30 sec"/>
+    <string name="h30" value="MP -60; Damage 900%; attacks up to 15 enemies; cooldown 20 sec"/>
   </imgdir>
   <imgdir name="1221012">
-    <string name="name" value="Hero&apos;s Will"/>
-    <string name="desc" value="Enables one to shrug off abnormal conditions. The higher the skill level, the more types of abnormal conditions one can nullify."/>
-    <string name="h1" value="MP - 30 escape from abnormal condition, Terms between skills 600secs"/>
-    <string name="h2" value="MP - 30 escape from abnormal condition, Terms between skills 540secs"/>
-    <string name="h3" value="MP - 30 escape from abnormal condition, Terms between skills 480secs"/>
-    <string name="h4" value="MP - 30 escape from abnormal condition, Terms between skills 420secs"/>
-    <string name="h5" value="MP - 30 escape from abnormal condition, Terms between skills 360secs"/>
+    <string name="name" value="Hero&#x27;s Will"/>
+    <string name="desc" value="[Master Level: 5]\nRemoves certain abnormal status effects. Higher levels reduce the cooldown."/>
+    <string name="h1" value="MP -30; Removes abnormal status; cooldown 600 sec"/>
+    <string name="h2" value="MP -30; Removes abnormal status; cooldown 540 sec"/>
+    <string name="h3" value="MP -30; Removes abnormal status; cooldown 480 sec"/>
+    <string name="h4" value="MP -30; Removes abnormal status; cooldown 420 sec"/>
+    <string name="h5" value="MP -30; Removes abnormal status; cooldown 360 sec"/>
   </imgdir>
   <imgdir name="132">
     <string name="bookName" value="Dark Knight of Darkness"/>
   </imgdir>
   <imgdir name="1321000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
-    <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
-    <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
-    <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
-    <string name="h4" value="MP - 10 ,  For 120Secs, all stats + 2% "/>
-    <string name="h5" value="MP - 10 ,  For 150Secs, all stats + 3% "/>
-    <string name="h6" value="MP - 20 ,  For 180Secs, all stats + 3% "/>
-    <string name="h7" value="MP - 20 ,  For 210Secs, all stats + 4% "/>
-    <string name="h8" value="MP - 20 ,  For 240Secs, all stats + 4% "/>
-    <string name="h9" value="MP - 20 ,  For 270Secs, all stats + 5% "/>
-    <string name="h10" value="MP - 20 ,  For 300Secs, all stats + 5% "/>
-    <string name="h11" value="MP - 30 ,  For 330Secs, all stats + 6% "/>
-    <string name="h12" value="MP - 30 ,  For 360Secs, all stats + 6% "/>
-    <string name="h13" value="MP - 30 ,  For 390Secs, all stats + 7% "/>
-    <string name="h14" value="MP - 30 ,  For 420Secs, all stats + 7% "/>
-    <string name="h15" value="MP - 30 ,  For 450Secs, all stats + 8% "/>
-    <string name="h16" value="MP - 40 ,  For 480Secs, all stats + 8% "/>
-    <string name="h17" value="MP - 40 ,  For 510Secs, all stats + 9% "/>
-    <string name="h18" value="MP - 40 ,  For 540Secs, all stats + 9% "/>
-    <string name="h19" value="MP - 40 ,  For 570Secs, all stats + 10% "/>
-    <string name="h20" value="MP - 40 ,  For 600Secs, all stats + 10% "/>
-    <string name="h21" value="MP - 50 ,  For 630Secs, all stats + 11% "/>
-    <string name="h22" value="MP - 50 ,  For 660Secs, all stats + 11% "/>
-    <string name="h23" value="MP - 50 ,  For 690Secs, all stats + 12% "/>
-    <string name="h24" value="MP - 50 ,  For 720Secs, all stats + 12% "/>
-    <string name="h25" value="MP - 50 ,  For 750Secs, all stats + 13% "/>
-    <string name="h26" value="MP - 60 ,  For 780Secs, all stats + 13% "/>
-    <string name="h27" value="MP - 60 ,  For 810Secs, all stats + 14% "/>
-    <string name="h28" value="MP - 60 ,  For 840Secs, all stats + 14% "/>
-    <string name="h29" value="MP - 60 ,  For 870Secs, all stats + 15% "/>
-    <string name="h30" value="MP - 60 ,  For 900Secs, all stats + 15% "/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily increases all stats of yourself and nearby party members by a percentage."/>
+    <string name="h1" value="MP -10; All stats +1% for 30 sec"/>
+    <string name="h2" value="MP -10; All stats +1% for 60 sec"/>
+    <string name="h3" value="MP -10; All stats +2% for 90 sec"/>
+    <string name="h4" value="MP -10; All stats +2% for 120 sec"/>
+    <string name="h5" value="MP -10; All stats +3% for 150 sec"/>
+    <string name="h6" value="MP -20; All stats +3% for 180 sec"/>
+    <string name="h7" value="MP -20; All stats +4% for 210 sec"/>
+    <string name="h8" value="MP -20; All stats +4% for 240 sec"/>
+    <string name="h9" value="MP -20; All stats +5% for 270 sec"/>
+    <string name="h10" value="MP -20; All stats +5% for 300 sec"/>
+    <string name="h11" value="MP -30; All stats +6% for 330 sec"/>
+    <string name="h12" value="MP -30; All stats +6% for 360 sec"/>
+    <string name="h13" value="MP -30; All stats +7% for 390 sec"/>
+    <string name="h14" value="MP -30; All stats +7% for 420 sec"/>
+    <string name="h15" value="MP -30; All stats +8% for 450 sec"/>
+    <string name="h16" value="MP -40; All stats +8% for 480 sec"/>
+    <string name="h17" value="MP -40; All stats +9% for 510 sec"/>
+    <string name="h18" value="MP -40; All stats +9% for 540 sec"/>
+    <string name="h19" value="MP -40; All stats +10% for 570 sec"/>
+    <string name="h20" value="MP -40; All stats +10% for 600 sec"/>
+    <string name="h21" value="MP -50; All stats +11% for 630 sec"/>
+    <string name="h22" value="MP -50; All stats +11% for 660 sec"/>
+    <string name="h23" value="MP -50; All stats +12% for 690 sec"/>
+    <string name="h24" value="MP -50; All stats +12% for 720 sec"/>
+    <string name="h25" value="MP -50; All stats +13% for 750 sec"/>
+    <string name="h26" value="MP -60; All stats +13% for 780 sec"/>
+    <string name="h27" value="MP -60; All stats +14% for 810 sec"/>
+    <string name="h28" value="MP -60; All stats +14% for 840 sec"/>
+    <string name="h29" value="MP -60; All stats +15% for 870 sec"/>
+    <string name="h30" value="MP -60; All stats +15% for 900 sec"/>
   </imgdir>
   <imgdir name="1321001">
     <string name="name" value="Monster Magnet"/>
-    <string name="desc" value="Pulls a monster from afar up close."/>
-    <string name="h1" value="MP - 10, Range 100%, pulls up to 3 enemies."/>
-    <string name="h2" value="MP - 10, Range 105%, pulls up to 3 enemies."/>
-    <string name="h3" value="MP - 10, Range 110%, pulls up to 3 enemies."/>
-    <string name="h4" value="MP - 10, Range 115%, pulls up to 3 enemies."/>
-    <string name="h5" value="MP - 10, Range 120%, pulls up to 3 enemies."/>
-    <string name="h6" value="MP - 13, Range 125%, pulls up to 3 enemies."/>
-    <string name="h7" value="MP - 13, Range 130%, pulls up to 3 enemies."/>
-    <string name="h8" value="MP - 13, Range 135%, pulls up to 4 enemies."/>
-    <string name="h9" value="MP - 13, Range 140%, pulls up to 4 enemies."/>
-    <string name="h10" value="MP - 13, Range 145%, pulls up to 4 enemies."/>
-    <string name="h11" value="MP - 18, Range 150%, pulls up to 4 enemies."/>
-    <string name="h12" value="MP - 18, Range 155%, pulls up to 4 enemies."/>
-    <string name="h13" value="MP - 18, Range 160%, pulls up to 4 enemies."/>
-    <string name="h14" value="MP - 18, Range 165%, pulls up to 4 enemies."/>
-    <string name="h15" value="MP - 18, Range 170%, pulls up to 5 enemies."/>
-    <string name="h16" value="MP - 21, Range 175%, pulls up to 5 enemies."/>
-    <string name="h17" value="MP - 21, Range 180%, pulls up to 5 enemies."/>
-    <string name="h18" value="MP - 21, Range 185%, pulls up to 5 enemies."/>
-    <string name="h19" value="MP - 21, Range 190%, pulls up to 5 enemies."/>
-    <string name="h20" value="MP - 21, Range 195%, pulls up to 5 enemies."/>
-    <string name="h21" value="MP - 26, Range 200%, pulls up to 5 enemies."/>
-    <string name="h22" value="MP - 26, Range 205%, pulls up to 6 enemies."/>
-    <string name="h23" value="MP - 26, Range 210%, pulls up to 6 enemies."/>
-    <string name="h24" value="MP - 26, Range 215%, pulls up to 6 enemies."/>
-    <string name="h25" value="MP - 26, Range 220%, pulls up to 6 enemies."/>
-    <string name="h26" value="MP - 25, Range 225%, pulls up to 6 enemies."/>
-    <string name="h27" value="MP - 24, Range 225%, pulls up to 6 enemies."/>
-    <string name="h28" value="MP - 23, Range 225%, pulls up to 6 enemies."/>
-    <string name="h29" value="MP - 22, Range 225%, pulls up to 7 enemies."/>
-    <string name="h30" value="MP - 21, Range 225%, pulls up to 7 enemies."/>
+    <string name="desc" value="[Master Level: 30]\nPulls distant monsters toward you with a given success rate."/>
+    <string name="h1" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h2" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h3" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h4" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h5" value="MP -10; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h6" value="MP -13; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h7" value="MP -13; Pulls up to 3 enemies at 100% success rate"/>
+    <string name="h8" value="MP -13; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h9" value="MP -13; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h10" value="MP -13; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h11" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h12" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h13" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h14" value="MP -18; Pulls up to 4 enemies at 100% success rate"/>
+    <string name="h15" value="MP -18; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h16" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h17" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h18" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h19" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h20" value="MP -21; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h21" value="MP -26; Pulls up to 5 enemies at 100% success rate"/>
+    <string name="h22" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h23" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h24" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h25" value="MP -26; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h26" value="MP -25; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h27" value="MP -24; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h28" value="MP -23; Pulls up to 6 enemies at 100% success rate"/>
+    <string name="h29" value="MP -22; Pulls up to 7 enemies at 100% success rate"/>
+    <string name="h30" value="MP -21; Pulls up to 7 enemies at 100% success rate"/>
   </imgdir>
   <imgdir name="1321002">
     <string name="name" value="Power Stance"/>
-    <string name="desc" value="Enables one to stay at the same spot after being struck, resisting knock-back effects."/>
-    <string name="h1" value="MP - 30 ,For 10secs, prevent from getting knock-backed  with success rate  42%."/>
-    <string name="h2" value="MP - 30 ,For 20Secs, prevent from getting Knock-backed with success rate 44%."/>
-    <string name="h3" value="MP - 30 ,For 30Secs, prevent from getting Knock-backed with success rate 46%."/>
-    <string name="h4" value="MP - 30 ,For 40Secs, prevent from getting Knock-backed with success rate 48%."/>
-    <string name="h5" value="MP - 30 ,For 50Secs, prevent from getting Knock-backed with success rate 50%."/>
-    <string name="h6" value="MP - 36 ,For 60Secs, prevent from getting Knock-backed with success rate 52%."/>
-    <string name="h7" value="MP - 36 ,For 70Secs, prevent from getting Knock-backed with success rate 54%."/>
-    <string name="h8" value="MP - 36 ,For 80Secs, prevent from getting Knock-backed with success rate 56%."/>
-    <string name="h9" value="MP - 36 ,For 90Secs, prevent from getting Knock-backed with success rate 58%."/>
-    <string name="h10" value="MP - 36 ,For 100Secs, prevent from getting Knock-backed with success rate 60%."/>
-    <string name="h11" value="MP - 42 ,For 110Secs, prevent from getting Knock-backed with success rate 62%."/>
-    <string name="h12" value="MP - 42 ,For 120Secs, prevent from getting Knock-backed with success rate 64%."/>
-    <string name="h13" value="MP - 42 ,For 130Secs, prevent from getting Knock-backed with success rate 66%."/>
-    <string name="h14" value="MP - 42 ,For 140Secs, prevent from getting Knock-backed with success rate 68%."/>
-    <string name="h15" value="MP - 42 ,For 150Secs, prevent from getting Knock-backed with success rate 70%."/>
-    <string name="h16" value="MP - 48 ,For 160Secs, prevent from getting Knock-backed with success rate 72%."/>
-    <string name="h17" value="MP - 48 ,For 170Secs, prevent from getting Knock-backed with success rate 74%."/>
-    <string name="h18" value="MP - 48 ,For 180Secs, prevent from getting Knock-backed with success rate 76%."/>
-    <string name="h19" value="MP - 48 ,For 190Secs, prevent from getting Knock-backed with success rate 78%."/>
-    <string name="h20" value="MP - 48 ,For 200Secs, prevent from getting Knock-backed with success rate 80%."/>
-    <string name="h21" value="MP - 54 ,For 210Secs, prevent from getting Knock-backed with success rate 81%."/>
-    <string name="h22" value="MP - 54 ,For 220Secs, prevent from getting Knock-backed with success rate 82%."/>
-    <string name="h23" value="MP - 54 ,For 230Secs, prevent from getting Knock-backed with success rate 83%."/>
-    <string name="h24" value="MP - 54 ,For 240Secs, prevent from getting Knock-backed with success rate 84%."/>
-    <string name="h25" value="MP - 54 ,For 250Secs, prevent from getting Knock-backed with success rate 85%."/>
-    <string name="h26" value="MP - 53 ,For 260Secs, prevent from getting Knock-backed with success rate 86%."/>
-    <string name="h27" value="MP - 52 ,For 270Secs, prevent from getting Knock-backed with success rate 87%."/>
-    <string name="h28" value="MP - 51 ,For 280Secs, prevent from getting Knock-backed with success rate 88%."/>
-    <string name="h29" value="MP - 50 ,For 290Secs, prevent from getting Knock-backed with success rate 89%."/>
-    <string name="h30" value="MP - 50 ,For 300Secs, prevent from getting Knock-backed with success rate 90%."/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily resists knockback from enemy attacks with a given success rate."/>
+    <string name="h1" value="MP -30; 42% knockback resistance for 10 sec"/>
+    <string name="h2" value="MP -30; 44% knockback resistance for 20 sec"/>
+    <string name="h3" value="MP -30; 46% knockback resistance for 30 sec"/>
+    <string name="h4" value="MP -30; 48% knockback resistance for 40 sec"/>
+    <string name="h5" value="MP -30; 50% knockback resistance for 50 sec"/>
+    <string name="h6" value="MP -36; 52% knockback resistance for 60 sec"/>
+    <string name="h7" value="MP -36; 54% knockback resistance for 70 sec"/>
+    <string name="h8" value="MP -36; 56% knockback resistance for 80 sec"/>
+    <string name="h9" value="MP -36; 58% knockback resistance for 90 sec"/>
+    <string name="h10" value="MP -36; 60% knockback resistance for 100 sec"/>
+    <string name="h11" value="MP -42; 62% knockback resistance for 110 sec"/>
+    <string name="h12" value="MP -42; 64% knockback resistance for 120 sec"/>
+    <string name="h13" value="MP -42; 66% knockback resistance for 130 sec"/>
+    <string name="h14" value="MP -42; 68% knockback resistance for 140 sec"/>
+    <string name="h15" value="MP -42; 70% knockback resistance for 150 sec"/>
+    <string name="h16" value="MP -48; 72% knockback resistance for 160 sec"/>
+    <string name="h17" value="MP -48; 74% knockback resistance for 170 sec"/>
+    <string name="h18" value="MP -48; 76% knockback resistance for 180 sec"/>
+    <string name="h19" value="MP -48; 78% knockback resistance for 190 sec"/>
+    <string name="h20" value="MP -48; 80% knockback resistance for 200 sec"/>
+    <string name="h21" value="MP -54; 81% knockback resistance for 210 sec"/>
+    <string name="h22" value="MP -54; 82% knockback resistance for 220 sec"/>
+    <string name="h23" value="MP -54; 83% knockback resistance for 230 sec"/>
+    <string name="h24" value="MP -54; 84% knockback resistance for 240 sec"/>
+    <string name="h25" value="MP -54; 85% knockback resistance for 250 sec"/>
+    <string name="h26" value="MP -53; 86% knockback resistance for 260 sec"/>
+    <string name="h27" value="MP -52; 87% knockback resistance for 270 sec"/>
+    <string name="h28" value="MP -51; 88% knockback resistance for 280 sec"/>
+    <string name="h29" value="MP -50; 89% knockback resistance for 290 sec"/>
+    <string name="h30" value="MP -50; 90% knockback resistance for 300 sec"/>
   </imgdir>
   <imgdir name="1321003">
     <string name="name" value="Rush"/>
-    <string name="desc" value="Makes a mad dash forward, pushing off up to 10 monsters."/>
-    <string name="h1" value="MP - 22 , Damage 72%, Range 80%"/>
-    <string name="h2" value="MP - 24 , Damage 74%, Range 80%"/>
-    <string name="h3" value="MP - 26 , Damage 76%, Range 80%"/>
-    <string name="h4" value="MP - 28 , Damage 78%, Range 85%"/>
-    <string name="h5" value="MP - 30 , Damage 80%, Range 85%"/>
-    <string name="h6" value="MP - 32 , Damage 82%, Range 85%"/>
-    <string name="h7" value="MP - 34 , Damage 84%, Range 85%"/>
-    <string name="h8" value="MP - 36 , Damage 86%, Range 90%"/>
-    <string name="h9" value="MP - 38 , Damage 88%, Range 90%"/>
-    <string name="h10" value="MP - 40 , Damage 90%, Range 90%"/>
-    <string name="h11" value="MP - 42 , Damage 92%, Range 95%"/>
-    <string name="h12" value="MP - 44 , Damage 94%, Range 95%"/>
-    <string name="h13" value="MP - 46 , Damage 96%, Range 95%"/>
-    <string name="h14" value="MP - 48 , Damage 98%, Range 100%"/>
-    <string name="h15" value="MP - 50 , Damage 100%, Range 100%"/>
-    <string name="h16" value="MP - 52 , Damage 102%, Range 100%"/>
-    <string name="h17" value="MP - 54 , Damage 104%, Range 105%"/>
-    <string name="h18" value="MP - 56 , Damage 106%, Range 105%"/>
-    <string name="h19" value="MP - 58 , Damage 108%, Range 105%"/>
-    <string name="h20" value="MP - 60 , Damage 110%, Range 110%"/>
-    <string name="h21" value="MP - 59 , Damage 112%, Range 110%"/>
-    <string name="h22" value="MP - 58 , Damage 114%, Range 115%"/>
-    <string name="h23" value="MP - 57 , Damage 116%, Range 115%"/>
-    <string name="h24" value="MP - 56 , Damage 118%, Range 115%"/>
-    <string name="h25" value="MP - 55 , Damage 120%, Range 120%"/>
-    <string name="h26" value="MP - 54 , Damage 122%, Range 120%"/>
-    <string name="h27" value="MP - 53 , Damage 124%, Range 120%"/>
-    <string name="h28" value="MP - 52 , Damage 126%, Range 125%"/>
-    <string name="h29" value="MP - 51 , Damage 128%, Range 125%"/>
-    <string name="h30" value="MP - 50 , Damage 130%, Range 125%"/>
+    <string name="desc" value="[Master Level: 30]\nRushes forward, damaging and pushing up to 15 monsters."/>
+    <string name="h1" value="MP -22; Damage 72%; pushes up to 15 enemies"/>
+    <string name="h2" value="MP -24; Damage 74%; pushes up to 15 enemies"/>
+    <string name="h3" value="MP -26; Damage 76%; pushes up to 15 enemies"/>
+    <string name="h4" value="MP -28; Damage 78%; pushes up to 15 enemies"/>
+    <string name="h5" value="MP -30; Damage 80%; pushes up to 15 enemies"/>
+    <string name="h6" value="MP -32; Damage 82%; pushes up to 15 enemies"/>
+    <string name="h7" value="MP -34; Damage 84%; pushes up to 15 enemies"/>
+    <string name="h8" value="MP -36; Damage 86%; pushes up to 15 enemies"/>
+    <string name="h9" value="MP -38; Damage 88%; pushes up to 15 enemies"/>
+    <string name="h10" value="MP -40; Damage 90%; pushes up to 15 enemies"/>
+    <string name="h11" value="MP -42; Damage 92%; pushes up to 15 enemies"/>
+    <string name="h12" value="MP -44; Damage 94%; pushes up to 15 enemies"/>
+    <string name="h13" value="MP -46; Damage 96%; pushes up to 15 enemies"/>
+    <string name="h14" value="MP -48; Damage 98%; pushes up to 15 enemies"/>
+    <string name="h15" value="MP -50; Damage 100%; pushes up to 15 enemies"/>
+    <string name="h16" value="MP -52; Damage 102%; pushes up to 15 enemies"/>
+    <string name="h17" value="MP -54; Damage 104%; pushes up to 15 enemies"/>
+    <string name="h18" value="MP -56; Damage 106%; pushes up to 15 enemies"/>
+    <string name="h19" value="MP -58; Damage 108%; pushes up to 15 enemies"/>
+    <string name="h20" value="MP -60; Damage 110%; pushes up to 15 enemies"/>
+    <string name="h21" value="MP -59; Damage 112%; pushes up to 15 enemies"/>
+    <string name="h22" value="MP -58; Damage 114%; pushes up to 15 enemies"/>
+    <string name="h23" value="MP -57; Damage 116%; pushes up to 15 enemies"/>
+    <string name="h24" value="MP -56; Damage 118%; pushes up to 15 enemies"/>
+    <string name="h25" value="MP -55; Damage 120%; pushes up to 15 enemies"/>
+    <string name="h26" value="MP -54; Damage 122%; pushes up to 15 enemies"/>
+    <string name="h27" value="MP -53; Damage 124%; pushes up to 15 enemies"/>
+    <string name="h28" value="MP -52; Damage 126%; pushes up to 15 enemies"/>
+    <string name="h29" value="MP -51; Damage 128%; pushes up to 15 enemies"/>
+    <string name="h30" value="MP -50; Damage 130%; pushes up to 15 enemies"/>
   </imgdir>
   <imgdir name="1320005">
     <string name="name" value="Achilles"/>
-    <string name="desc" value="Permanently increases the weapon defense of one&apos;s armor"/>
-    <string name="h1" value="  Damage taken from enemy - 0.5% ."/>
-    <string name="h2" value="  Damage taken from enemy - 1% ."/>
-    <string name="h3" value="  Damage taken from enemy - 1.5% ."/>
-    <string name="h4" value="  Damage taken from enemy - 2% ."/>
-    <string name="h5" value="  Damage taken from enemy - 2.5% ."/>
-    <string name="h6" value="  Damage taken from enemy - 3% ."/>
-    <string name="h7" value="  Damage taken from enemy - 3.5% ."/>
-    <string name="h8" value="  Damage taken from enemy - 4% ."/>
-    <string name="h9" value="  Damage taken from enemy - 4.5% ."/>
-    <string name="h10" value="  Damage taken from enemy - 5% ."/>
-    <string name="h11" value="  Damage taken from enemy - 5.5% ."/>
-    <string name="h12" value="  Damage taken from enemy - 6% ."/>
-    <string name="h13" value="  Damage taken from enemy - 6.5% ."/>
-    <string name="h14" value="  Damage taken from enemy - 7% ."/>
-    <string name="h15" value="  Damage taken from enemy - 7.5% ."/>
-    <string name="h16" value="  Damage taken from enemy - 8% ."/>
-    <string name="h17" value="  Damage taken from enemy - 8.5% ."/>
-    <string name="h18" value="  Damage taken from enemy - 9% ."/>
-    <string name="h19" value="  Damage taken from enemy - 9.5% ."/>
-    <string name="h20" value="  Damage taken from enemy - 10% ."/>
-    <string name="h21" value="  Damage taken from enemy - 10.5% ."/>
-    <string name="h22" value="  Damage taken from enemy - 11% ."/>
-    <string name="h23" value="  Damage taken from enemy - 11.5% ."/>
-    <string name="h24" value="  Damage taken from enemy - 12% ."/>
-    <string name="h25" value="  Damage taken from enemy - 12.5% ."/>
-    <string name="h26" value="  Damage taken from enemy - 13% ."/>
-    <string name="h27" value="  Damage taken from enemy - 13.5% ."/>
-    <string name="h28" value="  Damage taken from enemy - 14% ."/>
-    <string name="h29" value="  Damage taken from enemy - 14.5% ."/>
-    <string name="h30" value="  Damage taken from enemy - 15% ."/>
+    <string name="desc" value="[Master Level: 30]\nPermanently reduces damage received from enemies."/>
+    <string name="h1" value="Damage taken -0.5%"/>
+    <string name="h2" value="Damage taken -1%"/>
+    <string name="h3" value="Damage taken -1.5%"/>
+    <string name="h4" value="Damage taken -2%"/>
+    <string name="h5" value="Damage taken -2.5%"/>
+    <string name="h6" value="Damage taken -3%"/>
+    <string name="h7" value="Damage taken -3.5%"/>
+    <string name="h8" value="Damage taken -4%"/>
+    <string name="h9" value="Damage taken -4.5%"/>
+    <string name="h10" value="Damage taken -5%"/>
+    <string name="h11" value="Damage taken -5.5%"/>
+    <string name="h12" value="Damage taken -6%"/>
+    <string name="h13" value="Damage taken -6.5%"/>
+    <string name="h14" value="Damage taken -7%"/>
+    <string name="h15" value="Damage taken -7.5%"/>
+    <string name="h16" value="Damage taken -8%"/>
+    <string name="h17" value="Damage taken -8.5%"/>
+    <string name="h18" value="Damage taken -9%"/>
+    <string name="h19" value="Damage taken -9.5%"/>
+    <string name="h20" value="Damage taken -10%"/>
+    <string name="h21" value="Damage taken -10.5%"/>
+    <string name="h22" value="Damage taken -11%"/>
+    <string name="h23" value="Damage taken -11.5%"/>
+    <string name="h24" value="Damage taken -12%"/>
+    <string name="h25" value="Damage taken -12.5%"/>
+    <string name="h26" value="Damage taken -13%"/>
+    <string name="h27" value="Damage taken -13.5%"/>
+    <string name="h28" value="Damage taken -14%"/>
+    <string name="h29" value="Damage taken -14.5%"/>
+    <string name="h30" value="Damage taken -15%"/>
   </imgdir>
   <imgdir name="1320006">
     <string name="name" value="Berserk"/>
-    <string name="desc" value="Increases overall attack once the knight&apos;s HP drops below a certain level. However, the additional attack boost is nullified once HP recovers back past that level."/>
-    <string name="h1" value="When HP falls to 21% and below, Damage increases by 113%"/>
-    <string name="h2" value="When HP falls to 22% and below, Damage increases by 116%"/>
-    <string name="h3" value="When HP falls to 23% and below, Damage increases by 119%"/>
-    <string name="h4" value="hen HP falls to 24% and below, Damage increases by 122%"/>
-    <string name="h5" value="When HP falls to 25% and below, Damage increases by 125%"/>
-    <string name="h6" value="When HP falls to 26% and below, Damage increases by 128%"/>
-    <string name="h7" value="When HP falls to 27% and below, Damage increases by 131%"/>
-    <string name="h8" value="When HP falls to 28% and below, Damage increases by 134%"/>
-    <string name="h9" value="When HP falls to 29% and below, Damage increases by 137%"/>
-    <string name="h10" value="When HP falls to 30% and below, Damage increases by 140%"/>
-    <string name="h11" value="When HP falls to 31% and below, Damage increases by 143%"/>
-    <string name="h12" value="When HP falls to 32% and below, Damage increases by 146%"/>
-    <string name="h13" value="When HP falls to 33% and below, Damage increases by 149%"/>
-    <string name="h14" value="When HP falls to 34% and below, Damage increases by 152%"/>
-    <string name="h15" value="When HP falls to 35% and below, Damage increases by 155%"/>
-    <string name="h16" value="When HP falls to 36% and below, Damage increases by 158%"/>
-    <string name="h17" value="When HP falls to 37% and below, Damage increases by 161%"/>
-    <string name="h18" value="When HP falls to 38% and below, Damage increases by 164%"/>
-    <string name="h19" value="When HP falls to 39% and below, Damage increases by 167%"/>
-    <string name="h20" value="When HP falls to 40% and below, Damage increases by 170%"/>
-    <string name="h21" value="When HP falls to 41% and below, Damage increases by 173%"/>
-    <string name="h22" value="When HP falls to 42% and below, Damage increases by 176%"/>
-    <string name="h23" value="When HP falls to 43% and below, Damage increases by 179%"/>
-    <string name="h24" value="When HP falls to 44% and below, Damage increases by 182%"/>
-    <string name="h25" value="When HP falls to 45% and below, Damage increases by 185%"/>
-    <string name="h26" value="When HP falls to 46% and below, Damage increases by 188%"/>
-    <string name="h27" value="When HP falls to 47% and below, Damage increases by 191%"/>
-    <string name="h28" value="When HP falls to 48% and below, Damage increases by 194%"/>
-    <string name="h29" value="When HP falls to 49% and below, Damage increases by 197%"/>
-    <string name="h30" value="When HP falls to 50% and below, Damage increases by 200%"/>
+    <string name="desc" value="[Master Level: 30]\nIncreases damage when HP falls below the skill&#x27;s threshold. The effect ends when HP rises above that threshold."/>
+    <string name="h1" value="When HP is below 21%, damage +132%"/>
+    <string name="h2" value="When HP is below 22%, damage +134%"/>
+    <string name="h3" value="When HP is below 23%, damage +136%"/>
+    <string name="h4" value="When HP is below 24%, damage +138%"/>
+    <string name="h5" value="When HP is below 25%, damage +140%"/>
+    <string name="h6" value="When HP is below 26%, damage +142%"/>
+    <string name="h7" value="When HP is below 27%, damage +144%"/>
+    <string name="h8" value="When HP is below 28%, damage +146%"/>
+    <string name="h9" value="When HP is below 29%, damage +148%"/>
+    <string name="h10" value="When HP is below 30%, damage +150%"/>
+    <string name="h11" value="When HP is below 31%, damage +152%"/>
+    <string name="h12" value="When HP is below 32%, damage +154%"/>
+    <string name="h13" value="When HP is below 33%, damage +156%"/>
+    <string name="h14" value="When HP is below 34%, damage +158%"/>
+    <string name="h15" value="When HP is below 35%, damage +160%"/>
+    <string name="h16" value="When HP is below 36%, damage +162%"/>
+    <string name="h17" value="When HP is below 37%, damage +164%"/>
+    <string name="h18" value="When HP is below 38%, damage +166%"/>
+    <string name="h19" value="When HP is below 39%, damage +168%"/>
+    <string name="h20" value="When HP is below 40%, damage +170%"/>
+    <string name="h21" value="When HP is below 41%, damage +173%"/>
+    <string name="h22" value="When HP is below 42%, damage +176%"/>
+    <string name="h23" value="When HP is below 43%, damage +179%"/>
+    <string name="h24" value="When HP is below 44%, damage +182%"/>
+    <string name="h25" value="When HP is below 45%, damage +185%"/>
+    <string name="h26" value="When HP is below 46%, damage +188%"/>
+    <string name="h27" value="When HP is below 47%, damage +191%"/>
+    <string name="h28" value="When HP is below 48%, damage +194%"/>
+    <string name="h29" value="When HP is below 49%, damage +197%"/>
+    <string name="h30" value="When HP is below 50%, damage +200%"/>
   </imgdir>
   <imgdir name="1321007">
     <string name="name" value="Beholder"/>
-    <string name="desc" value="Temporarily summons Beholder. With the Beholder&apos;s incredible powers, the knight&apos;s weapon mastery permanently increases."/>
-    <string name="h1" value="MP - 114 , Summon Beholder for 11 Minutes,  Mastery + 5% ."/>
-    <string name="h2" value="MP - 108 , Summon Beholder for 12 Minutes,  Mastery + 5% ."/>
-    <string name="h3" value="MP - 102 , Summon Beholder for 13 Minutes,  Mastery + 10% ."/>
-    <string name="h4" value="MP - 96 , Summon Beholder for 14 Minutes,  Mastery + 10% ."/>
-    <string name="h5" value="MP - 90 , Summon Beholder for 15 Minutes,  Mastery + 10% ."/>
-    <string name="h6" value="MP - 84 , Summon Beholder for 16 Minutes,  Mastery + 10% ."/>
-    <string name="h7" value="MP - 78 , Summon Beholder for 17 Minutes,  Mastery + 15% ."/>
-    <string name="h8" value="MP - 72 , Summon Beholder for 18 Minutes,  Mastery + 15% ."/>
-    <string name="h9" value="MP - 66 , Summon Beholder for 19 Minutes,  Mastery + 15% ."/>
-    <string name="h10" value="MP - 60 , Summon Beholder for 20 Minutes,  Mastery + 20% ."/>
+    <string name="desc" value="[Master Level: 10]\nSummons the Beholder. While summoned, the Dark Knight&#x27;s weapon mastery increases."/>
+    <string name="h1" value="MP -114; Summons Beholder for 660 sec"/>
+    <string name="h2" value="MP -108; Summons Beholder for 720 sec"/>
+    <string name="h3" value="MP -102; Summons Beholder for 780 sec"/>
+    <string name="h4" value="MP -96; Summons Beholder for 840 sec"/>
+    <string name="h5" value="MP -90; Summons Beholder for 900 sec"/>
+    <string name="h6" value="MP -84; Summons Beholder for 960 sec"/>
+    <string name="h7" value="MP -78; Summons Beholder for 1020 sec"/>
+    <string name="h8" value="MP -72; Summons Beholder for 1080 sec"/>
+    <string name="h9" value="MP -66; Summons Beholder for 1140 sec"/>
+    <string name="h10" value="MP -60; Summons Beholder for 1200 sec"/>
   </imgdir>
   <imgdir name="1320008">
     <string name="name" value="Aura of the Beholder"/>
-    <string name="desc" value="The black spirit periodically restores the Dark Knight&apos;s HP. The amount of healing increases as the skill level rises."/>
-    <string name="h1" value="For every 10secs, recovers  HP + 40 ."/>
-    <string name="h2" value="For every 10secs, recovers  HP + 55 ."/>
-    <string name="h3" value="For every 10secs, recovers  HP + 70 ."/>
-    <string name="h4" value="For every 10secs, recovers  HP + 85 ."/>
-    <string name="h5" value="For every 9secs, recovers  HP + 100 ."/>
-    <string name="h6" value="For every 9secs, recovers  HP + 160 ."/>
-    <string name="h7" value="For every 9secs, recovers  HP + 170 ."/>
-    <string name="h8" value="For every 9secs, recovers  HP + 180 ."/>
-    <string name="h9" value="For every 8secs, recovers  HP + 190 ."/>
-    <string name="h10" value="For every 8secs, recovers  HP + 200 ."/>
-    <string name="h11" value="For every 8secs, recovers  HP + 260 ."/>
-    <string name="h12" value="For every 8secs, recovers  HP + 270 ."/>
-    <string name="h13" value="For every 7secs, recovers  HP + 280 ."/>
-    <string name="h14" value="For every 7secs, recovers  HP + 290 ."/>
-    <string name="h15" value="For every 7secs, recovers  HP + 300 ."/>
-    <string name="h16" value="For every 7secs, recovers  HP + 360 ."/>
-    <string name="h17" value="For every 6secs, recovers  HP + 370 ."/>
-    <string name="h18" value="For every 6secs, recovers  HP + 380 ."/>
-    <string name="h19" value="For every 6secs, recovers  HP + 390 ."/>
-    <string name="h20" value="For every 6secs, recovers  HP + 400 ."/>
-    <string name="h21" value="For every 5secs, recovers  HP + 460 ."/>
-    <string name="h22" value="For every 5secs, recovers  HP + 470 ."/>
-    <string name="h23" value="For every 5secs, recovers  HP + 480 ."/>
-    <string name="h24" value="For every 5secs, recovers  HP + 490 ."/>
-    <string name="h25" value="For every 4secs, recovers  HP + 500 ."/>
+    <string name="desc" value="[Master Level: 25]\nThe Beholder periodically restores the Dark Knight&#x27;s HP. Requires Beholder to be summoned."/>
+    <string name="h1" value="Recover HP +40 every 10 sec"/>
+    <string name="h2" value="Recover HP +55 every 10 sec"/>
+    <string name="h3" value="Recover HP +70 every 10 sec"/>
+    <string name="h4" value="Recover HP +85 every 10 sec"/>
+    <string name="h5" value="Recover HP +100 every 9 sec"/>
+    <string name="h6" value="Recover HP +160 every 9 sec"/>
+    <string name="h7" value="Recover HP +170 every 9 sec"/>
+    <string name="h8" value="Recover HP +180 every 9 sec"/>
+    <string name="h9" value="Recover HP +190 every 8 sec"/>
+    <string name="h10" value="Recover HP +200 every 8 sec"/>
+    <string name="h11" value="Recover HP +260 every 8 sec"/>
+    <string name="h12" value="Recover HP +270 every 8 sec"/>
+    <string name="h13" value="Recover HP +280 every 7 sec"/>
+    <string name="h14" value="Recover HP +290 every 7 sec"/>
+    <string name="h15" value="Recover HP +300 every 7 sec"/>
+    <string name="h16" value="Recover HP +360 every 7 sec"/>
+    <string name="h17" value="Recover HP +370 every 6 sec"/>
+    <string name="h18" value="Recover HP +380 every 6 sec"/>
+    <string name="h19" value="Recover HP +390 every 6 sec"/>
+    <string name="h20" value="Recover HP +400 every 6 sec"/>
+    <string name="h21" value="Recover HP +460 every 5 sec"/>
+    <string name="h22" value="Recover HP +470 every 5 sec"/>
+    <string name="h23" value="Recover HP +480 every 5 sec"/>
+    <string name="h24" value="Recover HP +490 every 5 sec"/>
+    <string name="h25" value="Recover HP +500 every 4 sec"/>
   </imgdir>
   <imgdir name="1320009">
     <string name="name" value="Hex of the Beholder"/>
-    <string name="desc" value="The black spirit periodically buffs the Dark Knight. Buff type depends on skill level."/>
-    <string name="h1" value="Buff for Weapon def on every 58secs for a duration of 20secs.  "/>
-    <string name="h2" value="Buff for Weapon def on every 56secs for a duration of 20secs.  "/>
-    <string name="h3" value="Buff for Weapon def on every 54secs for a duration of 20secs.  "/>
-    <string name="h4" value="Buff for Weapon def on every 52secs for a duration of 20secs.  "/>
-    <string name="h5" value="Buff for Weapon def on every 50secs for a duration of 20secs.  "/>
-    <string name="h6" value="Buff for Weapon Def and Magic Def on every 48secs for a duration of 40secs."/>
-    <string name="h7" value="Buff for Weapon Def and Magic Def on every 46secs for a duration of 40secs."/>
-    <string name="h8" value="Buff for Weapon Def and Magic Def on every 44secs for a duration of 40secs."/>
-    <string name="h9" value="Buff for Weapon Def and Magic Def on every 42secs for a duration of 40secs."/>
-    <string name="h10" value="Buff for Weapon Def and Magic Def on every 40secs for a duration of 40secs."/>
-    <string name="h11" value="Buff for Weapon Def, Magic Def and Accuracy on every 38secs for a duration of 60secs. "/>
-    <string name="h12" value="Buff for Weapon Def, Magic Def and Accuracy on every 36secs for a duration of 60secs. "/>
-    <string name="h13" value="Buff for Weapon Def, Magic Def and Accuracy on every 34secs for a duration of 60secs. "/>
-    <string name="h14" value="Buff for Weapon Def, Magic Def and Accuracy on every 32secs for a duration of 60secs. "/>
-    <string name="h15" value="Buff for Weapon Def, Magic Def and Accuracy on every 30secs for a duration of 60secs. "/>
-    <string name="h16" value="Buff for Weapon Def, Magic Def, Accuracy and Avoidability on every 28secs for a duration 80secs. "/>
-    <string name="h17" value="Buff for Weapon Def, Magic Def, Accuracy and Avoidability on every 26secs for a duration 80secs. "/>
-    <string name="h18" value="Buff for Weapon Def, Magic Def, Accuracy and Avoidability on every 24secs for a duration 80secs. "/>
-    <string name="h19" value="Buff for Weapon Def, Magic Def, Accuracy and Avoidability on every 22secs for a duration 80secs. "/>
-    <string name="h20" value="Buff for Weapon Def, Magic Def, Accuracy and Avoidability on every 20secs for a duration 80secs. "/>
-    <string name="h21" value="Buff for Weapon Def, Magic Def, Accuracy, Avoidability and Weapon Attack on every 18secs for a duration 80secs. "/>
-    <string name="h22" value="Buff for Weapon Def, Magic Def, Accuracy, Avoidability and Weapon Attack on every 16secs for a duration 80secs. "/>
-    <string name="h23" value="Buff for Weapon Def, Magic Def, Accuracy, Avoidability and Weapon Attack on every 14secs for a duration 80secs. "/>
-    <string name="h24" value="Buff for Weapon Def, Magic Def, Accuracy, Avoidability and Weapon Attack on every 12secs for a duration 80secs. "/>
-    <string name="h25" value="Buff for Weapon Def, Magic Def, Accuracy, Avoidability and Weapon Attack on every 10secs for a duration 80secs. "/>
+    <string name="desc" value="[Master Level: 25]\nThe Beholder periodically grants buffs to the Dark Knight. The buff types improve as the skill level rises. Requires Beholder to be summoned."/>
+    <string name="h1" value="Buff every 48 sec for 20 sec; Weapon DEF +20"/>
+    <string name="h2" value="Buff every 46 sec for 20 sec; Weapon DEF +20"/>
+    <string name="h3" value="Buff every 44 sec for 20 sec; Weapon DEF +20"/>
+    <string name="h4" value="Buff every 42 sec for 20 sec; Weapon DEF +20"/>
+    <string name="h5" value="Buff every 40 sec for 20 sec; Weapon DEF +20"/>
+    <string name="h6" value="Buff every 38 sec for 40 sec; Weapon DEF +40; Magic DEF +25"/>
+    <string name="h7" value="Buff every 36 sec for 40 sec; Weapon DEF +40; Magic DEF +25"/>
+    <string name="h8" value="Buff every 34 sec for 40 sec; Weapon DEF +40; Magic DEF +25"/>
+    <string name="h9" value="Buff every 32 sec for 40 sec; Weapon DEF +40; Magic DEF +25"/>
+    <string name="h10" value="Buff every 30 sec for 40 sec; Weapon DEF +40; Magic DEF +25"/>
+    <string name="h11" value="Buff every 28 sec for 60 sec; Weapon DEF +60; Magic DEF +50; Accuracy +10"/>
+    <string name="h12" value="Buff every 26 sec for 60 sec; Weapon DEF +60; Magic DEF +50; Accuracy +10"/>
+    <string name="h13" value="Buff every 24 sec for 60 sec; Weapon DEF +60; Magic DEF +50; Accuracy +10"/>
+    <string name="h14" value="Buff every 22 sec for 60 sec; Weapon DEF +60; Magic DEF +50; Accuracy +10"/>
+    <string name="h15" value="Buff every 20 sec for 60 sec; Weapon DEF +60; Magic DEF +50; Accuracy +10"/>
+    <string name="h16" value="Buff every 18 sec for 80 sec; Weapon DEF +80; Magic DEF +75; Accuracy +20; Avoidability +30"/>
+    <string name="h17" value="Buff every 16 sec for 80 sec; Weapon DEF +80; Magic DEF +75; Accuracy +20; Avoidability +30"/>
+    <string name="h18" value="Buff every 14 sec for 80 sec; Weapon DEF +80; Magic DEF +75; Accuracy +20; Avoidability +30"/>
+    <string name="h19" value="Buff every 12 sec for 80 sec; Weapon DEF +80; Magic DEF +75; Accuracy +20; Avoidability +30"/>
+    <string name="h20" value="Buff every 10 sec for 80 sec; Weapon DEF +80; Magic DEF +75; Accuracy +20; Avoidability +30"/>
+    <string name="h21" value="Buff every 8 sec for 100 sec; Weapon DEF +100; Magic DEF +100; Accuracy +25; Avoidability +50; Weapon ATT +3"/>
+    <string name="h22" value="Buff every 7 sec for 100 sec; Weapon DEF +100; Magic DEF +100; Accuracy +25; Avoidability +50; Weapon ATT +6"/>
+    <string name="h23" value="Buff every 6 sec for 100 sec; Weapon DEF +100; Magic DEF +100; Accuracy +25; Avoidability +50; Weapon ATT +9"/>
+    <string name="h24" value="Buff every 5 sec for 100 sec; Weapon DEF +100; Magic DEF +100; Accuracy +25; Avoidability +50; Weapon ATT +12"/>
+    <string name="h25" value="Buff every 4 sec for 99 sec; Weapon DEF +100; Magic DEF +100; Accuracy +25; Avoidability +50; Weapon ATT +15"/>
   </imgdir>
   <imgdir name="1321010">
-    <string name="name" value="Hero&apos;s Will"/>
-    <string name="desc" value="Enables one to shrug off abnormal conditions. The higher the skill level, the more types of abnormal conditions one can nullify."/>
-    <string name="h1" value="MP - 30 escape from abnormal condition, Terms between skills 600secs"/>
-    <string name="h2" value="MP - 30 escape from abnormal condition, Terms between skills 540secs"/>
-    <string name="h3" value="MP - 30 escape from abnormal condition, Terms between skills 480secs"/>
-    <string name="h4" value="MP - 30 escape from abnormal condition, Terms between skills 420secs"/>
-    <string name="h5" value="MP - 30 escape from abnormal condition, Terms between skills 360secs"/>
+    <string name="name" value="Hero&#x27;s Will"/>
+    <string name="desc" value="[Master Level: 5]\nRemoves certain abnormal status effects. Higher levels reduce the cooldown."/>
+    <string name="h1" value="MP -30; Removes abnormal status; cooldown 600 sec"/>
+    <string name="h2" value="MP -30; Removes abnormal status; cooldown 540 sec"/>
+    <string name="h3" value="MP -30; Removes abnormal status; cooldown 480 sec"/>
+    <string name="h4" value="MP -30; Removes abnormal status; cooldown 420 sec"/>
+    <string name="h5" value="MP -30; Removes abnormal status; cooldown 360 sec"/>
   </imgdir>
   <imgdir name="212">
     <string name="bookName" value="Highest class of Magic (F,P)"/>


### PR DESCRIPTION
改动内容
- 校正战士一转至四转各分支技能的中英文名称、技能描述和等级说明。
- 按实际技能参数修正伤害、消耗、持续时间、冷却时间、命中目标数、成功率、斗气上限、属性蓄力、灵魂助力等显示文本。
- 涉及职业技能文本，不涉及任务、NPC、道具或地图流程。
- 同步修正英文原版技能文本和中文技能文本，保持中英文目录对称。

影响范围
- 影响服务端读取的技能文本资源，也会影响客户端技能窗口显示文本。
- 本次修改包含技能 String WZ 文本，需要同步客户端资源包。

验证情况
- 已执行 XML 解析检查。
- 已执行战士技能文本乱码检查。
- 已执行战士技能等级说明完整性检查。
- 已执行 diff 空白格式检查。
- 未重新构建 Jar，Jar 包仅在正式 release 时打包。

客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。
