### PR TITLE
feat(autoban): 攻击间隔滑动窗口检测

### DIFF
--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -500,27 +500,28 @@ public class Character extends AbstractCharacterObject {
     private static final HpMpAlertService hpMpAlertService = ServerManager.getApplicationContext().getBean(HpMpAlertService.class);
     private static final InventoryService inventoryService = ServerManager.getApplicationContext().getBean(InventoryService.class);
 
-    /**
-     * 最后攻击时间
-     * 用来校验攻击速度是否过快
-     */
-    private final ConcurrentHashMap<Integer, Long> lastAttackTimes = new ConcurrentHashMap<>();
+    /** 各技能原始时间戳，仅被 >= MIN_INTERVAL 的正常包更新，暴发包透明通过 */
+    private final ConcurrentHashMap<Integer, Long> normalAttackTimes = new ConcurrentHashMap<>();
 
     /**
-     * 原子更新指定技能的最后攻击时间，并返回与上次记录的时间间隔（毫秒）。
-     * 若是首次记录或出现时钟回退，返回 Long.MAX_VALUE 表示本次不参与间隔判定。
+     * 获取指定技能距上次攻击的间隔毫秒数，并更新最后攻击时间。
+     * 间隔 < MIN_INTERVAL 时不更新时间戳，视为网络抖动透明跳过。
+     * 首次调用或时钟回退时返回 Long.MAX_VALUE，本次不参与间隔判定。
      */
-    public long updateLastAttackTimeAndGetInterval(int skillId, long currentTimeMillis) {
-        AtomicLong intervalMillis = new AtomicLong(Long.MAX_VALUE);
-        lastAttackTimes.compute(skillId, (ignored, previousTime) -> {
-            long previous = previousTime == null ? 0L : previousTime;
-            if (previous > 0L && currentTimeMillis > previous) {
-                intervalMillis.set(currentTimeMillis - previous);
+    public long getAttackInterval(int skillId, long now) {
+        AtomicLong intervalRef = new AtomicLong(Long.MAX_VALUE);
+        normalAttackTimes.compute(skillId, (ignored, prevTime) -> {
+            long prev = prevTime != null ? prevTime : 0L;
+            if (prev > 0L && now > prev) {
+                intervalRef.set(now - prev);
             }
-            // 保证每个技能的时间记录单调不回退，避免并发写入覆盖新值。
-            return Math.max(previous, currentTimeMillis);
+            long interval = intervalRef.get();
+            if (interval != Long.MAX_VALUE && interval < MIN_INTERVAL) {
+                return prev;
+            }
+            return Math.max(prev, now);
         });
-        return intervalMillis.get();
+        return intervalRef.get();
     }
 
 
@@ -9990,5 +9991,107 @@ public class Character extends AbstractCharacterObject {
      */
     public void enableActions() {
         sendPacket(PacketCreator.enableActions());
+    }
+
+    // ==================== 攻击间隔滑动窗口（稳定度识别） ====================
+
+    /** 窗口大小：最近 N 次攻击间隔 */
+    public static final int WINDOW_SIZE = 10;
+    /** 变异系数阈值：CV < 此值判定为稳定高速 */
+    public static final double STABLE_CV = 0.3;
+    /** 网络抖动透明上限：< 此值的间隔不更新状态、不入窗口 */
+    public static final long MIN_INTERVAL = 50;
+    /** 平均阈值：窗口 avg >= 此值判定为正常频率 */
+    public static final long NORMAL_AVG = 250;
+    /** 窗口自动过期时间：60s 无写入自动重置 */
+    private static final long CLEANUP_MS = 60_000;
+
+    /** 各技能攻击间隔滑动窗口 */
+    private final ConcurrentHashMap<Integer, AttackWindow> skillWindows = new ConcurrentHashMap<>();
+
+    /** 全局最后攻击时间戳，只被正常主动技能更新 */
+    private volatile long globalAttackTime;
+
+    /** 滑动窗口判定结果 */
+    public enum SkillWindowResult {
+        PASS,          // 数据不足 / avg >= 250 → 正常
+        STABLE_HACK,   // avg < 250 且 CV < STABLE_CV → 稳定高速
+        BURST          // avg < 250 但 CV >= STABLE_CV → 网络暴发
+    }
+
+    /** 环形缓冲，保存最近 N 次攻击间隔，满后自动计算 avg + CV */
+    static final class AttackWindow {
+        private final long[] buf = new long[WINDOW_SIZE];
+        private int idx;
+        private int count;
+        private long lastPush;
+
+        AttackWindow() {
+            this.lastPush = System.currentTimeMillis();
+        }
+
+        synchronized void push(long interval) {
+            long now = System.currentTimeMillis();
+            if (now - lastPush > CLEANUP_MS) {
+                idx = 0;
+                count = 0;
+            }
+            buf[idx] = interval;
+            idx = (idx + 1) % WINDOW_SIZE;
+            if (count < WINDOW_SIZE) count++;
+            lastPush = now;
+        }
+
+        synchronized boolean isFull() {
+            return count == WINDOW_SIZE;
+        }
+
+        synchronized double avg() {
+            long sum = 0;
+            for (int i = 0; i < count; i++) sum += buf[i];
+            return (double) sum / count;
+        }
+
+        synchronized double stddev() {
+            double a = avg();
+            double sumSq = 0;
+            for (int i = 0; i < count; i++) {
+                double d = buf[i] - a;
+                sumSq += d * d;
+            }
+            return Math.sqrt(sumSq / count);
+        }
+    }
+
+    /**
+     * 推入间隔到滑动窗口，返回窗口判定结果。
+     * 窗口不满或 avg >= 250 返回 PASS；
+     * avg < 250 且 CV < STABLE_CV 返回 STABLE_HACK；
+     * avg < 250 但 CV >= STABLE_CV 返回 BURST。
+     */
+    public SkillWindowResult checkSkillWindow(int skillId, long interval) {
+        AttackWindow w = skillWindows.computeIfAbsent(skillId, k -> new AttackWindow());
+        w.push(interval);
+        if (!w.isFull()) return SkillWindowResult.PASS;
+        double avg = w.avg();
+        if (avg >= NORMAL_AVG) return SkillWindowResult.PASS;
+        double cv = w.stddev() / avg;
+        return cv < STABLE_CV ? SkillWindowResult.STABLE_HACK : SkillWindowResult.BURST;
+    }
+
+    /** 获取指定技能的滑动窗口（外部只读 avg / isFull），无则返回 null */
+    public AttackWindow getSkillWindow(int skillId) {
+        return skillWindows.get(skillId);
+    }
+
+    /** 获取全局攻击间隔。首次或未设时返回 Long.MAX_VALUE */
+    public long getGlobalInterval(long now) {
+        long last = globalAttackTime;
+        return last == 0 ? Long.MAX_VALUE : now - last;
+    }
+
+    /** 更新全局攻击时间戳，只被正常主动技能调用 */
+    public void updateGlobalTime(long now) {
+        globalAttackTime = now;
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -1326,34 +1326,60 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
     }
 
     /**
-     * 检测攻击间隔
+     * 检测攻击间隔是否异常。
      *
-     * @param chr
+     * 三层过滤：
+     *   ① SKIP_SET / PASSIVE_SET → 直接跳过
+     *   ② < MIN_INTERVAL 网络抖动 → 透明跳过
+     *   ③ Per-skill 滑动窗口 avg + CV → 稳定高速计分，暴发仅警告
+     *   ④ 全局间隔 → 跨技能轮换计分
      */
     private static void detectionAttackInterval(Character chr, AttackInfo ret) {
         int skill = ret.skill;
-        //需要跳过检测的技能 比如弓箭手的暴风箭雨 火枪手的金属风暴
-        if (!SKIP_SKILL_ID_SET.contains(skill)) {
-            long interval = chr.updateLastAttackTimeAndGetInterval(skill, System.currentTimeMillis());
-            if (interval < 250) {
-                // 检测攻击间隔 小于350mm封号
-                AutobanFactory.ATTACK_INTERVAL.addPoint(chr.getAutoBanManager(), "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "攻击间隔: " + interval + "技能ID：" + skill);
-                log.warn("玩家{}地图ID：{}攻击间隔: {}技能ID：{}", chr.getName(), chr.getMapId(), interval, skill);
-            } else if (interval < 350) {
-                // 检测攻击间隔 小于500mm警告
-                AutobanFactory.ATTACK_INTERVAL.alert(chr, "玩家" + chr.getName() + "地图ID：" + chr.getMapId() + "攻击间隔: " + interval + "技能ID：" + skill);
-                log.warn("玩家{}地图ID：{}攻击间隔: {}技能ID：{}", chr.getName(), chr.getMapId(), interval, skill);
-            }
+        if (SKIP_SKILL_ID_SET.contains(skill)) return;
+        if (PASSIVE_SKILL_ID_SET.contains(skill)) return;
+
+        long now = System.currentTimeMillis();
+
+        long interval = chr.getAttackInterval(skill, now);
+        if (interval == Long.MAX_VALUE || interval < Character.MIN_INTERVAL) return;
+
+        String reason = "玩家" + chr.getName() + "地图ID：" + chr.getMapId()
+                + "攻击间隔: " + interval + "技能ID：" + skill;
+
+        switch (chr.checkSkillWindow(skill, interval)) {
+            case STABLE_HACK:
+                AutobanFactory.ATTACK_INTERVAL.addPoint(chr.getAutoBanManager(), reason);
+                return;
+            case BURST:
+                AutobanFactory.ATTACK_INTERVAL.alert(chr, reason);
+                break;
+            case PASS:
+                break;
+        }
+
+        long globalInterval = chr.getGlobalInterval(now);
+        if (globalInterval < Character.NORMAL_AVG) {
+            AutobanFactory.ATTACK_INTERVAL.addPoint(chr.getAutoBanManager(), reason);
+        } else {
+            chr.updateGlobalTime(now);
         }
     }
-    /**
-     * 跳过攻击速度检测的技能ID
-     */
+
+    /** 持续施法技能：按住时连续多包，全跳过 */
     private static final Set<Integer> SKIP_SKILL_ID_SET = Set.of(
-            // 弓箭 暴风箭雨
-            Bowmaster.HURRICANE,
-            // 火枪 金属风暴
-            Corsair.RAPID_FIRE
+            Bowmaster.HURRICANE,           // 弩弓 暴风箭雨
+            WindArcher.HURRICANE,          // 风灵 暴风箭雨
+            Corsair.RAPID_FIRE,            // 火枪 金属风暴
+            Evan.FIRE_BREATH,              // 龙 火焰喷射
+            Evan.ICE_BREATH                // 龙 寒冰喷射
+    );
+
+    /** 被动触伤技能：频率由怪物碰撞控制，全跳过 */
+    private static final Set<Integer> PASSIVE_SKILL_ID_SET = Set.of(
+            Aran.BODY_PRESSURE,            // 战神 身体压杀
+            Marauder.ENERGY_CHARGE,        // 船长 能量汇集
+            ThunderBreaker.ENERGY_CHARGE   // 雷鸣 能量汇集
     );
 
 

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -1355,7 +1355,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 AutobanFactory.ATTACK_INTERVAL.alert(chr, reason);
                 break;
             case PASS:
-                break;
+                return;
         }
 
         long globalInterval = chr.getGlobalInterval(now);
@@ -1372,14 +1372,26 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
             WindArcher.HURRICANE,          // 风灵 暴风箭雨
             Corsair.RAPID_FIRE,            // 火枪 金属风暴
             Evan.FIRE_BREATH,              // 龙 火焰喷射
-            Evan.ICE_BREATH                // 龙 寒冰喷射
+            Evan.ICE_BREATH,               // 龙 寒冰喷射
+            Hero.BRANDISH,                 // 英雄 轻舞飞扬（客户端已改为按住连发）
+            DawnWarrior.BRANDISH           // 魂骑士 轻舞飞扬（同上）
     );
 
-    /** 被动触伤技能：频率由怪物碰撞控制，全跳过 */
+    /** 被动触伤技能：频率不由玩家输入控制，全跳过 */
     private static final Set<Integer> PASSIVE_SKILL_ID_SET = Set.of(
             Aran.BODY_PRESSURE,            // 战神 身体压杀
             Marauder.ENERGY_CHARGE,        // 船长 能量汇集
-            ThunderBreaker.ENERGY_CHARGE   // 雷鸣 能量汇集
+            ThunderBreaker.ENERGY_CHARGE,  // 雷鸣 能量汇集
+            Fighter.FINAL_ATTACK_SWORD,    // 剑客 终极剑
+            Fighter.FINAL_ATTACK_AXE,      // 剑客 终极斧
+            Page.FINAL_ATTACK_SWORD,       // 勇士 终极剑
+            Page.FINAL_ATTACK_BW,          // 勇士 终极棍
+            Spearman.FINAL_ATTACK_SPEAR,   // 枪战士 终极枪
+            Spearman.FINAL_ATTACK_POLEARM, // 枪战士 终极矛
+            Hunter.FINAL_ATTACK,           // 猎人 终极弓
+            Crossbowman.FINAL_ATTACK,      // 弩弓手 终极弩
+            DawnWarrior.FINAL_ATTACK,      // 魂骑士 终极剑
+            WindArcher.FINAL_ATTACK        // 风灵使者 终极弓
     );
 
 


### PR DESCRIPTION
基于滑动窗口 + 变异系数(CV)的智能攻击间隔检测：

- 每技能独立环形窗口（WINDOW_SIZE=10）
- 稳定异常（CV<0.3 + avg<250ms）→ 自动计分封禁
- 网络突发（CV≥0.3）→ 仅 GM 提示
- 全局间隔跨技能轮换检测辅助
- 持续施法/被动触伤技能白名单过滤
- 50ms 网络抖动透明跳过