### PR TITLE
fix: 校正冒险家弓箭手技能说明与经典技能名

### DIFF
--- a/gms-server/wz-zh-CN/String.wz/Skill.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Skill.img.xml
@@ -8296,7 +8296,7 @@
         <string name="bookName" value="弓箭手技能"/>
     </imgdir>
     <imgdir name="3000000">
-        <string name="name" value="精准箭"/>
+        <string name="name" value="祝福之羽"/>
         <string name="h1" value="命中率+1"/>
         <string name="h10" value="命中率+10"/>
         <string name="h11" value="命中率+11"/>
@@ -8313,7 +8313,7 @@
         <string name="h7" value="命中率+7"/>
         <string name="h8" value="命中率+8"/>
         <string name="h9" value="命中率+9"/>
-        <string name="desc" value="[最高等级 : 16]\n增加攻击命中率"/>
+        <string name="desc" value="[最高等级 : 16]\n提高命中率。"/>
     </imgdir>
     <imgdir name="3000001">
         <string name="name" value="强力箭"/>
@@ -8337,7 +8337,7 @@
         <string name="h7" value="比率24%，伤害135%"/>
         <string name="h8" value="比率26%，伤害140%"/>
         <string name="h9" value="比率28%，伤害145%"/>
-        <string name="desc" value="[最高等级 : 20]\n可以增加箭的攻击力"/>
+        <string name="desc" value="[最高等级 : 20]\n攻击时有一定概率打出致命一击，提高伤害。"/>
     </imgdir>
     <imgdir name="3000002">
         <string name="name" value="远程箭"/>
@@ -8349,7 +8349,7 @@
         <string name="h6" value="弓与弩的射程距离增加90"/>
         <string name="h7" value="弓与弩的射程距离增加105"/>
         <string name="h8" value="弓与弩的射程距离增加120"/>
-        <string name="desc" value="[最高等级 : 8]\n增加射程距离.\n必需技能 : #c精准箭等级3以上#"/>
+        <string name="desc" value="[最高等级 : 8]\n增加弓和弩的攻击距离。\n需要技能 : #c祝福之羽 3级以上#"/>
     </imgdir>
     <imgdir name="3001003">
         <string name="name" value="集中术"/>
@@ -8373,7 +8373,7 @@
         <string name="h7" value="持续140秒，消费MP10，命中率+7和回避率+7"/>
         <string name="h8" value="持续150秒，消费MP10，命中率+8和回避率+8"/>
         <string name="h9" value="持续160秒，消费MP10，命中率+9和回避率+9"/>
-        <string name="desc" value="[最高等级 : 20]\n增加命中率和回避率.\n必需技能 : #c精准箭等级3以上#"/>
+        <string name="desc" value="[最高等级 : 20]\n在一定时间内提高命中率和回避率。\n需要技能 : #c祝福之羽 3级以上#"/>
     </imgdir>
     <imgdir name="3001004">
         <string name="name" value="断魂箭"/>
@@ -8397,7 +8397,7 @@
         <string name="h7" value="消耗MP9，攻击力 210%"/>
         <string name="h8" value="消耗MP10，攻击力 213%"/>
         <string name="h9" value="消耗MP10，攻击力 216%"/>
-        <string name="desc" value="[最高等级 : 20]\n强力的箭矢，造成强大的杀伤力"/>
+        <string name="desc" value="[最高等级 : 20]\n射出强力箭矢攻击1个敌人，造成更高伤害。"/>
     </imgdir>
     <imgdir name="3001005">
         <string name="name" value="二连射"/>
@@ -8421,7 +8421,7 @@
         <string name="h7" value="消耗MP11，攻击力 121%"/>
         <string name="h8" value="消耗MP12，攻击力 124%"/>
         <string name="h9" value="消耗MP12，攻击力 127%"/>
-        <string name="desc" value="[最高等级 : 20]\n一次射出两支箭，攻击怪物两次。\n必需技能 : #c断魂箭等级1以上#"/>
+        <string name="desc" value="[最高等级 : 20]\n同时射出2支箭，对1个敌人造成2次伤害。\n需要技能 : #c断魂箭 1级以上#"/>
     </imgdir>
     <imgdir name="310">
         <string name="bookName" value="猎人技能"/>
@@ -8448,7 +8448,7 @@
         <string name="h7" value="弓系列武器的熟练度+30%， 命中率+7"/>
         <string name="h8" value="弓系列武器的熟练度+30%， 命中率+8"/>
         <string name="h9" value="弓系列武器的熟练度+35%， 命中率+9"/>
-        <string name="desc" value="[最高等级 : 20]\n增加使用弓系武器的命中率及熟练度\n(必须装备弓)"/>
+        <string name="desc" value="[最高等级 : 20]\n提高弓的熟练度和命中率。\n必须装备弓。"/>
     </imgdir>
     <imgdir name="3100001">
         <string name="name" value="终极弓"/>
@@ -8482,7 +8482,7 @@
         <string name="h7" value="出现概率14%，发挥135%的最终攻击"/>
         <string name="h8" value="出现概率16%，发挥140%的最终攻击"/>
         <string name="h9" value="出现概率18%，发挥145%的最终攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n使用攻击技能后一定几率发动连续攻击\n（必须装备弓）.\n必要技能 : #c精准弓３级以上#"/>
+        <string name="desc" value="[最高等级 : 30]\n使用弓系攻击技能后，有一定概率追加一次终极攻击。\n必须装备弓。\n需要技能 : #c精准弓 3级以上#"/>
     </imgdir>
     <imgdir name="3101002">
         <string name="name" value="快速箭"/>
@@ -8506,7 +8506,7 @@
         <string name="h7" value="消耗HP23和MP23，持续70秒"/>
         <string name="h8" value="消耗HP22和MP22，持续80秒"/>
         <string name="h9" value="消耗HP21和MP21，持续90秒"/>
-        <string name="desc" value="[最高等级 : 20]\n攻击速度提升2个等级\n(必须装备弓)\n必需技能 : #c精准弓等级5以上#"/>
+        <string name="desc" value="[最高等级 : 20]\n消耗HP和MP，在一定时间内提升弓的攻击速度2级。\n必须装备弓。\n需要技能 : #c精准弓 5级以上#"/>
     </imgdir>
     <imgdir name="3101003">
         <string name="name" value="强弓"/>
@@ -8530,7 +8530,7 @@
         <string name="h7" value="消耗MP8，比率51%增加， 伤害170%，对象6个"/>
         <string name="h8" value="消耗MP8，比率54%增加， 伤害180%，对象6个"/>
         <string name="h9" value="消耗MP8，比率57%增加， 伤害190%，对象6个"/>
-        <string name="desc" value="[最高等级 : 20]\n用弓攻击时使怪物后退的比率增加，\n随着等级上升击退怪物数量会增加，\n怪物后退的概率增加，击退怪物数量会增加"/>
+        <string name="desc" value="[最高等级 : 20]\n用弓进行近身攻击时，有一定概率击退多个敌人并造成伤害。"/>
     </imgdir>
     <imgdir name="3101004">
         <string name="name" value="无形箭"/>
@@ -8554,7 +8554,7 @@
         <string name="h7" value="消耗MP15，持续210秒"/>
         <string name="h8" value="消耗MP15，持续240秒"/>
         <string name="h9" value="消耗MP15，持续270秒"/>
-        <string name="desc" value="[最高等级 : 20]\n一定时间内，攻击时不消耗箭。\n必需技能 : #c快速箭等级5以上#"/>
+        <string name="desc" value="[最高等级 : 20]\n在一定时间内使用弓攻击时不消耗箭矢。\n必须装备弓。\n需要技能 : #c快速箭 5级以上#"/>
     </imgdir>
     <imgdir name="3101005">
         <string name="name" value="爆炸箭"/>
@@ -8588,7 +8588,7 @@
         <string name="h7" value="消耗MP14，爆裂比率37%，攻击力114%"/>
         <string name="h8" value="消耗MP14，爆裂比率38%，攻击力116%"/>
         <string name="h9" value="消耗MP14，爆裂比率39%，攻击力118%"/>
-        <string name="desc" value="[最高等级 : 30]\n用装备爆裂弹的箭攻击怪物，能造成周围\n的怪物(最多6名)受到伤害及晕倒"/>
+        <string name="desc" value="[最高等级 : 30]\n发射爆裂箭攻击1个敌人，并对周围最多6个敌人造成伤害，且有一定概率使其昏迷。"/>
     </imgdir>
     <imgdir name="311">
         <string name="bookName" value="射手技能"/>
@@ -8615,10 +8615,10 @@
 		<string name="h7" value="移动速度+14"/>
 		<string name="h8" value="移动速度+16"/>
 		<string name="h9" value="移动速度+18"/>
-        <string name="desc" value="[最高等级:20]\n增加移动速度"/>
+        <string name="desc" value="[最高等级 : 20]\n提高移动速度。"/>
     </imgdir>
     <imgdir name="3110001">
-        <string name="name" value="贯穿箭"/>
+        <string name="name" value="致命箭"/>
         <string name="h1" value="33%几率发动，造成伤害110%，假如对方HP在20%以下时1%几率出现必杀"/>
         <string name="h10" value="60%几率发动，造成伤害200%，假如敌的HP在35%以下时5%几率出现必杀怪物"/>
         <string name="h11" value="63%几率发动，造成伤害205%，假如敌的HP在35%以下时6%几率出现必杀怪物"/>
@@ -8639,7 +8639,7 @@
         <string name="h7" value="51%几率发动，造成伤害170%，假如敌的HP在29%以下时4%几率出现必杀怪物"/>
         <string name="h8" value="54%几率发动，造成伤害180%，假如敌的HP在32%以下时4%几率出现必杀怪物"/>
         <string name="h9" value="57%几率发动，造成伤害190%，假如敌的HP在32%以下时5%几率出现必杀怪物"/>
-        <string name="desc" value="[最高等级:20]\n即使怪物靠得很近也能射箭，一定几率必杀怪物"/>
+        <string name="desc" value="[最高等级 : 20]\n即使在近距离也可射箭，并有一定概率对敌人造成致命伤害。"/>
     </imgdir>
     <imgdir name="3111002">
         <string name="name" value="替身术"/>
@@ -8663,7 +8663,7 @@
         <string name="h7" value="消费MP26，持续20秒 召唤HP10500的分身"/>
         <string name="h8" value="消费MP26，持续20秒 召唤HP12000的分身"/>
         <string name="h9" value="消费MP26，持续30秒 召唤HP13500的分身"/>
-        <string name="desc" value="[最高等级:20]\n一定时间制造自己的分身。\n分身存在的时候，怪物攻击分身"/>
+        <string name="desc" value="[最高等级 : 20]\n召唤替身吸引怪物攻击，持续一定时间。"/>
     </imgdir>
     <imgdir name="3111003">
         <string name="name" value="烈火箭"/>
@@ -8697,7 +8697,7 @@
         <string name="h7" value="消费MP20，造成伤害171%"/>
         <string name="h8" value="消费MP20，造成伤害174%"/>
         <string name="h9" value="消费MP20，造成伤害177%"/>
-        <string name="desc" value="[最高等级:30]\n用火属性的箭攻击多个怪物，属性纯度50%。\n最多攻击6个怪物，只有装备弓箭才能使用"/>
+        <string name="desc" value="[最高等级 : 30]\n用火属性箭攻击最多6个敌人，并附带火属性效果。\n必须装备弓。"/>
     </imgdir>
     <imgdir name="3111004">
         <string name="name" value="箭雨"/>
@@ -8731,7 +8731,7 @@
         <string name="h7" value="消费MP18，造成伤害191%"/>
         <string name="h8" value="消费MP18，造成伤害194%"/>
         <string name="h9" value="消费MP18，造成伤害197%"/>
-        <string name="desc" value="[最高等级:30]\n向天空射多支箭以攻击多个怪物。\n最多攻击6个,只有装备弓箭才能使用。\n必需技能 : #c贯穿箭等级5以上#"/>
+        <string name="desc" value="[最高等级 : 30]\n向空中射出大量箭矢，攻击最多6个敌人。\n必须装备弓。\n需要技能 : #c致命箭 5级以上#"/>
     </imgdir>
     <imgdir name="3111005">
         <string name="name" value="银鹰召唤"/>
@@ -8765,7 +8765,7 @@
 		<string name="h7" value="消费MP44和1个召唤石,121秒内41次攻击,68%几率出击"/>
 		<string name="h8" value="消费MP46和1个召唤石,124秒内44次攻击,71%几率出击"/>
 		<string name="h9" value="消费MP48和1个召唤石,127秒内47次攻击,74%几率出击"/>
-        <string name="desc" value="[最高等级:30]\n召唤银色老鹰\n在一定的时间内攻击附近的怪物。\n必需技能 : #c替身术等级5以上#"/>
+        <string name="desc" value="[最高等级 : 30]\n召唤银鹰，在一定时间内攻击附近敌人，并有一定概率使其眩晕。\n需要技能 : #c替身术 5级以上#"/>
     </imgdir>
     <imgdir name="3111006">
         <string name="name" value="箭扫射"/>
@@ -8799,7 +8799,7 @@
         <string name="h28" value="消费MP32, 造成伤害98%, 4次攻击"/>
         <string name="h29" value="消费MP32, 造成伤害99%, 4次攻击"/>
         <string name="h30" value="消费MP32, 造成伤害100%, 4次攻击"/>
-        <string name="desc" value="[最高等级:30]\n向一个怪物连续射4支箭"/>
+        <string name="desc" value="[最高等级 : 30]\n连续射出4支箭攻击1个敌人。"/>
     </imgdir>
     <imgdir name="312">
         <string name="bookName" value="神射手"/>
@@ -8835,7 +8835,7 @@
         <string name="h28" value="弓系武器的熟练度 90%, 物理 攻击力 9 上升"/>
         <string name="h29" value="弓系武器的熟练度 90%, 物理 攻击力 9 上升"/>
         <string name="h30" value="弓系武器的熟练度 90%, 物理 攻击力 10 上升"/>
-        <string name="desc" value="提高弓系武器的熟练度和攻击力. \n只可适用于拿弓系武器的时候.\n必要技能 : #c精准弓 20级#"/>
+        <string name="desc" value="进一步提高弓的熟练度和攻击力。\n必须装备弓。\n需要技能 : #c精准弓 20级#"/>
     </imgdir>
     <imgdir name="3121000">
         <string name="name" value="冒险岛勇士"/>
@@ -8869,7 +8869,7 @@
         <string name="h7" value="消耗MP 20，210秒内所有的属性点提高 4%"/>
         <string name="h8" value="消耗MP 20，240秒内所有的属性点提高 4%"/>
         <string name="h9" value="消耗MP 20，270秒内所有的属性点提高 5%"/>
-        <string name="desc" value="一定时间内把组队成员的所有属性点提高\n一定的百分比"/>
+        <string name="desc" value="在一定时间内按百分比提高自己和队员的全部属性。"/>
     </imgdir>
     <imgdir name="3121002">
         <string name="name" value="火眼晶晶"/>
@@ -8903,7 +8903,7 @@
         <string name="h7" value="消耗MP 29，持续时间 70秒，4%的必杀几率，伤害 17% 上升"/>
         <string name="h8" value="消耗MP 29，持续时间 80秒，4%的必杀几率，伤害 18% 上升"/>
         <string name="h9" value="消耗MP 29，持续时间 90秒，5%的必杀几率，伤害 19% 上升"/>
-        <string name="desc" value="赋予组队成员针对敌人寻找弱点\n并给予敌人致命伤的能力"/>
+        <string name="desc" value="在一定时间内提高自己和队员造成暴击的概率与暴击伤害。"/>
     </imgdir>
     <imgdir name="3121003">
         <string name="name" value="飞龙冲击波"/>
@@ -8937,7 +8937,7 @@
         <string name="h7" value="消耗MP 24，攻击力 54%，最大攻击6只"/>
         <string name="h8" value="消耗MP 24，攻击力 56%，最大攻击6只"/>
         <string name="h9" value="消耗MP 24，攻击力 58%，最大攻击6只"/>
-        <string name="desc" value="召唤龙的灵魂发射强有力的箭. \n被箭射中的敌人被退后很远"/>
+        <string name="desc" value="以龙之气息射出强力箭矢，攻击前方多个敌人并将其击退。"/>
     </imgdir>
     <imgdir name="3121004">
         <string name="name" value="暴风箭雨"/>
@@ -8971,7 +8971,7 @@
         <string name="h7" value="消耗MP 6，伤害 87%"/>
         <string name="h8" value="消耗MP 6，伤害 88%"/>
         <string name="h9" value="消耗MP 6，伤害 89%"/>
-        <string name="desc" value="像暴风雨一样快速的发射箭. \n摁住此技能键的状态可持续发射"/>
+        <string name="desc" value="以极快速度持续发射箭矢；按住技能键即可持续攻击。"/>
     </imgdir>
     <imgdir name="3121006">
         <string name="name" value="火凤凰"/>
@@ -9005,10 +9005,10 @@
         <string name="h7" value="消耗MP 54，攻击力 335，持续时间 131秒"/>
         <string name="h8" value="消耗MP 56，攻击力 340，持续时间 134秒"/>
         <string name="h9" value="消耗MP 58，攻击力 345，持续时间 137秒"/>
-        <string name="desc" value="一定时间内召唤火属性的火凤凰. \n最多攻击4只怪物.\n必要技能 : #c银鹰召唤 15级 以上#"/>
+        <string name="desc" value="召唤火凤凰，在一定时间内攻击最多4个敌人。\n需要技能 : #c银鹰召唤 15级以上#"/>
     </imgdir>
     <imgdir name="3121007">
-        <string name="name" value="击退箭"/>
+        <string name="name" value="牵制箭"/>
         <string name="h1" value="消耗MP 12，35秒内 11%的几率 5秒间 敌人移动速度 -2"/>
         <string name="h10" value="消耗MP 12，80秒内 20%的几率 5秒间 敌人移动速度 -20"/>
         <string name="h11" value="消耗MP 24，85秒内 21%的几率 10秒间 敌人移动速度 -22"/>
@@ -9039,7 +9039,7 @@
         <string name="h7" value="消耗MP 12，65秒内 17%的几率 5秒间 敌人移动速度 -14"/>
         <string name="h8" value="消耗MP 12，70秒内 18%的几率 5秒间 敌人移动速度 -16"/>
         <string name="h9" value="消耗MP 12，75秒内 19%的几率 5秒间 敌人移动速度 -18"/>
-        <string name="desc" value="用一定几率攻击敌人的腿部,\n使敌人降低移动速度"/>
+        <string name="desc" value="有一定概率射中敌人腿部，使其在一定时间内降低移动速度。"/>
     </imgdir>
     <imgdir name="3121008">
         <string name="name" value="集中精力"/>
@@ -9073,7 +9073,7 @@
         <string name="h7" value="消耗MP 17，攻击力 14 上升，消耗MP -14%，持续时间 120秒"/>
         <string name="h8" value="消耗MP 18，攻击力 15 上升，消耗MP -16%，持续时间 120秒"/>
         <string name="h9" value="消耗MP 19，攻击力 15 上升，消耗MP -18%，持续时间 120秒"/>
-        <string name="desc" value="一定时间内攻击力上升,\n技能使用时的魔法值也下降.\n#c 冷却时间 : 4分#"/>
+        <string name="desc" value="在一定时间内提高攻击力，并降低技能MP消耗。\n#c冷却时间 : 6分钟#"/>
     </imgdir>
     <imgdir name="3121009">
         <string name="name" value="勇士的意志"/>
@@ -9082,7 +9082,7 @@
         <string name="h3" value="消耗MP 30，解除诱惑异常状态，冷却时间8分钟"/>
         <string name="h4" value="消耗MP 30，解除诱惑异常状态，冷却时间7分钟"/>
         <string name="h5" value="消耗MP 30，解除诱惑异常状态，冷却时间6分钟"/>
-        <string name="desc" value="从异常状态中恢复. \n随着等级的上升,冷却时间逐渐缩短"/>
+        <string name="desc" value="解除异常状态。随着技能等级提高，冷却时间缩短。"/>
     </imgdir>
     <imgdir name="320">
         <string name="bookName" value="弩弓手技能"/>
@@ -9109,7 +9109,7 @@
         <string name="h7" value="弩系列武器的熟练度+30%，命中率+7"/>
         <string name="h8" value="弩系列武器的熟练度+30%，命中率+8"/>
         <string name="h9" value="弩系列武器的熟练度+35%，命中率+9"/>
-        <string name="desc" value="[最高等级 : 20]\n增加使用弩系武器的命中率及熟练度\n(必须装备弩)"/>
+        <string name="desc" value="[最高等级 : 20]\n提高弩的熟练度和命中率。\n必须装备弩。"/>
     </imgdir>
     <imgdir name="3200001">
         <string name="name" value="终极弩"/>
@@ -9143,7 +9143,7 @@
         <string name="h7" value="出现概率14%，发挥135%的最终攻击"/>
         <string name="h8" value="出现概率16%，发挥140%的最终攻击"/>
         <string name="h9" value="出现概率18%，发挥145%的最终攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n第一次攻击后发动连续攻击\n(必须装备弩)\n必需技能 : #c精准弩等级3以上#"/>
+        <string name="desc" value="[最高等级 : 30]\n使用弩系攻击技能后，有一定概率追加一次终极攻击。\n必须装备弩。\n需要技能 : #c精准弩 3级以上#"/>
     </imgdir>
     <imgdir name="3201002">
         <string name="name" value="快速弩"/>
@@ -9167,7 +9167,7 @@
         <string name="h7" value="消耗HP23和MP23，持续70秒"/>
         <string name="h8" value="消耗HP22和MP22，持续80秒"/>
         <string name="h9" value="消耗HP21和MP21，持续90秒"/>
-        <string name="desc" value="[最高等级 : 20]\n攻击速度提升3个等级\n(必须装备弩)\n必需技能 : #c精准弩等级5以上#"/>
+        <string name="desc" value="[最高等级 : 20]\n消耗HP和MP，在一定时间内提升弩的攻击速度2级。\n必须装备弩。\n需要技能 : #c精准弩 5级以上#"/>
     </imgdir>
     <imgdir name="3201003">
         <string name="name" value="强弩"/>
@@ -9191,7 +9191,7 @@
 		<string name="h7" value="消耗MP8，概率31%伤害+135%，对象3个"/>
 		<string name="h8" value="消耗MP8，概率34%伤害+140%，对象3个"/>
 		<string name="h9" value="消耗MP8，概率37%伤害+145%，对象3个"/>
-        <string name="desc" value="[最高等级 : 20]\n用弩攻击时，使怪物后退的概率增加，\n随着等级上升击退怪物数量会增加"/>
+        <string name="desc" value="[最高等级 : 20]\n用弩进行近身攻击时，有一定概率击退多个敌人并造成伤害。"/>
     </imgdir>
     <imgdir name="3201004">
         <string name="name" value="无形箭"/>
@@ -9215,7 +9215,7 @@
         <string name="h7" value="消耗MP15，持续210秒"/>
         <string name="h8" value="消耗MP15，持续240秒"/>
         <string name="h9" value="消耗MP15，持续270秒"/>
-        <string name="desc" value="[最高等级 : 20]\n一定时间内，攻击时不消耗箭\n必需技能 : #c快速弩等级5以上#"/>
+        <string name="desc" value="[最高等级 : 20]\n在一定时间内使用弩攻击时不消耗箭矢。\n必须装备弩。\n需要技能 : #c快速弩 5级以上#"/>
     </imgdir>
     <imgdir name="3201005">
         <string name="name" value="穿透箭"/>
@@ -9249,7 +9249,7 @@
         <string name="h7" value="消耗MP24，攻击力154%"/>
         <string name="h8" value="消耗MP24，攻击力156%"/>
         <string name="h9" value="消耗MP24，攻击力158%"/>
-        <string name="desc" value="[最高等级 : 30]\n使用钢铁弩箭贯穿怪物，最多能同时攻击\n8个怪物，但怪物伤害依数量而減少"/>
+        <string name="desc" value="[最高等级 : 30]\n射出可贯穿敌人的强力箭矢，最多攻击6个敌人；穿透过程中伤害会衰减。"/>
     </imgdir>
     <imgdir name="321">
         <string name="bookName" value="游侠技能"/>
@@ -9276,10 +9276,10 @@
 		<string name="h7" value="移动速度+14"/>
 		<string name="h8" value="移动速度+16"/>
 		<string name="h9" value="移动速度+18"/>
-        <string name="desc" value="[最高等级:20]\n增加移动速度"/>
+        <string name="desc" value="[最高等级 : 20]\n提高移动速度。"/>
     </imgdir>
     <imgdir name="3210001">
-        <string name="name" value="贯穿箭"/>
+        <string name="name" value="致命箭"/>
         <string name="h1" value="33%几率发动，造成伤害110%，假如对方HP在20%以下时1%几率出现必杀"/>
         <string name="h10" value="60%几率发动，造成伤害200%，假如敌的HP在35%以下时5%几率出现必杀怪物"/>
         <string name="h11" value="63%几率发动，造成伤害205%，假如敌的HP在35%以下时6%几率出现必杀怪物"/>
@@ -9300,7 +9300,7 @@
         <string name="h7" value="51%几率发动，造成伤害170%，假如敌的HP在29%以下时4%几率出现必杀怪物"/>
         <string name="h8" value="54%几率发动，造成伤害180%，假如敌的HP在32%以下时4%几率出现必杀怪物"/>
         <string name="h9" value="57%几率发动，造成伤害190%，假如敌的HP在32%以下时5%几率出现必杀怪物"/>
-        <string name="desc" value="[最高等级:20]\n即使怪物靠得很近的时候也能发射弩，\n一定几率必杀怪物"/>
+        <string name="desc" value="[最高等级 : 20]\n即使在近距离也可发射弩箭，并有一定概率对敌人造成致命伤害。"/>
     </imgdir>
     <imgdir name="3211002">
         <string name="name" value="替身术"/>
@@ -9324,7 +9324,7 @@
         <string name="h7" value="消费MP26，持续20秒 召唤HP10500的分身"/>
         <string name="h8" value="消费MP26，持续20秒 召唤HP12000的分身"/>
         <string name="h9" value="消费MP26，持续30秒 召唤HP13500的分身"/>
-        <string name="desc" value="[最高等级:20]\n一定时间制造自己的分身。\n分身存在的时候，怪物攻击分身"/>
+        <string name="desc" value="[最高等级 : 20]\n召唤替身吸引怪物攻击，持续一定时间。"/>
     </imgdir>
     <imgdir name="3211003">
         <string name="name" value="寒冰箭"/>
@@ -9358,7 +9358,7 @@
         <string name="h7" value="消费MP20，造成伤害151%，持续1秒冻结怪物"/>
         <string name="h8" value="消费MP20，造成伤害154%，持续1秒冻结怪物"/>
         <string name="h9" value="消费MP20，造成伤害157%，持续1秒冻结怪物"/>
-        <string name="desc" value="[最高等级:30]\n用冰属性的箭攻击多个怪物，属性纯度50%。\n最多攻击6个怪物，只有装备弩弓才能使用"/>
+        <string name="desc" value="[最高等级 : 30]\n用冰属性箭攻击最多6个敌人，并附带冰属性效果。\n必须装备弩。"/>
     </imgdir>
     <imgdir name="3211004">
         <string name="name" value="升龙弩"/>
@@ -9392,7 +9392,7 @@
         <string name="h7" value="消费MP18，造成伤害171%"/>
         <string name="h8" value="消费MP18，造成伤害174%"/>
         <string name="h9" value="消费MP18，造成伤害177%"/>
-        <string name="desc" value="[最高等级:30]\n向地下射箭然后钻上来攻击怪物。最多\n攻击6个怪物,只有装备弩弓才能使用.\n必需技能 : #c贯穿箭等级5以上#"/>
+        <string name="desc" value="[最高等级 : 30]\n向地面发射箭矢后爆发攻击，最多攻击6个敌人。\n必须装备弩。\n需要技能 : #c致命箭 5级以上#"/>
     </imgdir>
     <imgdir name="3211005">
         <string name="name" value="金鹰召唤"/>
@@ -9426,7 +9426,7 @@
         <string name="h7" value="消费MP44和召唤石1个,持续121秒,82次攻击,召唤的鹰以68%几率出击"/>
         <string name="h8" value="消费MP46和召唤石1个,持续124秒,88次攻击,召唤的鹰以71%几率出击"/>
         <string name="h9" value="消费MP48和召唤石1个,持续127秒,94次攻击,召唤的鹰以74%几率出击"/>
-        <string name="desc" value="[最高等级:30]\n召唤金色老鹰。\n在一定的时间内攻击附近的怪物。\n必需技能 : #c替身术等级5以上#"/>
+        <string name="desc" value="[最高等级 : 30]\n召唤金鹰，在一定时间内攻击附近敌人，并有一定概率使其眩晕。\n需要技能 : #c替身术 5级以上#"/>
     </imgdir>
     <imgdir name="3211006">
         <string name="name" value="箭扫射"/>
@@ -9460,7 +9460,7 @@
         <string name="h7" value="消费MP26，造成伤害87%，5次攻击"/>
         <string name="h8" value="消费MP26，造成伤害88%，5次攻击"/>
         <string name="h9" value="消费MP26，造成伤害89%，5次攻击"/>
-        <string name="desc" value="[最高等级:30]\n向单个怪物连续射5支箭"/>
+        <string name="desc" value="[最高等级 : 30]\n连续射出4支箭攻击1个敌人。"/>
     </imgdir>
     <imgdir name="322">
         <string name="bookName" value="弩箭神"/>
@@ -9497,7 +9497,7 @@
         <string name="h28" value="弩弓系武器的熟练度 90%, 物理 攻击力 9 上升"/>
         <string name="h29" value="弩弓系武器的熟练度 90%, 物理 攻击力 9 上升"/>
         <string name="h30" value="弩弓系武器的熟练度 90%, 物理 攻击力 10 上升"/>
-        <string name="desc" value="提高弩弓系武器的熟练度和攻击力. \n必须持有弩弓的时候才适用.\n必要技能 : #c精准弩 20级#"/>
+        <string name="desc" value="进一步提高弩的熟练度和攻击力。\n必须装备弩。\n需要技能 : #c精准弩 20级#"/>
     </imgdir>
     <imgdir name="3221000">
         <string name="name" value="冒险岛勇士"/>
@@ -9531,7 +9531,7 @@
         <string name="h7" value="消耗MP 20，210秒内所有的属性点提高 4%"/>
         <string name="h8" value="消耗MP 20，240秒内所有的属性点提高 4%"/>
         <string name="h9" value="消耗MP 20，270秒内所有的属性点提高 5%"/>
-        <string name="desc" value="一定时间内把组队成员的所有属性点提高\n一定的百分比"/>
+        <string name="desc" value="在一定时间内按百分比提高自己和队员的全部属性。"/>
     </imgdir>
     <imgdir name="3221001">
         <string name="name" value="穿透箭"/>
@@ -9565,7 +9565,7 @@
         <string name="h7" value="消耗MP18，最大攻击力 440%，最多攻击6只"/>
         <string name="h8" value="消耗MP18，最大攻击力 460%，最多攻击6只"/>
         <string name="h9" value="消耗MP18，最大攻击力 480%，最多攻击6只"/>
-        <string name="desc" value="复活龙的灵魂射箭.\n穿越敌人时吸收能量,变的更强"/>
+        <string name="desc" value="发射可持续蓄力的贯穿箭，最多攻击多个敌人；穿透目标越多，箭矢威力越强。"/>
     </imgdir>
     <imgdir name="3221002">
         <string name="name" value="火眼晶晶"/>
@@ -9599,7 +9599,7 @@
         <string name="h7" value="消耗MP 29，持续时间 70秒，4%的必杀几率，伤害 17% 上升"/>
         <string name="h8" value="消耗MP 29，持续时间 80秒，4%的必杀几率，伤害 18% 上升"/>
         <string name="h9" value="消耗MP 29，持续时间 90秒，5%的必杀几率，伤害 19% 上升"/>
-        <string name="desc" value="赋予组队成员针对敌人寻找弱点\n并给予敌人致命伤的能力"/>
+        <string name="desc" value="在一定时间内提高自己和队员造成暴击的概率与暴击伤害。"/>
     </imgdir>
     <imgdir name="3221003">
         <string name="name" value="飞龙冲击波"/>
@@ -9633,7 +9633,7 @@
         <string name="h7" value="消耗MP 24，攻击力 54%，最大攻击6只"/>
         <string name="h8" value="消耗MP 24，攻击力 56%，最大攻击6只"/>
         <string name="h9" value="消耗MP 24，攻击力 58%，最大攻击6只"/>
-        <string name="desc" value="召唤龙的灵魂发射强有力的箭. \n被箭射中的敌人被退后很远"/>
+        <string name="desc" value="以龙之气息射出强力箭矢，攻击前方多个敌人并将其击退。"/>
     </imgdir>
     <imgdir name="3221005">
         <string name="name" value="冰凤凰"/>
@@ -9667,10 +9667,10 @@
         <string name="h7" value="消耗MP 54，攻击力 285，持续时间 131秒"/>
         <string name="h8" value="消耗MP 56，攻击力 290，持续时间 134秒"/>
         <string name="h9" value="消耗MP 58，攻击力 295，持续时间 137秒"/>
-        <string name="desc" value="一定时间内召唤冰属性的冰凤凰. \n最多可攻击4只怪物.\n必要技能 : #c金鹰召唤 15级 以上#"/>
+        <string name="desc" value="召唤冰凤凰，在一定时间内攻击最多4个敌人。\n需要技能 : #c金鹰召唤 15级以上#"/>
     </imgdir>
     <imgdir name="3221006">
-        <string name="name" value="刺眼箭"/>
+        <string name="name" value="致盲箭"/>
         <string name="h1" value="消耗MP 12，35秒内 11%的几率 5秒间敌人命中率 -1%"/>
         <string name="h10" value="消耗MP 12，80秒内 20%的几率 5秒间敌人命中率 -10%"/>
         <string name="h11" value="消耗MP 24，85秒内 21%的几率 10秒间敌人命中率 -11%"/>
@@ -9701,7 +9701,7 @@
         <string name="h7" value="消耗MP 12，65秒内 17%的几率 5秒间敌人命中率 -7%"/>
         <string name="h8" value="消耗MP 12，70秒内 18%的几率 5秒间敌人命中率 -8%"/>
         <string name="h9" value="消耗MP 12，75秒内 19%的几率 5秒间敌人命中率 -9%"/>
-        <string name="desc" value="瞄准敌人的眼睛,阻碍视野. \n一定时间内降低敌人的命中率"/>
+        <string name="desc" value="有一定概率使敌人视野受阻，在一定时间内降低其命中率。"/>
     </imgdir>
     <imgdir name="3221007">
         <string name="name" value="一击要害箭"/>
@@ -9735,7 +9735,7 @@
         <string name="h28" value="消耗MP 13 , 冷却时间 15秒"/>
         <string name="h29" value="消耗MP 12 , 冷却时间 10秒"/>
         <string name="h30" value="消耗MP 11 , 冷却时间 5秒"/>
-        <string name="desc" value="瞄准敌人的要害,一击打倒敌人"/>
+        <string name="desc" value="瞄准敌人要害发动致命一击，造成极高固定伤害。"/>
     </imgdir>
     <imgdir name="3221008">
         <string name="name" value="勇士的意志"/>
@@ -9744,7 +9744,7 @@
         <string name="h3" value="消耗MP 30，解除诱惑异常状态，冷却时间8分钟"/>
         <string name="h4" value="消耗MP 30，解除诱惑异常状态，冷却时间7分钟"/>
         <string name="h5" value="消耗MP 30，解除诱惑异常状态，冷却时间6分钟"/>
-        <string name="desc" value="从异常状态中恢复. \n随着等级的上升,冷却时间逐渐缩短"/>
+        <string name="desc" value="解除异常状态。随着技能等级提高，冷却时间缩短。"/>
     </imgdir>
     <imgdir name="400">
         <string name="bookName" value="飞侠技能"/>

--- a/gms-server/wz-zh-CN/String.wz/Skill.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Skill.img.xml
@@ -8297,46 +8297,46 @@
     </imgdir>
     <imgdir name="3000000">
         <string name="name" value="祝福之羽"/>
-        <string name="h1" value="命中率+1"/>
-        <string name="h10" value="命中率+10"/>
-        <string name="h11" value="命中率+11"/>
-        <string name="h12" value="命中率+12"/>
-        <string name="h13" value="命中率+13"/>
-        <string name="h14" value="命中率+14"/>
-        <string name="h15" value="命中率+15"/>
-        <string name="h16" value="命中率+16"/>
-        <string name="h2" value="命中率+2"/>
-        <string name="h3" value="命中率+3"/>
-        <string name="h4" value="命中率+4"/>
-        <string name="h5" value="命中率+5"/>
-        <string name="h6" value="命中率+6"/>
-        <string name="h7" value="命中率+7"/>
-        <string name="h8" value="命中率+8"/>
-        <string name="h9" value="命中率+9"/>
+        <string name="h1" value="命中率 +1"/>
+        <string name="h10" value="命中率 +10"/>
+        <string name="h11" value="命中率 +11"/>
+        <string name="h12" value="命中率 +12"/>
+        <string name="h13" value="命中率 +13"/>
+        <string name="h14" value="命中率 +14"/>
+        <string name="h15" value="命中率 +15"/>
+        <string name="h16" value="命中率 +16"/>
+        <string name="h2" value="命中率 +2"/>
+        <string name="h3" value="命中率 +3"/>
+        <string name="h4" value="命中率 +4"/>
+        <string name="h5" value="命中率 +5"/>
+        <string name="h6" value="命中率 +6"/>
+        <string name="h7" value="命中率 +7"/>
+        <string name="h8" value="命中率 +8"/>
+        <string name="h9" value="命中率 +9"/>
         <string name="desc" value="[最高等级 : 16]\n提高命中率。"/>
     </imgdir>
     <imgdir name="3000001">
         <string name="name" value="强力箭"/>
-        <string name="h1" value="比率12%，伤害105%"/>
-        <string name="h10" value="比率30%，伤害150%"/>
-        <string name="h11" value="比率31%，伤害155%"/>
-        <string name="h12" value="比率32%，伤害160%"/>
-        <string name="h13" value="比率33%，伤害165%"/>
-        <string name="h14" value="比率34%，伤害170%"/>
-        <string name="h15" value="比率35%，伤害175%"/>
-        <string name="h16" value="比率36%，伤害180%"/>
-        <string name="h17" value="比率37%，伤害185%"/>
-        <string name="h18" value="比率38%，伤害190%"/>
-        <string name="h19" value="比率39%，伤害195%"/>
-        <string name="h2" value="比率14%，伤害110%"/>
-        <string name="h20" value="比率40%，伤害200%"/>
-        <string name="h3" value="比率16%，伤害115%"/>
-        <string name="h4" value="比率18%，伤害120%"/>
-        <string name="h5" value="比率20%，伤害125%"/>
-        <string name="h6" value="比率22%，伤害130%"/>
-        <string name="h7" value="比率24%，伤害135%"/>
-        <string name="h8" value="比率26%，伤害140%"/>
-        <string name="h9" value="比率28%，伤害145%"/>
+        <string name="h1" value="暴击率 12%，暴击伤害 105%"/>
+        <string name="h10" value="暴击率 30%，暴击伤害 150%"/>
+        <string name="h11" value="暴击率 31%，暴击伤害 155%"/>
+        <string name="h12" value="暴击率 32%，暴击伤害 160%"/>
+        <string name="h13" value="暴击率 33%，暴击伤害 165%"/>
+        <string name="h14" value="暴击率 34%，暴击伤害 170%"/>
+        <string name="h15" value="暴击率 35%，暴击伤害 175%"/>
+        <string name="h16" value="暴击率 36%，暴击伤害 180%"/>
+        <string name="h17" value="暴击率 37%，暴击伤害 185%"/>
+        <string name="h18" value="暴击率 38%，暴击伤害 190%"/>
+        <string name="h19" value="暴击率 39%，暴击伤害 195%"/>
+        <string name="h2" value="暴击率 14%，暴击伤害 110%"/>
+        <string name="h20" value="暴击率 40%，暴击伤害 200%"/>
+        <string name="h3" value="暴击率 16%，暴击伤害 115%"/>
+        <string name="h4" value="暴击率 18%，暴击伤害 120%"/>
+        <string name="h5" value="暴击率 20%，暴击伤害 125%"/>
+        <string name="h6" value="暴击率 22%，暴击伤害 130%"/>
+        <string name="h7" value="暴击率 24%，暴击伤害 135%"/>
+        <string name="h8" value="暴击率 26%，暴击伤害 140%"/>
+        <string name="h9" value="暴击率 28%，暴击伤害 145%"/>
         <string name="desc" value="[最高等级 : 20]\n攻击时有一定概率打出致命一击，提高伤害。"/>
     </imgdir>
     <imgdir name="3000002">
@@ -8353,74 +8353,74 @@
     </imgdir>
     <imgdir name="3001003">
         <string name="name" value="集中术"/>
-        <string name="h1" value="持续70秒，消费MP8，命中率+1和回避率+1"/>
-        <string name="h10" value="持续170秒，消费MP10，命中率+10和回避率+10"/>
-        <string name="h11" value="持续195秒，消费MP13，命中率+11和回避率+11"/>
-        <string name="h12" value="持续205秒，消费MP13，命中率+12和回避率+12"/>
-        <string name="h13" value="持续215秒，消费MP13，命中率+13和回避率+13"/>
-        <string name="h14" value="持续225秒，消费MP13，命中率+14和回避率+14"/>
-        <string name="h15" value="持续235秒，消费MP13，命中率+15和回避率+15"/>
-        <string name="h16" value="持续260秒，消费MP16，命中率+16和回避率+16"/>
-        <string name="h17" value="持续270秒，消费MP16，命中率+17和回避率+17"/>
-        <string name="h18" value="持续280秒，消费MP16，命中率+18和回避率+18"/>
-        <string name="h19" value="持续290秒，消费MP16，命中率+19和回避率+19"/>
-        <string name="h2" value="持续80秒，消费MP8，命中率+2和回避率+2"/>
-        <string name="h20" value="持续300秒，消费MP16，命中率+20和回避率+20"/>
-        <string name="h3" value="持续90秒，消费MP8，命中率+3和回避率+3"/>
-        <string name="h4" value="持续100秒，消费MP8，命中率+4和回避率+4"/>
-        <string name="h5" value="持续110秒，消费MP8，命中率+5和回避率+5"/>
-        <string name="h6" value="持续130秒，消费MP10，命中率+6和回避率+6"/>
-        <string name="h7" value="持续140秒，消费MP10，命中率+7和回避率+7"/>
-        <string name="h8" value="持续150秒，消费MP10，命中率+8和回避率+8"/>
-        <string name="h9" value="持续160秒，消费MP10，命中率+9和回避率+9"/>
+        <string name="h1" value="消耗MP 8，命中率 +1，回避率 +1，持续 70秒"/>
+        <string name="h10" value="消耗MP 10，命中率 +10，回避率 +10，持续 170秒"/>
+        <string name="h11" value="消耗MP 13，命中率 +11，回避率 +11，持续 195秒"/>
+        <string name="h12" value="消耗MP 13，命中率 +12，回避率 +12，持续 205秒"/>
+        <string name="h13" value="消耗MP 13，命中率 +13，回避率 +13，持续 215秒"/>
+        <string name="h14" value="消耗MP 13，命中率 +14，回避率 +14，持续 225秒"/>
+        <string name="h15" value="消耗MP 13，命中率 +15，回避率 +15，持续 235秒"/>
+        <string name="h16" value="消耗MP 16，命中率 +16，回避率 +16，持续 260秒"/>
+        <string name="h17" value="消耗MP 16，命中率 +17，回避率 +17，持续 270秒"/>
+        <string name="h18" value="消耗MP 16，命中率 +18，回避率 +18，持续 280秒"/>
+        <string name="h19" value="消耗MP 16，命中率 +19，回避率 +19，持续 290秒"/>
+        <string name="h2" value="消耗MP 8，命中率 +2，回避率 +2，持续 80秒"/>
+        <string name="h20" value="消耗MP 16，命中率 +20，回避率 +20，持续 300秒"/>
+        <string name="h3" value="消耗MP 8，命中率 +3，回避率 +3，持续 90秒"/>
+        <string name="h4" value="消耗MP 8，命中率 +4，回避率 +4，持续 100秒"/>
+        <string name="h5" value="消耗MP 8，命中率 +5，回避率 +5，持续 110秒"/>
+        <string name="h6" value="消耗MP 10，命中率 +6，回避率 +6，持续 130秒"/>
+        <string name="h7" value="消耗MP 10，命中率 +7，回避率 +7，持续 140秒"/>
+        <string name="h8" value="消耗MP 10，命中率 +8，回避率 +8，持续 150秒"/>
+        <string name="h9" value="消耗MP 10，命中率 +9，回避率 +9，持续 160秒"/>
         <string name="desc" value="[最高等级 : 20]\n在一定时间内提高命中率和回避率。\n需要技能 : #c祝福之羽 3级以上#"/>
     </imgdir>
     <imgdir name="3001004">
         <string name="name" value="断魂箭"/>
-        <string name="h1" value="消耗MP8，攻击力 190%"/>
-        <string name="h10" value="消耗MP10，攻击力 220%"/>
-        <string name="h11" value="消耗MP11，攻击力 223%"/>
-        <string name="h12" value="消耗MP11，攻击力 226%"/>
-        <string name="h13" value="消耗MP11，攻击力 230%"/>
-        <string name="h14" value="消耗MP12，攻击力 233%"/>
-        <string name="h15" value="消耗MP12，攻击力 236%"/>
-        <string name="h16" value="消耗MP12，攻击力 240%"/>
-        <string name="h17" value="消耗MP13，攻击力 243%"/>
-        <string name="h18" value="消耗MP13，攻击力 248%"/>
-        <string name="h19" value="消耗MP13，攻击力 253%"/>
-        <string name="h2" value="消耗MP8，攻击力 193%"/>
-        <string name="h20" value="消耗MP14，攻击力 260%"/>
-        <string name="h3" value="消耗MP8，攻击力 196%"/>
-        <string name="h4" value="消耗MP8，攻击力 200%"/>
-        <string name="h5" value="消耗MP9，攻击力 203%"/>
-        <string name="h6" value="消耗MP9，攻击力 206%"/>
-        <string name="h7" value="消耗MP9，攻击力 210%"/>
-        <string name="h8" value="消耗MP10，攻击力 213%"/>
-        <string name="h9" value="消耗MP10，攻击力 216%"/>
+        <string name="h1" value="消耗MP 7，伤害 190%"/>
+        <string name="h10" value="消耗MP 10，伤害 220%"/>
+        <string name="h11" value="消耗MP 11，伤害 223%"/>
+        <string name="h12" value="消耗MP 11，伤害 226%"/>
+        <string name="h13" value="消耗MP 11，伤害 230%"/>
+        <string name="h14" value="消耗MP 12，伤害 233%"/>
+        <string name="h15" value="消耗MP 12，伤害 236%"/>
+        <string name="h16" value="消耗MP 12，伤害 240%"/>
+        <string name="h17" value="消耗MP 13，伤害 243%"/>
+        <string name="h18" value="消耗MP 13，伤害 248%"/>
+        <string name="h19" value="消耗MP 13，伤害 253%"/>
+        <string name="h2" value="消耗MP 8，伤害 193%"/>
+        <string name="h20" value="消耗MP 14，伤害 260%"/>
+        <string name="h3" value="消耗MP 8，伤害 196%"/>
+        <string name="h4" value="消耗MP 8，伤害 200%"/>
+        <string name="h5" value="消耗MP 9，伤害 203%"/>
+        <string name="h6" value="消耗MP 9，伤害 206%"/>
+        <string name="h7" value="消耗MP 9，伤害 210%"/>
+        <string name="h8" value="消耗MP 10，伤害 213%"/>
+        <string name="h9" value="消耗MP 10，伤害 216%"/>
         <string name="desc" value="[最高等级 : 20]\n射出强力箭矢攻击1个敌人，造成更高伤害。"/>
     </imgdir>
     <imgdir name="3001005">
         <string name="name" value="二连射"/>
-        <string name="h1" value="消耗MP10，攻击力 103%"/>
-        <string name="h10" value="消耗MP12，攻击力 130%"/>
-        <string name="h11" value="消耗MP13，攻击力 133%"/>
-        <string name="h12" value="消耗MP13，攻击力 136%"/>
-        <string name="h13" value="消耗MP13，攻击力 139%"/>
-        <string name="h14" value="消耗MP14，攻击力 142%"/>
-        <string name="h15" value="消耗MP14，攻击力 145%"/>
-        <string name="h16" value="消耗MP14，攻击力 148%"/>
-        <string name="h17" value="消耗MP15，攻击力 151%"/>
-        <string name="h18" value="消耗MP15，攻击力 154%"/>
-        <string name="h19" value="消耗MP15，攻击力 157%"/>
-        <string name="h2" value="消耗MP10，攻击力 106%"/>
-        <string name="h20" value="消耗MP16，攻击力 160%"/>
-        <string name="h3" value="消耗MP10，攻击力 109%"/>
-        <string name="h4" value="消耗MP10，攻击力 112%"/>
-        <string name="h5" value="消耗MP11，攻击力 115%"/>
-        <string name="h6" value="消耗MP11，攻击力 118%"/>
-        <string name="h7" value="消耗MP11，攻击力 121%"/>
-        <string name="h8" value="消耗MP12，攻击力 124%"/>
-        <string name="h9" value="消耗MP12，攻击力 127%"/>
+        <string name="h1" value="消耗MP 10，每支箭伤害 92%，攻击 2次"/>
+        <string name="h10" value="消耗MP 12，每支箭伤害 110%，攻击 2次"/>
+        <string name="h11" value="消耗MP 13，每支箭伤害 112%，攻击 2次"/>
+        <string name="h12" value="消耗MP 13，每支箭伤害 114%，攻击 2次"/>
+        <string name="h13" value="消耗MP 13，每支箭伤害 116%，攻击 2次"/>
+        <string name="h14" value="消耗MP 14，每支箭伤害 118%，攻击 2次"/>
+        <string name="h15" value="消耗MP 14，每支箭伤害 120%，攻击 2次"/>
+        <string name="h16" value="消耗MP 14，每支箭伤害 122%，攻击 2次"/>
+        <string name="h17" value="消耗MP 15，每支箭伤害 124%，攻击 2次"/>
+        <string name="h18" value="消耗MP 15，每支箭伤害 126%，攻击 2次"/>
+        <string name="h19" value="消耗MP 15，每支箭伤害 128%，攻击 2次"/>
+        <string name="h2" value="消耗MP 10，每支箭伤害 94%，攻击 2次"/>
+        <string name="h20" value="消耗MP 16，每支箭伤害 130%，攻击 2次"/>
+        <string name="h3" value="消耗MP 10，每支箭伤害 96%，攻击 2次"/>
+        <string name="h4" value="消耗MP 10，每支箭伤害 98%，攻击 2次"/>
+        <string name="h5" value="消耗MP 11，每支箭伤害 100%，攻击 2次"/>
+        <string name="h6" value="消耗MP 11，每支箭伤害 102%，攻击 2次"/>
+        <string name="h7" value="消耗MP 11，每支箭伤害 104%，攻击 2次"/>
+        <string name="h8" value="消耗MP 12，每支箭伤害 106%，攻击 2次"/>
+        <string name="h9" value="消耗MP 12，每支箭伤害 108%，攻击 2次"/>
         <string name="desc" value="[最高等级 : 20]\n同时射出2支箭，对1个敌人造成2次伤害。\n需要技能 : #c断魂箭 1级以上#"/>
     </imgdir>
     <imgdir name="310">
@@ -8452,142 +8452,142 @@
     </imgdir>
     <imgdir name="3100001">
         <string name="name" value="终极弓"/>
-        <string name="h1" value="出现概率2%，发挥105%的最终攻击"/>
-        <string name="h10" value="出现概率20%，发挥150%的最终攻击"/>
-        <string name="h11" value="出现概率22%，发挥155%的最终攻击"/>
-        <string name="h12" value="出现概率24%，发挥160%的最终攻击"/>
-        <string name="h13" value="出现概率26%，发挥165%的最终攻击"/>
-        <string name="h14" value="出现概率28%，发挥170%的最终攻击"/>
-        <string name="h15" value="出现概率30%，发挥175%的最终攻击"/>
-        <string name="h16" value="出现概率32%，发挥180%的最终攻击"/>
-        <string name="h17" value="出现概率34%，发挥185%的最终攻击"/>
-        <string name="h18" value="出现概率36%，发挥190%的最终攻击"/>
-        <string name="h19" value="出现概率38%，发挥195%的最终攻击"/>
-        <string name="h2" value="出现概率4%，发挥110%的最终攻击"/>
-        <string name="h20" value="出现概率40%，发挥200%的最终攻击"/>
-        <string name="h21" value="出现概率42%，发挥205%的最终攻击"/>
-        <string name="h22" value="出现概率44%，发挥210%的最终攻击"/>
-        <string name="h23" value="出现概率46%，发挥215%的最终攻击"/>
-        <string name="h24" value="出现概率48%，发挥220%的最终攻击"/>
-        <string name="h25" value="出现概率50%，发挥225%的最终攻击"/>
-        <string name="h26" value="出现概率52%，发挥230%的最终攻击"/>
-        <string name="h27" value="出现概率54%，发挥235%的最终攻击"/>
-        <string name="h28" value="出现概率56%，发挥240%的最终攻击"/>
-        <string name="h29" value="出现概率58%，发挥245%的最终攻击"/>
-        <string name="h3" value="出现概率6%，发挥115%的最终攻击"/>
-        <string name="h30" value="出现概率60%，发挥250%的最终攻击"/>
-        <string name="h4" value="出现概率8%，发挥120%的最终攻击"/>
-        <string name="h5" value="出现概率10%，发挥125%的最终攻击"/>
-        <string name="h6" value="出现概率12%，发挥130%的最终攻击"/>
-        <string name="h7" value="出现概率14%，发挥135%的最终攻击"/>
-        <string name="h8" value="出现概率16%，发挥140%的最终攻击"/>
-        <string name="h9" value="出现概率18%，发挥145%的最终攻击"/>
+        <string name="h1" value="2%几率发动，终极攻击伤害 105%"/>
+        <string name="h10" value="20%几率发动，终极攻击伤害 150%"/>
+        <string name="h11" value="22%几率发动，终极攻击伤害 155%"/>
+        <string name="h12" value="24%几率发动，终极攻击伤害 160%"/>
+        <string name="h13" value="26%几率发动，终极攻击伤害 165%"/>
+        <string name="h14" value="28%几率发动，终极攻击伤害 170%"/>
+        <string name="h15" value="30%几率发动，终极攻击伤害 175%"/>
+        <string name="h16" value="32%几率发动，终极攻击伤害 180%"/>
+        <string name="h17" value="34%几率发动，终极攻击伤害 185%"/>
+        <string name="h18" value="36%几率发动，终极攻击伤害 190%"/>
+        <string name="h19" value="38%几率发动，终极攻击伤害 195%"/>
+        <string name="h2" value="4%几率发动，终极攻击伤害 110%"/>
+        <string name="h20" value="40%几率发动，终极攻击伤害 200%"/>
+        <string name="h21" value="42%几率发动，终极攻击伤害 205%"/>
+        <string name="h22" value="44%几率发动，终极攻击伤害 210%"/>
+        <string name="h23" value="46%几率发动，终极攻击伤害 215%"/>
+        <string name="h24" value="48%几率发动，终极攻击伤害 220%"/>
+        <string name="h25" value="50%几率发动，终极攻击伤害 225%"/>
+        <string name="h26" value="52%几率发动，终极攻击伤害 230%"/>
+        <string name="h27" value="54%几率发动，终极攻击伤害 235%"/>
+        <string name="h28" value="56%几率发动，终极攻击伤害 240%"/>
+        <string name="h29" value="58%几率发动，终极攻击伤害 245%"/>
+        <string name="h3" value="6%几率发动，终极攻击伤害 115%"/>
+        <string name="h30" value="60%几率发动，终极攻击伤害 250%"/>
+        <string name="h4" value="8%几率发动，终极攻击伤害 120%"/>
+        <string name="h5" value="10%几率发动，终极攻击伤害 125%"/>
+        <string name="h6" value="12%几率发动，终极攻击伤害 130%"/>
+        <string name="h7" value="14%几率发动，终极攻击伤害 135%"/>
+        <string name="h8" value="16%几率发动，终极攻击伤害 140%"/>
+        <string name="h9" value="18%几率发动，终极攻击伤害 145%"/>
         <string name="desc" value="[最高等级 : 30]\n使用弓系攻击技能后，有一定概率追加一次终极攻击。\n必须装备弓。\n需要技能 : #c精准弓 3级以上#"/>
     </imgdir>
     <imgdir name="3101002">
         <string name="name" value="快速箭"/>
-        <string name="h1" value="消耗HP29和MP29，持续10秒"/>
-        <string name="h10" value="消耗HP20和MP20，持续100秒"/>
-        <string name="h11" value="消耗HP19和MP19，持续110秒"/>
-        <string name="h12" value="消耗HP18和MP18，持续120秒"/>
-        <string name="h13" value="消耗HP17和MP17，持续130秒"/>
-        <string name="h14" value="消耗HP16和MP16，持续140秒"/>
-        <string name="h15" value="消耗HP15和MP15，持续150秒"/>
-        <string name="h16" value="消耗HP14和MP14，持续160秒"/>
-        <string name="h17" value="消耗HP13和MP13，持续170秒"/>
-        <string name="h18" value="消耗HP12和MP12，持续180秒"/>
-        <string name="h19" value="消耗HP11和MP11，持续190秒"/>
-        <string name="h2" value="消耗HP28和MP28，持续20秒"/>
-        <string name="h20" value="消耗HP10和MP10，持续200秒"/>
-        <string name="h3" value="消耗HP27和MP27，持续30秒"/>
-        <string name="h4" value="消耗HP26和MP26，持续40秒"/>
-        <string name="h5" value="消耗HP25和MP25，持续50秒"/>
-        <string name="h6" value="消耗HP24和MP24，持续60秒"/>
-        <string name="h7" value="消耗HP23和MP23，持续70秒"/>
-        <string name="h8" value="消耗HP22和MP22，持续80秒"/>
-        <string name="h9" value="消耗HP21和MP21，持续90秒"/>
+        <string name="h1" value="消耗HP 29，消耗MP 29，弓攻击速度提升2级，持续 10秒"/>
+        <string name="h10" value="消耗HP 20，消耗MP 20，弓攻击速度提升2级，持续 100秒"/>
+        <string name="h11" value="消耗HP 19，消耗MP 19，弓攻击速度提升2级，持续 110秒"/>
+        <string name="h12" value="消耗HP 18，消耗MP 18，弓攻击速度提升2级，持续 120秒"/>
+        <string name="h13" value="消耗HP 17，消耗MP 17，弓攻击速度提升2级，持续 130秒"/>
+        <string name="h14" value="消耗HP 16，消耗MP 16，弓攻击速度提升2级，持续 140秒"/>
+        <string name="h15" value="消耗HP 15，消耗MP 15，弓攻击速度提升2级，持续 150秒"/>
+        <string name="h16" value="消耗HP 14，消耗MP 14，弓攻击速度提升2级，持续 160秒"/>
+        <string name="h17" value="消耗HP 13，消耗MP 13，弓攻击速度提升2级，持续 170秒"/>
+        <string name="h18" value="消耗HP 12，消耗MP 12，弓攻击速度提升2级，持续 180秒"/>
+        <string name="h19" value="消耗HP 11，消耗MP 11，弓攻击速度提升2级，持续 190秒"/>
+        <string name="h2" value="消耗HP 28，消耗MP 28，弓攻击速度提升2级，持续 20秒"/>
+        <string name="h20" value="消耗HP 10，消耗MP 10，弓攻击速度提升2级，持续 200秒"/>
+        <string name="h3" value="消耗HP 27，消耗MP 27，弓攻击速度提升2级，持续 30秒"/>
+        <string name="h4" value="消耗HP 26，消耗MP 26，弓攻击速度提升2级，持续 40秒"/>
+        <string name="h5" value="消耗HP 25，消耗MP 25，弓攻击速度提升2级，持续 50秒"/>
+        <string name="h6" value="消耗HP 24，消耗MP 24，弓攻击速度提升2级，持续 60秒"/>
+        <string name="h7" value="消耗HP 23，消耗MP 23，弓攻击速度提升2级，持续 70秒"/>
+        <string name="h8" value="消耗HP 22，消耗MP 22，弓攻击速度提升2级，持续 80秒"/>
+        <string name="h9" value="消耗HP 21，消耗MP 21，弓攻击速度提升2级，持续 90秒"/>
         <string name="desc" value="[最高等级 : 20]\n消耗HP和MP，在一定时间内提升弓的攻击速度2级。\n必须装备弓。\n需要技能 : #c精准弓 5级以上#"/>
     </imgdir>
     <imgdir name="3101003">
         <string name="name" value="强弓"/>
-        <string name="h1" value="消耗MP8，比率33%增加， 伤害110%，对象6个"/>
-        <string name="h10" value="消耗MP8，比率60%增加， 伤害200%，对象6个"/>
-        <string name="h11" value="消耗MP15，比率63%增加， 伤害210%，对象6个"/>
-        <string name="h12" value="消耗MP15，比率66%增加， 伤害220%，对象6个"/>
-        <string name="h13" value="消耗MP15，比率69%增加， 伤害230%，对象6个"/>
-        <string name="h14" value="消耗MP15，比率72%增加， 伤害240%，对象6个"/>
-        <string name="h15" value="消耗MP15，比率75%增加， 伤害250%，对象6个"/>
-        <string name="h16" value="消耗MP15，比率78%增加， 伤害260%，对象6个"/>
-        <string name="h17" value="消耗MP15，比率81%增加， 伤害270%，对象6个"/>
-        <string name="h18" value="消耗MP15，比率84%增加， 伤害280%，对象6个"/>
-        <string name="h19" value="消耗MP15，比率87%增加， 伤害290%，对象6个"/>
-        <string name="h2" value="消耗MP8，比率36%增加， 伤害120%，对象6个"/>
-        <string name="h20" value="消耗MP15，比率90%增加， 伤害300%，对象6个"/>
-        <string name="h3" value="消耗MP8，比率39%增加， 伤害130%，对象6个"/>
-        <string name="h4" value="消耗MP8，比率42%增加， 伤害140%，对象6个"/>
-        <string name="h5" value="消耗MP8，比率45%增加， 伤害150%，对象6个"/>
-        <string name="h6" value="消耗MP8，比率48%增加， 伤害160%，对象6个"/>
-        <string name="h7" value="消耗MP8，比率51%增加， 伤害170%，对象6个"/>
-        <string name="h8" value="消耗MP8，比率54%增加， 伤害180%，对象6个"/>
-        <string name="h9" value="消耗MP8，比率57%增加， 伤害190%，对象6个"/>
+        <string name="h1" value="消耗MP 8，13%几率发动，伤害 105%，最多攻击 2个敌人"/>
+        <string name="h10" value="消耗MP 8，40%几率发动，伤害 150%，最多攻击 3个敌人"/>
+        <string name="h11" value="消耗MP 15，43%几率发动，伤害 155%，最多攻击 4个敌人"/>
+        <string name="h12" value="消耗MP 15，46%几率发动，伤害 160%，最多攻击 4个敌人"/>
+        <string name="h13" value="消耗MP 15，49%几率发动，伤害 165%，最多攻击 4个敌人"/>
+        <string name="h14" value="消耗MP 15，52%几率发动，伤害 170%，最多攻击 4个敌人"/>
+        <string name="h15" value="消耗MP 15，55%几率发动，伤害 175%，最多攻击 4个敌人"/>
+        <string name="h16" value="消耗MP 15，58%几率发动，伤害 180%，最多攻击 5个敌人"/>
+        <string name="h17" value="消耗MP 15，61%几率发动，伤害 185%，最多攻击 5个敌人"/>
+        <string name="h18" value="消耗MP 15，64%几率发动，伤害 190%，最多攻击 5个敌人"/>
+        <string name="h19" value="消耗MP 15，67%几率发动，伤害 195%，最多攻击 5个敌人"/>
+        <string name="h2" value="消耗MP 8，16%几率发动，伤害 110%，最多攻击 2个敌人"/>
+        <string name="h20" value="消耗MP 15，70%几率发动，伤害 200%，最多攻击 6个敌人"/>
+        <string name="h3" value="消耗MP 8，19%几率发动，伤害 115%，最多攻击 2个敌人"/>
+        <string name="h4" value="消耗MP 8，22%几率发动，伤害 120%，最多攻击 2个敌人"/>
+        <string name="h5" value="消耗MP 8，25%几率发动，伤害 125%，最多攻击 2个敌人"/>
+        <string name="h6" value="消耗MP 8，28%几率发动，伤害 130%，最多攻击 3个敌人"/>
+        <string name="h7" value="消耗MP 8，31%几率发动，伤害 135%，最多攻击 3个敌人"/>
+        <string name="h8" value="消耗MP 8，34%几率发动，伤害 140%，最多攻击 3个敌人"/>
+        <string name="h9" value="消耗MP 8，37%几率发动，伤害 145%，最多攻击 3个敌人"/>
         <string name="desc" value="[最高等级 : 20]\n用弓进行近身攻击时，有一定概率击退多个敌人并造成伤害。"/>
     </imgdir>
     <imgdir name="3101004">
         <string name="name" value="无形箭"/>
-        <string name="h1" value="消耗MP15，持续30秒"/>
-        <string name="h10" value="消耗MP15，持续300秒"/>
-        <string name="h11" value="消耗MP20，持续330秒"/>
-        <string name="h12" value="消耗MP20，持续360秒"/>
-        <string name="h13" value="消耗MP20，持续390秒"/>
-        <string name="h14" value="消耗MP20，持续420秒"/>
-        <string name="h15" value="消耗MP20，持续450秒"/>
-        <string name="h16" value="消耗MP20，持续480秒"/>
-        <string name="h17" value="消耗MP20，持续510秒"/>
-        <string name="h18" value="消耗MP20，持续540秒"/>
-        <string name="h19" value="消耗MP20，持续570秒"/>
-        <string name="h2" value="消耗MP15，持续60秒"/>
-        <string name="h20" value="消耗MP20，持续600秒"/>
-        <string name="h3" value="消耗MP15，持续90秒"/>
-        <string name="h4" value="消耗MP15，持续120秒"/>
-        <string name="h5" value="消耗MP15，持续150秒"/>
-        <string name="h6" value="消耗MP15，持续180秒"/>
-        <string name="h7" value="消耗MP15，持续210秒"/>
-        <string name="h8" value="消耗MP15，持续240秒"/>
-        <string name="h9" value="消耗MP15，持续270秒"/>
+        <string name="h1" value="消耗MP 15，30秒内攻击不消耗箭矢"/>
+        <string name="h10" value="消耗MP 15，300秒内攻击不消耗箭矢"/>
+        <string name="h11" value="消耗MP 20，330秒内攻击不消耗箭矢"/>
+        <string name="h12" value="消耗MP 20，360秒内攻击不消耗箭矢"/>
+        <string name="h13" value="消耗MP 20，390秒内攻击不消耗箭矢"/>
+        <string name="h14" value="消耗MP 20，420秒内攻击不消耗箭矢"/>
+        <string name="h15" value="消耗MP 20，450秒内攻击不消耗箭矢"/>
+        <string name="h16" value="消耗MP 20，480秒内攻击不消耗箭矢"/>
+        <string name="h17" value="消耗MP 20，510秒内攻击不消耗箭矢"/>
+        <string name="h18" value="消耗MP 20，540秒内攻击不消耗箭矢"/>
+        <string name="h19" value="消耗MP 20，570秒内攻击不消耗箭矢"/>
+        <string name="h2" value="消耗MP 15，60秒内攻击不消耗箭矢"/>
+        <string name="h20" value="消耗MP 20，600秒内攻击不消耗箭矢"/>
+        <string name="h3" value="消耗MP 15，90秒内攻击不消耗箭矢"/>
+        <string name="h4" value="消耗MP 15，120秒内攻击不消耗箭矢"/>
+        <string name="h5" value="消耗MP 15，150秒内攻击不消耗箭矢"/>
+        <string name="h6" value="消耗MP 15，180秒内攻击不消耗箭矢"/>
+        <string name="h7" value="消耗MP 15，210秒内攻击不消耗箭矢"/>
+        <string name="h8" value="消耗MP 15，240秒内攻击不消耗箭矢"/>
+        <string name="h9" value="消耗MP 15，270秒内攻击不消耗箭矢"/>
         <string name="desc" value="[最高等级 : 20]\n在一定时间内使用弓攻击时不消耗箭矢。\n必须装备弓。\n需要技能 : #c快速箭 5级以上#"/>
     </imgdir>
     <imgdir name="3101005">
         <string name="name" value="爆炸箭"/>
-        <string name="h1" value="消耗MP14，爆裂比率31%，攻击力102%"/>
-        <string name="h10" value="消耗MP14，爆裂比率40%，攻击力120%"/>
-        <string name="h11" value="消耗MP14，爆裂比率41%，攻击力122%"/>
-        <string name="h12" value="消耗MP14，爆裂比率42%，攻击力124%"/>
-        <string name="h13" value="消耗MP14，爆裂比率43%，攻击力126%"/>
-        <string name="h14" value="消耗MP14，爆裂比率44%，攻击力128%"/>
-        <string name="h15" value="消耗MP14，爆裂比率45%，攻击力130%"/>
-        <string name="h16" value="消耗MP28，爆裂比率46%，攻击力132%"/>
-        <string name="h17" value="消耗MP28，爆裂比率47%，攻击力134%"/>
-        <string name="h18" value="消耗MP28，爆裂比率48%，攻击力136%"/>
-        <string name="h19" value="消耗MP28，爆裂比率49%，攻击力138%"/>
-        <string name="h2" value="消耗MP14，爆裂比率32%，攻击力104%"/>
-        <string name="h20" value="消耗MP28，爆裂比率50%，攻击力140%"/>
-        <string name="h21" value="消耗MP28，爆裂比率51%，攻击力142%"/>
-        <string name="h22" value="消耗MP28，爆裂比率52%，攻击力144%"/>
-        <string name="h23" value="消耗MP28，爆裂比率53%，攻击力146%"/>
-        <string name="h24" value="消耗MP28，爆裂比率54%，攻击力148%"/>
-        <string name="h25" value="消耗MP28，爆裂比率55%，攻击力150%"/>
-        <string name="h26" value="消耗MP28，爆裂比率56%，攻击力152%"/>
-        <string name="h27" value="消耗MP28，爆裂比率57%，攻击力154%"/>
-        <string name="h28" value="消耗MP28，爆裂比率58%，攻击力156%"/>
-        <string name="h29" value="消耗MP28，爆裂比率59%，攻击力158%"/>
-        <string name="h3" value="消耗MP14，爆裂比率33%，攻击力106%"/>
-        <string name="h30" value="消耗MP28，爆裂比率60%，攻击力160%"/>
-        <string name="h4" value="消耗MP14，爆裂比率34%，攻击力108%"/>
-        <string name="h5" value="消耗MP14，爆裂比率35%，攻击力110%"/>
-        <string name="h6" value="消耗MP14，爆裂比率36%，攻击力112%"/>
-        <string name="h7" value="消耗MP14，爆裂比率37%，攻击力114%"/>
-        <string name="h8" value="消耗MP14，爆裂比率38%，攻击力116%"/>
-        <string name="h9" value="消耗MP14，爆裂比率39%，攻击力118%"/>
+        <string name="h1" value="消耗MP 14，伤害 72%，最多攻击 6个敌人，31%几率眩晕 2秒"/>
+        <string name="h10" value="消耗MP 14，伤害 90%，最多攻击 6个敌人，40%几率眩晕 2秒"/>
+        <string name="h11" value="消耗MP 14，伤害 92%，最多攻击 6个敌人，41%几率眩晕 4秒"/>
+        <string name="h12" value="消耗MP 14，伤害 94%，最多攻击 6个敌人，42%几率眩晕 4秒"/>
+        <string name="h13" value="消耗MP 14，伤害 96%，最多攻击 6个敌人，43%几率眩晕 4秒"/>
+        <string name="h14" value="消耗MP 14，伤害 98%，最多攻击 6个敌人，44%几率眩晕 4秒"/>
+        <string name="h15" value="消耗MP 14，伤害 100%，最多攻击 6个敌人，45%几率眩晕 4秒"/>
+        <string name="h16" value="消耗MP 28，伤害 102%，最多攻击 6个敌人，46%几率眩晕 4秒"/>
+        <string name="h17" value="消耗MP 28，伤害 104%，最多攻击 6个敌人，47%几率眩晕 4秒"/>
+        <string name="h18" value="消耗MP 28，伤害 106%，最多攻击 6个敌人，48%几率眩晕 4秒"/>
+        <string name="h19" value="消耗MP 28，伤害 108%，最多攻击 6个敌人，49%几率眩晕 4秒"/>
+        <string name="h2" value="消耗MP 14，伤害 74%，最多攻击 6个敌人，32%几率眩晕 2秒"/>
+        <string name="h20" value="消耗MP 28，伤害 110%，最多攻击 6个敌人，50%几率眩晕 4秒"/>
+        <string name="h21" value="消耗MP 28，伤害 112%，最多攻击 6个敌人，51%几率眩晕 6秒"/>
+        <string name="h22" value="消耗MP 28，伤害 114%，最多攻击 6个敌人，52%几率眩晕 6秒"/>
+        <string name="h23" value="消耗MP 28，伤害 116%，最多攻击 6个敌人，53%几率眩晕 6秒"/>
+        <string name="h24" value="消耗MP 28，伤害 118%，最多攻击 6个敌人，54%几率眩晕 6秒"/>
+        <string name="h25" value="消耗MP 28，伤害 120%，最多攻击 6个敌人，55%几率眩晕 6秒"/>
+        <string name="h26" value="消耗MP 28，伤害 122%，最多攻击 6个敌人，56%几率眩晕 6秒"/>
+        <string name="h27" value="消耗MP 28，伤害 124%，最多攻击 6个敌人，57%几率眩晕 6秒"/>
+        <string name="h28" value="消耗MP 28，伤害 126%，最多攻击 6个敌人，58%几率眩晕 6秒"/>
+        <string name="h29" value="消耗MP 28，伤害 128%，最多攻击 6个敌人，59%几率眩晕 6秒"/>
+        <string name="h3" value="消耗MP 14，伤害 76%，最多攻击 6个敌人，33%几率眩晕 2秒"/>
+        <string name="h30" value="消耗MP 28，伤害 130%，最多攻击 6个敌人，60%几率眩晕 6秒"/>
+        <string name="h4" value="消耗MP 14，伤害 78%，最多攻击 6个敌人，34%几率眩晕 2秒"/>
+        <string name="h5" value="消耗MP 14，伤害 80%，最多攻击 6个敌人，35%几率眩晕 2秒"/>
+        <string name="h6" value="消耗MP 14，伤害 82%，最多攻击 6个敌人，36%几率眩晕 2秒"/>
+        <string name="h7" value="消耗MP 14，伤害 84%，最多攻击 6个敌人，37%几率眩晕 2秒"/>
+        <string name="h8" value="消耗MP 14，伤害 86%，最多攻击 6个敌人，38%几率眩晕 2秒"/>
+        <string name="h9" value="消耗MP 14，伤害 88%，最多攻击 6个敌人，39%几率眩晕 2秒"/>
         <string name="desc" value="[最高等级 : 30]\n发射爆裂箭攻击1个敌人，并对周围最多6个敌人造成伤害，且有一定概率使其昏迷。"/>
     </imgdir>
     <imgdir name="311">
@@ -8595,210 +8595,210 @@
     </imgdir>
     <imgdir name="3110000">
         <string name="name" value="疾风步"/>
-        <string name="h1" value="移动速度+2"/>
-		<string name="h10" value="移动速度+20"/>
-		<string name="h11" value="移动速度+21"/>
-		<string name="h12" value="移动速度+22"/>
-		<string name="h13" value="移动速度+23"/>
-		<string name="h14" value="移动速度+24"/>
-		<string name="h15" value="移动速度+25"/>
-		<string name="h16" value="移动速度+26"/>
-		<string name="h17" value="移动速度+27"/>
-		<string name="h18" value="移动速度+28"/>
-		<string name="h19" value="移动速度+29"/>
-		<string name="h2" value="移动速度+4"/>
-		<string name="h20" value="移动速度+30"/>
-		<string name="h3" value="移动速度+6"/>
-		<string name="h4" value="移动速度+8"/>
-		<string name="h5" value="移动速度+10"/>
-		<string name="h6" value="移动速度+12"/>
-		<string name="h7" value="移动速度+14"/>
-		<string name="h8" value="移动速度+16"/>
-		<string name="h9" value="移动速度+18"/>
+        <string name="h1" value="移动速度 +2"/>
+		<string name="h10" value="移动速度 +20"/>
+		<string name="h11" value="移动速度 +21"/>
+		<string name="h12" value="移动速度 +22"/>
+		<string name="h13" value="移动速度 +23"/>
+		<string name="h14" value="移动速度 +24"/>
+		<string name="h15" value="移动速度 +25"/>
+		<string name="h16" value="移动速度 +26"/>
+		<string name="h17" value="移动速度 +27"/>
+		<string name="h18" value="移动速度 +28"/>
+		<string name="h19" value="移动速度 +29"/>
+		<string name="h2" value="移动速度 +4"/>
+		<string name="h20" value="移动速度 +30"/>
+		<string name="h3" value="移动速度 +6"/>
+		<string name="h4" value="移动速度 +8"/>
+		<string name="h5" value="移动速度 +10"/>
+		<string name="h6" value="移动速度 +12"/>
+		<string name="h7" value="移动速度 +14"/>
+		<string name="h8" value="移动速度 +16"/>
+		<string name="h9" value="移动速度 +18"/>
         <string name="desc" value="[最高等级 : 20]\n提高移动速度。"/>
     </imgdir>
     <imgdir name="3110001">
         <string name="name" value="贯穿箭"/>
-        <string name="h1" value="33%几率发动，造成伤害110%，假如对方HP在20%以下时1%几率出现必杀"/>
-        <string name="h10" value="60%几率发动，造成伤害200%，假如敌的HP在35%以下时5%几率出现必杀怪物"/>
-        <string name="h11" value="63%几率发动，造成伤害205%，假如敌的HP在35%以下时6%几率出现必杀怪物"/>
-        <string name="h12" value="66%几率发动，造成伤害210%，假如敌的HP在38%以下时6%几率出现必杀怪物"/>
-        <string name="h13" value="69%几率发动，造成伤害215%，假如敌的HP在38%以下时7%几率出现必杀怪物"/>
-        <string name="h14" value="72%几率发动，造成伤害220%，假如敌的HP在41%以下时7%几率出现必杀怪物"/>
-        <string name="h15" value="75%几率发动，造成伤害225%，假如敌的HP在41%以下时8%几率出现必杀怪物"/>
-        <string name="h16" value="78%几率发动，造成伤害230%，假如敌的HP在44%以下时8%几率出现必杀怪物"/>
-        <string name="h17" value="81%几率发动，造成伤害235%，假如敌的HP在44%以下时9%几率出现必杀怪物"/>
-        <string name="h18" value="84%几率发动，造成伤害240%，假如敌的HP在47%以下时9%几率出现必杀怪物"/>
-        <string name="h19" value="87%几率发动，造成伤害245%，假如敌的HP在47%以下时10%几率出现必杀怪物"/>
-        <string name="h2" value="36%几率发动，造成伤害120%，假如敌的HP在23%以下时1%几率出现必杀怪物"/>
-        <string name="h20" value="90%几率发动，造成伤害250%，假如敌的HP在50%以下时10%几率出现必杀怪物"/>
-        <string name="h3" value="39%几率发动，造成伤害130%，假如敌的HP在23%以下时2%几率出现必杀怪物"/>
-        <string name="h4" value="42%几率发动，造成伤害140%，假如敌的HP在26%以下时2%几率出现必杀怪物"/>
-        <string name="h5" value="45%几率发动，造成伤害150%，假如敌的HP在26%以下时3%几率出现必杀怪物"/>
-        <string name="h6" value="48%几率发动，造成伤害160%，假如敌的HP在29%以下时3%几率出现必杀怪物"/>
-        <string name="h7" value="51%几率发动，造成伤害170%，假如敌的HP在29%以下时4%几率出现必杀怪物"/>
-        <string name="h8" value="54%几率发动，造成伤害180%，假如敌的HP在32%以下时4%几率出现必杀怪物"/>
-        <string name="h9" value="57%几率发动，造成伤害190%，假如敌的HP在32%以下时5%几率出现必杀怪物"/>
+        <string name="h1" value="33%几率发动，伤害 110%，敌人HP在 20%以下时有 1%几率直接击败"/>
+        <string name="h10" value="60%几率发动，伤害 200%，敌人HP在 35%以下时有 5%几率直接击败"/>
+        <string name="h11" value="63%几率发动，伤害 205%，敌人HP在 35%以下时有 6%几率直接击败"/>
+        <string name="h12" value="66%几率发动，伤害 210%，敌人HP在 38%以下时有 6%几率直接击败"/>
+        <string name="h13" value="69%几率发动，伤害 215%，敌人HP在 38%以下时有 7%几率直接击败"/>
+        <string name="h14" value="72%几率发动，伤害 220%，敌人HP在 41%以下时有 7%几率直接击败"/>
+        <string name="h15" value="75%几率发动，伤害 225%，敌人HP在 41%以下时有 8%几率直接击败"/>
+        <string name="h16" value="78%几率发动，伤害 230%，敌人HP在 44%以下时有 8%几率直接击败"/>
+        <string name="h17" value="81%几率发动，伤害 235%，敌人HP在 44%以下时有 9%几率直接击败"/>
+        <string name="h18" value="84%几率发动，伤害 240%，敌人HP在 47%以下时有 9%几率直接击败"/>
+        <string name="h19" value="87%几率发动，伤害 245%，敌人HP在 47%以下时有 10%几率直接击败"/>
+        <string name="h2" value="36%几率发动，伤害 120%，敌人HP在 23%以下时有 1%几率直接击败"/>
+        <string name="h20" value="90%几率发动，伤害 250%，敌人HP在 50%以下时有 10%几率直接击败"/>
+        <string name="h3" value="39%几率发动，伤害 130%，敌人HP在 23%以下时有 2%几率直接击败"/>
+        <string name="h4" value="42%几率发动，伤害 140%，敌人HP在 26%以下时有 2%几率直接击败"/>
+        <string name="h5" value="45%几率发动，伤害 150%，敌人HP在 26%以下时有 3%几率直接击败"/>
+        <string name="h6" value="48%几率发动，伤害 160%，敌人HP在 29%以下时有 3%几率直接击败"/>
+        <string name="h7" value="51%几率发动，伤害 170%，敌人HP在 29%以下时有 4%几率直接击败"/>
+        <string name="h8" value="54%几率发动，伤害 180%，敌人HP在 32%以下时有 4%几率直接击败"/>
+        <string name="h9" value="57%几率发动，伤害 190%，敌人HP在 32%以下时有 5%几率直接击败"/>
         <string name="desc" value="[最高等级 : 20]\n即使在近距离也可射箭，并有一定概率对敌人造成致命伤害。"/>
     </imgdir>
     <imgdir name="3111002">
         <string name="name" value="替身术"/>
-        <string name="h1" value="消费MP23，持续5秒 召唤HP1500的分身"/>
-        <string name="h10" value="消费MP26，持续30秒 召唤HP15000的分身"/>
-        <string name="h11" value="消费MP29，持续30秒 召唤HP16500的分身"/>
-        <string name="h12" value="消费MP29，持续40秒 召唤HP18000的分身"/>
-        <string name="h13" value="消费MP29，持续40秒 召唤HP19500的分身"/>
-        <string name="h14" value="消费MP23，持续40秒 召唤HP21000的分身"/>
-        <string name="h15" value="消费MP29，持续50秒 召唤HP22500的分身"/>
-        <string name="h16" value="消费MP32，持续50秒 召唤HP24000的分身"/>
-        <string name="h17" value="消费MP32，持续50秒 召唤HP25500的分身"/>
-        <string name="h18" value="消费MP32，持续60秒 召唤HP27000的分身"/>
-        <string name="h19" value="消费MP32，持续60秒 召唤HP28500的分身"/>
-        <string name="h2" value="消费MP23，持续5秒 召唤HP3000的分身"/>
-        <string name="h20" value="消费MP32,持续60秒 召唤HP30000的分身"/>
-        <string name="h3" value="消费MP23，持续10秒 召唤HP4500的分身"/>
-        <string name="h4" value="消费MP23，持续10秒 召唤HP6000的分身"/>
-        <string name="h5" value="消费MP23，持续10秒 召唤HP7500的分身"/>
-        <string name="h6" value="消费MP26，持续20秒 召唤HP9000的分身"/>
-        <string name="h7" value="消费MP26，持续20秒 召唤HP10500的分身"/>
-        <string name="h8" value="消费MP26，持续20秒 召唤HP12000的分身"/>
-        <string name="h9" value="消费MP26，持续30秒 召唤HP13500的分身"/>
+        <string name="h1" value="消耗MP 23，召唤HP 500的替身，持续 5秒"/>
+        <string name="h10" value="消耗MP 26，召唤HP 1800的替身，持续 30秒"/>
+        <string name="h11" value="消耗MP 29，召唤HP 2000的替身，持续 30秒"/>
+        <string name="h12" value="消耗MP 29，召唤HP 2400的替身，持续 40秒"/>
+        <string name="h13" value="消耗MP 29，召唤HP 2800的替身，持续 40秒"/>
+        <string name="h14" value="消耗MP 29，召唤HP 3200的替身，持续 40秒"/>
+        <string name="h15" value="消耗MP 29，召唤HP 3600的替身，持续 50秒"/>
+        <string name="h16" value="消耗MP 32，召唤HP 4000的替身，持续 50秒"/>
+        <string name="h17" value="消耗MP 32，召唤HP 4500的替身，持续 50秒"/>
+        <string name="h18" value="消耗MP 32，召唤HP 5000的替身，持续 60秒"/>
+        <string name="h19" value="消耗MP 32，召唤HP 5500的替身，持续 60秒"/>
+        <string name="h2" value="消耗MP 23，召唤HP 600的替身，持续 5秒"/>
+        <string name="h20" value="消耗MP 32，召唤HP 6000的替身，持续 60秒"/>
+        <string name="h3" value="消耗MP 23，召唤HP 700的替身，持续 10秒"/>
+        <string name="h4" value="消耗MP 23，召唤HP 800的替身，持续 10秒"/>
+        <string name="h5" value="消耗MP 23，召唤HP 900的替身，持续 10秒"/>
+        <string name="h6" value="消耗MP 26，召唤HP 1000的替身，持续 20秒"/>
+        <string name="h7" value="消耗MP 26，召唤HP 1200的替身，持续 20秒"/>
+        <string name="h8" value="消耗MP 26，召唤HP 1400的替身，持续 20秒"/>
+        <string name="h9" value="消耗MP 26，召唤HP 1600的替身，持续 30秒"/>
         <string name="desc" value="[最高等级 : 20]\n召唤替身吸引怪物攻击，持续一定时间。"/>
     </imgdir>
     <imgdir name="3111003">
         <string name="name" value="烈火箭"/>
-        <string name="h1" value="消费MP20，造成伤害153%"/>
-        <string name="h10" value="消费MP20，造成伤害180%"/>
-        <string name="h11" value="消费MP25，造成伤害183%"/>
-        <string name="h12" value="消费MP25，造成伤害186%"/>
-        <string name="h13" value="消费MP25，造成伤害189%"/>
-        <string name="h14" value="消费MP25，造成伤害192%"/>
-        <string name="h15" value="消费MP25，造成伤害195%"/>
-        <string name="h16" value="消费MP25，造成伤害198%"/>
-        <string name="h17" value="消费MP25，造成伤害201%"/>
-        <string name="h18" value="消费MP25，造成伤害204%"/>
-        <string name="h19" value="消费MP25，造成伤害207%"/>
-        <string name="h2" value="消费MP20，造成伤害156%"/>
-        <string name="h20" value="消费MP25，造成伤害210%"/>
-        <string name="h21" value="消费MP30，造成伤害213%"/>
-        <string name="h22" value="消费MP30，造成伤害216%"/>
-        <string name="h23" value="消费MP30，造成伤害219%"/>
-        <string name="h24" value="消费MP30，造成伤害222%"/>
-        <string name="h25" value="消费MP30，造成伤害225%"/>
-        <string name="h26" value="消费MP30，造成伤害228%"/>
-        <string name="h27" value="消费MP30，造成伤害231%"/>
-        <string name="h28" value="消费MP30，造成伤害234%"/>
-        <string name="h29" value="消费MP30，造成伤害237%"/>
-        <string name="h3" value="消费MP20，造成伤害159%"/>
-        <string name="h30" value="消费MP30，造成伤害240%"/>
-        <string name="h4" value="消费MP20，造成伤害162%"/>
-        <string name="h5" value="消费MP20，造成伤害165%"/>
-        <string name="h6" value="消费MP20，造成伤害168%"/>
-        <string name="h7" value="消费MP20，造成伤害171%"/>
-        <string name="h8" value="消费MP20，造成伤害174%"/>
-        <string name="h9" value="消费MP20，造成伤害177%"/>
+        <string name="h1" value="消耗MP 20，伤害 50%，最多攻击 6个敌人"/>
+        <string name="h10" value="消耗MP 20，伤害 95%，最多攻击 6个敌人"/>
+        <string name="h11" value="消耗MP 25，伤害 100%，最多攻击 6个敌人"/>
+        <string name="h12" value="消耗MP 25，伤害 103%，最多攻击 6个敌人"/>
+        <string name="h13" value="消耗MP 25，伤害 106%，最多攻击 6个敌人"/>
+        <string name="h14" value="消耗MP 25，伤害 109%，最多攻击 6个敌人"/>
+        <string name="h15" value="消耗MP 25，伤害 112%，最多攻击 6个敌人"/>
+        <string name="h16" value="消耗MP 25，伤害 115%，最多攻击 6个敌人"/>
+        <string name="h17" value="消耗MP 25，伤害 118%，最多攻击 6个敌人"/>
+        <string name="h18" value="消耗MP 25，伤害 121%，最多攻击 6个敌人"/>
+        <string name="h19" value="消耗MP 25，伤害 124%，最多攻击 6个敌人"/>
+        <string name="h2" value="消耗MP 20，伤害 55%，最多攻击 6个敌人"/>
+        <string name="h20" value="消耗MP 25，伤害 127%，最多攻击 6个敌人"/>
+        <string name="h21" value="消耗MP 30，伤害 130%，最多攻击 6个敌人"/>
+        <string name="h22" value="消耗MP 30，伤害 133%，最多攻击 6个敌人"/>
+        <string name="h23" value="消耗MP 30，伤害 136%，最多攻击 6个敌人"/>
+        <string name="h24" value="消耗MP 30，伤害 139%，最多攻击 6个敌人"/>
+        <string name="h25" value="消耗MP 30，伤害 142%，最多攻击 6个敌人"/>
+        <string name="h26" value="消耗MP 30，伤害 144%，最多攻击 6个敌人"/>
+        <string name="h27" value="消耗MP 30，伤害 146%，最多攻击 6个敌人"/>
+        <string name="h28" value="消耗MP 30，伤害 148%，最多攻击 6个敌人"/>
+        <string name="h29" value="消耗MP 30，伤害 149%，最多攻击 6个敌人"/>
+        <string name="h3" value="消耗MP 20，伤害 60%，最多攻击 6个敌人"/>
+        <string name="h30" value="消耗MP 30，伤害 150%，最多攻击 6个敌人"/>
+        <string name="h4" value="消耗MP 20，伤害 65%，最多攻击 6个敌人"/>
+        <string name="h5" value="消耗MP 20，伤害 70%，最多攻击 6个敌人"/>
+        <string name="h6" value="消耗MP 20，伤害 75%，最多攻击 6个敌人"/>
+        <string name="h7" value="消耗MP 20，伤害 80%，最多攻击 6个敌人"/>
+        <string name="h8" value="消耗MP 20，伤害 85%，最多攻击 6个敌人"/>
+        <string name="h9" value="消耗MP 20，伤害 90%，最多攻击 6个敌人"/>
         <string name="desc" value="[最高等级 : 30]\n用火属性箭攻击最多6个敌人，并附带火属性效果。\n必须装备弓。"/>
     </imgdir>
     <imgdir name="3111004">
         <string name="name" value="箭雨"/>
-        <string name="h1" value="消费MP18，造成伤害173%"/>
-        <string name="h10" value="消费MP18，造成伤害200%"/>
-        <string name="h11" value="消费MP23，造成伤害203%"/>
-        <string name="h12" value="消费MP23，造成伤害206%"/>
-        <string name="h13" value="消费MP23，造成伤害209%"/>
-        <string name="h14" value="消费MP23，造成伤害212%"/>
-        <string name="h15" value="消费MP23，造成伤害215%"/>
-        <string name="h16" value="消费MP23，造成伤害218%"/>
-        <string name="h17" value="消费MP23，造成伤害221%"/>
-        <string name="h18" value="消费MP23，造成伤害224%"/>
-        <string name="h19" value="消费MP23，造成伤害227%"/>
-        <string name="h2" value="消费MP18，造成伤害176%"/>
-        <string name="h20" value="消费MP23，造成伤害230%"/>
-        <string name="h21" value="消费MP28，造成伤害233%"/>
-        <string name="h22" value="消费MP28，造成伤害236%"/>
-        <string name="h23" value="消费MP28，造成伤害239%"/>
-        <string name="h24" value="消费MP28，造成伤害242%"/>
-        <string name="h25" value="消费MP28，造成伤害245%"/>
-        <string name="h26" value="消费MP28，造成伤害248%"/>
-        <string name="h27" value="消费MP28，造成伤害251%"/>
-        <string name="h28" value="消费MP28，造成伤害254%"/>
-        <string name="h29" value="消费MP28，造成伤害257%"/>
-        <string name="h3" value="消费MP18，造成伤害179%"/>
-        <string name="h30" value="消费MP28，造成伤害260%"/>
-        <string name="h4" value="消费MP18，造成伤害182%"/>
-        <string name="h5" value="消费MP18，造成伤害185%"/>
-        <string name="h6" value="消费MP18，造成伤害188%"/>
-        <string name="h7" value="消费MP18，造成伤害191%"/>
-        <string name="h8" value="消费MP18，造成伤害194%"/>
-        <string name="h9" value="消费MP18，造成伤害197%"/>
+        <string name="h1" value="消耗MP 18，伤害 60%，最多攻击 6个敌人"/>
+        <string name="h10" value="消耗MP 18，伤害 105%，最多攻击 6个敌人"/>
+        <string name="h11" value="消耗MP 23，伤害 110%，最多攻击 6个敌人"/>
+        <string name="h12" value="消耗MP 23，伤害 113%，最多攻击 6个敌人"/>
+        <string name="h13" value="消耗MP 23，伤害 116%，最多攻击 6个敌人"/>
+        <string name="h14" value="消耗MP 23，伤害 119%，最多攻击 6个敌人"/>
+        <string name="h15" value="消耗MP 23，伤害 122%，最多攻击 6个敌人"/>
+        <string name="h16" value="消耗MP 23，伤害 125%，最多攻击 6个敌人"/>
+        <string name="h17" value="消耗MP 23，伤害 128%，最多攻击 6个敌人"/>
+        <string name="h18" value="消耗MP 23，伤害 131%，最多攻击 6个敌人"/>
+        <string name="h19" value="消耗MP 23，伤害 134%，最多攻击 6个敌人"/>
+        <string name="h2" value="消耗MP 18，伤害 65%，最多攻击 6个敌人"/>
+        <string name="h20" value="消耗MP 23，伤害 137%，最多攻击 6个敌人"/>
+        <string name="h21" value="消耗MP 28，伤害 140%，最多攻击 6个敌人"/>
+        <string name="h22" value="消耗MP 28，伤害 143%，最多攻击 6个敌人"/>
+        <string name="h23" value="消耗MP 28，伤害 146%，最多攻击 6个敌人"/>
+        <string name="h24" value="消耗MP 28，伤害 149%，最多攻击 6个敌人"/>
+        <string name="h25" value="消耗MP 28，伤害 152%，最多攻击 6个敌人"/>
+        <string name="h26" value="消耗MP 28，伤害 154%，最多攻击 6个敌人"/>
+        <string name="h27" value="消耗MP 28，伤害 156%，最多攻击 6个敌人"/>
+        <string name="h28" value="消耗MP 28，伤害 158%，最多攻击 6个敌人"/>
+        <string name="h29" value="消耗MP 28，伤害 159%，最多攻击 6个敌人"/>
+        <string name="h3" value="消耗MP 18，伤害 70%，最多攻击 6个敌人"/>
+        <string name="h30" value="消耗MP 28，伤害 160%，最多攻击 6个敌人"/>
+        <string name="h4" value="消耗MP 18，伤害 75%，最多攻击 6个敌人"/>
+        <string name="h5" value="消耗MP 18，伤害 80%，最多攻击 6个敌人"/>
+        <string name="h6" value="消耗MP 18，伤害 85%，最多攻击 6个敌人"/>
+        <string name="h7" value="消耗MP 18，伤害 90%，最多攻击 6个敌人"/>
+        <string name="h8" value="消耗MP 18，伤害 95%，最多攻击 6个敌人"/>
+        <string name="h9" value="消耗MP 18，伤害 100%，最多攻击 6个敌人"/>
         <string name="desc" value="[最高等级 : 30]\n向空中射出大量箭矢，攻击最多6个敌人。\n必须装备弓。\n需要技能 : #c贯穿箭 5级以上#"/>
     </imgdir>
     <imgdir name="3111005">
         <string name="name" value="银鹰召唤"/>
-        <string name="h1" value="消费MP32和1个召唤石,103秒内23次攻击,50%几率出击"/>
-		<string name="h10" value="消费MP50和1个召唤石,130秒内50次攻击,77%几率出击"/>
-		<string name="h11" value="消费MP52和1个召唤石,133秒内53次攻击,80%几率出击"/>
-		<string name="h12" value="消费MP54和1个召唤石,136秒内56次攻击,82%几率出击"/>
-		<string name="h13" value="消费MP56和1个召唤石,139秒内59次攻击,84%几率出击"/>
-		<string name="h14" value="消费MP58和1个召唤石,142秒内62次攻击,86%几率出击"/>
-		<string name="h15" value="消费MP60和1个召唤石,145秒内65次攻击,88%几率出击"/>
-		<string name="h16" value="消费MP62和1个召唤石,148秒内68次攻击,90%几率出击"/>
-		<string name="h17" value="消费MP64和1个召唤石,151秒内71次攻击,91%几率出击"/>
-		<string name="h18" value="消费MP66和1个召唤石,154秒内74次攻击,92%几率出击"/>
-		<string name="h19" value="消费MP68和1个召唤石,157秒内77次攻击,93%几率出击"/>
-		<string name="h2" value="消费MP34和1个召唤石,106秒内26次攻击,53%几率出击"/>
-		<string name="h20" value="消费MP70和1个召唤石,160秒内80次攻击,94%几率出击"/>
-		<string name="h21" value="消费MP71和1个召唤石,162秒内82次攻击,95%几率出击"/>
-		<string name="h22" value="消费MP72和1个召唤石,164秒内84次攻击,95%几率出击"/>
-		<string name="h23" value="消费MP73和1个召唤石,166秒内86次攻击,96%几率出击"/>
-		<string name="h24" value="消费MP74和1个召唤石,168秒内88次攻击,96%几率出击"/>
-		<string name="h25" value="消费MP75和1个召唤石,170秒内90次攻击,97%几率出击"/>
-		<string name="h26" value="消费MP76和1个召唤石,172秒内92次攻击,97%几率出击"/>
-		<string name="h27" value="消费MP77和1个召唤石,174秒内94次攻击,98%几率出击"/>
-		<string name="h28" value="消费MP78和1个召唤石,176秒内96次攻击,98%几率出击"/>
-		<string name="h29" value="消费MP79和1个召唤石,178秒内98次攻击,99%几率出击"/>
-		<string name="h3" value="消费MP36和1个召唤石,109秒内29次攻击,56%几率出击"/>
-		<string name="h30" value="消费MP80和1个召唤石,180秒内100次攻击,99%几率出击"/>
-		<string name="h4" value="消费MP38和1个召唤石,112秒内32次攻击,59%几率出击"/>
-		<string name="h5" value="消费MP40和1个召唤石,115秒内35次攻击,62%几率出击"/>
-		<string name="h6" value="消费MP42和1个召唤石,118秒内38次攻击,65%几率出击"/>
-		<string name="h7" value="消费MP44和1个召唤石,121秒内41次攻击,68%几率出击"/>
-		<string name="h8" value="消费MP46和1个召唤石,124秒内44次攻击,71%几率出击"/>
-		<string name="h9" value="消费MP48和1个召唤石,127秒内47次攻击,74%几率出击"/>
+        <string name="h1" value="消耗MP 32和1个召唤石，召唤银鹰 103秒，攻击力 23，50%几率眩晕"/>
+		<string name="h10" value="消耗MP 50和1个召唤石，召唤银鹰 130秒，攻击力 50，77%几率眩晕"/>
+		<string name="h11" value="消耗MP 52和1个召唤石，召唤银鹰 133秒，攻击力 53，80%几率眩晕"/>
+		<string name="h12" value="消耗MP 54和1个召唤石，召唤银鹰 136秒，攻击力 56，82%几率眩晕"/>
+		<string name="h13" value="消耗MP 56和1个召唤石，召唤银鹰 139秒，攻击力 59，84%几率眩晕"/>
+		<string name="h14" value="消耗MP 58和1个召唤石，召唤银鹰 142秒，攻击力 62，86%几率眩晕"/>
+		<string name="h15" value="消耗MP 60和1个召唤石，召唤银鹰 145秒，攻击力 65，88%几率眩晕"/>
+		<string name="h16" value="消耗MP 62和1个召唤石，召唤银鹰 148秒，攻击力 68，90%几率眩晕"/>
+		<string name="h17" value="消耗MP 64和1个召唤石，召唤银鹰 151秒，攻击力 71，91%几率眩晕"/>
+		<string name="h18" value="消耗MP 66和1个召唤石，召唤银鹰 154秒，攻击力 74，92%几率眩晕"/>
+		<string name="h19" value="消耗MP 68和1个召唤石，召唤银鹰 157秒，攻击力 77，93%几率眩晕"/>
+		<string name="h2" value="消耗MP 34和1个召唤石，召唤银鹰 106秒，攻击力 26，53%几率眩晕"/>
+		<string name="h20" value="消耗MP 70和1个召唤石，召唤银鹰 160秒，攻击力 80，94%几率眩晕"/>
+		<string name="h21" value="消耗MP 71和1个召唤石，召唤银鹰 162秒，攻击力 82，95%几率眩晕"/>
+		<string name="h22" value="消耗MP 72和1个召唤石，召唤银鹰 164秒，攻击力 84，95%几率眩晕"/>
+		<string name="h23" value="消耗MP 73和1个召唤石，召唤银鹰 166秒，攻击力 86，96%几率眩晕"/>
+		<string name="h24" value="消耗MP 74和1个召唤石，召唤银鹰 168秒，攻击力 88，96%几率眩晕"/>
+		<string name="h25" value="消耗MP 75和1个召唤石，召唤银鹰 170秒，攻击力 90，97%几率眩晕"/>
+		<string name="h26" value="消耗MP 76和1个召唤石，召唤银鹰 172秒，攻击力 92，97%几率眩晕"/>
+		<string name="h27" value="消耗MP 77和1个召唤石，召唤银鹰 174秒，攻击力 94，98%几率眩晕"/>
+		<string name="h28" value="消耗MP 78和1个召唤石，召唤银鹰 176秒，攻击力 96，98%几率眩晕"/>
+		<string name="h29" value="消耗MP 79和1个召唤石，召唤银鹰 178秒，攻击力 98，99%几率眩晕"/>
+		<string name="h3" value="消耗MP 36和1个召唤石，召唤银鹰 109秒，攻击力 29，56%几率眩晕"/>
+		<string name="h30" value="消耗MP 80和1个召唤石，召唤银鹰 180秒，攻击力 100，99%几率眩晕"/>
+		<string name="h4" value="消耗MP 38和1个召唤石，召唤银鹰 112秒，攻击力 32，59%几率眩晕"/>
+		<string name="h5" value="消耗MP 40和1个召唤石，召唤银鹰 115秒，攻击力 35，62%几率眩晕"/>
+		<string name="h6" value="消耗MP 42和1个召唤石，召唤银鹰 118秒，攻击力 38，65%几率眩晕"/>
+		<string name="h7" value="消耗MP 44和1个召唤石，召唤银鹰 121秒，攻击力 41，68%几率眩晕"/>
+		<string name="h8" value="消耗MP 46和1个召唤石，召唤银鹰 124秒，攻击力 44，71%几率眩晕"/>
+		<string name="h9" value="消耗MP 48和1个召唤石，召唤银鹰 127秒，攻击力 47，74%几率眩晕"/>
         <string name="desc" value="[最高等级 : 30]\n召唤银鹰，在一定时间内攻击附近敌人，并有一定概率使其眩晕。\n需要技能 : #c替身术 5级以上#"/>
     </imgdir>
     <imgdir name="3111006">
         <string name="name" value="箭扫射"/>
-       <string name="h1" value="消费MP26, 造成伤害71%, 4次攻击"/>
-        <string name="h2" value="消费MP26, 造成伤害72%, 4次攻击"/>
-        <string name="h3" value="消费MP26, 造成伤害73%, 4次攻击"/>
-        <string name="h4" value="消费MP26, 造成伤害74%, 4次攻击"/>
-        <string name="h5" value="消费MP26, 造成伤害75%, 4次攻击"/>
-        <string name="h6" value="消费MP26, 造成伤害76%, 4次攻击"/>
-        <string name="h7" value="消费MP26, 造成伤害77%, 4次攻击"/>
-        <string name="h8" value="消费MP26, 造成伤害78%, 4次攻击"/>
-        <string name="h9" value="消费MP26, 造成伤害79%, 4次攻击"/>
-        <string name="h10" value="消费MP26, 造成伤害80%, 4次攻击"/>
-        <string name="h11" value="消费MP26, 造成伤害81%, 4次攻击"/>
-        <string name="h12" value="消费MP26, 造成伤害82%, 4次攻击"/>
-        <string name="h13" value="消费MP26, 造成伤害83%, 4次攻击"/>
-        <string name="h14" value="消费MP26, 造成伤害84%, 4次攻击"/>
-        <string name="h15" value="消费MP26, 造成伤害85%, 4次攻击"/>
-        <string name="h16" value="消费MP32, 造成伤害86%, 4次攻击"/>
-        <string name="h17" value="消费MP32, 造成伤害87%, 4次攻击"/>
-        <string name="h18" value="消费MP32, 造成伤害88%, 4次攻击"/>
-        <string name="h19" value="消费MP32, 造成伤害89%, 4次攻击"/>
-        <string name="h20" value="消费MP32, 造成伤害90%, 4次攻击"/>
-        <string name="h21" value="消费MP32, 造成伤害91%, 4次攻击"/>
-        <string name="h22" value="消费MP32, 造成伤害92%, 4次攻击"/>
-        <string name="h23" value="消费MP32, 造成伤害93%, 4次攻击"/>
-        <string name="h24" value="消费MP32, 造成伤害94%, 4次攻击"/>
-        <string name="h25" value="消费MP32, 造成伤害95%, 4次攻击"/>
-        <string name="h26" value="消费MP32, 造成伤害96%, 4次攻击"/>
-        <string name="h27" value="消费MP32, 造成伤害97%, 4次攻击"/>
-        <string name="h28" value="消费MP32, 造成伤害98%, 4次攻击"/>
-        <string name="h29" value="消费MP32, 造成伤害99%, 4次攻击"/>
-        <string name="h30" value="消费MP32, 造成伤害100%, 4次攻击"/>
+       <string name="h1" value="消耗MP 26，每支箭伤害 71%，攻击 4次"/>
+        <string name="h2" value="消耗MP 26，每支箭伤害 72%，攻击 4次"/>
+        <string name="h3" value="消耗MP 26，每支箭伤害 73%，攻击 4次"/>
+        <string name="h4" value="消耗MP 26，每支箭伤害 74%，攻击 4次"/>
+        <string name="h5" value="消耗MP 26，每支箭伤害 75%，攻击 4次"/>
+        <string name="h6" value="消耗MP 26，每支箭伤害 76%，攻击 4次"/>
+        <string name="h7" value="消耗MP 26，每支箭伤害 77%，攻击 4次"/>
+        <string name="h8" value="消耗MP 26，每支箭伤害 78%，攻击 4次"/>
+        <string name="h9" value="消耗MP 26，每支箭伤害 79%，攻击 4次"/>
+        <string name="h10" value="消耗MP 26，每支箭伤害 80%，攻击 4次"/>
+        <string name="h11" value="消耗MP 26，每支箭伤害 81%，攻击 4次"/>
+        <string name="h12" value="消耗MP 26，每支箭伤害 82%，攻击 4次"/>
+        <string name="h13" value="消耗MP 26，每支箭伤害 83%，攻击 4次"/>
+        <string name="h14" value="消耗MP 26，每支箭伤害 84%，攻击 4次"/>
+        <string name="h15" value="消耗MP 26，每支箭伤害 85%，攻击 4次"/>
+        <string name="h16" value="消耗MP 32，每支箭伤害 86%，攻击 4次"/>
+        <string name="h17" value="消耗MP 32，每支箭伤害 87%，攻击 4次"/>
+        <string name="h18" value="消耗MP 32，每支箭伤害 88%，攻击 4次"/>
+        <string name="h19" value="消耗MP 32，每支箭伤害 89%，攻击 4次"/>
+        <string name="h20" value="消耗MP 32，每支箭伤害 90%，攻击 4次"/>
+        <string name="h21" value="消耗MP 32，每支箭伤害 91%，攻击 4次"/>
+        <string name="h22" value="消耗MP 32，每支箭伤害 92%，攻击 4次"/>
+        <string name="h23" value="消耗MP 32，每支箭伤害 93%，攻击 4次"/>
+        <string name="h24" value="消耗MP 32，每支箭伤害 94%，攻击 4次"/>
+        <string name="h25" value="消耗MP 32，每支箭伤害 95%，攻击 4次"/>
+        <string name="h26" value="消耗MP 32，每支箭伤害 96%，攻击 4次"/>
+        <string name="h27" value="消耗MP 32，每支箭伤害 97%，攻击 4次"/>
+        <string name="h28" value="消耗MP 32，每支箭伤害 98%，攻击 4次"/>
+        <string name="h29" value="消耗MP 32，每支箭伤害 99%，攻击 4次"/>
+        <string name="h30" value="消耗MP 32，每支箭伤害 100%，攻击 4次"/>
         <string name="desc" value="[最高等级 : 30]\n连续射出4支箭攻击1个敌人。"/>
     </imgdir>
     <imgdir name="312">
@@ -8839,249 +8839,249 @@
     </imgdir>
     <imgdir name="3121000">
         <string name="name" value="冒险岛勇士"/>
-        <string name="h1" value="消耗MP 10，30秒内所有的属性点提高 1%"/>
-        <string name="h10" value="消耗MP 20，300秒内所有的属性点提高 5%"/>
-        <string name="h11" value="消耗MP 30，330秒内所有的属性点提高 6%"/>
-        <string name="h12" value="消耗MP 30，360秒内所有的属性点提高 6%"/>
-        <string name="h13" value="消耗MP 30，390秒内所有的属性点提高 7%"/>
-        <string name="h14" value="消耗MP 30，420秒内所有的属性点提高 7%"/>
-        <string name="h15" value="消耗MP 30，450秒内所有的属性点提高 8%"/>
-        <string name="h16" value="消耗MP 40，480秒内所有的属性点提高 8%"/>
-        <string name="h17" value="消耗MP 40，510秒内所有的属性点提高 9%"/>
-        <string name="h18" value="消耗MP 40，540秒内所有的属性点提高 9%"/>
-        <string name="h19" value="消耗MP 40，570秒内所有的属性点提高 10%"/>
-        <string name="h2" value="消耗MP 10，60秒内所有的属性点提高 1%"/>
-        <string name="h20" value="消耗MP 40，600秒内所有的属性点提高 10%"/>
-        <string name="h21" value="消耗MP 50，630秒内所有的属性点提高 11%"/>
-        <string name="h22" value="消耗MP 50，660秒内所有的属性点提高 11%"/>
-        <string name="h23" value="消耗MP 50，690秒内所有的属性点提高 12%"/>
-        <string name="h24" value="消耗MP 50，720秒内所有的属性点提高 12%"/>
-        <string name="h25" value="消耗MP 50，750秒内所有的属性点提高 13%"/>
-        <string name="h26" value="消耗MP 60，780秒内所有的属性点提高 13%"/>
-        <string name="h27" value="消耗MP 60，810秒内所有的属性点提高 14%"/>
-        <string name="h28" value="消耗MP 60，840秒内所有的属性点提高 14%"/>
-        <string name="h29" value="消耗MP 60，870秒内所有的属性点提高 15%"/>
-        <string name="h3" value="消耗MP 10，90秒内所有的属性点提高 2%"/>
-        <string name="h30" value="消耗MP 60，900秒内所有的属性点提高 15%"/>
-        <string name="h4" value="消耗MP 10，120秒内所有的属性点提高 2%"/>
-        <string name="h5" value="消耗MP 10，150秒内所有的属性点提高 3%"/>
-        <string name="h6" value="消耗MP 20，180秒内所有的属性点提高 3%"/>
-        <string name="h7" value="消耗MP 20，210秒内所有的属性点提高 4%"/>
-        <string name="h8" value="消耗MP 20，240秒内所有的属性点提高 4%"/>
-        <string name="h9" value="消耗MP 20，270秒内所有的属性点提高 5%"/>
+        <string name="h1" value="消耗MP 10，所有属性 +1%，持续 30秒"/>
+        <string name="h10" value="消耗MP 20，所有属性 +5%，持续 300秒"/>
+        <string name="h11" value="消耗MP 30，所有属性 +6%，持续 330秒"/>
+        <string name="h12" value="消耗MP 30，所有属性 +6%，持续 360秒"/>
+        <string name="h13" value="消耗MP 30，所有属性 +7%，持续 390秒"/>
+        <string name="h14" value="消耗MP 30，所有属性 +7%，持续 420秒"/>
+        <string name="h15" value="消耗MP 30，所有属性 +8%，持续 450秒"/>
+        <string name="h16" value="消耗MP 40，所有属性 +8%，持续 480秒"/>
+        <string name="h17" value="消耗MP 40，所有属性 +9%，持续 510秒"/>
+        <string name="h18" value="消耗MP 40，所有属性 +9%，持续 540秒"/>
+        <string name="h19" value="消耗MP 40，所有属性 +10%，持续 570秒"/>
+        <string name="h2" value="消耗MP 10，所有属性 +1%，持续 60秒"/>
+        <string name="h20" value="消耗MP 40，所有属性 +10%，持续 600秒"/>
+        <string name="h21" value="消耗MP 50，所有属性 +11%，持续 630秒"/>
+        <string name="h22" value="消耗MP 50，所有属性 +11%，持续 660秒"/>
+        <string name="h23" value="消耗MP 50，所有属性 +12%，持续 690秒"/>
+        <string name="h24" value="消耗MP 50，所有属性 +12%，持续 720秒"/>
+        <string name="h25" value="消耗MP 50，所有属性 +13%，持续 750秒"/>
+        <string name="h26" value="消耗MP 60，所有属性 +13%，持续 780秒"/>
+        <string name="h27" value="消耗MP 60，所有属性 +14%，持续 810秒"/>
+        <string name="h28" value="消耗MP 60，所有属性 +14%，持续 840秒"/>
+        <string name="h29" value="消耗MP 60，所有属性 +15%，持续 870秒"/>
+        <string name="h3" value="消耗MP 10，所有属性 +2%，持续 90秒"/>
+        <string name="h30" value="消耗MP 60，所有属性 +15%，持续 900秒"/>
+        <string name="h4" value="消耗MP 10，所有属性 +2%，持续 120秒"/>
+        <string name="h5" value="消耗MP 10，所有属性 +3%，持续 150秒"/>
+        <string name="h6" value="消耗MP 20，所有属性 +3%，持续 180秒"/>
+        <string name="h7" value="消耗MP 20，所有属性 +4%，持续 210秒"/>
+        <string name="h8" value="消耗MP 20，所有属性 +4%，持续 240秒"/>
+        <string name="h9" value="消耗MP 20，所有属性 +5%，持续 270秒"/>
         <string name="desc" value="在一定时间内按百分比提高自己和队员的全部属性。"/>
     </imgdir>
     <imgdir name="3121002">
         <string name="name" value="火眼晶晶"/>
-        <string name="h1" value="消耗MP 29，持续时间 10秒，1%的必杀几率，伤害 11% 上升"/>
-        <string name="h10" value="消耗MP 29，持续时间 100秒，5%的必杀几率，伤害 20% 上升"/>
-        <string name="h11" value="消耗MP 37，持续时间 110秒，6%的必杀几率，伤害 21% 上升"/>
-        <string name="h12" value="消耗MP 37，持续时间 120秒，6%的必杀几率，伤害 22% 上升"/>
-        <string name="h13" value="消耗MP 37，持续时间 130秒，7%的必杀几率，伤害 23% 上升"/>
-        <string name="h14" value="消耗MP 37，持续时间 140秒，7%的必杀几率，伤害 24% 上升"/>
-        <string name="h15" value="消耗MP 37，持续时间 150秒，8%的必杀几率，伤害 25% 上升"/>
-        <string name="h16" value="消耗MP 37，持续时间 160秒，8%的必杀几率，伤害 26% 上升"/>
-        <string name="h17" value="消耗MP 37，持续时间 170秒，9%的必杀几率，伤害 27% 上升"/>
-        <string name="h18" value="消耗MP 37，持续时间 180秒，9%的必杀几率，伤害 28% 上升"/>
-        <string name="h19" value="消耗MP 37，持续时间 190秒，10%的必杀几率，伤害 29% 上升"/>
-        <string name="h2" value="消耗MP 29，持续时间 20秒，1%的必杀几率，伤害 12% 上升"/>
-        <string name="h20" value="消耗MP 37，持续时间 200秒，10%的必杀几率，伤害 30% 上升"/>
-        <string name="h21" value="消耗MP 45，持续时间 210秒，11%的必杀几率，伤害 31% 上升"/>
-        <string name="h22" value="消耗MP 45，持续时间 220秒，11%的必杀几率，伤害 32% 上升"/>
-        <string name="h23" value="消耗MP 45，持续时间 230秒，12%的必杀几率，伤害 33% 上升"/>
-        <string name="h24" value="消耗MP 45，持续时间 240秒，12%的必杀几率，伤害 34% 上升"/>
-        <string name="h25" value="消耗MP 45，持续时间 250秒，13%的必杀几率，伤害 35% 上升"/>
-        <string name="h26" value="消耗MP 44，持续时间 260秒，13%的必杀几率，伤害 36% 上升"/>
-        <string name="h27" value="消耗MP 43，持续时间 270秒，14%的必杀几率，伤害 37% 上升"/>
-        <string name="h28" value="消耗MP 42，持续时间 280秒，14%的必杀几率，伤害 38% 上升"/>
-        <string name="h29" value="消耗MP 41，持续时间 290秒，15%的必杀几率，伤害 39% 上升"/>
-        <string name="h3" value="消耗MP 29，持续时间 30秒，2%的必杀几率，伤害 13% 上升"/>
-        <string name="h30" value="消耗MP 40，持续时间 300秒，15%的必杀几率，伤害 40% 上升"/>
-        <string name="h4" value="消耗MP 29，持续时间 40秒，2%的必杀几率，伤害 14% 上升"/>
-        <string name="h5" value="消耗MP 29，持续时间 50秒，3%的必杀几率，伤害 15% 上升"/>
-        <string name="h6" value="消耗MP 29，持续时间 60秒，3%的必杀几率，伤害 16% 上升"/>
-        <string name="h7" value="消耗MP 29，持续时间 70秒，4%的必杀几率，伤害 17% 上升"/>
-        <string name="h8" value="消耗MP 29，持续时间 80秒，4%的必杀几率，伤害 18% 上升"/>
-        <string name="h9" value="消耗MP 29，持续时间 90秒，5%的必杀几率，伤害 19% 上升"/>
+        <string name="h1" value="消耗MP 29，暴击率 +1%，暴击伤害 +11%，持续 10秒"/>
+        <string name="h10" value="消耗MP 29，暴击率 +5%，暴击伤害 +20%，持续 100秒"/>
+        <string name="h11" value="消耗MP 37，暴击率 +6%，暴击伤害 +21%，持续 110秒"/>
+        <string name="h12" value="消耗MP 37，暴击率 +6%，暴击伤害 +22%，持续 120秒"/>
+        <string name="h13" value="消耗MP 37，暴击率 +7%，暴击伤害 +23%，持续 130秒"/>
+        <string name="h14" value="消耗MP 37，暴击率 +7%，暴击伤害 +24%，持续 140秒"/>
+        <string name="h15" value="消耗MP 37，暴击率 +8%，暴击伤害 +25%，持续 150秒"/>
+        <string name="h16" value="消耗MP 37，暴击率 +8%，暴击伤害 +26%，持续 160秒"/>
+        <string name="h17" value="消耗MP 37，暴击率 +9%，暴击伤害 +27%，持续 170秒"/>
+        <string name="h18" value="消耗MP 37，暴击率 +9%，暴击伤害 +28%，持续 180秒"/>
+        <string name="h19" value="消耗MP 37，暴击率 +10%，暴击伤害 +29%，持续 190秒"/>
+        <string name="h2" value="消耗MP 29，暴击率 +1%，暴击伤害 +12%，持续 20秒"/>
+        <string name="h20" value="消耗MP 37，暴击率 +10%，暴击伤害 +30%，持续 200秒"/>
+        <string name="h21" value="消耗MP 45，暴击率 +11%，暴击伤害 +31%，持续 210秒"/>
+        <string name="h22" value="消耗MP 45，暴击率 +11%，暴击伤害 +32%，持续 220秒"/>
+        <string name="h23" value="消耗MP 45，暴击率 +12%，暴击伤害 +33%，持续 230秒"/>
+        <string name="h24" value="消耗MP 45，暴击率 +12%，暴击伤害 +34%，持续 240秒"/>
+        <string name="h25" value="消耗MP 45，暴击率 +13%，暴击伤害 +35%，持续 250秒"/>
+        <string name="h26" value="消耗MP 44，暴击率 +13%，暴击伤害 +36%，持续 260秒"/>
+        <string name="h27" value="消耗MP 43，暴击率 +14%，暴击伤害 +37%，持续 270秒"/>
+        <string name="h28" value="消耗MP 42，暴击率 +14%，暴击伤害 +38%，持续 280秒"/>
+        <string name="h29" value="消耗MP 41，暴击率 +15%，暴击伤害 +39%，持续 290秒"/>
+        <string name="h3" value="消耗MP 29，暴击率 +2%，暴击伤害 +13%，持续 30秒"/>
+        <string name="h30" value="消耗MP 40，暴击率 +15%，暴击伤害 +40%，持续 300秒"/>
+        <string name="h4" value="消耗MP 29，暴击率 +2%，暴击伤害 +14%，持续 40秒"/>
+        <string name="h5" value="消耗MP 29，暴击率 +3%，暴击伤害 +15%，持续 50秒"/>
+        <string name="h6" value="消耗MP 29，暴击率 +3%，暴击伤害 +16%，持续 60秒"/>
+        <string name="h7" value="消耗MP 29，暴击率 +4%，暴击伤害 +17%，持续 70秒"/>
+        <string name="h8" value="消耗MP 29，暴击率 +4%，暴击伤害 +18%，持续 80秒"/>
+        <string name="h9" value="消耗MP 29，暴击率 +5%，暴击伤害 +19%，持续 90秒"/>
         <string name="desc" value="在一定时间内提高自己和队员造成暴击的概率与暴击伤害。"/>
     </imgdir>
     <imgdir name="3121003">
         <string name="name" value="飞龙冲击波"/>
-        <string name="h1" value="消耗MP 24，攻击力 42%，最大攻击6只"/>
-        <string name="h10" value="消耗MP 24，攻击力 60%，最大攻击6只"/>
-        <string name="h11" value="消耗MP 30，攻击力 62%，最大攻击6只"/>
-        <string name="h12" value="消耗MP 30，攻击力 64%，最大攻击6只"/>
-        <string name="h13" value="消耗MP 30，攻击力 66%，最大攻击6只"/>
-        <string name="h14" value="消耗MP 30，攻击力 68%，最大攻击6只"/>
-        <string name="h15" value="消耗MP 30，攻击力 70%，最大攻击6只"/>
-        <string name="h16" value="消耗MP 30，攻击力 72%，最大攻击6只"/>
-        <string name="h17" value="消耗MP 30，攻击力 74%，最大攻击6只"/>
-        <string name="h18" value="消耗MP 30，攻击力 76%，最大攻击6只"/>
-        <string name="h19" value="消耗MP 30，攻击力 78%，最大攻击6只"/>
-        <string name="h2" value="消耗MP 24，攻击力 44%，最大攻击6只"/>
-        <string name="h20" value="消耗MP 30，攻击力 80%，最大攻击6只"/>
-        <string name="h21" value="消耗MP 36，攻击力 82%，最大攻击6只"/>
-        <string name="h22" value="消耗MP 36，攻击力 84%，最大攻击6只"/>
-        <string name="h23" value="消耗MP 36，攻击力 86%，最大攻击6只"/>
-        <string name="h24" value="消耗MP 36，攻击力 88%，最大攻击6只"/>
-        <string name="h25" value="消耗MP 36，攻击力 90%，最大攻击6只"/>
-        <string name="h26" value="消耗MP 36，攻击力 92%，最大攻击6只"/>
-        <string name="h27" value="消耗MP 36，攻击力 94%，最大攻击6只"/>
-        <string name="h28" value="消耗MP 36，攻击力 96%，最大攻击6只"/>
-        <string name="h29" value="消耗MP 36，攻击力 98%，最大攻击6只"/>
-        <string name="h3" value="消耗MP 24，攻击力 46%，最大攻击6只"/>
-        <string name="h30" value="消耗MP 36，攻击力 100%，最大攻击6只"/>
-        <string name="h4" value="消耗MP 24，攻击力 48%，最大攻击6只"/>
-        <string name="h5" value="消耗MP 24，攻击力 50%，最大攻击6只"/>
-        <string name="h6" value="消耗MP 24，攻击力 52%，最大攻击6只"/>
-        <string name="h7" value="消耗MP 24，攻击力 54%，最大攻击6只"/>
-        <string name="h8" value="消耗MP 24，攻击力 56%，最大攻击6只"/>
-        <string name="h9" value="消耗MP 24，攻击力 58%，最大攻击6只"/>
+        <string name="h1" value="消耗MP 24，伤害 42%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h10" value="消耗MP 24，伤害 60%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h11" value="消耗MP 30，伤害 62%，最多攻击 5个敌人"/>
+        <string name="h12" value="消耗MP 30，伤害 64%，最多攻击 5个敌人"/>
+        <string name="h13" value="消耗MP 30，伤害 66%，最多攻击 5个敌人"/>
+        <string name="h14" value="消耗MP 30，伤害 68%，最多攻击 5个敌人"/>
+        <string name="h15" value="消耗MP 30，伤害 70%，最多攻击 5个敌人"/>
+        <string name="h16" value="消耗MP 30，伤害 72%，最多攻击 5个敌人"/>
+        <string name="h17" value="消耗MP 30，伤害 74%，最多攻击 5个敌人"/>
+        <string name="h18" value="消耗MP 30，伤害 76%，最多攻击 5个敌人"/>
+        <string name="h19" value="消耗MP 30，伤害 78%，最多攻击 5个敌人"/>
+        <string name="h2" value="消耗MP 24，伤害 44%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h20" value="消耗MP 30，伤害 80%，最多攻击 5个敌人"/>
+        <string name="h21" value="消耗MP 36，伤害 82%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h22" value="消耗MP 36，伤害 84%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h23" value="消耗MP 36，伤害 86%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h24" value="消耗MP 36，伤害 88%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h25" value="消耗MP 36，伤害 90%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h26" value="消耗MP 36，伤害 92%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h27" value="消耗MP 36，伤害 94%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h28" value="消耗MP 36，伤害 96%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h29" value="消耗MP 36，伤害 98%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h3" value="消耗MP 24，伤害 46%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h30" value="消耗MP 36，伤害 100%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h4" value="消耗MP 24，伤害 48%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h5" value="消耗MP 24，伤害 50%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h6" value="消耗MP 24，伤害 52%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h7" value="消耗MP 24，伤害 54%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h8" value="消耗MP 24，伤害 56%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h9" value="消耗MP 24，伤害 58%，最多攻击 4个敌人，100%几率击退"/>
         <string name="desc" value="以龙之气息射出强力箭矢，攻击前方多个敌人并将其击退。"/>
     </imgdir>
     <imgdir name="3121004">
         <string name="name" value="暴风箭雨"/>
-        <string name="h1" value="消耗MP 6，伤害 81%"/>
-        <string name="h10" value="消耗MP 6，伤害 90%"/>
-        <string name="h11" value="消耗MP 8，伤害 91%"/>
-        <string name="h12" value="消耗MP 8，伤害 92%"/>
-        <string name="h13" value="消耗MP 8，伤害 93%"/>
-        <string name="h14" value="消耗MP 8，伤害 94%"/>
-        <string name="h15" value="消耗MP 8，伤害 95%"/>
-        <string name="h16" value="消耗MP 8，伤害 96%"/>
-        <string name="h17" value="消耗MP 8，伤害 97%"/>
-        <string name="h18" value="消耗MP 8，伤害 98%"/>
-        <string name="h19" value="消耗MP 8，伤害 99%"/>
-        <string name="h2" value="消耗MP 6，伤害 82%"/>
-        <string name="h20" value="消耗MP 8，伤害 100%"/>
-        <string name="h21" value="消耗MP 10，伤害 101%"/>
-        <string name="h22" value="消耗MP 10，伤害 102%"/>
-        <string name="h23" value="消耗MP 10，伤害 103%"/>
-        <string name="h24" value="消耗MP 10，伤害 104%"/>
-        <string name="h25" value="消耗MP 10，伤害 105%"/>
-        <string name="h26" value="消耗MP 9，伤害 106%"/>
-        <string name="h27" value="消耗MP 9，伤害 107%"/>
-        <string name="h28" value="消耗MP 9，伤害 108%"/>
-        <string name="h29" value="消耗MP 9，伤害 109%"/>
-        <string name="h3" value="消耗MP 6，伤害 83%"/>
-        <string name="h30" value="消耗MP 9，伤害 110%"/>
-        <string name="h4" value="消耗MP 6，伤害 84%"/>
-        <string name="h5" value="消耗MP 6，伤害 85%"/>
-        <string name="h6" value="消耗MP 6，伤害 86%"/>
-        <string name="h7" value="消耗MP 6，伤害 87%"/>
-        <string name="h8" value="消耗MP 6，伤害 88%"/>
-        <string name="h9" value="消耗MP 6，伤害 89%"/>
+        <string name="h1" value="消耗MP 6，持续按键时每支箭伤害 51%"/>
+        <string name="h10" value="消耗MP 6，持续按键时每支箭伤害 60%"/>
+        <string name="h11" value="消耗MP 8，持续按键时每支箭伤害 71%"/>
+        <string name="h12" value="消耗MP 8，持续按键时每支箭伤害 72%"/>
+        <string name="h13" value="消耗MP 8，持续按键时每支箭伤害 73%"/>
+        <string name="h14" value="消耗MP 8，持续按键时每支箭伤害 74%"/>
+        <string name="h15" value="消耗MP 8，持续按键时每支箭伤害 75%"/>
+        <string name="h16" value="消耗MP 8，持续按键时每支箭伤害 76%"/>
+        <string name="h17" value="消耗MP 8，持续按键时每支箭伤害 77%"/>
+        <string name="h18" value="消耗MP 8，持续按键时每支箭伤害 78%"/>
+        <string name="h19" value="消耗MP 8，持续按键时每支箭伤害 79%"/>
+        <string name="h2" value="消耗MP 6，持续按键时每支箭伤害 52%"/>
+        <string name="h20" value="消耗MP 8，持续按键时每支箭伤害 80%"/>
+        <string name="h21" value="消耗MP 10，持续按键时每支箭伤害 91%"/>
+        <string name="h22" value="消耗MP 10，持续按键时每支箭伤害 92%"/>
+        <string name="h23" value="消耗MP 10，持续按键时每支箭伤害 93%"/>
+        <string name="h24" value="消耗MP 10，持续按键时每支箭伤害 94%"/>
+        <string name="h25" value="消耗MP 10，持续按键时每支箭伤害 95%"/>
+        <string name="h26" value="消耗MP 9，持续按键时每支箭伤害 96%"/>
+        <string name="h27" value="消耗MP 9，持续按键时每支箭伤害 97%"/>
+        <string name="h28" value="消耗MP 9，持续按键时每支箭伤害 98%"/>
+        <string name="h29" value="消耗MP 9，持续按键时每支箭伤害 99%"/>
+        <string name="h3" value="消耗MP 6，持续按键时每支箭伤害 53%"/>
+        <string name="h30" value="消耗MP 9，持续按键时每支箭伤害 100%"/>
+        <string name="h4" value="消耗MP 6，持续按键时每支箭伤害 54%"/>
+        <string name="h5" value="消耗MP 6，持续按键时每支箭伤害 55%"/>
+        <string name="h6" value="消耗MP 6，持续按键时每支箭伤害 56%"/>
+        <string name="h7" value="消耗MP 6，持续按键时每支箭伤害 57%"/>
+        <string name="h8" value="消耗MP 6，持续按键时每支箭伤害 58%"/>
+        <string name="h9" value="消耗MP 6，持续按键时每支箭伤害 59%"/>
         <string name="desc" value="以极快速度持续发射箭矢；按住技能键即可持续攻击。"/>
     </imgdir>
     <imgdir name="3121006">
         <string name="name" value="火凤凰"/>
-        <string name="h1" value="消耗MP 42，攻击力 305，持续时间 113秒"/>
-        <string name="h10" value="消耗MP 60，攻击力 350，持续时间 140秒"/>
-        <string name="h11" value="消耗MP 62，攻击力 405，持续时间 143秒"/>
-        <string name="h12" value="消耗MP 64，攻击力 410，持续时间 146秒"/>
-        <string name="h13" value="消耗MP 66，攻击力 415，持续时间 149秒"/>
-        <string name="h14" value="消耗MP 68，攻击力 420，持续时间 152秒"/>
-        <string name="h15" value="消耗MP 70，攻击力 425，持续时间 155秒"/>
-        <string name="h16" value="消耗MP 72，攻击力 430，持续时间 158秒"/>
-        <string name="h17" value="消耗MP 74，攻击力 435，持续时间 161秒"/>
-        <string name="h18" value="消耗MP 76，攻击力 440，持续时间 164秒"/>
-        <string name="h19" value="消耗MP 78，攻击力 445，持续时间 167秒"/>
-        <string name="h2" value="消耗MP 44，攻击力 310，持续时间 116秒"/>
-        <string name="h20" value="消耗MP 80，攻击力 450，持续时间 170秒"/>
-        <string name="h21" value="消耗MP 82，攻击力 505，持续时间 173秒"/>
-        <string name="h22" value="消耗MP 84，攻击力 510，持续时间 176秒"/>
-        <string name="h23" value="消耗MP 86，攻击力 515，持续时间 179秒"/>
-        <string name="h24" value="消耗MP 88，攻击力 520，持续时间 182秒"/>
-        <string name="h25" value="消耗MP 90，攻击力 525，持续时间 185秒"/>
-        <string name="h26" value="消耗MP 92，攻击力 530，持续时间 188秒"/>
-        <string name="h27" value="消耗MP 94，攻击力 535，持续时间 191秒"/>
-        <string name="h28" value="消耗MP 96，攻击力 540，持续时间 194秒"/>
-        <string name="h29" value="消耗MP 98，攻击力 545，持续时间 197秒"/>
-        <string name="h3" value="消耗MP 46，攻击力 315，持续时间 119秒"/>
-        <string name="h30" value="消耗MP 100，攻击力 550，持续时间 200秒"/>
-        <string name="h4" value="消耗MP 48，攻击力 320，持续时间 122秒"/>
-        <string name="h5" value="消耗MP 50，攻击力 325，持续时间 125秒"/>
-        <string name="h6" value="消耗MP 52，攻击力 330，持续时间 128秒"/>
-        <string name="h7" value="消耗MP 54，攻击力 335，持续时间 131秒"/>
-        <string name="h8" value="消耗MP 56，攻击力 340，持续时间 134秒"/>
-        <string name="h9" value="消耗MP 58，攻击力 345，持续时间 137秒"/>
+        <string name="h1" value="消耗MP 42，召唤火凤凰 113秒，攻击力 305"/>
+        <string name="h10" value="消耗MP 60，召唤火凤凰 140秒，攻击力 350"/>
+        <string name="h11" value="消耗MP 62，召唤火凤凰 143秒，攻击力 405"/>
+        <string name="h12" value="消耗MP 64，召唤火凤凰 146秒，攻击力 410"/>
+        <string name="h13" value="消耗MP 66，召唤火凤凰 149秒，攻击力 415"/>
+        <string name="h14" value="消耗MP 68，召唤火凤凰 152秒，攻击力 420"/>
+        <string name="h15" value="消耗MP 70，召唤火凤凰 155秒，攻击力 425"/>
+        <string name="h16" value="消耗MP 72，召唤火凤凰 158秒，攻击力 430"/>
+        <string name="h17" value="消耗MP 74，召唤火凤凰 161秒，攻击力 435"/>
+        <string name="h18" value="消耗MP 76，召唤火凤凰 164秒，攻击力 440"/>
+        <string name="h19" value="消耗MP 78，召唤火凤凰 167秒，攻击力 445"/>
+        <string name="h2" value="消耗MP 44，召唤火凤凰 116秒，攻击力 310"/>
+        <string name="h20" value="消耗MP 80，召唤火凤凰 170秒，攻击力 450"/>
+        <string name="h21" value="消耗MP 82，召唤火凤凰 173秒，攻击力 505"/>
+        <string name="h22" value="消耗MP 84，召唤火凤凰 176秒，攻击力 510"/>
+        <string name="h23" value="消耗MP 86，召唤火凤凰 179秒，攻击力 515"/>
+        <string name="h24" value="消耗MP 88，召唤火凤凰 182秒，攻击力 520"/>
+        <string name="h25" value="消耗MP 90，召唤火凤凰 185秒，攻击力 525"/>
+        <string name="h26" value="消耗MP 92，召唤火凤凰 188秒，攻击力 530"/>
+        <string name="h27" value="消耗MP 94，召唤火凤凰 191秒，攻击力 535"/>
+        <string name="h28" value="消耗MP 96，召唤火凤凰 194秒，攻击力 540"/>
+        <string name="h29" value="消耗MP 98，召唤火凤凰 197秒，攻击力 545"/>
+        <string name="h3" value="消耗MP 46，召唤火凤凰 119秒，攻击力 315"/>
+        <string name="h30" value="消耗MP 100，召唤火凤凰 200秒，攻击力 550"/>
+        <string name="h4" value="消耗MP 48，召唤火凤凰 122秒，攻击力 320"/>
+        <string name="h5" value="消耗MP 50，召唤火凤凰 125秒，攻击力 325"/>
+        <string name="h6" value="消耗MP 52，召唤火凤凰 128秒，攻击力 330"/>
+        <string name="h7" value="消耗MP 54，召唤火凤凰 131秒，攻击力 335"/>
+        <string name="h8" value="消耗MP 56，召唤火凤凰 134秒，攻击力 340"/>
+        <string name="h9" value="消耗MP 58，召唤火凤凰 137秒，攻击力 345"/>
         <string name="desc" value="召唤火凤凰，在一定时间内攻击最多4个敌人。\n需要技能 : #c银鹰召唤 15级以上#"/>
     </imgdir>
     <imgdir name="3121007">
         <string name="name" value="击退箭"/>
-        <string name="h1" value="消耗MP 12，35秒内 11%的几率 5秒间 敌人移动速度 -2"/>
-        <string name="h10" value="消耗MP 12，80秒内 20%的几率 5秒间 敌人移动速度 -20"/>
-        <string name="h11" value="消耗MP 24，85秒内 21%的几率 10秒间 敌人移动速度 -22"/>
-        <string name="h12" value="消耗MP 24，90秒内 22%的几率 10秒间 敌人移动速度 -24"/>
-        <string name="h13" value="消耗MP 24，95秒内 23%的几率 10秒间 敌人移动速度 -26"/>
-        <string name="h14" value="消耗MP 24，100秒内 24%的几率 10秒间 敌人移动速度 -28"/>
-        <string name="h15" value="消耗MP 24，105秒内 25%的几率 10秒间 敌人移动速度 -30"/>
-        <string name="h16" value="消耗MP 24，110秒内 26%的几率 10秒间 敌人移动速度 -32"/>
-        <string name="h17" value="消耗MP 24，115秒内 27%的几率 10秒间 敌人移动速度 -34"/>
-        <string name="h18" value="消耗MP 24，120秒内 28%的几率 10秒间 敌人移动速度 -36"/>
-        <string name="h19" value="消耗MP 24，125秒内 29%的几率 10秒间 敌人移动速度 -38"/>
-        <string name="h2" value="消耗MP 12，40秒内 12%的几率 5秒间 敌人移动速度 -4"/>
-        <string name="h20" value="消耗MP 24，130秒内 30%的几率 10秒间 敌人移动速度 -40"/>
-        <string name="h21" value="消耗MP 36，135秒内 31%的几率 15秒间 敌人移动速度 -42"/>
-        <string name="h22" value="消耗MP 36，140秒内 32%的几率 15秒间 敌人移动速度 -44"/>
-        <string name="h23" value="消耗MP 36，145秒内 33%的几率 15秒间 敌人移动速度 -46"/>
-        <string name="h24" value="消耗MP 36，150秒内 34%的几率 15秒间 敌人移动速度 -48"/>
-        <string name="h25" value="消耗MP 35，155秒内 35%的几率 15秒间 敌人移动速度 -50"/>
-        <string name="h26" value="消耗MP 34，160秒内 36%的几率 15秒间 敌人移动速度 -52"/>
-        <string name="h27" value="消耗MP 33，165秒内 37%的几率 15秒间 敌人移动速度 -54"/>
-        <string name="h28" value="消耗MP 32，170秒内 38%的几率 15秒间 敌人移动速度 -56"/>
-        <string name="h29" value="消耗MP 31，175秒内 39%的几率 15秒间 敌人移动速度 -58"/>
-        <string name="h3" value="消耗MP 12，45秒内 13%的几率 5秒间 敌人移动速度 -6"/>
-        <string name="h30" value="消耗MP 30，180秒内 40%的几率 15秒间 敌人移动速度 -60"/>
-        <string name="h4" value="消耗MP 12，50秒内 14%的几率 5秒间 敌人移动速度 -8"/>
-        <string name="h5" value="消耗MP 12，55秒内 15%的几率 5秒间 敌人移动速度 -10"/>
-        <string name="h6" value="消耗MP 12，60秒内 16%的几率 5秒间 敌人移动速度 -12"/>
-        <string name="h7" value="消耗MP 12，65秒内 17%的几率 5秒间 敌人移动速度 -14"/>
-        <string name="h8" value="消耗MP 12，70秒内 18%的几率 5秒间 敌人移动速度 -16"/>
-        <string name="h9" value="消耗MP 12，75秒内 19%的几率 5秒间 敌人移动速度 -18"/>
+        <string name="h1" value="消耗MP 12，35秒内有 11%几率使敌人移动速度 -2，持续 5秒"/>
+        <string name="h10" value="消耗MP 12，80秒内有 20%几率使敌人移动速度 -20，持续 5秒"/>
+        <string name="h11" value="消耗MP 24，85秒内有 21%几率使敌人移动速度 -22，持续 10秒"/>
+        <string name="h12" value="消耗MP 24，90秒内有 22%几率使敌人移动速度 -24，持续 10秒"/>
+        <string name="h13" value="消耗MP 24，95秒内有 23%几率使敌人移动速度 -26，持续 10秒"/>
+        <string name="h14" value="消耗MP 24，100秒内有 24%几率使敌人移动速度 -28，持续 10秒"/>
+        <string name="h15" value="消耗MP 24，105秒内有 25%几率使敌人移动速度 -30，持续 10秒"/>
+        <string name="h16" value="消耗MP 24，110秒内有 26%几率使敌人移动速度 -32，持续 10秒"/>
+        <string name="h17" value="消耗MP 24，115秒内有 27%几率使敌人移动速度 -34，持续 10秒"/>
+        <string name="h18" value="消耗MP 24，120秒内有 28%几率使敌人移动速度 -36，持续 10秒"/>
+        <string name="h19" value="消耗MP 24，125秒内有 29%几率使敌人移动速度 -38，持续 10秒"/>
+        <string name="h2" value="消耗MP 12，40秒内有 12%几率使敌人移动速度 -4，持续 5秒"/>
+        <string name="h20" value="消耗MP 24，130秒内有 30%几率使敌人移动速度 -40，持续 10秒"/>
+        <string name="h21" value="消耗MP 36，135秒内有 31%几率使敌人移动速度 -42，持续 15秒"/>
+        <string name="h22" value="消耗MP 36，140秒内有 32%几率使敌人移动速度 -44，持续 15秒"/>
+        <string name="h23" value="消耗MP 36，145秒内有 33%几率使敌人移动速度 -46，持续 15秒"/>
+        <string name="h24" value="消耗MP 36，150秒内有 34%几率使敌人移动速度 -48，持续 15秒"/>
+        <string name="h25" value="消耗MP 35，155秒内有 35%几率使敌人移动速度 -50，持续 15秒"/>
+        <string name="h26" value="消耗MP 34，160秒内有 36%几率使敌人移动速度 -52，持续 15秒"/>
+        <string name="h27" value="消耗MP 33，165秒内有 37%几率使敌人移动速度 -54，持续 15秒"/>
+        <string name="h28" value="消耗MP 32，170秒内有 38%几率使敌人移动速度 -56，持续 15秒"/>
+        <string name="h29" value="消耗MP 31，175秒内有 39%几率使敌人移动速度 -58，持续 15秒"/>
+        <string name="h3" value="消耗MP 12，45秒内有 13%几率使敌人移动速度 -6，持续 5秒"/>
+        <string name="h30" value="消耗MP 30，180秒内有 40%几率使敌人移动速度 -60，持续 15秒"/>
+        <string name="h4" value="消耗MP 12，50秒内有 14%几率使敌人移动速度 -8，持续 5秒"/>
+        <string name="h5" value="消耗MP 12，55秒内有 15%几率使敌人移动速度 -10，持续 5秒"/>
+        <string name="h6" value="消耗MP 12，60秒内有 16%几率使敌人移动速度 -12，持续 5秒"/>
+        <string name="h7" value="消耗MP 12，65秒内有 17%几率使敌人移动速度 -14，持续 5秒"/>
+        <string name="h8" value="消耗MP 12，70秒内有 18%几率使敌人移动速度 -16，持续 5秒"/>
+        <string name="h9" value="消耗MP 12，75秒内有 19%几率使敌人移动速度 -18，持续 5秒"/>
         <string name="desc" value="有一定概率射中敌人腿部，使其在一定时间内降低移动速度。"/>
     </imgdir>
     <imgdir name="3121008">
         <string name="name" value="集中精力"/>
-        <string name="h1" value="消耗MP 11，攻击力 11 上升，消耗MP -2%，持续时间 120秒"/>
-        <string name="h10" value="消耗MP 20，攻击力 16 上升，消耗MP -20%，持续时间 120秒"/>
-        <string name="h11" value="消耗MP 21，攻击力 16 上升，消耗MP -22%，持续时间 180秒"/>
-        <string name="h12" value="消耗MP 22，攻击力 17 上升，消耗MP -24%，持续时间 180秒"/>
-        <string name="h13" value="消耗MP 23，攻击力 17 上升，消耗MP -26%，持续时间 180秒"/>
-        <string name="h14" value="消耗MP 24，攻击力 18 上升，消耗MP -28%，持续时间 180秒"/>
-        <string name="h15" value="消耗MP 25，攻击力 18 上升，消耗MP -30%，持续时间 180秒"/>
-        <string name="h16" value="消耗MP 26，攻击力 19 上升，消耗MP -32%，持续时间 180秒"/>
-        <string name="h17" value="消耗MP 27，攻击力 19 上升，消耗MP -34%，持续时间 180秒"/>
-        <string name="h18" value="消耗MP 28，攻击力 20 上升，消耗MP -36%，持续时间 180秒"/>
-        <string name="h19" value="消耗MP 29，攻击力 20 上升，消耗MP -38%，持续时间 180秒"/>
-        <string name="h2" value="消耗MP 12，攻击力 12 上升，消耗MP -4%，持续时间 120秒"/>
-        <string name="h20" value="消耗MP 30，攻击力 21 上升，消耗MP -40%，持续时间 180秒"/>
-        <string name="h21" value="消耗MP 31，攻击力 21 上升，消耗MP -41%，持续时间 240秒"/>
-        <string name="h22" value="消耗MP 32，攻击力 22 上升，消耗MP -42%，持续时间 240秒"/>
-        <string name="h23" value="消耗MP 33，攻击力 22 上升，消耗MP -43%，持续时间 240秒"/>
-        <string name="h24" value="消耗MP 34，攻击力 23 上升，消耗MP -44%，持续时间 240秒"/>
-        <string name="h25" value="消耗MP 35，攻击力 23 上升，消耗MP -45%，持续时间 240秒"/>
-        <string name="h26" value="消耗MP 36，攻击力 24 上升，消耗MP -46%，持续时间 240秒"/>
-        <string name="h27" value="消耗MP 37，攻击力 24 上升，消耗MP -47%，持续时间 240秒"/>
-        <string name="h28" value="消耗MP 38，攻击力 25 上升，消耗MP -48%，持续时间 240秒"/>
-        <string name="h29" value="消耗MP 39，攻击力 25 上升，消耗MP -49%，持续时间 240秒"/>
-        <string name="h3" value="消耗MP 13，攻击力 12 上升，消耗MP -6%，持续时间 120秒"/>
-        <string name="h30" value="消耗MP 40，攻击力 26 上升，消耗MP -50%，持续时间 240秒"/>
-        <string name="h4" value="消耗MP 14，攻击力 13 上升，消耗MP -8%，持续时间 120秒"/>
-        <string name="h5" value="消耗MP 15，攻击力 13 上升，消耗MP -10%，持续时间 120秒"/>
-        <string name="h6" value="消耗MP 16，攻击力 14 上升，消耗MP -12%，持续时间 120秒"/>
-        <string name="h7" value="消耗MP 17，攻击力 14 上升，消耗MP -14%，持续时间 120秒"/>
-        <string name="h8" value="消耗MP 18，攻击力 15 上升，消耗MP -16%，持续时间 120秒"/>
-        <string name="h9" value="消耗MP 19，攻击力 15 上升，消耗MP -18%，持续时间 120秒"/>
+        <string name="h1" value="消耗MP 11，攻击力 +11，技能MP消耗 -2%，持续 120秒，冷却 360秒"/>
+        <string name="h10" value="消耗MP 20，攻击力 +16，技能MP消耗 -20%，持续 120秒，冷却 360秒"/>
+        <string name="h11" value="消耗MP 21，攻击力 +16，技能MP消耗 -22%，持续 180秒，冷却 360秒"/>
+        <string name="h12" value="消耗MP 22，攻击力 +17，技能MP消耗 -24%，持续 180秒，冷却 360秒"/>
+        <string name="h13" value="消耗MP 23，攻击力 +17，技能MP消耗 -26%，持续 180秒，冷却 360秒"/>
+        <string name="h14" value="消耗MP 24，攻击力 +18，技能MP消耗 -28%，持续 180秒，冷却 360秒"/>
+        <string name="h15" value="消耗MP 25，攻击力 +18，技能MP消耗 -30%，持续 180秒，冷却 360秒"/>
+        <string name="h16" value="消耗MP 26，攻击力 +19，技能MP消耗 -32%，持续 180秒，冷却 360秒"/>
+        <string name="h17" value="消耗MP 27，攻击力 +19，技能MP消耗 -34%，持续 180秒，冷却 360秒"/>
+        <string name="h18" value="消耗MP 28，攻击力 +20，技能MP消耗 -36%，持续 180秒，冷却 360秒"/>
+        <string name="h19" value="消耗MP 29，攻击力 +20，技能MP消耗 -38%，持续 180秒，冷却 360秒"/>
+        <string name="h2" value="消耗MP 12，攻击力 +12，技能MP消耗 -4%，持续 120秒，冷却 360秒"/>
+        <string name="h20" value="消耗MP 30，攻击力 +21，技能MP消耗 -40%，持续 180秒，冷却 360秒"/>
+        <string name="h21" value="消耗MP 31，攻击力 +21，技能MP消耗 -41%，持续 240秒，冷却 360秒"/>
+        <string name="h22" value="消耗MP 32，攻击力 +22，技能MP消耗 -42%，持续 240秒，冷却 360秒"/>
+        <string name="h23" value="消耗MP 33，攻击力 +22，技能MP消耗 -43%，持续 240秒，冷却 360秒"/>
+        <string name="h24" value="消耗MP 34，攻击力 +23，技能MP消耗 -44%，持续 240秒，冷却 360秒"/>
+        <string name="h25" value="消耗MP 35，攻击力 +23，技能MP消耗 -45%，持续 240秒，冷却 360秒"/>
+        <string name="h26" value="消耗MP 36，攻击力 +24，技能MP消耗 -46%，持续 240秒，冷却 360秒"/>
+        <string name="h27" value="消耗MP 37，攻击力 +24，技能MP消耗 -47%，持续 240秒，冷却 360秒"/>
+        <string name="h28" value="消耗MP 38，攻击力 +25，技能MP消耗 -48%，持续 240秒，冷却 360秒"/>
+        <string name="h29" value="消耗MP 39，攻击力 +25，技能MP消耗 -49%，持续 240秒，冷却 360秒"/>
+        <string name="h3" value="消耗MP 13，攻击力 +12，技能MP消耗 -6%，持续 120秒，冷却 360秒"/>
+        <string name="h30" value="消耗MP 40，攻击力 +26，技能MP消耗 -50%，持续 240秒，冷却 360秒"/>
+        <string name="h4" value="消耗MP 14，攻击力 +13，技能MP消耗 -8%，持续 120秒，冷却 360秒"/>
+        <string name="h5" value="消耗MP 15，攻击力 +13，技能MP消耗 -10%，持续 120秒，冷却 360秒"/>
+        <string name="h6" value="消耗MP 16，攻击力 +14，技能MP消耗 -12%，持续 120秒，冷却 360秒"/>
+        <string name="h7" value="消耗MP 17，攻击力 +14，技能MP消耗 -14%，持续 120秒，冷却 360秒"/>
+        <string name="h8" value="消耗MP 18，攻击力 +15，技能MP消耗 -16%，持续 120秒，冷却 360秒"/>
+        <string name="h9" value="消耗MP 19，攻击力 +15，技能MP消耗 -18%，持续 120秒，冷却 360秒"/>
         <string name="desc" value="在一定时间内提高攻击力，并降低技能MP消耗。\n#c冷却时间 : 6分钟#"/>
     </imgdir>
     <imgdir name="3121009">
         <string name="name" value="勇士的意志"/>
-        <string name="h1" value="消耗MP 30，解除诱惑异常状态，冷却时间10分钟"/>
-        <string name="h2" value="消耗MP 30，解除诱惑异常状态，冷却时间9分钟"/>
-        <string name="h3" value="消耗MP 30，解除诱惑异常状态，冷却时间8分钟"/>
-        <string name="h4" value="消耗MP 30，解除诱惑异常状态，冷却时间7分钟"/>
-        <string name="h5" value="消耗MP 30，解除诱惑异常状态，冷却时间6分钟"/>
+        <string name="h1" value="消耗MP 30，解除异常状态，冷却 600秒"/>
+        <string name="h2" value="消耗MP 30，解除异常状态，冷却 540秒"/>
+        <string name="h3" value="消耗MP 30，解除异常状态，冷却 480秒"/>
+        <string name="h4" value="消耗MP 30，解除异常状态，冷却 420秒"/>
+        <string name="h5" value="消耗MP 30，解除异常状态，冷却 360秒"/>
         <string name="desc" value="解除异常状态。随着技能等级提高，冷却时间缩短。"/>
     </imgdir>
     <imgdir name="320">
@@ -9113,142 +9113,142 @@
     </imgdir>
     <imgdir name="3200001">
         <string name="name" value="终极弩"/>
-        <string name="h1" value="出现概率2%，发挥105%的最终攻击"/>
-        <string name="h10" value="出现概率20%，发挥150%的最终攻击"/>
-        <string name="h11" value="出现概率22%，发挥155%的最终攻击"/>
-        <string name="h12" value="出现概率24%，发挥160%的最终攻击"/>
-        <string name="h13" value="出现概率26%，发挥165%的最终攻击"/>
-        <string name="h14" value="出现概率28%，发挥170%的最终攻击"/>
-        <string name="h15" value="出现概率30%，发挥175%的最终攻击"/>
-        <string name="h16" value="出现概率32%，发挥180%的最终攻击"/>
-        <string name="h17" value="出现概率34%，发挥185%的最终攻击"/>
-        <string name="h18" value="出现概率36%，发挥190%的最终攻击"/>
-        <string name="h19" value="出现概率38%，发挥195%的最终攻击"/>
-        <string name="h2" value="出现概率4%，发挥110%的最终攻击"/>
-        <string name="h20" value="出现概率40%，发挥200%的最终攻击"/>
-        <string name="h21" value="出现概率42%，发挥205%的最终攻击"/>
-        <string name="h22" value="出现概率44%，发挥210%的最终攻击"/>
-        <string name="h23" value="出现概率46%，发挥215%的最终攻击"/>
-        <string name="h24" value="出现概率48%，发挥220%的最终攻击"/>
-        <string name="h25" value="出现概率50%，发挥225%的最终攻击"/>
-        <string name="h26" value="出现概率52%，发挥230%的最终攻击"/>
-        <string name="h27" value="出现概率54%，发挥235%的最终攻击"/>
-        <string name="h28" value="出现概率56%，发挥240%的最终攻击"/>
-        <string name="h29" value="出现概率58%，发挥245%的最终攻击"/>
-        <string name="h3" value="出现概率6%，发挥115%的最终攻击"/>
-        <string name="h30" value="出现概率60%，发挥250%的最终攻击"/>
-        <string name="h4" value="出现概率8%，发挥120%的最终攻击"/>
-        <string name="h5" value="出现概率10%，发挥125%的最终攻击"/>
-        <string name="h6" value="出现概率12%，发挥130%的最终攻击"/>
-        <string name="h7" value="出现概率14%，发挥135%的最终攻击"/>
-        <string name="h8" value="出现概率16%，发挥140%的最终攻击"/>
-        <string name="h9" value="出现概率18%，发挥145%的最终攻击"/>
+        <string name="h1" value="2%几率发动，终极攻击伤害 105%"/>
+        <string name="h10" value="20%几率发动，终极攻击伤害 150%"/>
+        <string name="h11" value="22%几率发动，终极攻击伤害 155%"/>
+        <string name="h12" value="24%几率发动，终极攻击伤害 160%"/>
+        <string name="h13" value="26%几率发动，终极攻击伤害 165%"/>
+        <string name="h14" value="28%几率发动，终极攻击伤害 170%"/>
+        <string name="h15" value="30%几率发动，终极攻击伤害 175%"/>
+        <string name="h16" value="32%几率发动，终极攻击伤害 180%"/>
+        <string name="h17" value="34%几率发动，终极攻击伤害 185%"/>
+        <string name="h18" value="36%几率发动，终极攻击伤害 190%"/>
+        <string name="h19" value="38%几率发动，终极攻击伤害 195%"/>
+        <string name="h2" value="4%几率发动，终极攻击伤害 110%"/>
+        <string name="h20" value="40%几率发动，终极攻击伤害 200%"/>
+        <string name="h21" value="42%几率发动，终极攻击伤害 205%"/>
+        <string name="h22" value="44%几率发动，终极攻击伤害 210%"/>
+        <string name="h23" value="46%几率发动，终极攻击伤害 215%"/>
+        <string name="h24" value="48%几率发动，终极攻击伤害 220%"/>
+        <string name="h25" value="50%几率发动，终极攻击伤害 225%"/>
+        <string name="h26" value="52%几率发动，终极攻击伤害 230%"/>
+        <string name="h27" value="54%几率发动，终极攻击伤害 235%"/>
+        <string name="h28" value="56%几率发动，终极攻击伤害 240%"/>
+        <string name="h29" value="58%几率发动，终极攻击伤害 245%"/>
+        <string name="h3" value="6%几率发动，终极攻击伤害 115%"/>
+        <string name="h30" value="60%几率发动，终极攻击伤害 250%"/>
+        <string name="h4" value="8%几率发动，终极攻击伤害 120%"/>
+        <string name="h5" value="10%几率发动，终极攻击伤害 125%"/>
+        <string name="h6" value="12%几率发动，终极攻击伤害 130%"/>
+        <string name="h7" value="14%几率发动，终极攻击伤害 135%"/>
+        <string name="h8" value="16%几率发动，终极攻击伤害 140%"/>
+        <string name="h9" value="18%几率发动，终极攻击伤害 145%"/>
         <string name="desc" value="[最高等级 : 30]\n使用弩系攻击技能后，有一定概率追加一次终极攻击。\n必须装备弩。\n需要技能 : #c精准弩 3级以上#"/>
     </imgdir>
     <imgdir name="3201002">
         <string name="name" value="快速弩"/>
-        <string name="h1" value="消耗HP29和MP29，持续10秒"/>
-        <string name="h10" value="消耗HP20和MP20，持续100秒"/>
-        <string name="h11" value="消耗HP19和MP19，持续110秒"/>
-        <string name="h12" value="消耗HP18和MP18，持续120秒"/>
-        <string name="h13" value="消耗HP17和MP17，持续130秒"/>
-        <string name="h14" value="消耗HP16和MP16，持续140秒"/>
-        <string name="h15" value="消耗HP15和MP15，持续150秒"/>
-        <string name="h16" value="消耗HP14和MP14，持续160秒"/>
-        <string name="h17" value="消耗HP13和MP13，持续170秒"/>
-        <string name="h18" value="消耗HP12和MP12，持续180秒"/>
-        <string name="h19" value="消耗HP11和MP11，持续190秒"/>
-        <string name="h2" value="消耗HP28和MP28，持续20秒"/>
-        <string name="h20" value="消耗HP10和MP10，持续200秒"/>
-        <string name="h3" value="消耗HP27和MP27，持续30秒"/>
-        <string name="h4" value="消耗HP26和MP26，持续40秒"/>
-        <string name="h5" value="消耗HP25和MP25，持续50秒"/>
-        <string name="h6" value="消耗HP24和MP24，持续60秒"/>
-        <string name="h7" value="消耗HP23和MP23，持续70秒"/>
-        <string name="h8" value="消耗HP22和MP22，持续80秒"/>
-        <string name="h9" value="消耗HP21和MP21，持续90秒"/>
+        <string name="h1" value="消耗HP 29，消耗MP 29，弩攻击速度提升2级，持续 10秒"/>
+        <string name="h10" value="消耗HP 20，消耗MP 20，弩攻击速度提升2级，持续 100秒"/>
+        <string name="h11" value="消耗HP 19，消耗MP 19，弩攻击速度提升2级，持续 110秒"/>
+        <string name="h12" value="消耗HP 18，消耗MP 18，弩攻击速度提升2级，持续 120秒"/>
+        <string name="h13" value="消耗HP 17，消耗MP 17，弩攻击速度提升2级，持续 130秒"/>
+        <string name="h14" value="消耗HP 16，消耗MP 16，弩攻击速度提升2级，持续 140秒"/>
+        <string name="h15" value="消耗HP 15，消耗MP 15，弩攻击速度提升2级，持续 150秒"/>
+        <string name="h16" value="消耗HP 14，消耗MP 14，弩攻击速度提升2级，持续 160秒"/>
+        <string name="h17" value="消耗HP 13，消耗MP 13，弩攻击速度提升2级，持续 170秒"/>
+        <string name="h18" value="消耗HP 12，消耗MP 12，弩攻击速度提升2级，持续 180秒"/>
+        <string name="h19" value="消耗HP 11，消耗MP 11，弩攻击速度提升2级，持续 190秒"/>
+        <string name="h2" value="消耗HP 28，消耗MP 28，弩攻击速度提升2级，持续 20秒"/>
+        <string name="h20" value="消耗HP 10，消耗MP 10，弩攻击速度提升2级，持续 200秒"/>
+        <string name="h3" value="消耗HP 27，消耗MP 27，弩攻击速度提升2级，持续 30秒"/>
+        <string name="h4" value="消耗HP 26，消耗MP 26，弩攻击速度提升2级，持续 40秒"/>
+        <string name="h5" value="消耗HP 25，消耗MP 25，弩攻击速度提升2级，持续 50秒"/>
+        <string name="h6" value="消耗HP 24，消耗MP 24，弩攻击速度提升2级，持续 60秒"/>
+        <string name="h7" value="消耗HP 23，消耗MP 23，弩攻击速度提升2级，持续 70秒"/>
+        <string name="h8" value="消耗HP 22，消耗MP 22，弩攻击速度提升2级，持续 80秒"/>
+        <string name="h9" value="消耗HP 21，消耗MP 21，弩攻击速度提升2级，持续 90秒"/>
         <string name="desc" value="[最高等级 : 20]\n消耗HP和MP，在一定时间内提升弩的攻击速度2级。\n必须装备弩。\n需要技能 : #c精准弩 5级以上#"/>
     </imgdir>
     <imgdir name="3201003">
         <string name="name" value="强弩"/>
-        <string name="h1" value="消耗MP8，概率13%伤害+105%，目标2个"/>
-		<string name="h10" value="消耗MP8，概率40%伤害+150%，对象3个"/>
-		<string name="h11" value="消耗MP15，概率43%伤害+155%，对象4个"/>
-		<string name="h12" value="消耗MP15，概率46%伤害+160%，对象4个"/>
-		<string name="h13" value="消耗MP15，概率49%伤害+165%，对象4个"/>
-		<string name="h14" value="消耗MP15，概率52%伤害+170%，对象4个"/>
-		<string name="h15" value="消耗MP15，概率55%伤害+175%，对象4个"/>
-		<string name="h16" value="消耗MP15，概率58%伤害+180%，对象5个"/>
-		<string name="h17" value="消耗MP15，概率61%伤害+185%，对象5个"/>
-		<string name="h18" value="消耗MP15，概率64%伤害+190%，对象5个"/>
-		<string name="h19" value="消耗MP15，概率67%伤害+195%，对象5个"/>
-		<string name="h2" value="消耗MP8，概率16%伤害+110%，对象2个"/>
-		<string name="h20" value="消耗MP15，概率70%伤害+200%，对象6个"/>
-		<string name="h3" value="消耗MP8，概率19%伤害+115%，对象2个"/>
-		<string name="h4" value="消耗MP8，概率22%伤害+120%，对象2个"/>
-		<string name="h5" value="消耗MP8，概率25%伤害+125%，对象2个"/>
-		<string name="h6" value="消耗MP8，概率28%伤害+130%，对象3个"/>
-		<string name="h7" value="消耗MP8，概率31%伤害+135%，对象3个"/>
-		<string name="h8" value="消耗MP8，概率34%伤害+140%，对象3个"/>
-		<string name="h9" value="消耗MP8，概率37%伤害+145%，对象3个"/>
+        <string name="h1" value="消耗MP 8，13%几率发动，伤害 105%，最多攻击 2个敌人"/>
+		<string name="h10" value="消耗MP 8，40%几率发动，伤害 150%，最多攻击 3个敌人"/>
+		<string name="h11" value="消耗MP 15，43%几率发动，伤害 155%，最多攻击 4个敌人"/>
+		<string name="h12" value="消耗MP 15，46%几率发动，伤害 160%，最多攻击 4个敌人"/>
+		<string name="h13" value="消耗MP 15，49%几率发动，伤害 165%，最多攻击 4个敌人"/>
+		<string name="h14" value="消耗MP 15，52%几率发动，伤害 170%，最多攻击 4个敌人"/>
+		<string name="h15" value="消耗MP 15，55%几率发动，伤害 175%，最多攻击 4个敌人"/>
+		<string name="h16" value="消耗MP 15，58%几率发动，伤害 180%，最多攻击 5个敌人"/>
+		<string name="h17" value="消耗MP 15，61%几率发动，伤害 185%，最多攻击 5个敌人"/>
+		<string name="h18" value="消耗MP 15，64%几率发动，伤害 190%，最多攻击 5个敌人"/>
+		<string name="h19" value="消耗MP 15，67%几率发动，伤害 195%，最多攻击 5个敌人"/>
+		<string name="h2" value="消耗MP 8，16%几率发动，伤害 110%，最多攻击 2个敌人"/>
+		<string name="h20" value="消耗MP 15，70%几率发动，伤害 200%，最多攻击 6个敌人"/>
+		<string name="h3" value="消耗MP 8，19%几率发动，伤害 115%，最多攻击 2个敌人"/>
+		<string name="h4" value="消耗MP 8，22%几率发动，伤害 120%，最多攻击 2个敌人"/>
+		<string name="h5" value="消耗MP 8，25%几率发动，伤害 125%，最多攻击 2个敌人"/>
+		<string name="h6" value="消耗MP 8，28%几率发动，伤害 130%，最多攻击 3个敌人"/>
+		<string name="h7" value="消耗MP 8，31%几率发动，伤害 135%，最多攻击 3个敌人"/>
+		<string name="h8" value="消耗MP 8，34%几率发动，伤害 140%，最多攻击 3个敌人"/>
+		<string name="h9" value="消耗MP 8，37%几率发动，伤害 145%，最多攻击 3个敌人"/>
         <string name="desc" value="[最高等级 : 20]\n用弩进行近身攻击时，有一定概率击退多个敌人并造成伤害。"/>
     </imgdir>
     <imgdir name="3201004">
         <string name="name" value="无形箭"/>
-        <string name="h1" value="消耗MP15，持续30秒"/>
-        <string name="h10" value="消耗MP15，持续300秒"/>
-        <string name="h11" value="消耗MP20，持续330秒"/>
-        <string name="h12" value="消耗MP20，持续360秒"/>
-        <string name="h13" value="消耗MP20，持续390秒"/>
-        <string name="h14" value="消耗MP20，持续420秒"/>
-        <string name="h15" value="消耗MP20，持续450秒"/>
-        <string name="h16" value="消耗MP20，持续480秒"/>
-        <string name="h17" value="消耗MP20，持续510秒"/>
-        <string name="h18" value="消耗MP20，持续540秒"/>
-        <string name="h19" value="消耗MP20，持续570秒"/>
-        <string name="h2" value="消耗MP15，持续60秒"/>
-        <string name="h20" value="消耗MP20，持续600秒"/>
-        <string name="h3" value="消耗MP15，持续90秒"/>
-        <string name="h4" value="消耗MP15，持续120秒"/>
-        <string name="h5" value="消耗MP15，持续150秒"/>
-        <string name="h6" value="消耗MP15，持续180秒"/>
-        <string name="h7" value="消耗MP15，持续210秒"/>
-        <string name="h8" value="消耗MP15，持续240秒"/>
-        <string name="h9" value="消耗MP15，持续270秒"/>
+        <string name="h1" value="消耗MP 15，30秒内攻击不消耗箭矢"/>
+        <string name="h10" value="消耗MP 15，300秒内攻击不消耗箭矢"/>
+        <string name="h11" value="消耗MP 20，330秒内攻击不消耗箭矢"/>
+        <string name="h12" value="消耗MP 20，360秒内攻击不消耗箭矢"/>
+        <string name="h13" value="消耗MP 20，390秒内攻击不消耗箭矢"/>
+        <string name="h14" value="消耗MP 20，420秒内攻击不消耗箭矢"/>
+        <string name="h15" value="消耗MP 20，450秒内攻击不消耗箭矢"/>
+        <string name="h16" value="消耗MP 20，480秒内攻击不消耗箭矢"/>
+        <string name="h17" value="消耗MP 20，510秒内攻击不消耗箭矢"/>
+        <string name="h18" value="消耗MP 20，540秒内攻击不消耗箭矢"/>
+        <string name="h19" value="消耗MP 20，570秒内攻击不消耗箭矢"/>
+        <string name="h2" value="消耗MP 15，60秒内攻击不消耗箭矢"/>
+        <string name="h20" value="消耗MP 20，600秒内攻击不消耗箭矢"/>
+        <string name="h3" value="消耗MP 15，90秒内攻击不消耗箭矢"/>
+        <string name="h4" value="消耗MP 15，120秒内攻击不消耗箭矢"/>
+        <string name="h5" value="消耗MP 15，150秒内攻击不消耗箭矢"/>
+        <string name="h6" value="消耗MP 15，180秒内攻击不消耗箭矢"/>
+        <string name="h7" value="消耗MP 15，210秒内攻击不消耗箭矢"/>
+        <string name="h8" value="消耗MP 15，240秒内攻击不消耗箭矢"/>
+        <string name="h9" value="消耗MP 15，270秒内攻击不消耗箭矢"/>
         <string name="desc" value="[最高等级 : 20]\n在一定时间内使用弩攻击时不消耗箭矢。\n必须装备弩。\n需要技能 : #c快速弩 5级以上#"/>
     </imgdir>
     <imgdir name="3201005">
         <string name="name" value="穿透箭"/>
-        <string name="h1" value="消耗MP23，攻击力142%"/>
-        <string name="h10" value="消耗MP24，攻击力160%"/>
-        <string name="h11" value="消耗MP25，攻击力162%"/>
-        <string name="h12" value="消耗MP25，攻击力164%"/>
-        <string name="h13" value="消耗MP25，攻击力166%"/>
-        <string name="h14" value="消耗MP25，攻击力168%"/>
-        <string name="h15" value="消耗MP25，攻击力170%"/>
-        <string name="h16" value="消耗MP25，攻击力172%"/>
-        <string name="h17" value="消耗MP25，攻击力174%"/>
-        <string name="h18" value="消耗MP26，攻击力176%"/>
-        <string name="h19" value="消耗MP26，攻击力178%"/>
-        <string name="h2" value="消耗MP23，攻击力144%"/>
-        <string name="h20" value="消耗MP26，攻击力180%"/>
-        <string name="h21" value="消耗MP27，攻击力182%"/>
-        <string name="h22" value="消耗MP27，攻击力184%"/>
-        <string name="h23" value="消耗MP27，攻击力186%"/>
-        <string name="h24" value="消耗MP27，攻击力188%"/>
-        <string name="h25" value="消耗MP27，攻击力190%"/>
-        <string name="h26" value="消耗MP28，攻击力192%"/>
-        <string name="h27" value="消耗MP28，攻击力194%"/>
-        <string name="h28" value="消耗MP28，攻击力196%"/>
-        <string name="h29" value="消耗MP28，攻击力198%"/>
-        <string name="h3" value="消耗MP23，攻击力146%"/>
-        <string name="h30" value="消耗MP28，攻击力200%"/>
-        <string name="h4" value="消耗MP23，攻击力148%"/>
-        <string name="h5" value="消耗MP23，攻击力150%"/>
-        <string name="h6" value="消耗MP23，攻击力152%"/>
-        <string name="h7" value="消耗MP24，攻击力154%"/>
-        <string name="h8" value="消耗MP24，攻击力156%"/>
-        <string name="h9" value="消耗MP24，攻击力158%"/>
+        <string name="h1" value="消耗MP 23，伤害 122%，最多攻击 6个敌人"/>
+        <string name="h10" value="消耗MP 24，伤害 140%，最多攻击 6个敌人"/>
+        <string name="h11" value="消耗MP 25，伤害 142%，最多攻击 6个敌人"/>
+        <string name="h12" value="消耗MP 25，伤害 144%，最多攻击 6个敌人"/>
+        <string name="h13" value="消耗MP 25，伤害 146%，最多攻击 6个敌人"/>
+        <string name="h14" value="消耗MP 25，伤害 148%，最多攻击 6个敌人"/>
+        <string name="h15" value="消耗MP 25，伤害 150%，最多攻击 6个敌人"/>
+        <string name="h16" value="消耗MP 26，伤害 152%，最多攻击 6个敌人"/>
+        <string name="h17" value="消耗MP 26，伤害 154%，最多攻击 6个敌人"/>
+        <string name="h18" value="消耗MP 26，伤害 156%，最多攻击 6个敌人"/>
+        <string name="h19" value="消耗MP 26，伤害 158%，最多攻击 6个敌人"/>
+        <string name="h2" value="消耗MP 23，伤害 124%，最多攻击 6个敌人"/>
+        <string name="h20" value="消耗MP 27，伤害 160%，最多攻击 6个敌人"/>
+        <string name="h21" value="消耗MP 27，伤害 162%，最多攻击 6个敌人"/>
+        <string name="h22" value="消耗MP 27，伤害 164%，最多攻击 6个敌人"/>
+        <string name="h23" value="消耗MP 27，伤害 166%，最多攻击 6个敌人"/>
+        <string name="h24" value="消耗MP 27，伤害 168%，最多攻击 6个敌人"/>
+        <string name="h25" value="消耗MP 27，伤害 170%，最多攻击 6个敌人"/>
+        <string name="h26" value="消耗MP 28，伤害 172%，最多攻击 6个敌人"/>
+        <string name="h27" value="消耗MP 28，伤害 174%，最多攻击 6个敌人"/>
+        <string name="h28" value="消耗MP 28，伤害 176%，最多攻击 6个敌人"/>
+        <string name="h29" value="消耗MP 28，伤害 178%，最多攻击 6个敌人"/>
+        <string name="h3" value="消耗MP 23，伤害 126%，最多攻击 6个敌人"/>
+        <string name="h30" value="消耗MP 28，伤害 180%，最多攻击 6个敌人"/>
+        <string name="h4" value="消耗MP 23，伤害 128%，最多攻击 6个敌人"/>
+        <string name="h5" value="消耗MP 23，伤害 130%，最多攻击 6个敌人"/>
+        <string name="h6" value="消耗MP 24，伤害 132%，最多攻击 6个敌人"/>
+        <string name="h7" value="消耗MP 24，伤害 134%，最多攻击 6个敌人"/>
+        <string name="h8" value="消耗MP 24，伤害 136%，最多攻击 6个敌人"/>
+        <string name="h9" value="消耗MP 24，伤害 138%，最多攻击 6个敌人"/>
         <string name="desc" value="[最高等级 : 30]\n射出可贯穿敌人的强力箭矢，最多攻击6个敌人；穿透过程中伤害会衰减。"/>
     </imgdir>
     <imgdir name="321">
@@ -9256,210 +9256,210 @@
     </imgdir>
     <imgdir name="3210000">
         <string name="name" value="疾风步"/>
-        <string name="h1" value="移动速度+2"/>
-		<string name="h10" value="移动速度+20"/>
-		<string name="h11" value="移动速度+21"/>
-		<string name="h12" value="移动速度+22"/>
-		<string name="h13" value="移动速度+23"/>
-		<string name="h14" value="移动速度+24"/>
-		<string name="h15" value="移动速度+25"/>
-		<string name="h16" value="移动速度+26"/>
-		<string name="h17" value="移动速度+27"/>
-		<string name="h18" value="移动速度+28"/>
-		<string name="h19" value="移动速度+29"/>
-		<string name="h2" value="移动速度+4"/>
-		<string name="h20" value="移动速度+30"/>
-		<string name="h3" value="移动速度+6"/>
-		<string name="h4" value="移动速度+8"/>
-		<string name="h5" value="移动速度+10"/>
-		<string name="h6" value="移动速度+12"/>
-		<string name="h7" value="移动速度+14"/>
-		<string name="h8" value="移动速度+16"/>
-		<string name="h9" value="移动速度+18"/>
+        <string name="h1" value="移动速度 +2"/>
+		<string name="h10" value="移动速度 +20"/>
+		<string name="h11" value="移动速度 +21"/>
+		<string name="h12" value="移动速度 +22"/>
+		<string name="h13" value="移动速度 +23"/>
+		<string name="h14" value="移动速度 +24"/>
+		<string name="h15" value="移动速度 +25"/>
+		<string name="h16" value="移动速度 +26"/>
+		<string name="h17" value="移动速度 +27"/>
+		<string name="h18" value="移动速度 +28"/>
+		<string name="h19" value="移动速度 +29"/>
+		<string name="h2" value="移动速度 +4"/>
+		<string name="h20" value="移动速度 +30"/>
+		<string name="h3" value="移动速度 +6"/>
+		<string name="h4" value="移动速度 +8"/>
+		<string name="h5" value="移动速度 +10"/>
+		<string name="h6" value="移动速度 +12"/>
+		<string name="h7" value="移动速度 +14"/>
+		<string name="h8" value="移动速度 +16"/>
+		<string name="h9" value="移动速度 +18"/>
         <string name="desc" value="[最高等级 : 20]\n提高移动速度。"/>
     </imgdir>
     <imgdir name="3210001">
         <string name="name" value="贯穿箭"/>
-        <string name="h1" value="33%几率发动，造成伤害110%，假如对方HP在20%以下时1%几率出现必杀"/>
-        <string name="h10" value="60%几率发动，造成伤害200%，假如敌的HP在35%以下时5%几率出现必杀怪物"/>
-        <string name="h11" value="63%几率发动，造成伤害205%，假如敌的HP在35%以下时6%几率出现必杀怪物"/>
-        <string name="h12" value="66%几率发动，造成伤害210%，假如敌的HP在38%以下时6%几率出现必杀怪物"/>
-        <string name="h13" value="69%几率发动，造成伤害215%，假如敌的HP在38%以下时7%几率出现必杀怪物"/>
-        <string name="h14" value="72%几率发动，造成伤害220%，假如敌的HP在41%以下时7%几率出现必杀怪物"/>
-        <string name="h15" value="75%几率发动，造成伤害225%，假如敌的HP在41%以下时8%几率出现必杀怪物"/>
-        <string name="h16" value="78%几率发动，造成伤害230%，假如敌的HP在44%以下时8%几率出现必杀怪物"/>
-        <string name="h17" value="81%几率发动，造成伤害235%，假如敌的HP在44%以下时9%几率出现必杀怪物"/>
-        <string name="h18" value="84%几率发动，造成伤害240%，假如敌的HP在47%以下时9%几率出现必杀怪物"/>
-        <string name="h19" value="87%几率发动，造成伤害245%，假如敌的HP在47%以下时10%几率出现必杀怪物"/>
-        <string name="h2" value="36%几率发动，造成伤害120%，假如敌的HP在23%以下时1%几率出现必杀怪物"/>
-        <string name="h20" value="90%几率发动，造成伤害250%，假如敌的HP在50%以下时10%几率出现必杀怪物"/>
-        <string name="h3" value="39%几率发动，造成伤害130%，假如敌的HP在23%以下时2%几率出现必杀怪物"/>
-        <string name="h4" value="42%几率发动，造成伤害140%，假如敌的HP在26%以下时2%几率出现必杀怪物"/>
-        <string name="h5" value="45%几率发动，造成伤害150%，假如敌的HP在26%以下时3%几率出现必杀怪物"/>
-        <string name="h6" value="48%几率发动，造成伤害160%，假如敌的HP在29%以下时3%几率出现必杀怪物"/>
-        <string name="h7" value="51%几率发动，造成伤害170%，假如敌的HP在29%以下时4%几率出现必杀怪物"/>
-        <string name="h8" value="54%几率发动，造成伤害180%，假如敌的HP在32%以下时4%几率出现必杀怪物"/>
-        <string name="h9" value="57%几率发动，造成伤害190%，假如敌的HP在32%以下时5%几率出现必杀怪物"/>
+        <string name="h1" value="33%几率发动，伤害 110%，敌人HP在 20%以下时有 1%几率直接击败"/>
+        <string name="h10" value="60%几率发动，伤害 200%，敌人HP在 35%以下时有 5%几率直接击败"/>
+        <string name="h11" value="63%几率发动，伤害 205%，敌人HP在 35%以下时有 6%几率直接击败"/>
+        <string name="h12" value="66%几率发动，伤害 210%，敌人HP在 38%以下时有 6%几率直接击败"/>
+        <string name="h13" value="69%几率发动，伤害 215%，敌人HP在 38%以下时有 7%几率直接击败"/>
+        <string name="h14" value="72%几率发动，伤害 220%，敌人HP在 41%以下时有 7%几率直接击败"/>
+        <string name="h15" value="75%几率发动，伤害 225%，敌人HP在 41%以下时有 8%几率直接击败"/>
+        <string name="h16" value="78%几率发动，伤害 230%，敌人HP在 44%以下时有 8%几率直接击败"/>
+        <string name="h17" value="81%几率发动，伤害 235%，敌人HP在 44%以下时有 9%几率直接击败"/>
+        <string name="h18" value="84%几率发动，伤害 240%，敌人HP在 47%以下时有 9%几率直接击败"/>
+        <string name="h19" value="87%几率发动，伤害 245%，敌人HP在 47%以下时有 10%几率直接击败"/>
+        <string name="h2" value="36%几率发动，伤害 120%，敌人HP在 23%以下时有 1%几率直接击败"/>
+        <string name="h20" value="90%几率发动，伤害 250%，敌人HP在 50%以下时有 10%几率直接击败"/>
+        <string name="h3" value="39%几率发动，伤害 130%，敌人HP在 23%以下时有 2%几率直接击败"/>
+        <string name="h4" value="42%几率发动，伤害 140%，敌人HP在 26%以下时有 2%几率直接击败"/>
+        <string name="h5" value="45%几率发动，伤害 150%，敌人HP在 26%以下时有 3%几率直接击败"/>
+        <string name="h6" value="48%几率发动，伤害 160%，敌人HP在 29%以下时有 3%几率直接击败"/>
+        <string name="h7" value="51%几率发动，伤害 170%，敌人HP在 29%以下时有 4%几率直接击败"/>
+        <string name="h8" value="54%几率发动，伤害 180%，敌人HP在 32%以下时有 4%几率直接击败"/>
+        <string name="h9" value="57%几率发动，伤害 190%，敌人HP在 32%以下时有 5%几率直接击败"/>
         <string name="desc" value="[最高等级 : 20]\n即使在近距离也可发射弩箭，并有一定概率对敌人造成致命伤害。"/>
     </imgdir>
     <imgdir name="3211002">
         <string name="name" value="替身术"/>
-        <string name="h1" value="消费MP23，持续5秒 召唤HP1500的分身"/>
-        <string name="h10" value="消费MP26，持续30秒 召唤HP15000的分身"/>
-        <string name="h11" value="消费MP29，持续30秒 召唤HP16500的分身"/>
-        <string name="h12" value="消费MP29，持续40秒 召唤HP18000的分身"/>
-        <string name="h13" value="消费MP29，持续40秒 召唤HP19500的分身"/>
-        <string name="h14" value="消费MP23，持续40秒 召唤HP21000的分身"/>
-        <string name="h15" value="消费MP29，持续50秒 召唤HP22500的分身"/>
-        <string name="h16" value="消费MP32，持续50秒 召唤HP24000的分身"/>
-        <string name="h17" value="消费MP32，持续50秒 召唤HP25500的分身"/>
-        <string name="h18" value="消费MP32，持续60秒 召唤HP27000的分身"/>
-        <string name="h19" value="消费MP32，持续60秒 召唤HP28500的分身"/>
-        <string name="h2" value="消费MP23，持续5秒 召唤HP3000的分身"/>
-        <string name="h20" value="消费MP32,持续60秒 召唤HP30000的分身"/>
-        <string name="h3" value="消费MP23，持续10秒 召唤HP4500的分身"/>
-        <string name="h4" value="消费MP23，持续10秒 召唤HP6000的分身"/>
-        <string name="h5" value="消费MP23，持续10秒 召唤HP7500的分身"/>
-        <string name="h6" value="消费MP26，持续20秒 召唤HP9000的分身"/>
-        <string name="h7" value="消费MP26，持续20秒 召唤HP10500的分身"/>
-        <string name="h8" value="消费MP26，持续20秒 召唤HP12000的分身"/>
-        <string name="h9" value="消费MP26，持续30秒 召唤HP13500的分身"/>
+        <string name="h1" value="消耗MP 23，召唤HP 500的替身，持续 5秒"/>
+        <string name="h10" value="消耗MP 26，召唤HP 1800的替身，持续 30秒"/>
+        <string name="h11" value="消耗MP 29，召唤HP 2000的替身，持续 30秒"/>
+        <string name="h12" value="消耗MP 29，召唤HP 2400的替身，持续 40秒"/>
+        <string name="h13" value="消耗MP 29，召唤HP 2800的替身，持续 40秒"/>
+        <string name="h14" value="消耗MP 29，召唤HP 3200的替身，持续 40秒"/>
+        <string name="h15" value="消耗MP 29，召唤HP 3600的替身，持续 50秒"/>
+        <string name="h16" value="消耗MP 32，召唤HP 4000的替身，持续 50秒"/>
+        <string name="h17" value="消耗MP 32，召唤HP 4500的替身，持续 50秒"/>
+        <string name="h18" value="消耗MP 32，召唤HP 5000的替身，持续 60秒"/>
+        <string name="h19" value="消耗MP 32，召唤HP 5500的替身，持续 60秒"/>
+        <string name="h2" value="消耗MP 23，召唤HP 600的替身，持续 5秒"/>
+        <string name="h20" value="消耗MP 32，召唤HP 6000的替身，持续 60秒"/>
+        <string name="h3" value="消耗MP 23，召唤HP 700的替身，持续 10秒"/>
+        <string name="h4" value="消耗MP 23，召唤HP 800的替身，持续 10秒"/>
+        <string name="h5" value="消耗MP 23，召唤HP 900的替身，持续 10秒"/>
+        <string name="h6" value="消耗MP 26，召唤HP 1000的替身，持续 20秒"/>
+        <string name="h7" value="消耗MP 26，召唤HP 1200的替身，持续 20秒"/>
+        <string name="h8" value="消耗MP 26，召唤HP 1400的替身，持续 20秒"/>
+        <string name="h9" value="消耗MP 26，召唤HP 1600的替身，持续 30秒"/>
         <string name="desc" value="[最高等级 : 20]\n召唤替身吸引怪物攻击，持续一定时间。"/>
     </imgdir>
     <imgdir name="3211003">
         <string name="name" value="寒冰箭"/>
-        <string name="h1" value="消费MP20，造成伤害133%，持续1秒冻结怪物"/>
-        <string name="h10" value="消费MP20，造成伤害160%，持续1秒冻结怪物"/>
-        <string name="h11" value="消费MP25，造成伤害163%，持续2秒冻结怪物"/>
-        <string name="h12" value="消费MP25，造成伤害166%，持续2秒冻结怪物"/>
-        <string name="h13" value="消费MP25，造成伤害169%，持续2秒冻结怪物"/>
-        <string name="h14" value="消费MP25，造成伤害172%，持续2秒冻结怪物"/>
-        <string name="h15" value="消费MP25，造成伤害175%，持续2秒冻结怪物"/>
-        <string name="h16" value="消费MP25，造成伤害178%，持续2秒冻结怪物"/>
-        <string name="h17" value="消费MP25，造成伤害181%，持续2秒冻结怪物"/>
-        <string name="h18" value="消费MP25，造成伤害184%，持续2秒冻结怪物"/>
-        <string name="h19" value="消费MP25，造成伤害187%，持续2秒冻结怪物"/>
-        <string name="h2" value="消费MP20，造成伤害136%，持续1秒冻结怪物"/>
-        <string name="h20" value="消费MP25，造成伤害190%，持续2秒冻结怪物"/>
-        <string name="h21" value="消费MP30，造成伤害192%，持续3秒冻结怪物"/>
-        <string name="h22" value="消费MP30，造成伤害194%，持续3秒冻结怪物"/>
-        <string name="h23" value="消费MP30，造成伤害196%，持续3秒冻结怪物"/>
-        <string name="h24" value="消费MP30，造成伤害198%，持续3秒冻结怪物"/>
-        <string name="h25" value="消费MP30，造成伤害200%，持续3秒冻结怪物"/>
-        <string name="h26" value="消费MP30，造成伤害202%，持续3秒冻结怪物"/>
-        <string name="h27" value="消费MP30，造成伤害204%，持续3秒冻结怪物"/>
-        <string name="h28" value="消费MP30，造成伤害206%，持续3秒冻结怪物"/>
-        <string name="h29" value="消费MP30，造成伤害208%，持续3秒冻结怪物"/>
-        <string name="h3" value="消费MP20，造成伤害139%，持续1秒冻结怪物"/>
-        <string name="h30" value="消费MP30，造成伤害210%，持续3秒冻结怪物"/>
-        <string name="h4" value="消费MP20，造成伤害142%，持续1秒冻结怪物"/>
-        <string name="h5" value="消费MP20，造成伤害145%，持续1秒冻结怪物"/>
-        <string name="h6" value="消费MP20，造成伤害148%，持续1秒冻结怪物"/>
-        <string name="h7" value="消费MP20，造成伤害151%，持续1秒冻结怪物"/>
-        <string name="h8" value="消费MP20，造成伤害154%，持续1秒冻结怪物"/>
-        <string name="h9" value="消费MP20，造成伤害157%，持续1秒冻结怪物"/>
+        <string name="h1" value="消耗MP 20，伤害 100%，最多攻击 6个敌人，冻结 1秒"/>
+        <string name="h10" value="消耗MP 20，伤害 118%，最多攻击 6个敌人，冻结 1秒"/>
+        <string name="h11" value="消耗MP 25，伤害 120%，最多攻击 6个敌人，冻结 2秒"/>
+        <string name="h12" value="消耗MP 25，伤害 122%，最多攻击 6个敌人，冻结 2秒"/>
+        <string name="h13" value="消耗MP 25，伤害 124%，最多攻击 6个敌人，冻结 2秒"/>
+        <string name="h14" value="消耗MP 25，伤害 126%，最多攻击 6个敌人，冻结 2秒"/>
+        <string name="h15" value="消耗MP 25，伤害 128%，最多攻击 6个敌人，冻结 2秒"/>
+        <string name="h16" value="消耗MP 25，伤害 130%，最多攻击 6个敌人，冻结 2秒"/>
+        <string name="h17" value="消耗MP 25，伤害 131%，最多攻击 6个敌人，冻结 2秒"/>
+        <string name="h18" value="消耗MP 25，伤害 132%，最多攻击 6个敌人，冻结 2秒"/>
+        <string name="h19" value="消耗MP 25，伤害 133%，最多攻击 6个敌人，冻结 2秒"/>
+        <string name="h2" value="消耗MP 20，伤害 102%，最多攻击 6个敌人，冻结 1秒"/>
+        <string name="h20" value="消耗MP 30，伤害 134%，最多攻击 6个敌人，冻结 2秒"/>
+        <string name="h21" value="消耗MP 30，伤害 135%，最多攻击 6个敌人，冻结 3秒"/>
+        <string name="h22" value="消耗MP 30，伤害 136%，最多攻击 6个敌人，冻结 3秒"/>
+        <string name="h23" value="消耗MP 30，伤害 136%，最多攻击 6个敌人，冻结 3秒"/>
+        <string name="h24" value="消耗MP 30，伤害 137%，最多攻击 6个敌人，冻结 3秒"/>
+        <string name="h25" value="消耗MP 30，伤害 137%，最多攻击 6个敌人，冻结 3秒"/>
+        <string name="h26" value="消耗MP 30，伤害 138%，最多攻击 6个敌人，冻结 3秒"/>
+        <string name="h27" value="消耗MP 30，伤害 138%，最多攻击 6个敌人，冻结 3秒"/>
+        <string name="h28" value="消耗MP 30，伤害 139%，最多攻击 6个敌人，冻结 3秒"/>
+        <string name="h29" value="消耗MP 30，伤害 139%，最多攻击 6个敌人，冻结 3秒"/>
+        <string name="h3" value="消耗MP 20，伤害 104%，最多攻击 6个敌人，冻结 1秒"/>
+        <string name="h30" value="消耗MP 30，伤害 140%，最多攻击 6个敌人，冻结 3秒"/>
+        <string name="h4" value="消耗MP 20，伤害 106%，最多攻击 6个敌人，冻结 1秒"/>
+        <string name="h5" value="消耗MP 20，伤害 108%，最多攻击 6个敌人，冻结 1秒"/>
+        <string name="h6" value="消耗MP 20，伤害 110%，最多攻击 6个敌人，冻结 1秒"/>
+        <string name="h7" value="消耗MP 20，伤害 112%，最多攻击 6个敌人，冻结 1秒"/>
+        <string name="h8" value="消耗MP 20，伤害 114%，最多攻击 6个敌人，冻结 1秒"/>
+        <string name="h9" value="消耗MP 20，伤害 116%，最多攻击 6个敌人，冻结 1秒"/>
         <string name="desc" value="[最高等级 : 30]\n用冰属性箭攻击最多6个敌人，并附带冰属性效果。\n必须装备弩。"/>
     </imgdir>
     <imgdir name="3211004">
         <string name="name" value="升龙弩"/>
-        <string name="h1" value="消费MP18，造成伤害153%"/>
-        <string name="h10" value="消费MP18，造成伤害180%"/>
-        <string name="h11" value="消费MP23，造成伤害183%"/>
-        <string name="h12" value="消费MP23，造成伤害186%"/>
-        <string name="h13" value="消费MP23，造成伤害189%"/>
-        <string name="h14" value="消费MP23，造成伤害192%"/>
-        <string name="h15" value="消费MP23，造成伤害195%"/>
-        <string name="h16" value="消费MP23，造成伤害198%"/>
-        <string name="h17" value="消费MP23，造成伤害201%"/>
-        <string name="h18" value="消费MP23，造成伤害204%"/>
-        <string name="h19" value="消费MP23，造成伤害207%"/>
-        <string name="h2" value="消费MP18，造成伤害156%"/>
-        <string name="h20" value="消费MP23，造成伤害210%"/>
-        <string name="h21" value="消费MP28，造成伤害213%"/>
-        <string name="h22" value="消费MP28，造成伤害216%"/>
-        <string name="h23" value="消费MP28，造成伤害219%"/>
-        <string name="h24" value="消费MP28，造成伤害222%"/>
-        <string name="h25" value="消费MP28，造成伤害225%"/>
-        <string name="h26" value="消费MP28，造成伤害228%"/>
-        <string name="h27" value="消费MP28，造成伤害231%"/>
-        <string name="h28" value="消费MP28，造成伤害234%"/>
-        <string name="h29" value="消费MP28，造成伤害237%"/>
-        <string name="h3" value="消费MP18，造成伤害159%"/>
-        <string name="h30" value="消费MP28，造成伤害240%"/>
-        <string name="h4" value="消费MP18，造成伤害162%"/>
-        <string name="h5" value="消费MP18，造成伤害165%"/>
-        <string name="h6" value="消费MP18，造成伤害168%"/>
-        <string name="h7" value="消费MP18，造成伤害171%"/>
-        <string name="h8" value="消费MP18，造成伤害174%"/>
-        <string name="h9" value="消费MP18，造成伤害177%"/>
+        <string name="h1" value="消耗MP 18，伤害 60%，最多攻击 6个敌人"/>
+        <string name="h10" value="消耗MP 18，伤害 105%，最多攻击 6个敌人"/>
+        <string name="h11" value="消耗MP 23，伤害 110%，最多攻击 6个敌人"/>
+        <string name="h12" value="消耗MP 23，伤害 113%，最多攻击 6个敌人"/>
+        <string name="h13" value="消耗MP 23，伤害 116%，最多攻击 6个敌人"/>
+        <string name="h14" value="消耗MP 23，伤害 119%，最多攻击 6个敌人"/>
+        <string name="h15" value="消耗MP 23，伤害 122%，最多攻击 6个敌人"/>
+        <string name="h16" value="消耗MP 23，伤害 125%，最多攻击 6个敌人"/>
+        <string name="h17" value="消耗MP 23，伤害 128%，最多攻击 6个敌人"/>
+        <string name="h18" value="消耗MP 23，伤害 131%，最多攻击 6个敌人"/>
+        <string name="h19" value="消耗MP 23，伤害 134%，最多攻击 6个敌人"/>
+        <string name="h2" value="消耗MP 18，伤害 65%，最多攻击 6个敌人"/>
+        <string name="h20" value="消耗MP 23，伤害 137%，最多攻击 6个敌人"/>
+        <string name="h21" value="消耗MP 28，伤害 140%，最多攻击 6个敌人"/>
+        <string name="h22" value="消耗MP 28，伤害 143%，最多攻击 6个敌人"/>
+        <string name="h23" value="消耗MP 28，伤害 146%，最多攻击 6个敌人"/>
+        <string name="h24" value="消耗MP 28，伤害 149%，最多攻击 6个敌人"/>
+        <string name="h25" value="消耗MP 28，伤害 152%，最多攻击 6个敌人"/>
+        <string name="h26" value="消耗MP 28，伤害 154%，最多攻击 6个敌人"/>
+        <string name="h27" value="消耗MP 28，伤害 156%，最多攻击 6个敌人"/>
+        <string name="h28" value="消耗MP 28，伤害 158%，最多攻击 6个敌人"/>
+        <string name="h29" value="消耗MP 28，伤害 159%，最多攻击 6个敌人"/>
+        <string name="h3" value="消耗MP 18，伤害 70%，最多攻击 6个敌人"/>
+        <string name="h30" value="消耗MP 28，伤害 160%，最多攻击 6个敌人"/>
+        <string name="h4" value="消耗MP 18，伤害 75%，最多攻击 6个敌人"/>
+        <string name="h5" value="消耗MP 18，伤害 80%，最多攻击 6个敌人"/>
+        <string name="h6" value="消耗MP 18，伤害 85%，最多攻击 6个敌人"/>
+        <string name="h7" value="消耗MP 18，伤害 90%，最多攻击 6个敌人"/>
+        <string name="h8" value="消耗MP 18，伤害 95%，最多攻击 6个敌人"/>
+        <string name="h9" value="消耗MP 18，伤害 100%，最多攻击 6个敌人"/>
         <string name="desc" value="[最高等级 : 30]\n向地面发射箭矢后爆发攻击，最多攻击6个敌人。\n必须装备弩。\n需要技能 : #c贯穿箭 5级以上#"/>
     </imgdir>
     <imgdir name="3211005">
         <string name="name" value="金鹰召唤"/>
-        <string name="h1" value="消费MP32和召唤石1个,持续103秒,46次攻击,召唤的鹰以50%几率出击"/>
-        <string name="h10" value="消费MP50和召唤石1个,持续130秒,100次攻击,召唤的鹰以77%几率出击"/>
-        <string name="h11" value="消费MP52和召唤石1个,持续133秒,106次攻击,召唤的鹰以80%几率出击"/>
-        <string name="h12" value="消费MP54和召唤石1个,持续136秒,112次攻击,召唤的鹰以82%几率出击"/>
-        <string name="h13" value="消费MP56和召唤石1个,持续139秒,118次攻击,召唤的鹰以84%几率出击"/>
-        <string name="h14" value="消费MP58和召唤石1个,持续142秒,126次攻击,召唤的鹰以86%几率出击"/>
-        <string name="h15" value="消费MP60和召唤石1个,持续145秒,130次攻击,召唤的鹰以88%几率出击"/>
-        <string name="h16" value="消费MP62和召唤石1个,持续148秒,136次攻击,召唤的鹰以90%几率出击"/>
-        <string name="h17" value="消费MP64和召唤石1个,持续151秒,142次攻击,召唤的鹰以91%几率出击"/>
-        <string name="h18" value="消费MP66和召唤石1个,持续154秒,148次攻击,召唤的鹰以92%几率出击"/>
-        <string name="h19" value="消费MP68和召唤石1个,持续160秒,154次攻击,召唤的鹰以93%几率出击"/>
-        <string name="h2" value="消费MP34和召唤石1个,持续106秒,52次攻击,召唤的鹰以53%几率出击"/>
-        <string name="h20" value="消费MP70和召唤石1个,持续162秒,160次攻击,召唤的鹰以94%几率出击"/>
-        <string name="h21" value="消费MP71和召唤石1个,持续164秒,164次攻击,召唤的鹰以95%几率出击"/>
-        <string name="h22" value="消费MP72和召唤石1个,持续166秒,168次攻击,召唤的鹰以96%几率出击"/>
-        <string name="h23" value="消费MP73和召唤石1个,持续168秒,172次攻击,召唤的鹰以96%几率出击"/>
-        <string name="h24" value="消费MP74和召唤石1个,持续170秒,176次攻击,召唤的鹰以97%几率出击"/>
-        <string name="h25" value="消费MP75和召唤石1个,持续172秒,180次攻击,召唤的鹰以97%几率出击"/>
-        <string name="h26" value="消费MP76和召唤石1个,持续174秒,184次攻击,召唤的鹰以98%几率出击"/>
-        <string name="h27" value="消费MP77和召唤石1个,持续176秒,188次攻击,召唤的鹰以98%几率出击"/>
-        <string name="h28" value="消费MP78和召唤石1个,持续178秒,192次攻击,召唤的鹰以99%几率出击"/>
-        <string name="h29" value="消费MP79和召唤石1个,持续180秒,196次攻击,召唤的鹰以99%几率出击"/>
-        <string name="h3" value="消费MP36和召唤石1个,持续109秒,58次攻击,召唤的鹰以56%几率出击"/>
-        <string name="h30" value="消费MP80和召唤石1个,持续180秒,200次攻击,召唤的鹰以100%几率出击"/>
-        <string name="h4" value="消费MP38和召唤石1个,持续112秒,64次攻击,召唤的鹰以59%几率出击"/>
-        <string name="h5" value="消费MP40和召唤石1个,持续115秒,70次攻击,召唤的鹰以62%几率出击"/>
-        <string name="h6" value="消费MP42和召唤石1个,持续118秒,76次攻击,召唤的鹰以65%几率出击"/>
-        <string name="h7" value="消费MP44和召唤石1个,持续121秒,82次攻击,召唤的鹰以68%几率出击"/>
-        <string name="h8" value="消费MP46和召唤石1个,持续124秒,88次攻击,召唤的鹰以71%几率出击"/>
-        <string name="h9" value="消费MP48和召唤石1个,持续127秒,94次攻击,召唤的鹰以74%几率出击"/>
+        <string name="h1" value="消耗MP 32和1个召唤石，召唤金鹰 103秒，攻击力 23，50%几率眩晕"/>
+        <string name="h10" value="消耗MP 50和1个召唤石，召唤金鹰 130秒，攻击力 50，77%几率眩晕"/>
+        <string name="h11" value="消耗MP 52和1个召唤石，召唤金鹰 133秒，攻击力 53，80%几率眩晕"/>
+        <string name="h12" value="消耗MP 54和1个召唤石，召唤金鹰 136秒，攻击力 56，82%几率眩晕"/>
+        <string name="h13" value="消耗MP 56和1个召唤石，召唤金鹰 139秒，攻击力 59，84%几率眩晕"/>
+        <string name="h14" value="消耗MP 58和1个召唤石，召唤金鹰 142秒，攻击力 62，86%几率眩晕"/>
+        <string name="h15" value="消耗MP 60和1个召唤石，召唤金鹰 145秒，攻击力 65，88%几率眩晕"/>
+        <string name="h16" value="消耗MP 62和1个召唤石，召唤金鹰 148秒，攻击力 68，90%几率眩晕"/>
+        <string name="h17" value="消耗MP 64和1个召唤石，召唤金鹰 151秒，攻击力 71，91%几率眩晕"/>
+        <string name="h18" value="消耗MP 66和1个召唤石，召唤金鹰 154秒，攻击力 74，92%几率眩晕"/>
+        <string name="h19" value="消耗MP 68和1个召唤石，召唤金鹰 160秒，攻击力 77，93%几率眩晕"/>
+        <string name="h2" value="消耗MP 34和1个召唤石，召唤金鹰 106秒，攻击力 26，53%几率眩晕"/>
+        <string name="h20" value="消耗MP 70和1个召唤石，召唤金鹰 162秒，攻击力 80，94%几率眩晕"/>
+        <string name="h21" value="消耗MP 71和1个召唤石，召唤金鹰 164秒，攻击力 82，95%几率眩晕"/>
+        <string name="h22" value="消耗MP 72和1个召唤石，召唤金鹰 166秒，攻击力 84，95%几率眩晕"/>
+        <string name="h23" value="消耗MP 73和1个召唤石，召唤金鹰 168秒，攻击力 86，96%几率眩晕"/>
+        <string name="h24" value="消耗MP 74和1个召唤石，召唤金鹰 170秒，攻击力 88，96%几率眩晕"/>
+        <string name="h25" value="消耗MP 75和1个召唤石，召唤金鹰 172秒，攻击力 90，97%几率眩晕"/>
+        <string name="h26" value="消耗MP 76和1个召唤石，召唤金鹰 174秒，攻击力 92，97%几率眩晕"/>
+        <string name="h27" value="消耗MP 77和1个召唤石，召唤金鹰 176秒，攻击力 94，98%几率眩晕"/>
+        <string name="h28" value="消耗MP 78和1个召唤石，召唤金鹰 178秒，攻击力 96，98%几率眩晕"/>
+        <string name="h29" value="消耗MP 79和1个召唤石，召唤金鹰 180秒，攻击力 98，99%几率眩晕"/>
+        <string name="h3" value="消耗MP 36和1个召唤石，召唤金鹰 109秒，攻击力 29，56%几率眩晕"/>
+        <string name="h30" value="消耗MP 80和1个召唤石，召唤金鹰 180秒，攻击力 100，99%几率眩晕"/>
+        <string name="h4" value="消耗MP 38和1个召唤石，召唤金鹰 112秒，攻击力 32，59%几率眩晕"/>
+        <string name="h5" value="消耗MP 40和1个召唤石，召唤金鹰 115秒，攻击力 35，62%几率眩晕"/>
+        <string name="h6" value="消耗MP 42和1个召唤石，召唤金鹰 118秒，攻击力 38，65%几率眩晕"/>
+        <string name="h7" value="消耗MP 44和1个召唤石，召唤金鹰 121秒，攻击力 41，68%几率眩晕"/>
+        <string name="h8" value="消耗MP 46和1个召唤石，召唤金鹰 124秒，攻击力 44，71%几率眩晕"/>
+        <string name="h9" value="消耗MP 48和1个召唤石，召唤金鹰 127秒，攻击力 47，74%几率眩晕"/>
         <string name="desc" value="[最高等级 : 30]\n召唤金鹰，在一定时间内攻击附近敌人，并有一定概率使其眩晕。\n需要技能 : #c替身术 5级以上#"/>
     </imgdir>
     <imgdir name="3211006">
         <string name="name" value="箭扫射"/>
-        <string name="h1" value="消费MP26，造成伤害81%，5次攻击"/>
-        <string name="h10" value="消费MP26，造成伤害90%，5次攻击"/>
-        <string name="h11" value="消费MP26，造成伤害91%，5次攻击"/>
-        <string name="h12" value="消费MP26，造成伤害92%，5次攻击"/>
-        <string name="h13" value="消费MP26，造成伤害93%，5次攻击"/>
-        <string name="h14" value="消费MP26，造成伤害94%，5次攻击"/>
-        <string name="h15" value="消费MP26，造成伤害95%，5次攻击"/>
-        <string name="h16" value="消费MP32，造成伤害96%，5次攻击"/>
-        <string name="h17" value="消费MP32，造成伤害97%，5次攻击"/>
-        <string name="h18" value="消费MP32，造成伤害98%，5次攻击"/>
-        <string name="h19" value="消费MP32，造成伤害99%，5次攻击"/>
-        <string name="h2" value="消费MP26，造成伤害82%，5次攻击"/>
-        <string name="h20" value="消费MP32，造成伤害100%，5次攻击"/>
-        <string name="h21" value="消费MP32，造成伤害101%，5次攻击"/>
-        <string name="h22" value="消费MP32，造成伤害102%，5次攻击"/>
-        <string name="h23" value="消费MP32，造成伤害103%，5次攻击"/>
-        <string name="h24" value="消费MP32，造成伤害104%，5次攻击"/>
-        <string name="h25" value="消费MP32，造成伤害105%，5次攻击"/>
-        <string name="h26" value="消费MP32，造成伤害106%，5次攻击"/>
-        <string name="h27" value="消费MP32，造成伤害107%，5次攻击"/>
-        <string name="h28" value="消费MP32，造成伤害108%，5次攻击"/>
-        <string name="h29" value="消费MP32，造成伤害109%，5次攻击"/>
-        <string name="h3" value="消费MP26，造成伤害83%，5次攻击"/>
-        <string name="h30" value="消费MP32，造成伤害110%，5次攻击"/>
-        <string name="h4" value="消费MP26，造成伤害84%，5次攻击"/>
-        <string name="h5" value="消费MP26，造成伤害85%，5次攻击"/>
-        <string name="h6" value="消费MP26，造成伤害86%，5次攻击"/>
-        <string name="h7" value="消费MP26，造成伤害87%，5次攻击"/>
-        <string name="h8" value="消费MP26，造成伤害88%，5次攻击"/>
-        <string name="h9" value="消费MP26，造成伤害89%，5次攻击"/>
+        <string name="h1" value="消耗MP 26，每支箭伤害 71%，攻击 4次"/>
+        <string name="h10" value="消耗MP 26，每支箭伤害 80%，攻击 4次"/>
+        <string name="h11" value="消耗MP 26，每支箭伤害 81%，攻击 4次"/>
+        <string name="h12" value="消耗MP 26，每支箭伤害 82%，攻击 4次"/>
+        <string name="h13" value="消耗MP 26，每支箭伤害 83%，攻击 4次"/>
+        <string name="h14" value="消耗MP 26，每支箭伤害 84%，攻击 4次"/>
+        <string name="h15" value="消耗MP 26，每支箭伤害 85%，攻击 4次"/>
+        <string name="h16" value="消耗MP 32，每支箭伤害 86%，攻击 4次"/>
+        <string name="h17" value="消耗MP 32，每支箭伤害 87%，攻击 4次"/>
+        <string name="h18" value="消耗MP 32，每支箭伤害 88%，攻击 4次"/>
+        <string name="h19" value="消耗MP 32，每支箭伤害 89%，攻击 4次"/>
+        <string name="h2" value="消耗MP 26，每支箭伤害 72%，攻击 4次"/>
+        <string name="h20" value="消耗MP 32，每支箭伤害 90%，攻击 4次"/>
+        <string name="h21" value="消耗MP 32，每支箭伤害 91%，攻击 4次"/>
+        <string name="h22" value="消耗MP 32，每支箭伤害 92%，攻击 4次"/>
+        <string name="h23" value="消耗MP 32，每支箭伤害 93%，攻击 4次"/>
+        <string name="h24" value="消耗MP 32，每支箭伤害 94%，攻击 4次"/>
+        <string name="h25" value="消耗MP 32，每支箭伤害 95%，攻击 4次"/>
+        <string name="h26" value="消耗MP 32，每支箭伤害 96%，攻击 4次"/>
+        <string name="h27" value="消耗MP 32，每支箭伤害 97%，攻击 4次"/>
+        <string name="h28" value="消耗MP 32，每支箭伤害 98%，攻击 4次"/>
+        <string name="h29" value="消耗MP 32，每支箭伤害 99%，攻击 4次"/>
+        <string name="h3" value="消耗MP 26，每支箭伤害 73%，攻击 4次"/>
+        <string name="h30" value="消耗MP 32，每支箭伤害 100%，攻击 4次"/>
+        <string name="h4" value="消耗MP 26，每支箭伤害 74%，攻击 4次"/>
+        <string name="h5" value="消耗MP 26，每支箭伤害 75%，攻击 4次"/>
+        <string name="h6" value="消耗MP 26，每支箭伤害 76%，攻击 4次"/>
+        <string name="h7" value="消耗MP 26，每支箭伤害 77%，攻击 4次"/>
+        <string name="h8" value="消耗MP 26，每支箭伤害 78%，攻击 4次"/>
+        <string name="h9" value="消耗MP 26，每支箭伤害 79%，攻击 4次"/>
         <string name="desc" value="[最高等级 : 30]\n连续射出4支箭攻击1个敌人。"/>
     </imgdir>
     <imgdir name="322">
@@ -9501,249 +9501,249 @@
     </imgdir>
     <imgdir name="3221000">
         <string name="name" value="冒险岛勇士"/>
-        <string name="h1" value="消耗MP 10，30秒内所有的属性点提高 1%"/>
-        <string name="h10" value="消耗MP 20，300秒内所有的属性点提高 5%"/>
-        <string name="h11" value="消耗MP 30，330秒内所有的属性点提高 6%"/>
-        <string name="h12" value="消耗MP 30，360秒内所有的属性点提高 6%"/>
-        <string name="h13" value="消耗MP 30，390秒内所有的属性点提高 7%"/>
-        <string name="h14" value="消耗MP 30，420秒内所有的属性点提高 7%"/>
-        <string name="h15" value="消耗MP 30，450秒内所有的属性点提高 8%"/>
-        <string name="h16" value="消耗MP 40，480秒内所有的属性点提高 8%"/>
-        <string name="h17" value="消耗MP 40，510秒内所有的属性点提高 9%"/>
-        <string name="h18" value="消耗MP 40，540秒内所有的属性点提高 9%"/>
-        <string name="h19" value="消耗MP 40，570秒内所有的属性点提高 10%"/>
-        <string name="h2" value="消耗MP 10，60秒内所有的属性点提高 1%"/>
-        <string name="h20" value="消耗MP 40，600秒内所有的属性点提高 10%"/>
-        <string name="h21" value="消耗MP 50，630秒内所有的属性点提高 11%"/>
-        <string name="h22" value="消耗MP 50，660秒内所有的属性点提高 11%"/>
-        <string name="h23" value="消耗MP 50，690秒内所有的属性点提高 12%"/>
-        <string name="h24" value="消耗MP 50，720秒内所有的属性点提高 12%"/>
-        <string name="h25" value="消耗MP 50，750秒内所有的属性点提高 13%"/>
-        <string name="h26" value="消耗MP 60，780秒内所有的属性点提高 13%"/>
-        <string name="h27" value="消耗MP 60，810秒内所有的属性点提高 14%"/>
-        <string name="h28" value="消耗MP 60，840秒内所有的属性点提高 14%"/>
-        <string name="h29" value="消耗MP 60，870秒内所有的属性点提高 15%"/>
-        <string name="h3" value="消耗MP 10，90秒内所有的属性点提高 2%"/>
-        <string name="h30" value="消耗MP 60，900秒内所有的属性点提高 15%"/>
-        <string name="h4" value="消耗MP 10，120秒内所有的属性点提高 2%"/>
-        <string name="h5" value="消耗MP 10，150秒内所有的属性点提高 3%"/>
-        <string name="h6" value="消耗MP 20，180秒内所有的属性点提高 3%"/>
-        <string name="h7" value="消耗MP 20，210秒内所有的属性点提高 4%"/>
-        <string name="h8" value="消耗MP 20，240秒内所有的属性点提高 4%"/>
-        <string name="h9" value="消耗MP 20，270秒内所有的属性点提高 5%"/>
+        <string name="h1" value="消耗MP 10，所有属性 +1%，持续 30秒"/>
+        <string name="h10" value="消耗MP 20，所有属性 +5%，持续 300秒"/>
+        <string name="h11" value="消耗MP 30，所有属性 +6%，持续 330秒"/>
+        <string name="h12" value="消耗MP 30，所有属性 +6%，持续 360秒"/>
+        <string name="h13" value="消耗MP 30，所有属性 +7%，持续 390秒"/>
+        <string name="h14" value="消耗MP 30，所有属性 +7%，持续 420秒"/>
+        <string name="h15" value="消耗MP 30，所有属性 +8%，持续 450秒"/>
+        <string name="h16" value="消耗MP 40，所有属性 +8%，持续 480秒"/>
+        <string name="h17" value="消耗MP 40，所有属性 +9%，持续 510秒"/>
+        <string name="h18" value="消耗MP 40，所有属性 +9%，持续 540秒"/>
+        <string name="h19" value="消耗MP 40，所有属性 +10%，持续 570秒"/>
+        <string name="h2" value="消耗MP 10，所有属性 +1%，持续 60秒"/>
+        <string name="h20" value="消耗MP 40，所有属性 +10%，持续 600秒"/>
+        <string name="h21" value="消耗MP 50，所有属性 +11%，持续 630秒"/>
+        <string name="h22" value="消耗MP 50，所有属性 +11%，持续 660秒"/>
+        <string name="h23" value="消耗MP 50，所有属性 +12%，持续 690秒"/>
+        <string name="h24" value="消耗MP 50，所有属性 +12%，持续 720秒"/>
+        <string name="h25" value="消耗MP 50，所有属性 +13%，持续 750秒"/>
+        <string name="h26" value="消耗MP 60，所有属性 +13%，持续 780秒"/>
+        <string name="h27" value="消耗MP 60，所有属性 +14%，持续 810秒"/>
+        <string name="h28" value="消耗MP 60，所有属性 +14%，持续 840秒"/>
+        <string name="h29" value="消耗MP 60，所有属性 +15%，持续 870秒"/>
+        <string name="h3" value="消耗MP 10，所有属性 +2%，持续 90秒"/>
+        <string name="h30" value="消耗MP 60，所有属性 +15%，持续 900秒"/>
+        <string name="h4" value="消耗MP 10，所有属性 +2%，持续 120秒"/>
+        <string name="h5" value="消耗MP 10，所有属性 +3%，持续 150秒"/>
+        <string name="h6" value="消耗MP 20，所有属性 +3%，持续 180秒"/>
+        <string name="h7" value="消耗MP 20，所有属性 +4%，持续 210秒"/>
+        <string name="h8" value="消耗MP 20，所有属性 +4%，持续 240秒"/>
+        <string name="h9" value="消耗MP 20，所有属性 +5%，持续 270秒"/>
         <string name="desc" value="在一定时间内按百分比提高自己和队员的全部属性。"/>
     </imgdir>
     <imgdir name="3221001">
         <string name="name" value="穿透箭"/>
-        <string name="h1" value="消耗MP18，最大攻击力 320%，最多攻击6只"/>
-        <string name="h10" value="消耗MP18，最大攻击力 500%，最多攻击6只"/>
-        <string name="h11" value="消耗MP28，最大攻击力 520%，最多攻击6只"/>
-        <string name="h12" value="消耗MP28，最大攻击力 540%，最多攻击6只"/>
-        <string name="h13" value="消耗MP28，最大攻击力 560%，最多攻击6只"/>
-        <string name="h14" value="消耗MP28，最大攻击力 580%，最多攻击6只"/>
-        <string name="h15" value="消耗MP28，最大攻击力 600%，最多攻击6只"/>
-        <string name="h16" value="消耗MP28，最大攻击力 620%，最多攻击6只"/>
-        <string name="h17" value="消耗MP28，最大攻击力 640%，最多攻击6只"/>
-        <string name="h18" value="消耗MP28，最大攻击力 660%，最多攻击6只"/>
-        <string name="h19" value="消耗MP28，最大攻击力 680%，最多攻击6只"/>
-        <string name="h2" value="消耗MP18，最大攻击力 340%，最多攻击6只"/>
-        <string name="h20" value="消耗MP28，最大攻击力 700%，最多攻击6只"/>
-        <string name="h21" value="消耗MP38，最大攻击力 715%，最多攻击6只"/>
-        <string name="h22" value="消耗MP38，最大攻击力 730%，最多攻击6只"/>
-        <string name="h23" value="消耗MP38，最大攻击力 745%，最多攻击6只"/>
-        <string name="h24" value="消耗MP38，最大攻击力 760%，最多攻击6只"/>
-        <string name="h25" value="消耗MP38，最大攻击力 775%，最多攻击6只"/>
-        <string name="h26" value="消耗MP37，最大攻击力 790%，最多攻击6只"/>
-        <string name="h27" value="消耗MP36，最大攻击力 805%，最多攻击6只"/>
-        <string name="h28" value="消耗MP35，最大攻击力 820%，最多攻击6只"/>
-        <string name="h29" value="消耗MP34，最大攻击力 835%，最多攻击6只"/>
-        <string name="h3" value="消耗MP18，最大攻击力 360%，最多攻击6只"/>
-        <string name="h30" value="消耗MP33，最大攻击力 850%，最多攻击6只"/>
-        <string name="h4" value="消耗MP18，最大攻击力 380%，最多攻击6只"/>
-        <string name="h5" value="消耗MP18，最大攻击力 400%，最多攻击6只"/>
-        <string name="h6" value="消耗MP18，最大攻击力 420%，最多攻击6只"/>
-        <string name="h7" value="消耗MP18，最大攻击力 440%，最多攻击6只"/>
-        <string name="h8" value="消耗MP18，最大攻击力 460%，最多攻击6只"/>
-        <string name="h9" value="消耗MP18，最大攻击力 480%，最多攻击6只"/>
+        <string name="h1" value="消耗MP 18，蓄力最高伤害 320%，最多攻击 4个敌人"/>
+        <string name="h10" value="消耗MP 18，蓄力最高伤害 500%，最多攻击 4个敌人"/>
+        <string name="h11" value="消耗MP 28，蓄力最高伤害 520%，最多攻击 5个敌人"/>
+        <string name="h12" value="消耗MP 28，蓄力最高伤害 540%，最多攻击 5个敌人"/>
+        <string name="h13" value="消耗MP 28，蓄力最高伤害 560%，最多攻击 5个敌人"/>
+        <string name="h14" value="消耗MP 28，蓄力最高伤害 580%，最多攻击 5个敌人"/>
+        <string name="h15" value="消耗MP 28，蓄力最高伤害 600%，最多攻击 5个敌人"/>
+        <string name="h16" value="消耗MP 28，蓄力最高伤害 620%，最多攻击 5个敌人"/>
+        <string name="h17" value="消耗MP 28，蓄力最高伤害 640%，最多攻击 5个敌人"/>
+        <string name="h18" value="消耗MP 28，蓄力最高伤害 660%，最多攻击 5个敌人"/>
+        <string name="h19" value="消耗MP 28，蓄力最高伤害 680%，最多攻击 5个敌人"/>
+        <string name="h2" value="消耗MP 18，蓄力最高伤害 340%，最多攻击 4个敌人"/>
+        <string name="h20" value="消耗MP 28，蓄力最高伤害 700%，最多攻击 5个敌人"/>
+        <string name="h21" value="消耗MP 38，蓄力最高伤害 715%，最多攻击 6个敌人"/>
+        <string name="h22" value="消耗MP 38，蓄力最高伤害 730%，最多攻击 6个敌人"/>
+        <string name="h23" value="消耗MP 38，蓄力最高伤害 745%，最多攻击 6个敌人"/>
+        <string name="h24" value="消耗MP 38，蓄力最高伤害 760%，最多攻击 6个敌人"/>
+        <string name="h25" value="消耗MP 38，蓄力最高伤害 775%，最多攻击 6个敌人"/>
+        <string name="h26" value="消耗MP 37，蓄力最高伤害 790%，最多攻击 6个敌人"/>
+        <string name="h27" value="消耗MP 36，蓄力最高伤害 805%，最多攻击 6个敌人"/>
+        <string name="h28" value="消耗MP 35，蓄力最高伤害 820%，最多攻击 6个敌人"/>
+        <string name="h29" value="消耗MP 34，蓄力最高伤害 835%，最多攻击 6个敌人"/>
+        <string name="h3" value="消耗MP 18，蓄力最高伤害 360%，最多攻击 4个敌人"/>
+        <string name="h30" value="消耗MP 33，蓄力最高伤害 850%，最多攻击 6个敌人"/>
+        <string name="h4" value="消耗MP 18，蓄力最高伤害 380%，最多攻击 4个敌人"/>
+        <string name="h5" value="消耗MP 18，蓄力最高伤害 400%，最多攻击 4个敌人"/>
+        <string name="h6" value="消耗MP 18，蓄力最高伤害 420%，最多攻击 4个敌人"/>
+        <string name="h7" value="消耗MP 18，蓄力最高伤害 440%，最多攻击 4个敌人"/>
+        <string name="h8" value="消耗MP 18，蓄力最高伤害 460%，最多攻击 4个敌人"/>
+        <string name="h9" value="消耗MP 18，蓄力最高伤害 480%，最多攻击 4个敌人"/>
         <string name="desc" value="发射可持续蓄力的贯穿箭，最多攻击多个敌人；穿透目标越多，箭矢威力越强。"/>
     </imgdir>
     <imgdir name="3221002">
         <string name="name" value="火眼晶晶"/>
-        <string name="h1" value="消耗MP 29，持续时间 10秒，1%的必杀几率，伤害 11% 上升"/>
-        <string name="h10" value="消耗MP 29，持续时间 100秒，5%的必杀几率，伤害 20% 上升"/>
-        <string name="h11" value="消耗MP 37，持续时间 110秒，6%的必杀几率，伤害 21% 上升"/>
-        <string name="h12" value="消耗MP 37，持续时间 120秒，6%的必杀几率，伤害 22% 上升"/>
-        <string name="h13" value="消耗MP 37，持续时间 130秒，7%的必杀几率，伤害 23% 上升"/>
-        <string name="h14" value="消耗MP 37，持续时间 140秒，7%的必杀几率，伤害 24% 上升"/>
-        <string name="h15" value="消耗MP 37，持续时间 150秒，8%的必杀几率，伤害 25% 上升"/>
-        <string name="h16" value="消耗MP 37，持续时间 160秒，8%的必杀几率，伤害 26% 上升"/>
-        <string name="h17" value="消耗MP 37，持续时间 170秒，9%的必杀几率，伤害 27% 上升"/>
-        <string name="h18" value="消耗MP 37，持续时间 180秒，9%的必杀几率，伤害 28% 上升"/>
-        <string name="h19" value="消耗MP 37，持续时间 190秒，10%的必杀几率，伤害 29% 上升"/>
-        <string name="h2" value="消耗MP 29，持续时间 20秒，1%的必杀几率，伤害 12% 上升"/>
-        <string name="h20" value="消耗MP 37，持续时间 200秒，10%的必杀几率，伤害 30% 上升"/>
-        <string name="h21" value="消耗MP 45，持续时间 210秒，11%的必杀几率，伤害 31% 上升"/>
-        <string name="h22" value="消耗MP 45，持续时间 220秒，11%的必杀几率，伤害 32% 上升"/>
-        <string name="h23" value="消耗MP 45，持续时间 230秒，12%的必杀几率，伤害 33% 上升"/>
-        <string name="h24" value="消耗MP 45，持续时间 240秒，12%的必杀几率，伤害 34% 上升"/>
-        <string name="h25" value="消耗MP 45，持续时间 250秒，13%的必杀几率，伤害 35% 上升"/>
-        <string name="h26" value="消耗MP 44，持续时间 260秒，13%的必杀几率，伤害 36% 上升"/>
-        <string name="h27" value="消耗MP 43，持续时间 270秒，14%的必杀几率，伤害 37% 上升"/>
-        <string name="h28" value="消耗MP 42，持续时间 280秒，14%的必杀几率，伤害 38% 上升"/>
-        <string name="h29" value="消耗MP 41，持续时间 290秒，15%的必杀几率，伤害 39% 上升"/>
-        <string name="h3" value="消耗MP 29，持续时间 30秒，2%的必杀几率，伤害 13% 上升"/>
-        <string name="h30" value="消耗MP 40，持续时间 300秒，15%的必杀几率，伤害 40% 上升"/>
-        <string name="h4" value="消耗MP 29，持续时间 40秒，2%的必杀几率，伤害 14% 上升"/>
-        <string name="h5" value="消耗MP 29，持续时间 50秒，3%的必杀几率，伤害 15% 上升"/>
-        <string name="h6" value="消耗MP 29，持续时间 60秒，3%的必杀几率，伤害 16% 上升"/>
-        <string name="h7" value="消耗MP 29，持续时间 70秒，4%的必杀几率，伤害 17% 上升"/>
-        <string name="h8" value="消耗MP 29，持续时间 80秒，4%的必杀几率，伤害 18% 上升"/>
-        <string name="h9" value="消耗MP 29，持续时间 90秒，5%的必杀几率，伤害 19% 上升"/>
+        <string name="h1" value="消耗MP 29，暴击率 +1%，暴击伤害 +11%，持续 10秒"/>
+        <string name="h10" value="消耗MP 29，暴击率 +5%，暴击伤害 +20%，持续 100秒"/>
+        <string name="h11" value="消耗MP 37，暴击率 +6%，暴击伤害 +21%，持续 110秒"/>
+        <string name="h12" value="消耗MP 37，暴击率 +6%，暴击伤害 +22%，持续 120秒"/>
+        <string name="h13" value="消耗MP 37，暴击率 +7%，暴击伤害 +23%，持续 130秒"/>
+        <string name="h14" value="消耗MP 37，暴击率 +7%，暴击伤害 +24%，持续 140秒"/>
+        <string name="h15" value="消耗MP 37，暴击率 +8%，暴击伤害 +25%，持续 150秒"/>
+        <string name="h16" value="消耗MP 37，暴击率 +8%，暴击伤害 +26%，持续 160秒"/>
+        <string name="h17" value="消耗MP 37，暴击率 +9%，暴击伤害 +27%，持续 170秒"/>
+        <string name="h18" value="消耗MP 37，暴击率 +9%，暴击伤害 +28%，持续 180秒"/>
+        <string name="h19" value="消耗MP 37，暴击率 +10%，暴击伤害 +29%，持续 190秒"/>
+        <string name="h2" value="消耗MP 29，暴击率 +1%，暴击伤害 +12%，持续 20秒"/>
+        <string name="h20" value="消耗MP 37，暴击率 +10%，暴击伤害 +30%，持续 200秒"/>
+        <string name="h21" value="消耗MP 45，暴击率 +11%，暴击伤害 +31%，持续 210秒"/>
+        <string name="h22" value="消耗MP 45，暴击率 +11%，暴击伤害 +32%，持续 220秒"/>
+        <string name="h23" value="消耗MP 45，暴击率 +12%，暴击伤害 +33%，持续 230秒"/>
+        <string name="h24" value="消耗MP 45，暴击率 +12%，暴击伤害 +34%，持续 240秒"/>
+        <string name="h25" value="消耗MP 45，暴击率 +13%，暴击伤害 +35%，持续 250秒"/>
+        <string name="h26" value="消耗MP 44，暴击率 +13%，暴击伤害 +36%，持续 260秒"/>
+        <string name="h27" value="消耗MP 43，暴击率 +14%，暴击伤害 +37%，持续 270秒"/>
+        <string name="h28" value="消耗MP 42，暴击率 +14%，暴击伤害 +38%，持续 280秒"/>
+        <string name="h29" value="消耗MP 41，暴击率 +15%，暴击伤害 +39%，持续 290秒"/>
+        <string name="h3" value="消耗MP 29，暴击率 +2%，暴击伤害 +13%，持续 30秒"/>
+        <string name="h30" value="消耗MP 40，暴击率 +15%，暴击伤害 +40%，持续 300秒"/>
+        <string name="h4" value="消耗MP 29，暴击率 +2%，暴击伤害 +14%，持续 40秒"/>
+        <string name="h5" value="消耗MP 29，暴击率 +3%，暴击伤害 +15%，持续 50秒"/>
+        <string name="h6" value="消耗MP 29，暴击率 +3%，暴击伤害 +16%，持续 60秒"/>
+        <string name="h7" value="消耗MP 29，暴击率 +4%，暴击伤害 +17%，持续 70秒"/>
+        <string name="h8" value="消耗MP 29，暴击率 +4%，暴击伤害 +18%，持续 80秒"/>
+        <string name="h9" value="消耗MP 29，暴击率 +5%，暴击伤害 +19%，持续 90秒"/>
         <string name="desc" value="在一定时间内提高自己和队员造成暴击的概率与暴击伤害。"/>
     </imgdir>
     <imgdir name="3221003">
         <string name="name" value="飞龙冲击波"/>
-        <string name="h1" value="消耗MP 24，攻击力 42%，最大攻击6只"/>
-        <string name="h10" value="消耗MP 24，攻击力 60%，最大攻击6只"/>
-        <string name="h11" value="消耗MP 30，攻击力 62%，最大攻击6只"/>
-        <string name="h12" value="消耗MP 30，攻击力 64%，最大攻击6只"/>
-        <string name="h13" value="消耗MP 30，攻击力 66%，最大攻击6只"/>
-        <string name="h14" value="消耗MP 30，攻击力 68%，最大攻击6只"/>
-        <string name="h15" value="消耗MP 30，攻击力 70%，最大攻击6只"/>
-        <string name="h16" value="消耗MP 30，攻击力 72%，最大攻击6只"/>
-        <string name="h17" value="消耗MP 30，攻击力 74%，最大攻击6只"/>
-        <string name="h18" value="消耗MP 30，攻击力 76%，最大攻击6只"/>
-        <string name="h19" value="消耗MP 30，攻击力 78%，最大攻击6只"/>
-        <string name="h2" value="消耗MP 24，攻击力 44%，最大攻击6只"/>
-        <string name="h20" value="消耗MP 30，攻击力 80%，最大攻击6只"/>
-        <string name="h21" value="消耗MP 36，攻击力 82%，最大攻击6只"/>
-        <string name="h22" value="消耗MP 36，攻击力 84%，最大攻击6只"/>
-        <string name="h23" value="消耗MP 36，攻击力 86%，最大攻击6只"/>
-        <string name="h24" value="消耗MP 36，攻击力 88%，最大攻击6只"/>
-        <string name="h25" value="消耗MP 36，攻击力 90%，最大攻击6只"/>
-        <string name="h26" value="消耗MP 36，攻击力 92%，最大攻击6只"/>
-        <string name="h27" value="消耗MP 36，攻击力 94%，最大攻击6只"/>
-        <string name="h28" value="消耗MP 36，攻击力 96%，最大攻击6只"/>
-        <string name="h29" value="消耗MP 36，攻击力 98%，最大攻击6只"/>
-        <string name="h3" value="消耗MP 24，攻击力 46%，最大攻击6只"/>
-        <string name="h30" value="消耗MP 36，攻击力 100%，最大攻击6只"/>
-        <string name="h4" value="消耗MP 24，攻击力 48%，最大攻击6只"/>
-        <string name="h5" value="消耗MP 24，攻击力 50%，最大攻击6只"/>
-        <string name="h6" value="消耗MP 24，攻击力 52%，最大攻击6只"/>
-        <string name="h7" value="消耗MP 24，攻击力 54%，最大攻击6只"/>
-        <string name="h8" value="消耗MP 24，攻击力 56%，最大攻击6只"/>
-        <string name="h9" value="消耗MP 24，攻击力 58%，最大攻击6只"/>
+        <string name="h1" value="消耗MP 24，伤害 42%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h10" value="消耗MP 24，伤害 60%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h11" value="消耗MP 30，伤害 62%，最多攻击 5个敌人"/>
+        <string name="h12" value="消耗MP 30，伤害 64%，最多攻击 5个敌人"/>
+        <string name="h13" value="消耗MP 30，伤害 66%，最多攻击 5个敌人"/>
+        <string name="h14" value="消耗MP 30，伤害 68%，最多攻击 5个敌人"/>
+        <string name="h15" value="消耗MP 30，伤害 70%，最多攻击 5个敌人"/>
+        <string name="h16" value="消耗MP 30，伤害 72%，最多攻击 5个敌人"/>
+        <string name="h17" value="消耗MP 30，伤害 74%，最多攻击 5个敌人"/>
+        <string name="h18" value="消耗MP 30，伤害 76%，最多攻击 5个敌人"/>
+        <string name="h19" value="消耗MP 30，伤害 78%，最多攻击 5个敌人"/>
+        <string name="h2" value="消耗MP 24，伤害 44%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h20" value="消耗MP 30，伤害 80%，最多攻击 5个敌人"/>
+        <string name="h21" value="消耗MP 36，伤害 82%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h22" value="消耗MP 36，伤害 84%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h23" value="消耗MP 36，伤害 86%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h24" value="消耗MP 36，伤害 88%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h25" value="消耗MP 36，伤害 90%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h26" value="消耗MP 36，伤害 92%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h27" value="消耗MP 36，伤害 94%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h28" value="消耗MP 36，伤害 96%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h29" value="消耗MP 36，伤害 98%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h3" value="消耗MP 24，伤害 46%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h30" value="消耗MP 36，伤害 100%，最多攻击 6个敌人，100%几率击退"/>
+        <string name="h4" value="消耗MP 24，伤害 48%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h5" value="消耗MP 24，伤害 50%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h6" value="消耗MP 24，伤害 52%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h7" value="消耗MP 24，伤害 54%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h8" value="消耗MP 24，伤害 56%，最多攻击 4个敌人，100%几率击退"/>
+        <string name="h9" value="消耗MP 24，伤害 58%，最多攻击 4个敌人，100%几率击退"/>
         <string name="desc" value="以龙之气息射出强力箭矢，攻击前方多个敌人并将其击退。"/>
     </imgdir>
     <imgdir name="3221005">
         <string name="name" value="冰凤凰"/>
-        <string name="h1" value="消耗MP 42，攻击力 255，持续时间 113秒"/>
-        <string name="h10" value="消耗MP 60，攻击力 300，持续时间 140秒"/>
-        <string name="h11" value="消耗MP 62，攻击力 355，持续时间 143秒"/>
-        <string name="h12" value="消耗MP 64，攻击力 360，持续时间 146秒"/>
-        <string name="h13" value="消耗MP 66，攻击力 365，持续时间 149秒"/>
-        <string name="h14" value="消耗MP 68，攻击力 370，持续时间 152秒"/>
-        <string name="h15" value="消耗MP 70，攻击力 375，持续时间 155秒"/>
-        <string name="h16" value="消耗MP 72，攻击力 380，持续时间 158秒"/>
-        <string name="h17" value="消耗MP 74，攻击力 385，持续时间 161秒"/>
-        <string name="h18" value="消耗MP 76，攻击力 390，持续时间 164秒"/>
-        <string name="h19" value="消耗MP 78，攻击力 395，持续时间 167秒"/>
-        <string name="h2" value="消耗MP 44，攻击力 260，持续时间 116秒"/>
-        <string name="h20" value="消耗MP 80，攻击力 400，持续时间 170秒"/>
-        <string name="h21" value="消耗MP 82，攻击力 455，持续时间 173秒"/>
-        <string name="h22" value="消耗MP 84，攻击力 460，持续时间 176秒"/>
-        <string name="h23" value="消耗MP 86，攻击力 465，持续时间 179秒"/>
-        <string name="h24" value="消耗MP 88，攻击力 470，持续时间 182秒"/>
-        <string name="h25" value="消耗MP 90，攻击力 475，持续时间 185秒"/>
-        <string name="h26" value="消耗MP 92，攻击力 480，持续时间 188秒"/>
-        <string name="h27" value="消耗MP 94，攻击力 485，持续时间 191秒"/>
-        <string name="h28" value="消耗MP 96，攻击力 490，持续时间 194秒"/>
-        <string name="h29" value="消耗MP 98，攻击力 495，持续时间 197秒"/>
-        <string name="h3" value="消耗MP 46，攻击力 265，持续时间 119秒"/>
-        <string name="h30" value="消耗MP 100，攻击力 500，持续时间 200秒"/>
-        <string name="h4" value="消耗MP 48，攻击力 270，持续时间 122秒"/>
-        <string name="h5" value="消耗MP 50，攻击力 275，持续时间 125秒"/>
-        <string name="h6" value="消耗MP 52，攻击力 280，持续时间 128秒"/>
-        <string name="h7" value="消耗MP 54，攻击力 285，持续时间 131秒"/>
-        <string name="h8" value="消耗MP 56，攻击力 290，持续时间 134秒"/>
-        <string name="h9" value="消耗MP 58，攻击力 295，持续时间 137秒"/>
+        <string name="h1" value="消耗MP 42，召唤冰凤凰 113秒，攻击力 255"/>
+        <string name="h10" value="消耗MP 60，召唤冰凤凰 140秒，攻击力 300"/>
+        <string name="h11" value="消耗MP 62，召唤冰凤凰 143秒，攻击力 355"/>
+        <string name="h12" value="消耗MP 64，召唤冰凤凰 146秒，攻击力 360"/>
+        <string name="h13" value="消耗MP 66，召唤冰凤凰 149秒，攻击力 365"/>
+        <string name="h14" value="消耗MP 68，召唤冰凤凰 152秒，攻击力 370"/>
+        <string name="h15" value="消耗MP 70，召唤冰凤凰 155秒，攻击力 375"/>
+        <string name="h16" value="消耗MP 72，召唤冰凤凰 158秒，攻击力 380"/>
+        <string name="h17" value="消耗MP 74，召唤冰凤凰 161秒，攻击力 385"/>
+        <string name="h18" value="消耗MP 76，召唤冰凤凰 164秒，攻击力 390"/>
+        <string name="h19" value="消耗MP 78，召唤冰凤凰 167秒，攻击力 395"/>
+        <string name="h2" value="消耗MP 44，召唤冰凤凰 116秒，攻击力 260"/>
+        <string name="h20" value="消耗MP 80，召唤冰凤凰 170秒，攻击力 400"/>
+        <string name="h21" value="消耗MP 82，召唤冰凤凰 173秒，攻击力 455"/>
+        <string name="h22" value="消耗MP 84，召唤冰凤凰 176秒，攻击力 460"/>
+        <string name="h23" value="消耗MP 86，召唤冰凤凰 179秒，攻击力 465"/>
+        <string name="h24" value="消耗MP 88，召唤冰凤凰 182秒，攻击力 470"/>
+        <string name="h25" value="消耗MP 90，召唤冰凤凰 185秒，攻击力 475"/>
+        <string name="h26" value="消耗MP 92，召唤冰凤凰 188秒，攻击力 480"/>
+        <string name="h27" value="消耗MP 94，召唤冰凤凰 191秒，攻击力 485"/>
+        <string name="h28" value="消耗MP 96，召唤冰凤凰 194秒，攻击力 490"/>
+        <string name="h29" value="消耗MP 98，召唤冰凤凰 197秒，攻击力 495"/>
+        <string name="h3" value="消耗MP 46，召唤冰凤凰 119秒，攻击力 265"/>
+        <string name="h30" value="消耗MP 100，召唤冰凤凰 200秒，攻击力 500"/>
+        <string name="h4" value="消耗MP 48，召唤冰凤凰 122秒，攻击力 270"/>
+        <string name="h5" value="消耗MP 50，召唤冰凤凰 125秒，攻击力 275"/>
+        <string name="h6" value="消耗MP 52，召唤冰凤凰 128秒，攻击力 280"/>
+        <string name="h7" value="消耗MP 54，召唤冰凤凰 131秒，攻击力 285"/>
+        <string name="h8" value="消耗MP 56，召唤冰凤凰 134秒，攻击力 290"/>
+        <string name="h9" value="消耗MP 58，召唤冰凤凰 137秒，攻击力 295"/>
         <string name="desc" value="召唤冰凤凰，在一定时间内攻击最多4个敌人。\n需要技能 : #c金鹰召唤 15级以上#"/>
     </imgdir>
     <imgdir name="3221006">
         <string name="name" value="致盲箭"/>
-        <string name="h1" value="消耗MP 12，35秒内 11%的几率 5秒间敌人命中率 -1%"/>
-        <string name="h10" value="消耗MP 12，80秒内 20%的几率 5秒间敌人命中率 -10%"/>
-        <string name="h11" value="消耗MP 24，85秒内 21%的几率 10秒间敌人命中率 -11%"/>
-        <string name="h12" value="消耗MP 24，90秒内 22%的几率 10秒间敌人命中率 -12%"/>
-        <string name="h13" value="消耗MP 24，95秒内 23%的几率 10秒间敌人命中率 -13%"/>
-        <string name="h14" value="消耗MP 24，100秒内 24%的几率 10秒间敌人命中率 -14%"/>
-        <string name="h15" value="消耗MP 24，105秒内 25%的几率 10秒间敌人命中率 -15%"/>
-        <string name="h16" value="消耗MP 24，110秒内 26%的几率 10秒间敌人命中率 -16%"/>
-        <string name="h17" value="消耗MP 24，115秒内 27%的几率 10秒间敌人命中率 -17%"/>
-        <string name="h18" value="消耗MP 24，120秒内 28%的几率 10秒间敌人命中率 -18%"/>
-        <string name="h19" value="消耗MP 24，125秒内 29%的几率 10秒间敌人命中率 -19%"/>
-        <string name="h2" value="消耗MP 12，40秒内 12%的几率 5秒间敌人命中率 -2%"/>
-        <string name="h20" value="消耗MP 24，130秒内 30%的几率 10秒间敌人命中率 -20%"/>
-        <string name="h21" value="消耗MP 36，135秒内 31%的几率 15秒间敌人命中率 -21%"/>
-        <string name="h22" value="消耗MP 36，140秒内 32%的几率 15秒间敌人命中率 -22%"/>
-        <string name="h23" value="消耗MP 36，145秒内 33%的几率 15秒间敌人命中率 -23%"/>
-        <string name="h24" value="消耗MP 36，150秒内 34%的几率 15秒间敌人命中率 -24%"/>
-        <string name="h25" value="消耗MP 35，155秒内 35%的几率 15秒间敌人命中率 -25%"/>
-        <string name="h26" value="消耗MP 34，160秒内 36%的几率 15秒间敌人命中率 -26%"/>
-        <string name="h27" value="消耗MP 33，165秒内 37%的几率 15秒间敌人命中率 -27%"/>
-        <string name="h28" value="消耗MP 32，170秒内 38%的几率 15秒间敌人命中率 -28%"/>
-        <string name="h29" value="消耗MP 31，175秒内 39%的几率 15秒间敌人命中率 -29%"/>
-        <string name="h3" value="消耗MP 12，45秒内 13%的几率 5秒间敌人命中率 -3%"/>
-        <string name="h30" value="消耗MP 30，180秒内 40%的几率 15秒间敌人命中率 -30%"/>
-        <string name="h4" value="消耗MP 12，50秒内 14%的几率 5秒间敌人命中率 -4%"/>
-        <string name="h5" value="消耗MP 12，55秒内 15%的几率 5秒间敌人命中率 -5%"/>
-        <string name="h6" value="消耗MP 12，60秒内 16%的几率 5秒间敌人命中率 -6%"/>
-        <string name="h7" value="消耗MP 12，65秒内 17%的几率 5秒间敌人命中率 -7%"/>
-        <string name="h8" value="消耗MP 12，70秒内 18%的几率 5秒间敌人命中率 -8%"/>
-        <string name="h9" value="消耗MP 12，75秒内 19%的几率 5秒间敌人命中率 -9%"/>
+        <string name="h1" value="消耗MP 12，35秒内有 11%几率使敌人命中率 -1%，持续 5秒"/>
+        <string name="h10" value="消耗MP 12，80秒内有 20%几率使敌人命中率 -10%，持续 5秒"/>
+        <string name="h11" value="消耗MP 24，85秒内有 21%几率使敌人命中率 -11%，持续 10秒"/>
+        <string name="h12" value="消耗MP 24，90秒内有 22%几率使敌人命中率 -12%，持续 10秒"/>
+        <string name="h13" value="消耗MP 24，95秒内有 23%几率使敌人命中率 -13%，持续 10秒"/>
+        <string name="h14" value="消耗MP 24，100秒内有 24%几率使敌人命中率 -14%，持续 10秒"/>
+        <string name="h15" value="消耗MP 24，105秒内有 25%几率使敌人命中率 -15%，持续 10秒"/>
+        <string name="h16" value="消耗MP 24，110秒内有 26%几率使敌人命中率 -16%，持续 10秒"/>
+        <string name="h17" value="消耗MP 24，115秒内有 27%几率使敌人命中率 -17%，持续 10秒"/>
+        <string name="h18" value="消耗MP 24，120秒内有 28%几率使敌人命中率 -18%，持续 10秒"/>
+        <string name="h19" value="消耗MP 24，125秒内有 29%几率使敌人命中率 -19%，持续 10秒"/>
+        <string name="h2" value="消耗MP 12，40秒内有 12%几率使敌人命中率 -2%，持续 5秒"/>
+        <string name="h20" value="消耗MP 24，130秒内有 30%几率使敌人命中率 -20%，持续 10秒"/>
+        <string name="h21" value="消耗MP 36，135秒内有 31%几率使敌人命中率 -21%，持续 15秒"/>
+        <string name="h22" value="消耗MP 36，140秒内有 32%几率使敌人命中率 -22%，持续 15秒"/>
+        <string name="h23" value="消耗MP 36，145秒内有 33%几率使敌人命中率 -23%，持续 15秒"/>
+        <string name="h24" value="消耗MP 36，150秒内有 34%几率使敌人命中率 -24%，持续 15秒"/>
+        <string name="h25" value="消耗MP 35，155秒内有 35%几率使敌人命中率 -25%，持续 15秒"/>
+        <string name="h26" value="消耗MP 34，160秒内有 36%几率使敌人命中率 -26%，持续 15秒"/>
+        <string name="h27" value="消耗MP 33，165秒内有 37%几率使敌人命中率 -27%，持续 15秒"/>
+        <string name="h28" value="消耗MP 32，170秒内有 38%几率使敌人命中率 -28%，持续 15秒"/>
+        <string name="h29" value="消耗MP 31，175秒内有 39%几率使敌人命中率 -29%，持续 15秒"/>
+        <string name="h3" value="消耗MP 12，45秒内有 13%几率使敌人命中率 -3%，持续 5秒"/>
+        <string name="h30" value="消耗MP 30，180秒内有 40%几率使敌人命中率 -30%，持续 15秒"/>
+        <string name="h4" value="消耗MP 12，50秒内有 14%几率使敌人命中率 -4%，持续 5秒"/>
+        <string name="h5" value="消耗MP 12，55秒内有 15%几率使敌人命中率 -5%，持续 5秒"/>
+        <string name="h6" value="消耗MP 12，60秒内有 16%几率使敌人命中率 -6%，持续 5秒"/>
+        <string name="h7" value="消耗MP 12，65秒内有 17%几率使敌人命中率 -7%，持续 5秒"/>
+        <string name="h8" value="消耗MP 12，70秒内有 18%几率使敌人命中率 -8%，持续 5秒"/>
+        <string name="h9" value="消耗MP 12，75秒内有 19%几率使敌人命中率 -9%，持续 5秒"/>
         <string name="desc" value="有一定概率使敌人视野受阻，在一定时间内降低其命中率。"/>
     </imgdir>
     <imgdir name="3221007">
         <string name="name" value="一击要害箭"/>
-        <string name="h1" value="消耗MP 40 , 冷却时间 250秒"/>
-        <string name="h2" value="消耗MP 39 , 冷却时间 240秒"/>
-        <string name="h3" value="消耗MP 38 , 冷却时间 230秒"/>
-        <string name="h4" value="消耗MP 37 , 冷却时间 220秒"/>
-        <string name="h5" value="消耗MP 36 , 冷却时间 210秒"/>
-        <string name="h6" value="消耗MP 35 , 冷却时间 200秒"/>
-        <string name="h7" value="消耗MP 34 , 冷却时间 190秒"/>
-        <string name="h8" value="消耗MP 33 , 冷却时间 180秒"/>
-        <string name="h9" value="消耗MP 32 , 冷却时间 170秒"/>
-        <string name="h10" value="消耗MP 31 , 冷却时间 160秒"/>
-        <string name="h11" value="消耗MP 30 , 冷却时间 150秒"/>
-        <string name="h12" value="消耗MP 29 , 冷却时间 140秒"/>
-        <string name="h13" value="消耗MP 28 , 冷却时间 130秒"/>
-        <string name="h14" value="消耗MP 27 , 冷却时间 120秒"/>
-        <string name="h15" value="消耗MP 26 , 冷却时间 110秒"/>
-        <string name="h16" value="消耗MP 25 , 冷却时间 100秒"/>
-        <string name="h17" value="消耗MP 24 , 冷却时间 90秒"/>
-        <string name="h18" value="消耗MP 23 , 冷却时间 80秒"/>
-        <string name="h19" value="消耗MP 22 , 冷却时间 70秒"/>
-        <string name="h20" value="消耗MP 21 , 冷却时间 60秒"/>
-        <string name="h21" value="消耗MP 20 , 冷却时间 50秒"/>
-        <string name="h22" value="消耗MP 19 , 冷却时间 45秒"/>
-        <string name="h23" value="消耗MP 18 , 冷却时间 40秒"/>
-        <string name="h24" value="消耗MP 17 , 冷却时间 35秒"/>
-        <string name="h25" value="消耗MP 16 , 冷却时间 30秒"/>
-        <string name="h26" value="消耗MP 15 , 冷却时间 25秒"/>
-        <string name="h27" value="消耗MP 14 , 冷却时间 20秒"/>
-        <string name="h28" value="消耗MP 13 , 冷却时间 15秒"/>
-        <string name="h29" value="消耗MP 12 , 冷却时间 10秒"/>
-        <string name="h30" value="消耗MP 11 , 冷却时间 5秒"/>
-        <string name="desc" value="瞄准敌人要害发动致命一击，造成极高固定伤害。"/>
+        <string name="h1" value="消耗MP 40，固定伤害 195000-199999，冷却 250秒"/>
+        <string name="h2" value="消耗MP 39，固定伤害 195000-199999，冷却 240秒"/>
+        <string name="h3" value="消耗MP 38，固定伤害 195000-199999，冷却 230秒"/>
+        <string name="h4" value="消耗MP 37，固定伤害 195000-199999，冷却 220秒"/>
+        <string name="h5" value="消耗MP 36，固定伤害 195000-199999，冷却 210秒"/>
+        <string name="h6" value="消耗MP 35，固定伤害 195000-199999，冷却 200秒"/>
+        <string name="h7" value="消耗MP 34，固定伤害 195000-199999，冷却 190秒"/>
+        <string name="h8" value="消耗MP 33，固定伤害 195000-199999，冷却 180秒"/>
+        <string name="h9" value="消耗MP 32，固定伤害 195000-199999，冷却 170秒"/>
+        <string name="h10" value="消耗MP 31，固定伤害 195000-199999，冷却 160秒"/>
+        <string name="h11" value="消耗MP 30，固定伤害 195000-199999，冷却 150秒"/>
+        <string name="h12" value="消耗MP 29，固定伤害 195000-199999，冷却 140秒"/>
+        <string name="h13" value="消耗MP 28，固定伤害 195000-199999，冷却 130秒"/>
+        <string name="h14" value="消耗MP 27，固定伤害 195000-199999，冷却 120秒"/>
+        <string name="h15" value="消耗MP 26，固定伤害 195000-199999，冷却 110秒"/>
+        <string name="h16" value="消耗MP 25，固定伤害 195000-199999，冷却 100秒"/>
+        <string name="h17" value="消耗MP 24，固定伤害 195000-199999，冷却 90秒"/>
+        <string name="h18" value="消耗MP 23，固定伤害 195000-199999，冷却 80秒"/>
+        <string name="h19" value="消耗MP 22，固定伤害 195000-199999，冷却 70秒"/>
+        <string name="h20" value="消耗MP 21，固定伤害 195000-199999，冷却 60秒"/>
+        <string name="h21" value="消耗MP 20，固定伤害 195000-199999，冷却 50秒"/>
+        <string name="h22" value="消耗MP 19，固定伤害 195000-199999，冷却 45秒"/>
+        <string name="h23" value="消耗MP 18，固定伤害 195000-199999，冷却 40秒"/>
+        <string name="h24" value="消耗MP 17，固定伤害 195000-199999，冷却 35秒"/>
+        <string name="h25" value="消耗MP 16，固定伤害 195000-199999，冷却 30秒"/>
+        <string name="h26" value="消耗MP 15，固定伤害 195000-199999，冷却 25秒"/>
+        <string name="h27" value="消耗MP 14，固定伤害 195000-199999，冷却 20秒"/>
+        <string name="h28" value="消耗MP 13，固定伤害 195000-199999，冷却 15秒"/>
+        <string name="h29" value="消耗MP 12，固定伤害 195000-199999，冷却 10秒"/>
+        <string name="h30" value="消耗MP 11，固定伤害 195000-199999，冷却 4秒"/>
+        <string name="desc" value="瞄准敌人要害发动致命一击，造成195000-199999固定伤害。"/>
     </imgdir>
     <imgdir name="3221008">
         <string name="name" value="勇士的意志"/>
-        <string name="h1" value="消耗MP 30，解除诱惑异常状态，冷却时间10分钟"/>
-        <string name="h2" value="消耗MP 30，解除诱惑异常状态，冷却时间9分钟"/>
-        <string name="h3" value="消耗MP 30，解除诱惑异常状态，冷却时间8分钟"/>
-        <string name="h4" value="消耗MP 30，解除诱惑异常状态，冷却时间7分钟"/>
-        <string name="h5" value="消耗MP 30，解除诱惑异常状态，冷却时间6分钟"/>
+        <string name="h1" value="消耗MP 30，解除异常状态，冷却 600秒"/>
+        <string name="h2" value="消耗MP 30，解除异常状态，冷却 540秒"/>
+        <string name="h3" value="消耗MP 30，解除异常状态，冷却 480秒"/>
+        <string name="h4" value="消耗MP 30，解除异常状态，冷却 420秒"/>
+        <string name="h5" value="消耗MP 30，解除异常状态，冷却 360秒"/>
         <string name="desc" value="解除异常状态。随着技能等级提高，冷却时间缩短。"/>
     </imgdir>
     <imgdir name="400">

--- a/gms-server/wz-zh-CN/String.wz/Skill.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Skill.img.xml
@@ -8618,7 +8618,7 @@
         <string name="desc" value="[最高等级 : 20]\n提高移动速度。"/>
     </imgdir>
     <imgdir name="3110001">
-        <string name="name" value="致命箭"/>
+        <string name="name" value="贯穿箭"/>
         <string name="h1" value="33%几率发动，造成伤害110%，假如对方HP在20%以下时1%几率出现必杀"/>
         <string name="h10" value="60%几率发动，造成伤害200%，假如敌的HP在35%以下时5%几率出现必杀怪物"/>
         <string name="h11" value="63%几率发动，造成伤害205%，假如敌的HP在35%以下时6%几率出现必杀怪物"/>
@@ -8731,7 +8731,7 @@
         <string name="h7" value="消费MP18，造成伤害191%"/>
         <string name="h8" value="消费MP18，造成伤害194%"/>
         <string name="h9" value="消费MP18，造成伤害197%"/>
-        <string name="desc" value="[最高等级 : 30]\n向空中射出大量箭矢，攻击最多6个敌人。\n必须装备弓。\n需要技能 : #c致命箭 5级以上#"/>
+        <string name="desc" value="[最高等级 : 30]\n向空中射出大量箭矢，攻击最多6个敌人。\n必须装备弓。\n需要技能 : #c贯穿箭 5级以上#"/>
     </imgdir>
     <imgdir name="3111005">
         <string name="name" value="银鹰召唤"/>
@@ -9008,7 +9008,7 @@
         <string name="desc" value="召唤火凤凰，在一定时间内攻击最多4个敌人。\n需要技能 : #c银鹰召唤 15级以上#"/>
     </imgdir>
     <imgdir name="3121007">
-        <string name="name" value="牵制箭"/>
+        <string name="name" value="击退箭"/>
         <string name="h1" value="消耗MP 12，35秒内 11%的几率 5秒间 敌人移动速度 -2"/>
         <string name="h10" value="消耗MP 12，80秒内 20%的几率 5秒间 敌人移动速度 -20"/>
         <string name="h11" value="消耗MP 24，85秒内 21%的几率 10秒间 敌人移动速度 -22"/>
@@ -9279,7 +9279,7 @@
         <string name="desc" value="[最高等级 : 20]\n提高移动速度。"/>
     </imgdir>
     <imgdir name="3210001">
-        <string name="name" value="致命箭"/>
+        <string name="name" value="贯穿箭"/>
         <string name="h1" value="33%几率发动，造成伤害110%，假如对方HP在20%以下时1%几率出现必杀"/>
         <string name="h10" value="60%几率发动，造成伤害200%，假如敌的HP在35%以下时5%几率出现必杀怪物"/>
         <string name="h11" value="63%几率发动，造成伤害205%，假如敌的HP在35%以下时6%几率出现必杀怪物"/>
@@ -9392,7 +9392,7 @@
         <string name="h7" value="消费MP18，造成伤害171%"/>
         <string name="h8" value="消费MP18，造成伤害174%"/>
         <string name="h9" value="消费MP18，造成伤害177%"/>
-        <string name="desc" value="[最高等级 : 30]\n向地面发射箭矢后爆发攻击，最多攻击6个敌人。\n必须装备弩。\n需要技能 : #c致命箭 5级以上#"/>
+        <string name="desc" value="[最高等级 : 30]\n向地面发射箭矢后爆发攻击，最多攻击6个敌人。\n必须装备弩。\n需要技能 : #c贯穿箭 5级以上#"/>
     </imgdir>
     <imgdir name="3211005">
         <string name="name" value="金鹰召唤"/>

--- a/gms-server/wz/String.wz/Skill.img.xml
+++ b/gms-server/wz/String.wz/Skill.img.xml
@@ -330,26 +330,26 @@
   <imgdir name="3000001">
     <string name="name" value="Critical Shot"/>
     <string name="desc" value="[Master Level : 20]\nGrants a chance to inflict a critical hit, increasing damage."/>
-    <string name="h1" value="12% success rate, critical damage 105%"/>
-    <string name="h2" value="14% success rate, critical damage 110%"/>
-    <string name="h3" value="16% success rate, critical damage 115%"/>
-    <string name="h4" value="18% success rate, critical damage 120%"/>
-    <string name="h5" value="20% success rate, critical damage 125%"/>
-    <string name="h6" value="22% success rate, critical damage 130%"/>
-    <string name="h7" value="24% success rate, critical damage 135%"/>
-    <string name="h8" value="26% success rate, critical damage 140%"/>
-    <string name="h9" value="28% success rate, critical damage 145%"/>
-    <string name="h10" value="30% success rate, critical damage 150%"/>
-    <string name="h11" value="31% success rate, critical damage 155%"/>
-    <string name="h12" value="32% success rate, critical damage 160%"/>
-    <string name="h13" value="33% success rate, critical damage 165%"/>
-    <string name="h14" value="34% success rate, critical damage 170%"/>
-    <string name="h15" value="35% success rate, critical damage 175%"/>
-    <string name="h16" value="36% success rate, critical damage 180%"/>
-    <string name="h17" value="37% success rate, critical damage 185%"/>
-    <string name="h18" value="38% success rate, critical damage 190%"/>
-    <string name="h19" value="39% success rate, critical damage 195%"/>
-    <string name="h20" value="40% success rate, critical damage 200%"/>
+    <string name="h1" value="Critical chance 12% and critical damage 105%"/>
+    <string name="h2" value="Critical chance 14% and critical damage 110%"/>
+    <string name="h3" value="Critical chance 16% and critical damage 115%"/>
+    <string name="h4" value="Critical chance 18% and critical damage 120%"/>
+    <string name="h5" value="Critical chance 20% and critical damage 125%"/>
+    <string name="h6" value="Critical chance 22% and critical damage 130%"/>
+    <string name="h7" value="Critical chance 24% and critical damage 135%"/>
+    <string name="h8" value="Critical chance 26% and critical damage 140%"/>
+    <string name="h9" value="Critical chance 28% and critical damage 145%"/>
+    <string name="h10" value="Critical chance 30% and critical damage 150%"/>
+    <string name="h11" value="Critical chance 31% and critical damage 155%"/>
+    <string name="h12" value="Critical chance 32% and critical damage 160%"/>
+    <string name="h13" value="Critical chance 33% and critical damage 165%"/>
+    <string name="h14" value="Critical chance 34% and critical damage 170%"/>
+    <string name="h15" value="Critical chance 35% and critical damage 175%"/>
+    <string name="h16" value="Critical chance 36% and critical damage 180%"/>
+    <string name="h17" value="Critical chance 37% and critical damage 185%"/>
+    <string name="h18" value="Critical chance 38% and critical damage 190%"/>
+    <string name="h19" value="Critical chance 39% and critical damage 195%"/>
+    <string name="h20" value="Critical chance 40% and critical damage 200%"/>
   </imgdir>
   <imgdir name="3000002">
     <string name="name" value="The Eye of Amazon"/>
@@ -366,74 +366,74 @@
   <imgdir name="3001003">
     <string name="name" value="Focus"/>
     <string name="desc" value="[Master Level : 20]\nTemporarily increases Accuracy and Avoidability.\nRequired Skill : #cThe Blessing of Amazon Lv. 3 or higher#"/>
-    <string name="h1" value="MP -8; accuracy +1, avoidability +1 for 70 sec. "/>
-    <string name="h2" value="MP -8; accuracy +2, avoidability +2 for 80 sec. "/>
-    <string name="h3" value="MP -8; accuracy +3, avoidability +3 for 90 sec. "/>
-    <string name="h4" value="MP -8; accuracy +4, avoidability +4 for 100 sec. "/>
-    <string name="h5" value="MP -8; accuracy +5, avoidability +5 for 110 sec. "/>
-    <string name="h6" value="MP -10; accuracy +6, avoidability +6 for 130 sec. "/>
-    <string name="h7" value="MP -10; accuracy +7, avoidability +7 for 140 sec. "/>
-    <string name="h8" value="MP -10; accuracy +8, avoidability +8 for 150 sec. "/>
-    <string name="h9" value="MP -10; accuracy +9, avoidability +9 for 160 sec. "/>
-    <string name="h10" value="MP -10; accuracy +10, avoidability +10 for 170 sec. "/>
-    <string name="h11" value="MP -13; accuracy +11, avoidability +11 for 195 sec. "/>
-    <string name="h12" value="MP -13; accuracy +12, avoidability +12 for 205 sec."/>
-    <string name="h13" value="MP -13; accuracy +13, avoidability +13 for 215 sec."/>
-    <string name="h14" value="MP -13; accuracy +14, avoidability +14 for 225 sec."/>
-    <string name="h15" value="MP -13; accuracy +15, avoidability +15 for 235 sec."/>
-    <string name="h16" value="MP -16; accuracy +16, avoidability +16 for 260 sec."/>
-    <string name="h17" value="MP -16; accuracy +17, avoidability +17 for 270 sec."/>
-    <string name="h18" value="MP -16; accuracy +18, avoidability +18 for 280 sec."/>
-    <string name="h19" value="MP -16; accuracy +19, avoidability +19 for 290 sec."/>
-    <string name="h20" value="MP -16; accuracy +20, avoidability +20 for 300 sec."/>
+    <string name="h1" value="MP -8; Accuracy +1, Avoidability +1 for 70 sec"/>
+    <string name="h2" value="MP -8; Accuracy +2, Avoidability +2 for 80 sec"/>
+    <string name="h3" value="MP -8; Accuracy +3, Avoidability +3 for 90 sec"/>
+    <string name="h4" value="MP -8; Accuracy +4, Avoidability +4 for 100 sec"/>
+    <string name="h5" value="MP -8; Accuracy +5, Avoidability +5 for 110 sec"/>
+    <string name="h6" value="MP -10; Accuracy +6, Avoidability +6 for 130 sec"/>
+    <string name="h7" value="MP -10; Accuracy +7, Avoidability +7 for 140 sec"/>
+    <string name="h8" value="MP -10; Accuracy +8, Avoidability +8 for 150 sec"/>
+    <string name="h9" value="MP -10; Accuracy +9, Avoidability +9 for 160 sec"/>
+    <string name="h10" value="MP -10; Accuracy +10, Avoidability +10 for 170 sec"/>
+    <string name="h11" value="MP -13; Accuracy +11, Avoidability +11 for 195 sec"/>
+    <string name="h12" value="MP -13; Accuracy +12, Avoidability +12 for 205 sec"/>
+    <string name="h13" value="MP -13; Accuracy +13, Avoidability +13 for 215 sec"/>
+    <string name="h14" value="MP -13; Accuracy +14, Avoidability +14 for 225 sec"/>
+    <string name="h15" value="MP -13; Accuracy +15, Avoidability +15 for 235 sec"/>
+    <string name="h16" value="MP -16; Accuracy +16, Avoidability +16 for 260 sec"/>
+    <string name="h17" value="MP -16; Accuracy +17, Avoidability +17 for 270 sec"/>
+    <string name="h18" value="MP -16; Accuracy +18, Avoidability +18 for 280 sec"/>
+    <string name="h19" value="MP -16; Accuracy +19, Avoidability +19 for 290 sec"/>
+    <string name="h20" value="MP -16; Accuracy +20, Avoidability +20 for 300 sec"/>
   </imgdir>
   <imgdir name="3001004">
     <string name="name" value="Arrow Blow"/>
     <string name="desc" value="[Master Level : 20]\nFires a powerful arrow at 1 enemy for increased damage."/>
-    <string name="h1" value="MP -7; damage 141%"/>
-    <string name="h2" value="MP -7; damage 146%"/>
-    <string name="h3" value="MP -7; damage 151%"/>
-    <string name="h4" value="MP -7; damage 156%"/>
-    <string name="h5" value="MP -7; damage 164%"/>
-    <string name="h6" value="MP -7; damage 169%"/>
-    <string name="h7" value="MP -7; damage 174%"/>
-    <string name="h8" value="MP -8; damage 182%"/>
-    <string name="h9" value="MP -8; damage 187%"/>
-    <string name="h10" value="MP -9; damage 195%"/>
-    <string name="h11" value="MP -9; damage 200%"/>
-    <string name="h12" value="MP -10; damage 208%"/>
-    <string name="h13" value="MP -10; damage 213%"/>
-    <string name="h14" value="MP -11; damage 221%"/>
-    <string name="h15" value="MP -11; damage 226%"/>
-    <string name="h16" value="MP -12; damage 234%"/>
-    <string name="h17" value="MP -12; damage 239%"/>
-    <string name="h18" value="MP -13; damage 247%"/>
-    <string name="h19" value="MP -13; damage 252%"/>
-    <string name="h20" value="MP -14; damage 260%"/>
+    <string name="h1" value="MP -7; Damage 190%"/>
+    <string name="h2" value="MP -8; Damage 193%"/>
+    <string name="h3" value="MP -8; Damage 196%"/>
+    <string name="h4" value="MP -8; Damage 200%"/>
+    <string name="h5" value="MP -9; Damage 203%"/>
+    <string name="h6" value="MP -9; Damage 206%"/>
+    <string name="h7" value="MP -9; Damage 210%"/>
+    <string name="h8" value="MP -10; Damage 213%"/>
+    <string name="h9" value="MP -10; Damage 216%"/>
+    <string name="h10" value="MP -10; Damage 220%"/>
+    <string name="h11" value="MP -11; Damage 223%"/>
+    <string name="h12" value="MP -11; Damage 226%"/>
+    <string name="h13" value="MP -11; Damage 230%"/>
+    <string name="h14" value="MP -12; Damage 233%"/>
+    <string name="h15" value="MP -12; Damage 236%"/>
+    <string name="h16" value="MP -12; Damage 240%"/>
+    <string name="h17" value="MP -13; Damage 243%"/>
+    <string name="h18" value="MP -13; Damage 248%"/>
+    <string name="h19" value="MP -13; Damage 253%"/>
+    <string name="h20" value="MP -14; Damage 260%"/>
   </imgdir>
   <imgdir name="3001005">
     <string name="name" value="Double Shot"/>
     <string name="desc" value="[Master Level : 20]\nFires 2 arrows at once, hitting 1 enemy twice.\nRequired Skill : #cArrow Blow Lv. 1 or higher#"/>
-    <string name="h1" value="MP -10; damage 92%"/>
-    <string name="h2" value="MP -10; damage 94%"/>
-    <string name="h3" value="MP -10; damage 96%"/>
-    <string name="h4" value="MP -10; damage 98%"/>
-    <string name="h5" value="MP -11; damage 100%"/>
-    <string name="h6" value="MP -11; damage 102%"/>
-    <string name="h7" value="MP -11; damage 104%"/>
-    <string name="h8" value="MP -12; damage 106%"/>
-    <string name="h9" value="MP -12; damage 108%"/>
-    <string name="h10" value="MP -12; damage 110%"/>
-    <string name="h11" value="MP -13; damage 112%"/>
-    <string name="h12" value="MP -13; damage 114%"/>
-    <string name="h13" value="MP -13; damage 116%"/>
-    <string name="h14" value="MP -14; damage 118%"/>
-    <string name="h15" value="MP -14; damage 120%"/>
-    <string name="h16" value="MP -14; damage 122%"/>
-    <string name="h17" value="MP -15; damage 124%"/>
-    <string name="h18" value="MP -15; damage 126%"/>
-    <string name="h19" value="MP -15; damage 128%"/>
-    <string name="h20" value="MP -16; damage 130%"/>
+    <string name="h1" value="MP -10; Damage 92% per arrow, 2 hits"/>
+    <string name="h2" value="MP -10; Damage 94% per arrow, 2 hits"/>
+    <string name="h3" value="MP -10; Damage 96% per arrow, 2 hits"/>
+    <string name="h4" value="MP -10; Damage 98% per arrow, 2 hits"/>
+    <string name="h5" value="MP -11; Damage 100% per arrow, 2 hits"/>
+    <string name="h6" value="MP -11; Damage 102% per arrow, 2 hits"/>
+    <string name="h7" value="MP -11; Damage 104% per arrow, 2 hits"/>
+    <string name="h8" value="MP -12; Damage 106% per arrow, 2 hits"/>
+    <string name="h9" value="MP -12; Damage 108% per arrow, 2 hits"/>
+    <string name="h10" value="MP -12; Damage 110% per arrow, 2 hits"/>
+    <string name="h11" value="MP -13; Damage 112% per arrow, 2 hits"/>
+    <string name="h12" value="MP -13; Damage 114% per arrow, 2 hits"/>
+    <string name="h13" value="MP -13; Damage 116% per arrow, 2 hits"/>
+    <string name="h14" value="MP -14; Damage 118% per arrow, 2 hits"/>
+    <string name="h15" value="MP -14; Damage 120% per arrow, 2 hits"/>
+    <string name="h16" value="MP -14; Damage 122% per arrow, 2 hits"/>
+    <string name="h17" value="MP -15; Damage 124% per arrow, 2 hits"/>
+    <string name="h18" value="MP -15; Damage 126% per arrow, 2 hits"/>
+    <string name="h19" value="MP -15; Damage 128% per arrow, 2 hits"/>
+    <string name="h20" value="MP -16; Damage 130% per arrow, 2 hits"/>
   </imgdir>
   <imgdir name="400">
     <string name="bookName" value="Thief Skills"/>
@@ -1776,142 +1776,142 @@
   <imgdir name="3100001">
     <string name="name" value="Final Attack: Bow"/>
     <string name="desc" value="[Master Level : 30]\nAfter using a bow attack skill, there is a chance to trigger an additional Final Attack.\nRequires a bow.\nRequired Skill : #cBow Mastery Lv. 3 or higher#"/>
-    <string name="h1" value="2% Success rate, final attack with bow damage 105% "/>
-    <string name="h2" value="4% Success rate, final attack with bow damage 110% "/>
-    <string name="h3" value="6% Success rate, final attack with bow damage 115% "/>
-    <string name="h4" value="8% Success rate, final attack with bow damage 120% "/>
-    <string name="h5" value="10% Success rate, final attack with bow damage 125% "/>
-    <string name="h6" value="12% Success rate, final attack with bow damage 130% "/>
-    <string name="h7" value="14% Success rate, final attack with bow damage 135% "/>
-    <string name="h8" value="16% Success rate, final attack with bow damage 140% "/>
-    <string name="h9" value="18% Success rate, final attack with bow damage 145% "/>
-    <string name="h10" value="20% Success rate, final attack with bow damage 150% "/>
-    <string name="h11" value="22% Success rate, final attack with bow damage 155% "/>
-    <string name="h12" value="24% Success rate, final attack with bow damage 160% "/>
-    <string name="h13" value="26% Success rate, final attack with bow damage 165% "/>
-    <string name="h14" value="28% Success rate, final attack with bow damage 170% "/>
-    <string name="h15" value="30% Success rate, final attack with bow damage 175% "/>
-    <string name="h16" value="32% Success rate, final attack with bow damage 180% "/>
-    <string name="h17" value="34% Success rate, final attack with bow damage 185% "/>
-    <string name="h18" value="36% Success rate, final attack with bow damage 190% "/>
-    <string name="h19" value="38% Success rate, final attack with bow damage 195% "/>
-    <string name="h20" value="40% Success rate, final attack with bow damage 200% "/>
-    <string name="h21" value="42% Success rate, final attack with bow damage 205% "/>
-    <string name="h22" value="44% Success rate, final attack with bow damage 210% "/>
-    <string name="h23" value="46% Success rate, final attack with bow damage 215% "/>
-    <string name="h24" value="48% Success rate, final attack with bow damage 220% "/>
-    <string name="h25" value="50% Success rate, final attack with bow damage 225% "/>
-    <string name="h26" value="52% Success rate, final attack with bow damage 230% "/>
-    <string name="h27" value="54% Success rate, final attack with bow damage 235% "/>
-    <string name="h28" value="56% Success rate, final attack with bow damage 240% "/>
-    <string name="h29" value="50% Success rate, final attack with bow damage 245% "/>
-    <string name="h30" value="60% Success rate, final attack with bow damage 250% "/>
+    <string name="h1" value="2% chance, 105% final attack damage with bow"/>
+    <string name="h2" value="4% chance, 110% final attack damage with bow"/>
+    <string name="h3" value="6% chance, 115% final attack damage with bow"/>
+    <string name="h4" value="8% chance, 120% final attack damage with bow"/>
+    <string name="h5" value="10% chance, 125% final attack damage with bow"/>
+    <string name="h6" value="12% chance, 130% final attack damage with bow"/>
+    <string name="h7" value="14% chance, 135% final attack damage with bow"/>
+    <string name="h8" value="16% chance, 140% final attack damage with bow"/>
+    <string name="h9" value="18% chance, 145% final attack damage with bow"/>
+    <string name="h10" value="20% chance, 150% final attack damage with bow"/>
+    <string name="h11" value="22% chance, 155% final attack damage with bow"/>
+    <string name="h12" value="24% chance, 160% final attack damage with bow"/>
+    <string name="h13" value="26% chance, 165% final attack damage with bow"/>
+    <string name="h14" value="28% chance, 170% final attack damage with bow"/>
+    <string name="h15" value="30% chance, 175% final attack damage with bow"/>
+    <string name="h16" value="32% chance, 180% final attack damage with bow"/>
+    <string name="h17" value="34% chance, 185% final attack damage with bow"/>
+    <string name="h18" value="36% chance, 190% final attack damage with bow"/>
+    <string name="h19" value="38% chance, 195% final attack damage with bow"/>
+    <string name="h20" value="40% chance, 200% final attack damage with bow"/>
+    <string name="h21" value="42% chance, 205% final attack damage with bow"/>
+    <string name="h22" value="44% chance, 210% final attack damage with bow"/>
+    <string name="h23" value="46% chance, 215% final attack damage with bow"/>
+    <string name="h24" value="48% chance, 220% final attack damage with bow"/>
+    <string name="h25" value="50% chance, 225% final attack damage with bow"/>
+    <string name="h26" value="52% chance, 230% final attack damage with bow"/>
+    <string name="h27" value="54% chance, 235% final attack damage with bow"/>
+    <string name="h28" value="56% chance, 240% final attack damage with bow"/>
+    <string name="h29" value="58% chance, 245% final attack damage with bow"/>
+    <string name="h30" value="60% chance, 250% final attack damage with bow"/>
   </imgdir>
   <imgdir name="3101002">
     <string name="name" value="Bow Booster"/>
     <string name="desc" value="[Master Level : 20]\nConsumes HP and MP to increase Bow attack speed by 2 stages for a period of time.\nRequires a bow.\nRequired Skill : #cBow Mastery Lv. 5 or higher#"/>
-    <string name="h1" value="HP -29, MP -29; increase in bow attacking speed for 10 sec."/>
-    <string name="h2" value="HP -28, MP -28; increase in bow attacking speed for 20 sec."/>
-    <string name="h3" value="HP -27, MP -27; increase in bow attacking speed for 30 sec."/>
-    <string name="h4" value="HP -26, MP -26; increase in bow attacking speed for 40 sec."/>
-    <string name="h5" value="HP -25, MP -25; increase in bow attacking speed for 50 sec."/>
-    <string name="h6" value="HP -24, MP -24; increase in bow attacking speed for 60 sec."/>
-    <string name="h7" value="HP -23, MP -23; increase in bow attacking speed for 70 sec."/>
-    <string name="h8" value="HP -22, MP -22; increase in bow attacking speed for 80 sec."/>
-    <string name="h9" value="HP -21, MP -21; increase in bow attacking speed for 90 sec."/>
-    <string name="h10" value="HP -20, MP -20; increase in bow attacking speed for 100 sec."/>
-    <string name="h11" value="HP -19, MP -19; increase in bow attacking speed for 110 sec."/>
-    <string name="h12" value="HP -18, MP -18; increase in bow attacking speed for 120 sec."/>
-    <string name="h13" value="HP -17, MP -17; increase in bow attacking speed for 130 sec."/>
-    <string name="h14" value="HP -16, MP -16; increase in bow attacking speed for 140 sec."/>
-    <string name="h15" value="HP -15, MP -15; increase in bow attacking speed for 150 sec."/>
-    <string name="h16" value="HP -14, MP -14; increase in bow attacking speed for 160 sec."/>
-    <string name="h17" value="HP -13, MP -13; increase in bow attacking speed for 170 sec."/>
-    <string name="h18" value="HP -12, MP -12; increase in bow attacking speed for 180 sec."/>
-    <string name="h19" value="HP -11, MP -11; increase in bow attacking speed for 190 sec."/>
-    <string name="h20" value="HP -10, MP -10; increase in bow attacking speed for 200 sec."/>
+    <string name="h1" value="HP -29, MP -29; Bow attack speed +2 stages for 10 sec"/>
+    <string name="h2" value="HP -28, MP -28; Bow attack speed +2 stages for 20 sec"/>
+    <string name="h3" value="HP -27, MP -27; Bow attack speed +2 stages for 30 sec"/>
+    <string name="h4" value="HP -26, MP -26; Bow attack speed +2 stages for 40 sec"/>
+    <string name="h5" value="HP -25, MP -25; Bow attack speed +2 stages for 50 sec"/>
+    <string name="h6" value="HP -24, MP -24; Bow attack speed +2 stages for 60 sec"/>
+    <string name="h7" value="HP -23, MP -23; Bow attack speed +2 stages for 70 sec"/>
+    <string name="h8" value="HP -22, MP -22; Bow attack speed +2 stages for 80 sec"/>
+    <string name="h9" value="HP -21, MP -21; Bow attack speed +2 stages for 90 sec"/>
+    <string name="h10" value="HP -20, MP -20; Bow attack speed +2 stages for 100 sec"/>
+    <string name="h11" value="HP -19, MP -19; Bow attack speed +2 stages for 110 sec"/>
+    <string name="h12" value="HP -18, MP -18; Bow attack speed +2 stages for 120 sec"/>
+    <string name="h13" value="HP -17, MP -17; Bow attack speed +2 stages for 130 sec"/>
+    <string name="h14" value="HP -16, MP -16; Bow attack speed +2 stages for 140 sec"/>
+    <string name="h15" value="HP -15, MP -15; Bow attack speed +2 stages for 150 sec"/>
+    <string name="h16" value="HP -14, MP -14; Bow attack speed +2 stages for 160 sec"/>
+    <string name="h17" value="HP -13, MP -13; Bow attack speed +2 stages for 170 sec"/>
+    <string name="h18" value="HP -12, MP -12; Bow attack speed +2 stages for 180 sec"/>
+    <string name="h19" value="HP -11, MP -11; Bow attack speed +2 stages for 190 sec"/>
+    <string name="h20" value="HP -10, MP -10; Bow attack speed +2 stages for 200 sec"/>
   </imgdir>
   <imgdir name="3101003">
     <string name="name" value="Power Knock-Back"/>
     <string name="desc" value="[Master Level : 20]\nSwings the bow at close range to damage and knock back multiple enemies with a certain success rate."/>
-    <string name="h1" value="MP -8; knock-back +2%, damage 105%, knock-back 2 enemies."/>
-    <string name="h2" value="MP -8; knock-back +4%, damage 110%, knock-back 2 enemies."/>
-    <string name="h3" value="MP -8; knock-back +6%, damage 115%, knock-back 2 enemies."/>
-    <string name="h4" value="MP -8; knock-back +8%, damage 120%, knock-back 2 enemies."/>
-    <string name="h5" value="MP -8; knock-back +10%, damage 125%, knock-back 2 enemies."/>
-    <string name="h6" value="MP -8; knock-back +12%, damage 130%, knock-back 3 enemies."/>
-    <string name="h7" value="MP -8; knock-back +14%, damage 135%, knock-back 3 enemies."/>
-    <string name="h8" value="MP -8; knock-back +16%, damage 140%, knock-back 3 enemies."/>
-    <string name="h9" value="MP -8; knock-back +18%, damage 145%, knock-back 3 enemies."/>
-    <string name="h10" value="MP -8; knock-back +20%, damage 150%, knock-back 3 enemies."/>
-    <string name="h11" value="MP -15; knock-back +22%, damage 155%, knock-back 4 enemies."/>
-    <string name="h12" value="MP -15; knock-back +24%, damage 160%, knock-back 4 enemies."/>
-    <string name="h13" value="MP -15; knock-back +26%, damage 165%, knock-back 4 enemies."/>
-    <string name="h14" value="MP -15; knock-back +28%, damage 170%, knock-back 4 enemies."/>
-    <string name="h15" value="MP -15; knock-back +30%, damage 175%, knock-back 4 enemies."/>
-    <string name="h16" value="MP -15; knock-back +32%, damage 180%, knock-back 5 enemies."/>
-    <string name="h17" value="MP -15; knock-back +34%, damage 185%, knock-back 5 enemies."/>
-    <string name="h18" value="MP -15; knock-back +36%, damage 190%, knock-back 5 enemies."/>
-    <string name="h19" value="MP -15; knock-back +38%, damage 195%, knock-back 5 enemies."/>
-    <string name="h20" value="MP -15; knock-back +40%, damage 200%, knock-back 6 enemies."/>
+    <string name="h1" value="MP -8; 13% chance, Damage 105% against up to 2 enemies"/>
+    <string name="h2" value="MP -8; 16% chance, Damage 110% against up to 2 enemies"/>
+    <string name="h3" value="MP -8; 19% chance, Damage 115% against up to 2 enemies"/>
+    <string name="h4" value="MP -8; 22% chance, Damage 120% against up to 2 enemies"/>
+    <string name="h5" value="MP -8; 25% chance, Damage 125% against up to 2 enemies"/>
+    <string name="h6" value="MP -8; 28% chance, Damage 130% against up to 3 enemies"/>
+    <string name="h7" value="MP -8; 31% chance, Damage 135% against up to 3 enemies"/>
+    <string name="h8" value="MP -8; 34% chance, Damage 140% against up to 3 enemies"/>
+    <string name="h9" value="MP -8; 37% chance, Damage 145% against up to 3 enemies"/>
+    <string name="h10" value="MP -8; 40% chance, Damage 150% against up to 3 enemies"/>
+    <string name="h11" value="MP -15; 43% chance, Damage 155% against up to 4 enemies"/>
+    <string name="h12" value="MP -15; 46% chance, Damage 160% against up to 4 enemies"/>
+    <string name="h13" value="MP -15; 49% chance, Damage 165% against up to 4 enemies"/>
+    <string name="h14" value="MP -15; 52% chance, Damage 170% against up to 4 enemies"/>
+    <string name="h15" value="MP -15; 55% chance, Damage 175% against up to 4 enemies"/>
+    <string name="h16" value="MP -15; 58% chance, Damage 180% against up to 5 enemies"/>
+    <string name="h17" value="MP -15; 61% chance, Damage 185% against up to 5 enemies"/>
+    <string name="h18" value="MP -15; 64% chance, Damage 190% against up to 5 enemies"/>
+    <string name="h19" value="MP -15; 67% chance, Damage 195% against up to 5 enemies"/>
+    <string name="h20" value="MP -15; 70% chance, Damage 200% against up to 6 enemies"/>
   </imgdir>
   <imgdir name="3101004">
     <string name="name" value="Soul Arrow: Bow"/>
     <string name="desc" value="[Master Level : 20]\nTemporarily allows bow attacks without consuming arrows.\nRequires a bow.\nRequired Skill : #cBow Booster Lv. 5 or higher#"/>
-    <string name="h1" value="MP -15; attack for 30 sec without using up an arrow."/>
-    <string name="h2" value="MP -15, attack for 60 sec without using up an arrow."/>
-    <string name="h3" value="MP -15, attack for 90 sec without using up an arrow."/>
-    <string name="h4" value="MP -15, attack for 120 sec without using up an arrow."/>
-    <string name="h5" value="MP -15, attack for 150 sec without using up an arrow."/>
-    <string name="h6" value="MP -15, attack for 180 sec without using up an arrow."/>
-    <string name="h7" value="MP -15, attack for 210 sec without using up an arrow."/>
-    <string name="h8" value="MP -15, attack for 240 sec without using up an arrow."/>
-    <string name="h9" value="MP -15, attack for 270 sec without using up an arrow."/>
-    <string name="h10" value="MP -15, attack for 300 sec without using up an arrow."/>
-    <string name="h11" value="MP -20, attack for 330 sec without using up an arrow."/>
-    <string name="h12" value="MP -20, attack for 360 sec without using up an arrow."/>
-    <string name="h13" value="MP -20, attack for 390 sec without using up an arrow."/>
-    <string name="h14" value="MP -20, attack for 420 sec without using up an arrow."/>
-    <string name="h15" value="MP -20, attack for 450 sec without using up an arrow."/>
-    <string name="h16" value="MP -20, attack for 480 sec without using up an arrow."/>
-    <string name="h17" value="MP -20, attack for 510 sec without using up an arrow."/>
-    <string name="h18" value="MP -20, attack for 540 sec without using up an arrow."/>
-    <string name="h19" value="MP -20, attack for 570 sec without using up an arrow."/>
-    <string name="h20" value="MP -20, attack for 600 sec without using up an arrow."/>
+    <string name="h1" value="MP -15; attack without consuming arrows for 30 sec"/>
+    <string name="h2" value="MP -15; attack without consuming arrows for 60 sec"/>
+    <string name="h3" value="MP -15; attack without consuming arrows for 90 sec"/>
+    <string name="h4" value="MP -15; attack without consuming arrows for 120 sec"/>
+    <string name="h5" value="MP -15; attack without consuming arrows for 150 sec"/>
+    <string name="h6" value="MP -15; attack without consuming arrows for 180 sec"/>
+    <string name="h7" value="MP -15; attack without consuming arrows for 210 sec"/>
+    <string name="h8" value="MP -15; attack without consuming arrows for 240 sec"/>
+    <string name="h9" value="MP -15; attack without consuming arrows for 270 sec"/>
+    <string name="h10" value="MP -15; attack without consuming arrows for 300 sec"/>
+    <string name="h11" value="MP -20; attack without consuming arrows for 330 sec"/>
+    <string name="h12" value="MP -20; attack without consuming arrows for 360 sec"/>
+    <string name="h13" value="MP -20; attack without consuming arrows for 390 sec"/>
+    <string name="h14" value="MP -20; attack without consuming arrows for 420 sec"/>
+    <string name="h15" value="MP -20; attack without consuming arrows for 450 sec"/>
+    <string name="h16" value="MP -20; attack without consuming arrows for 480 sec"/>
+    <string name="h17" value="MP -20; attack without consuming arrows for 510 sec"/>
+    <string name="h18" value="MP -20; attack without consuming arrows for 540 sec"/>
+    <string name="h19" value="MP -20; attack without consuming arrows for 570 sec"/>
+    <string name="h20" value="MP -20; attack without consuming arrows for 600 sec"/>
   </imgdir>
   <imgdir name="3101005">
     <string name="name" value="Arrow Bomb: Bow"/>
     <string name="desc" value="[Master Level : 30]\nFires an explosive arrow at 1 enemy, damaging up to 6 nearby enemies and possibly stunning them.\nRequires a bow."/>
-    <string name="h1" value="MP -14, stunner 31%, damage 72%"/>
-    <string name="h2" value="MP -14, stunner 32%, damage 74%"/>
-    <string name="h3" value="MP -14, stunner 33%, damage 76%"/>
-    <string name="h4" value="MP -14, stunner 34%, damage 78%"/>
-    <string name="h5" value="MP -14, stunner 35%, damage 80%"/>
-    <string name="h6" value="MP -14, stunner 36%, damage 82%"/>
-    <string name="h7" value="MP -14, stunner 37%, damage 84%"/>
-    <string name="h8" value="MP -14, stunner 38%, damage 86%"/>
-    <string name="h9" value="MP -14, stunner 39%, damage 88%"/>
-    <string name="h10" value="MP -14, stunner 40%, damage 90%"/>
-    <string name="h11" value="MP -14, stunner 41%, damage 92%"/>
-    <string name="h12" value="MP -14, stunner 42%, damage 94%"/>
-    <string name="h13" value="MP -14, stunner 43%, damage 96%"/>
-    <string name="h14" value="MP -14, stunner 44%, damage 98%"/>
-    <string name="h15" value="MP -14, stunner 45%, damage 100%"/>
-    <string name="h16" value="MP -28, stunner 46%, damage 102%"/>
-    <string name="h17" value="MP -28, stunner 47%, damage 104%"/>
-    <string name="h18" value="MP -28, stunner 48%, damage 106%"/>
-    <string name="h19" value="MP -28, stunner 49%, damage 108%"/>
-    <string name="h20" value="MP -28, stunner 50%, damage 110%"/>
-    <string name="h21" value="MP -28, stunner 51%, damage 112%"/>
-    <string name="h22" value="MP -28, stunner 52%, damage 114%"/>
-    <string name="h23" value="MP -28, stunner 53%, damage 116%"/>
-    <string name="h24" value="MP -28, stunner 54%, damage 118%"/>
-    <string name="h25" value="MP -28, stunner 55%, damage 120%"/>
-    <string name="h26" value="MP -28, stunner 56%, damage 122%"/>
-    <string name="h27" value="MP -28, stunner 57%, damage 124%"/>
-    <string name="h28" value="MP -28, stunner 58%, damage 126%"/>
-    <string name="h29" value="MP -28, stunner 59%, damage 128%"/>
-    <string name="h30" value="MP -28, stunner 60%, damage 130%"/>
+    <string name="h1" value="MP -14; Damage 72% against up to 6 enemies, 31% stun chance for 2 sec"/>
+    <string name="h2" value="MP -14; Damage 74% against up to 6 enemies, 32% stun chance for 2 sec"/>
+    <string name="h3" value="MP -14; Damage 76% against up to 6 enemies, 33% stun chance for 2 sec"/>
+    <string name="h4" value="MP -14; Damage 78% against up to 6 enemies, 34% stun chance for 2 sec"/>
+    <string name="h5" value="MP -14; Damage 80% against up to 6 enemies, 35% stun chance for 2 sec"/>
+    <string name="h6" value="MP -14; Damage 82% against up to 6 enemies, 36% stun chance for 2 sec"/>
+    <string name="h7" value="MP -14; Damage 84% against up to 6 enemies, 37% stun chance for 2 sec"/>
+    <string name="h8" value="MP -14; Damage 86% against up to 6 enemies, 38% stun chance for 2 sec"/>
+    <string name="h9" value="MP -14; Damage 88% against up to 6 enemies, 39% stun chance for 2 sec"/>
+    <string name="h10" value="MP -14; Damage 90% against up to 6 enemies, 40% stun chance for 2 sec"/>
+    <string name="h11" value="MP -14; Damage 92% against up to 6 enemies, 41% stun chance for 4 sec"/>
+    <string name="h12" value="MP -14; Damage 94% against up to 6 enemies, 42% stun chance for 4 sec"/>
+    <string name="h13" value="MP -14; Damage 96% against up to 6 enemies, 43% stun chance for 4 sec"/>
+    <string name="h14" value="MP -14; Damage 98% against up to 6 enemies, 44% stun chance for 4 sec"/>
+    <string name="h15" value="MP -14; Damage 100% against up to 6 enemies, 45% stun chance for 4 sec"/>
+    <string name="h16" value="MP -28; Damage 102% against up to 6 enemies, 46% stun chance for 4 sec"/>
+    <string name="h17" value="MP -28; Damage 104% against up to 6 enemies, 47% stun chance for 4 sec"/>
+    <string name="h18" value="MP -28; Damage 106% against up to 6 enemies, 48% stun chance for 4 sec"/>
+    <string name="h19" value="MP -28; Damage 108% against up to 6 enemies, 49% stun chance for 4 sec"/>
+    <string name="h20" value="MP -28; Damage 110% against up to 6 enemies, 50% stun chance for 4 sec"/>
+    <string name="h21" value="MP -28; Damage 112% against up to 6 enemies, 51% stun chance for 6 sec"/>
+    <string name="h22" value="MP -28; Damage 114% against up to 6 enemies, 52% stun chance for 6 sec"/>
+    <string name="h23" value="MP -28; Damage 116% against up to 6 enemies, 53% stun chance for 6 sec"/>
+    <string name="h24" value="MP -28; Damage 118% against up to 6 enemies, 54% stun chance for 6 sec"/>
+    <string name="h25" value="MP -28; Damage 120% against up to 6 enemies, 55% stun chance for 6 sec"/>
+    <string name="h26" value="MP -28; Damage 122% against up to 6 enemies, 56% stun chance for 6 sec"/>
+    <string name="h27" value="MP -28; Damage 124% against up to 6 enemies, 57% stun chance for 6 sec"/>
+    <string name="h28" value="MP -28; Damage 126% against up to 6 enemies, 58% stun chance for 6 sec"/>
+    <string name="h29" value="MP -28; Damage 128% against up to 6 enemies, 59% stun chance for 6 sec"/>
+    <string name="h30" value="MP -28; Damage 130% against up to 6 enemies, 60% stun chance for 6 sec"/>
   </imgdir>
   <imgdir name="320">
     <string name="bookName" value="Crossbowman Guide"/>
@@ -1943,142 +1943,142 @@
   <imgdir name="3200001">
     <string name="name" value="Final Attack: Crossbow"/>
     <string name="desc" value="[Master Level : 30]\nAfter using a crossbow attack skill, there is a chance to trigger an additional Final Attack.\nRequires a crossbow.\nRequired Skill : #cCrossbow Mastery Lv. 3 or higher#"/>
-    <string name="h1" value="2% Success rate,\r\nfinal attack with crossbow damage 105% "/>
-    <string name="h2" value="4% Success rate,\r\nfinal attack with crossbow damage 110% "/>
-    <string name="h3" value="6% Success rate,\r\nfinal attack with crossbow damage 115% "/>
-    <string name="h4" value="8% Success rate,\r\nfinal attack with crossbow damage 120% "/>
-    <string name="h5" value="10% Success rate,\r\nfinal attack with crossbow damage 125% "/>
-    <string name="h6" value="12% Success rate,\r\nfinal attack with crossbow damage 130% "/>
-    <string name="h7" value="14% Success rate,\r\nfinal attack with crossbow damage 135% "/>
-    <string name="h8" value="16% Success rate,\r\nfinal attack with crossbow damage 140%"/>
-    <string name="h9" value="18% Success rate,\r\nfinal attack with crossbow damage 145% "/>
-    <string name="h10" value="20% Success rate,\r\nfinal attack with crossbow damage 150% "/>
-    <string name="h11" value="22% Success rate,\r\nfinal attack with crossbow damage 155% "/>
-    <string name="h12" value="24% Success rate,\r\nfinal attack with crossbow damage 160%"/>
-    <string name="h13" value="26% Success rate,\r\nfinal attack with crossbow damage 165% "/>
-    <string name="h14" value="28% Success rate,\r\nfinal attack with crossbow damage 170% "/>
-    <string name="h15" value="30% Success rate,\r\nfinal attack with crossbow damage 175% "/>
-    <string name="h16" value="32% Success rate,\r\nfinal attack with crossbow damage 180% "/>
-    <string name="h17" value="34% Success rate,\r\nfinal attack with crossbow damage 185% "/>
-    <string name="h18" value="36% Success rate,\r\nfinal attack with crossbow damage 190% "/>
-    <string name="h19" value="38% Success rate,\r\nfinal attack with crossbow damage 195% "/>
-    <string name="h20" value="38% Success rate,\r\nfinal attack with crossbow damage 200%"/>
-    <string name="h21" value="42% Success rate,\r\nfinal attack with crossbow damage 205% "/>
-    <string name="h22" value="44% Success rate,\r\nfinal attack with crossbow damage 210% "/>
-    <string name="h23" value="46% Success rate,\r\nfinal attack with crossbow damage 215% "/>
-    <string name="h24" value="48% Success rate,\r\nfinal attack with crossbow damage 220% "/>
-    <string name="h25" value="50% Success rate,\r\nfinal attack with crossbow damage 225% "/>
-    <string name="h26" value="52% Success rate,\r\nfinal attack with crossbow damage 230% "/>
-    <string name="h27" value="54% Success rate,\r\nfinal attack with crossbow damage 235% "/>
-    <string name="h28" value="56% Success rate,\r\nfinal attack with crossbow damage 240% "/>
-    <string name="h29" value="58% Success rate,\r\nfinal attack with crossbow damage 245% "/>
-    <string name="h30" value="60% Success rate,\r\nfinal attack with crossbow damage 250% "/>
+    <string name="h1" value="2% chance, 105% final attack damage with crossbow"/>
+    <string name="h2" value="4% chance, 110% final attack damage with crossbow"/>
+    <string name="h3" value="6% chance, 115% final attack damage with crossbow"/>
+    <string name="h4" value="8% chance, 120% final attack damage with crossbow"/>
+    <string name="h5" value="10% chance, 125% final attack damage with crossbow"/>
+    <string name="h6" value="12% chance, 130% final attack damage with crossbow"/>
+    <string name="h7" value="14% chance, 135% final attack damage with crossbow"/>
+    <string name="h8" value="16% chance, 140% final attack damage with crossbow"/>
+    <string name="h9" value="18% chance, 145% final attack damage with crossbow"/>
+    <string name="h10" value="20% chance, 150% final attack damage with crossbow"/>
+    <string name="h11" value="22% chance, 155% final attack damage with crossbow"/>
+    <string name="h12" value="24% chance, 160% final attack damage with crossbow"/>
+    <string name="h13" value="26% chance, 165% final attack damage with crossbow"/>
+    <string name="h14" value="28% chance, 170% final attack damage with crossbow"/>
+    <string name="h15" value="30% chance, 175% final attack damage with crossbow"/>
+    <string name="h16" value="32% chance, 180% final attack damage with crossbow"/>
+    <string name="h17" value="34% chance, 185% final attack damage with crossbow"/>
+    <string name="h18" value="36% chance, 190% final attack damage with crossbow"/>
+    <string name="h19" value="38% chance, 195% final attack damage with crossbow"/>
+    <string name="h20" value="40% chance, 200% final attack damage with crossbow"/>
+    <string name="h21" value="42% chance, 205% final attack damage with crossbow"/>
+    <string name="h22" value="44% chance, 210% final attack damage with crossbow"/>
+    <string name="h23" value="46% chance, 215% final attack damage with crossbow"/>
+    <string name="h24" value="48% chance, 220% final attack damage with crossbow"/>
+    <string name="h25" value="50% chance, 225% final attack damage with crossbow"/>
+    <string name="h26" value="52% chance, 230% final attack damage with crossbow"/>
+    <string name="h27" value="54% chance, 235% final attack damage with crossbow"/>
+    <string name="h28" value="56% chance, 240% final attack damage with crossbow"/>
+    <string name="h29" value="58% chance, 245% final attack damage with crossbow"/>
+    <string name="h30" value="60% chance, 250% final attack damage with crossbow"/>
   </imgdir>
   <imgdir name="3201002">
     <string name="name" value="Crossbow Booster"/>
     <string name="desc" value="[Master Level : 20]\nConsumes HP and MP to increase Crossbow attack speed by 2 stages for a period of time.\nRequires a crossbow.\nRequired Skill : #cCrossbow Mastery Lv. 5 or higher#"/>
-    <string name="h1" value="HP -29, MP -29; improves crossbow speed for 10 sec."/>
-    <string name="h2" value="HP -28, MP -28; improves crossbow speed for 20 sec."/>
-    <string name="h3" value="HP -27, MP -27; improves crossbow speed for 30 sec."/>
-    <string name="h4" value="HP -26, MP -26; improves crossbow speed for 40 sec."/>
-    <string name="h5" value="HP -25, MP -25; improves crossbow speed for 50 sec."/>
-    <string name="h6" value="HP -24, MP -24; improves crossbow speed for 60 sec."/>
-    <string name="h7" value="HP -23, MP -23; improves crossbow speed for 70 sec."/>
-    <string name="h8" value="HP -22, MP -22; improves crossbow speed for 80 sec."/>
-    <string name="h9" value="HP -21, MP -21; improves crossbow speed for 90 sec."/>
-    <string name="h10" value="HP -20, MP -20; improves crossbow speed for 100 sec."/>
-    <string name="h11" value="HP -19, MP -19; improves crossbow speed for 110 sec."/>
-    <string name="h12" value="HP -18, MP -18; improves crossbow speed for 120 sec."/>
-    <string name="h13" value="HP -17, MP -17; improves crossbow speed for 130 sec."/>
-    <string name="h14" value="HP -16, MP -16; improves crossbow speed for 140 sec."/>
-    <string name="h15" value="HP -15, MP -15; improves crossbow speed for 150 sec."/>
-    <string name="h16" value="HP -14, MP -14; improves crossbow speed for 160 sec."/>
-    <string name="h17" value="HP -13, MP -13; improves crossbow speed for 170 sec."/>
-    <string name="h18" value="HP -12, MP -12; improves crossbow speed for 180 sec."/>
-    <string name="h19" value="HP -11, MP -11; improves crossbow speed for 190 sec."/>
-    <string name="h20" value="HP -10, MP -10; improves crossbow speed for 200 sec."/>
+    <string name="h1" value="HP -29, MP -29; Crossbow attack speed +2 stages for 10 sec"/>
+    <string name="h2" value="HP -28, MP -28; Crossbow attack speed +2 stages for 20 sec"/>
+    <string name="h3" value="HP -27, MP -27; Crossbow attack speed +2 stages for 30 sec"/>
+    <string name="h4" value="HP -26, MP -26; Crossbow attack speed +2 stages for 40 sec"/>
+    <string name="h5" value="HP -25, MP -25; Crossbow attack speed +2 stages for 50 sec"/>
+    <string name="h6" value="HP -24, MP -24; Crossbow attack speed +2 stages for 60 sec"/>
+    <string name="h7" value="HP -23, MP -23; Crossbow attack speed +2 stages for 70 sec"/>
+    <string name="h8" value="HP -22, MP -22; Crossbow attack speed +2 stages for 80 sec"/>
+    <string name="h9" value="HP -21, MP -21; Crossbow attack speed +2 stages for 90 sec"/>
+    <string name="h10" value="HP -20, MP -20; Crossbow attack speed +2 stages for 100 sec"/>
+    <string name="h11" value="HP -19, MP -19; Crossbow attack speed +2 stages for 110 sec"/>
+    <string name="h12" value="HP -18, MP -18; Crossbow attack speed +2 stages for 120 sec"/>
+    <string name="h13" value="HP -17, MP -17; Crossbow attack speed +2 stages for 130 sec"/>
+    <string name="h14" value="HP -16, MP -16; Crossbow attack speed +2 stages for 140 sec"/>
+    <string name="h15" value="HP -15, MP -15; Crossbow attack speed +2 stages for 150 sec"/>
+    <string name="h16" value="HP -14, MP -14; Crossbow attack speed +2 stages for 160 sec"/>
+    <string name="h17" value="HP -13, MP -13; Crossbow attack speed +2 stages for 170 sec"/>
+    <string name="h18" value="HP -12, MP -12; Crossbow attack speed +2 stages for 180 sec"/>
+    <string name="h19" value="HP -11, MP -11; Crossbow attack speed +2 stages for 190 sec"/>
+    <string name="h20" value="HP -10, MP -10; Crossbow attack speed +2 stages for 200 sec"/>
   </imgdir>
   <imgdir name="3201003">
     <string name="name" value="Power Knock-Back"/>
     <string name="desc" value="[Master Level : 20]\nSwings the crossbow at close range to damage and knock back multiple enemies with a certain success rate."/>
-    <string name="h1" value="MP -8; knock-back +2%, damage 105%, knock-back 2 enemies."/>
-    <string name="h2" value="MP -8; knock-back +4%, damage 110%, knock-back 2 enemies."/>
-    <string name="h3" value="MP -8; knock-back +6%, damage 115%, knock-back 2 enemies."/>
-    <string name="h4" value="MP -8; knock-back +8%, damage 120%, knock-back 2 enemies."/>
-    <string name="h5" value="MP -8; knock-back +10%, damage 125%, knock-back 2 enemies."/>
-    <string name="h6" value="MP -8; knock-back +12%, damage 130%, knock-back 3 enemies."/>
-    <string name="h7" value="MP -8; knock-back +14%, damage 135%, knock-back 3 enemies."/>
-    <string name="h8" value="MP -8; knock-back +16%, damage 140%, knock-back 3 enemies."/>
-    <string name="h9" value="MP -8; knock-back +18%, damage 145%, knock-back 3 enemies."/>
-    <string name="h10" value="MP -8; knock-back +20%, damage 150%, knock-back 3 enemies."/>
-    <string name="h11" value="MP -15; knock-back +22%, damage 155%, knock-back 4 enemies."/>
-    <string name="h12" value="MP -15; knock-back +24%, damage 160%, knock-back 4 enemies."/>
-    <string name="h13" value="MP -15; knock-back +26%, damage 165%, knock-back 4 enemies."/>
-    <string name="h14" value="MP -15; knock-back +28%, damage 170%, knock-back 4 enemies."/>
-    <string name="h15" value="MP -15; knock-back +30%, damage 175%, knock-back 4 enemies."/>
-    <string name="h16" value="MP -15; knock-back +32%, damage 180%, knock-back 5 enemies."/>
-    <string name="h17" value="MP -15; knock-back +34%, damage 185%, knock-back 5 enemies."/>
-    <string name="h18" value="MP -15; knock-back +36%, damage 190%, knock-back 5 enemies."/>
-    <string name="h19" value="MP -15; knock-back +38%, damage 195%, knock-back 5 enemies."/>
-    <string name="h20" value="MP -15; knock-back +40%, damage 200%, knock-back 6 enemies."/>
+    <string name="h1" value="MP -8; 13% chance, Damage 105% against up to 2 enemies"/>
+    <string name="h2" value="MP -8; 16% chance, Damage 110% against up to 2 enemies"/>
+    <string name="h3" value="MP -8; 19% chance, Damage 115% against up to 2 enemies"/>
+    <string name="h4" value="MP -8; 22% chance, Damage 120% against up to 2 enemies"/>
+    <string name="h5" value="MP -8; 25% chance, Damage 125% against up to 2 enemies"/>
+    <string name="h6" value="MP -8; 28% chance, Damage 130% against up to 3 enemies"/>
+    <string name="h7" value="MP -8; 31% chance, Damage 135% against up to 3 enemies"/>
+    <string name="h8" value="MP -8; 34% chance, Damage 140% against up to 3 enemies"/>
+    <string name="h9" value="MP -8; 37% chance, Damage 145% against up to 3 enemies"/>
+    <string name="h10" value="MP -8; 40% chance, Damage 150% against up to 3 enemies"/>
+    <string name="h11" value="MP -15; 43% chance, Damage 155% against up to 4 enemies"/>
+    <string name="h12" value="MP -15; 46% chance, Damage 160% against up to 4 enemies"/>
+    <string name="h13" value="MP -15; 49% chance, Damage 165% against up to 4 enemies"/>
+    <string name="h14" value="MP -15; 52% chance, Damage 170% against up to 4 enemies"/>
+    <string name="h15" value="MP -15; 55% chance, Damage 175% against up to 4 enemies"/>
+    <string name="h16" value="MP -15; 58% chance, Damage 180% against up to 5 enemies"/>
+    <string name="h17" value="MP -15; 61% chance, Damage 185% against up to 5 enemies"/>
+    <string name="h18" value="MP -15; 64% chance, Damage 190% against up to 5 enemies"/>
+    <string name="h19" value="MP -15; 67% chance, Damage 195% against up to 5 enemies"/>
+    <string name="h20" value="MP -15; 70% chance, Damage 200% against up to 6 enemies"/>
   </imgdir>
   <imgdir name="3201004">
     <string name="name" value="Soul Arrow: Crossbow"/>
     <string name="desc" value="[Master Level : 20]\nTemporarily allows crossbow attacks without consuming arrows.\nRequires a crossbow.\nRequired Skill : #cCrossbow Booster Lv. 5 or higher#"/>
-    <string name="h1" value="MP -15; attack for 30 sec without using up an arrow."/>
-    <string name="h2" value="MP -15; attack for 60 sec without using up an arrow."/>
-    <string name="h3" value="MP -15; attack for 90 sec without using up an arrow."/>
-    <string name="h4" value="MP -15; attack for 120 sec without using up an arrow."/>
-    <string name="h5" value="MP -15; attack for 150 sec without using up an arrow."/>
-    <string name="h6" value="MP -15; attack for 180 sec without using up an arrow."/>
-    <string name="h7" value="MP -15; attack for 210 sec without using up an arrow."/>
-    <string name="h8" value="MP -15; attack for 240 sec without using up an arrow."/>
-    <string name="h9" value="MP -15; attack for 270 sec without using up an arrow."/>
-    <string name="h10" value="MP -15; attack for 300 sec without using up an arrow."/>
-    <string name="h11" value="MP -20; attack for 330 sec without using up an arrow."/>
-    <string name="h12" value="MP -20; attack for 360 sec without using up an arrow."/>
-    <string name="h13" value="MP -20; attack for 390 sec without using up an arrow."/>
-    <string name="h14" value="MP -20; attack for 420 sec without using up an arrow."/>
-    <string name="h15" value="MP -20; attack for 450 sec without using up an arrow."/>
-    <string name="h16" value="MP -20; attack for 480 sec without using up an arrow."/>
-    <string name="h17" value="MP -20; attack for 510 sec without using up an arrow."/>
-    <string name="h18" value="MP -20; attack for 540 sec without using up an arrow."/>
-    <string name="h19" value="MP -20; attack for 570 sec without using up an arrow."/>
-    <string name="h20" value="MP -20; attack for 600 sec without using up an arrow."/>
+    <string name="h1" value="MP -15; attack without consuming arrows for 30 sec"/>
+    <string name="h2" value="MP -15; attack without consuming arrows for 60 sec"/>
+    <string name="h3" value="MP -15; attack without consuming arrows for 90 sec"/>
+    <string name="h4" value="MP -15; attack without consuming arrows for 120 sec"/>
+    <string name="h5" value="MP -15; attack without consuming arrows for 150 sec"/>
+    <string name="h6" value="MP -15; attack without consuming arrows for 180 sec"/>
+    <string name="h7" value="MP -15; attack without consuming arrows for 210 sec"/>
+    <string name="h8" value="MP -15; attack without consuming arrows for 240 sec"/>
+    <string name="h9" value="MP -15; attack without consuming arrows for 270 sec"/>
+    <string name="h10" value="MP -15; attack without consuming arrows for 300 sec"/>
+    <string name="h11" value="MP -20; attack without consuming arrows for 330 sec"/>
+    <string name="h12" value="MP -20; attack without consuming arrows for 360 sec"/>
+    <string name="h13" value="MP -20; attack without consuming arrows for 390 sec"/>
+    <string name="h14" value="MP -20; attack without consuming arrows for 420 sec"/>
+    <string name="h15" value="MP -20; attack without consuming arrows for 450 sec"/>
+    <string name="h16" value="MP -20; attack without consuming arrows for 480 sec"/>
+    <string name="h17" value="MP -20; attack without consuming arrows for 510 sec"/>
+    <string name="h18" value="MP -20; attack without consuming arrows for 540 sec"/>
+    <string name="h19" value="MP -20; attack without consuming arrows for 570 sec"/>
+    <string name="h20" value="MP -20; attack without consuming arrows for 600 sec"/>
   </imgdir>
   <imgdir name="3201005">
     <string name="name" value="Iron Arrow: Crossbow"/>
     <string name="desc" value="[Master Level : 30]\nFires a powerful piercing arrow that can hit up to 6 enemies; damage decreases as it pierces through targets."/>
-    <string name="h1" value="MP -25, damage 64%"/>
-    <string name="h2" value="MP -25, damage 68%"/>
-    <string name="h3" value="MP -25, damage 72%"/>
-    <string name="h4" value="MP -25, damage 76%"/>
-    <string name="h5" value="MP -25, damage 80%"/>
-    <string name="h6" value="MP -25, damage 84%"/>
-    <string name="h7" value="MP -25, damage 88%"/>
-    <string name="h8" value="MP -25, damage 92%"/>
-    <string name="h9" value="MP -25, damage 96%"/>
-    <string name="h10" value="MP -25, damage 100%"/>
-    <string name="h11" value="MP -25, damage 104%"/>
-    <string name="h12" value="MP -25, damage 108%"/>
-    <string name="h13" value="MP -25, damage 112%"/>
-    <string name="h14" value="MP -25, damage 116%"/>
-    <string name="h15" value="MP -25, damage 120%"/>
-    <string name="h16" value="MP -28, damage 124%"/>
-    <string name="h17" value="MP -28, damage 128%"/>
-    <string name="h18" value="MP -28, damage 132%"/>
-    <string name="h19" value="MP -28, damage 136%"/>
-    <string name="h20" value="MP -28, damage 140%"/>
-    <string name="h21" value="MP -28, damage 144%"/>
-    <string name="h22" value="MP -28, damage 148%"/>
-    <string name="h23" value="MP -28, damage 152%"/>
-    <string name="h24" value="MP -28, damage 156%"/>
-    <string name="h25" value="MP -28, damage 160%"/>
-    <string name="h26" value="MP -28, damage 164%"/>
-    <string name="h27" value="MP -28, damage 168%"/>
-    <string name="h28" value="MP -28, damage 172%"/>
-    <string name="h29" value="MP -28, damage 176%"/>
-    <string name="h30" value="MP -28, damage 180%"/>
+    <string name="h1" value="MP -23; Damage 122% against up to 6 enemies"/>
+    <string name="h2" value="MP -23; Damage 124% against up to 6 enemies"/>
+    <string name="h3" value="MP -23; Damage 126% against up to 6 enemies"/>
+    <string name="h4" value="MP -23; Damage 128% against up to 6 enemies"/>
+    <string name="h5" value="MP -23; Damage 130% against up to 6 enemies"/>
+    <string name="h6" value="MP -24; Damage 132% against up to 6 enemies"/>
+    <string name="h7" value="MP -24; Damage 134% against up to 6 enemies"/>
+    <string name="h8" value="MP -24; Damage 136% against up to 6 enemies"/>
+    <string name="h9" value="MP -24; Damage 138% against up to 6 enemies"/>
+    <string name="h10" value="MP -24; Damage 140% against up to 6 enemies"/>
+    <string name="h11" value="MP -25; Damage 142% against up to 6 enemies"/>
+    <string name="h12" value="MP -25; Damage 144% against up to 6 enemies"/>
+    <string name="h13" value="MP -25; Damage 146% against up to 6 enemies"/>
+    <string name="h14" value="MP -25; Damage 148% against up to 6 enemies"/>
+    <string name="h15" value="MP -25; Damage 150% against up to 6 enemies"/>
+    <string name="h16" value="MP -26; Damage 152% against up to 6 enemies"/>
+    <string name="h17" value="MP -26; Damage 154% against up to 6 enemies"/>
+    <string name="h18" value="MP -26; Damage 156% against up to 6 enemies"/>
+    <string name="h19" value="MP -26; Damage 158% against up to 6 enemies"/>
+    <string name="h20" value="MP -27; Damage 160% against up to 6 enemies"/>
+    <string name="h21" value="MP -27; Damage 162% against up to 6 enemies"/>
+    <string name="h22" value="MP -27; Damage 164% against up to 6 enemies"/>
+    <string name="h23" value="MP -27; Damage 166% against up to 6 enemies"/>
+    <string name="h24" value="MP -27; Damage 168% against up to 6 enemies"/>
+    <string name="h25" value="MP -27; Damage 170% against up to 6 enemies"/>
+    <string name="h26" value="MP -28; Damage 172% against up to 6 enemies"/>
+    <string name="h27" value="MP -28; Damage 174% against up to 6 enemies"/>
+    <string name="h28" value="MP -28; Damage 176% against up to 6 enemies"/>
+    <string name="h29" value="MP -28; Damage 178% against up to 6 enemies"/>
+    <string name="h30" value="MP -28; Damage 180% against up to 6 enemies"/>
   </imgdir>
   <imgdir name="410">
     <string name="bookName" value="Assassin Skills"/>
@@ -3924,210 +3924,210 @@
   <imgdir name="3110000">
     <string name="name" value="Thrust"/>
     <string name="desc" value="[Master Level : 20]\nIncreases movement speed."/>
-    <string name="h1" value="Speed + 2"/>
-    <string name="h2" value="Speed + 4"/>
-    <string name="h3" value="Speed + 6"/>
-    <string name="h4" value="Speed + 8"/>
-    <string name="h5" value="Speed + 10"/>
-    <string name="h6" value="Speed + 12"/>
-    <string name="h7" value="Speed + 14"/>
-    <string name="h8" value="Speed + 16"/>
-    <string name="h9" value="Speed + 18"/>
-    <string name="h10" value="Speed + 20"/>
-    <string name="h11" value="Speed + 21"/>
-    <string name="h12" value="Speed + 22"/>
-    <string name="h13" value="Speed + 23"/>
-    <string name="h14" value="Speed + 24"/>
-    <string name="h15" value="Speed + 25"/>
-    <string name="h16" value="Speed + 26"/>
-    <string name="h17" value="Speed + 27"/>
-    <string name="h18" value="Speed + 28"/>
-    <string name="h19" value="Speed + 29"/>
-    <string name="h20" value="Speed + 30"/>
+    <string name="h1" value="Speed +2"/>
+    <string name="h2" value="Speed +4"/>
+    <string name="h3" value="Speed +6"/>
+    <string name="h4" value="Speed +8"/>
+    <string name="h5" value="Speed +10"/>
+    <string name="h6" value="Speed +12"/>
+    <string name="h7" value="Speed +14"/>
+    <string name="h8" value="Speed +16"/>
+    <string name="h9" value="Speed +18"/>
+    <string name="h10" value="Speed +20"/>
+    <string name="h11" value="Speed +21"/>
+    <string name="h12" value="Speed +22"/>
+    <string name="h13" value="Speed +23"/>
+    <string name="h14" value="Speed +24"/>
+    <string name="h15" value="Speed +25"/>
+    <string name="h16" value="Speed +26"/>
+    <string name="h17" value="Speed +27"/>
+    <string name="h18" value="Speed +28"/>
+    <string name="h19" value="Speed +29"/>
+    <string name="h20" value="Speed +30"/>
   </imgdir>
   <imgdir name="3110001">
     <string name="name" value="Mortal Blow"/>
     <string name="desc" value="[Master Level : 20]\nAllows attacks at very close range and grants a chance to inflict a deadly blow."/>
-    <string name="h1" value="32% success rate, Damage 110%; Kills the monster with HP at 20% or lower at 1% success rate"/>
-    <string name="h2" value="34% success rate, Damage 120%; Kills the monster with HP at 23% or lower at 1% success rate"/>
-    <string name="h3" value="36% success rate, Damage 130%; Kills the monster with HP at 23% or lower at 2% success rate"/>
-    <string name="h4" value="38% success rate, Damage 140%; Kills the monster with HP at 26% or lower at 2% success rate"/>
-    <string name="h5" value="40% success rate, Damage 150%; Kills the monster with HP at 26% or lower at 3% success rate"/>
-    <string name="h6" value="42% success rate, Damage 160%; Kills the monster with HP at 29% or lower at 3% success rate"/>
-    <string name="h7" value="44% success rate, Damage 170%; Kills the monster with HP at 29% or lower at 4% success rate"/>
-    <string name="h8" value="46% success rate, Damage 180%; Kills the monster with HP at 32% or lower at 4% success rate"/>
-    <string name="h9" value="48% success rate, Damage 190%; Kills the monster with HP at 32% or lower at 5% success rate"/>
-    <string name="h10" value="50% success rate, Damage 200%; Kills the monster with HP at 35% or lower at 5% success rate"/>
-    <string name="h11" value="52% success rate, Damage 205%; Kills the monster with HP at 35% or lower at 6% success rate"/>
-    <string name="h12" value="54% success rate, Damage 210%; Kills the monster with HP at 38% or lower at 6% success rate"/>
-    <string name="h13" value="56% success rate, Damage 215%; Kills the monster with HP at 38% or lower at 7% success rate"/>
-    <string name="h14" value="58% success rate, Damage 220%; Kills the monster with HP at 41% or lower at 7% success rate"/>
-    <string name="h15" value="60% success rate, Damage 225%; Kills the monster with HP at 41% or lower at 8% success rate"/>
-    <string name="h16" value="62% success rate, Damage 230%; Kills the monster with HP at 44% or lower at 8% success rate"/>
-    <string name="h17" value="64% success rate, Damage 235%; Kills the monster with HP at 44% or lower at 9% success rate"/>
-    <string name="h18" value="66% success rate, Damage 240%; Kills the monster with HP at 47% or lower at 9% success rate"/>
-    <string name="h19" value="68% success rate, Damage 245%; Kills the monster with HP at 47% or lower at 10% success rate"/>
-    <string name="h20" value="70% success rate, Damage 250%; Kills the monster with HP at 50% or lower at 10% success rate"/>
+    <string name="h1" value="33% chance, Damage 110%; 1% chance to instantly defeat enemies at 20% HP or lower"/>
+    <string name="h2" value="36% chance, Damage 120%; 1% chance to instantly defeat enemies at 23% HP or lower"/>
+    <string name="h3" value="39% chance, Damage 130%; 2% chance to instantly defeat enemies at 23% HP or lower"/>
+    <string name="h4" value="42% chance, Damage 140%; 2% chance to instantly defeat enemies at 26% HP or lower"/>
+    <string name="h5" value="45% chance, Damage 150%; 3% chance to instantly defeat enemies at 26% HP or lower"/>
+    <string name="h6" value="48% chance, Damage 160%; 3% chance to instantly defeat enemies at 29% HP or lower"/>
+    <string name="h7" value="51% chance, Damage 170%; 4% chance to instantly defeat enemies at 29% HP or lower"/>
+    <string name="h8" value="54% chance, Damage 180%; 4% chance to instantly defeat enemies at 32% HP or lower"/>
+    <string name="h9" value="57% chance, Damage 190%; 5% chance to instantly defeat enemies at 32% HP or lower"/>
+    <string name="h10" value="60% chance, Damage 200%; 5% chance to instantly defeat enemies at 35% HP or lower"/>
+    <string name="h11" value="63% chance, Damage 205%; 6% chance to instantly defeat enemies at 35% HP or lower"/>
+    <string name="h12" value="66% chance, Damage 210%; 6% chance to instantly defeat enemies at 38% HP or lower"/>
+    <string name="h13" value="69% chance, Damage 215%; 7% chance to instantly defeat enemies at 38% HP or lower"/>
+    <string name="h14" value="72% chance, Damage 220%; 7% chance to instantly defeat enemies at 41% HP or lower"/>
+    <string name="h15" value="75% chance, Damage 225%; 8% chance to instantly defeat enemies at 41% HP or lower"/>
+    <string name="h16" value="78% chance, Damage 230%; 8% chance to instantly defeat enemies at 44% HP or lower"/>
+    <string name="h17" value="81% chance, Damage 235%; 9% chance to instantly defeat enemies at 44% HP or lower"/>
+    <string name="h18" value="84% chance, Damage 240%; 9% chance to instantly defeat enemies at 47% HP or lower"/>
+    <string name="h19" value="87% chance, Damage 245%; 10% chance to instantly defeat enemies at 47% HP or lower"/>
+    <string name="h20" value="90% chance, Damage 250%; 10% chance to instantly defeat enemies at 50% HP or lower"/>
   </imgdir>
   <imgdir name="3111002">
     <string name="name" value="Puppet"/>
     <string name="desc" value="[Master Level : 20]\nSummons a puppet that attracts monster attacks for a period of time."/>
-    <string name="h1" value="MP - 23; For 5 sec., summons HP 500 puppet"/>
-    <string name="h2" value="MP - 23; For 5 sec., summons HP 600 puppet"/>
-    <string name="h3" value="MP - 23; For 10 sec., summons HP 700 puppet"/>
-    <string name="h4" value="MP - 23; For 10 sec., summons HP 800 puppet"/>
-    <string name="h5" value="MP - 23; For 10 sec., summons HP 900 puppet"/>
-    <string name="h6" value="MP - 26; For 20 sec., summons HP 1000 puppet"/>
-    <string name="h7" value="MP - 26; For 20 sec., summons HP 1200 puppet"/>
-    <string name="h8" value="MP - 26; For 20 sec., summons HP 1400 puppet"/>
-    <string name="h9" value="MP - 26; For 30 sec., summons HP 1600 puppet"/>
-    <string name="h10" value="MP - 26; For 30 sec., summons HP 1800 puppet"/>
-    <string name="h11" value="MP - 29; For 30 sec., summons HP 2000 puppet"/>
-    <string name="h12" value="MP - 29; For 40 sec., summons HP 2400 puppet"/>
-    <string name="h13" value="MP - 29; For 40 sec., summons HP 2800 puppet"/>
-    <string name="h14" value="MP - 29; For 40 sec., summons HP 3200 puppet"/>
-    <string name="h15" value="MP - 29; For 50 sec., summons HP 3600 puppet"/>
-    <string name="h16" value="MP - 32; For 50 sec., summons HP 4000 puppet"/>
-    <string name="h17" value="MP - 32; For 50 sec., summons HP 4500 puppet"/>
-    <string name="h18" value="MP - 32; For 60 sec., summons HP 5000 puppet"/>
-    <string name="h19" value="MP - 32; For 60 sec., summons HP 5500 puppet"/>
-    <string name="h20" value="MP - 32; For 60 sec., summons HP 6000 puppet"/>
+    <string name="h1" value="MP -23; summons a puppet with 500 HP for 5 sec"/>
+    <string name="h2" value="MP -23; summons a puppet with 600 HP for 5 sec"/>
+    <string name="h3" value="MP -23; summons a puppet with 700 HP for 10 sec"/>
+    <string name="h4" value="MP -23; summons a puppet with 800 HP for 10 sec"/>
+    <string name="h5" value="MP -23; summons a puppet with 900 HP for 10 sec"/>
+    <string name="h6" value="MP -26; summons a puppet with 1000 HP for 20 sec"/>
+    <string name="h7" value="MP -26; summons a puppet with 1200 HP for 20 sec"/>
+    <string name="h8" value="MP -26; summons a puppet with 1400 HP for 20 sec"/>
+    <string name="h9" value="MP -26; summons a puppet with 1600 HP for 30 sec"/>
+    <string name="h10" value="MP -26; summons a puppet with 1800 HP for 30 sec"/>
+    <string name="h11" value="MP -29; summons a puppet with 2000 HP for 30 sec"/>
+    <string name="h12" value="MP -29; summons a puppet with 2400 HP for 40 sec"/>
+    <string name="h13" value="MP -29; summons a puppet with 2800 HP for 40 sec"/>
+    <string name="h14" value="MP -29; summons a puppet with 3200 HP for 40 sec"/>
+    <string name="h15" value="MP -29; summons a puppet with 3600 HP for 50 sec"/>
+    <string name="h16" value="MP -32; summons a puppet with 4000 HP for 50 sec"/>
+    <string name="h17" value="MP -32; summons a puppet with 4500 HP for 50 sec"/>
+    <string name="h18" value="MP -32; summons a puppet with 5000 HP for 60 sec"/>
+    <string name="h19" value="MP -32; summons a puppet with 5500 HP for 60 sec"/>
+    <string name="h20" value="MP -32; summons a puppet with 6000 HP for 60 sec"/>
   </imgdir>
   <imgdir name="3111003">
     <string name="name" value="Inferno"/>
     <string name="desc" value="[Master Level : 30]\nAttacks up to 6 enemies with fire arrows, dealing fire-element damage.\nRequires a bow."/>
-    <string name="h1" value="MP - 20, Damage 50%"/>
-    <string name="h2" value="MP - 20, Damage 55%"/>
-    <string name="h3" value="MP - 20, Damage 60%"/>
-    <string name="h4" value="MP - 20, Damage 65%"/>
-    <string name="h5" value="MP - 20, Damage 70%"/>
-    <string name="h6" value="MP - 20, Damage 75%"/>
-    <string name="h7" value="MP - 20, Damage 80%"/>
-    <string name="h8" value="MP - 20, Damage 85%"/>
-    <string name="h9" value="MP - 20, Damage 90%"/>
-    <string name="h10" value="MP - 20, Damage 95%"/>
-    <string name="h11" value="MP - 25, Damage 100%"/>
-    <string name="h12" value="MP - 25, Damage 103%"/>
-    <string name="h13" value="MP - 25, Damage 106%"/>
-    <string name="h14" value="MP - 25, Damage 109%"/>
-    <string name="h15" value="MP - 25, Damage 112%"/>
-    <string name="h16" value="MP - 25, Damage 115%"/>
-    <string name="h17" value="MP - 25, Damage 118%"/>
-    <string name="h18" value="MP - 25, Damage 121%"/>
-    <string name="h19" value="MP - 25, Damage 124%"/>
-    <string name="h20" value="MP - 25, Damage 127%"/>
-    <string name="h21" value="MP - 30, Damage 130%"/>
-    <string name="h22" value="MP - 30, Damage 133%"/>
-    <string name="h23" value="MP - 30, Damage 136%"/>
-    <string name="h24" value="MP - 30, Damage 139%"/>
-    <string name="h25" value="MP - 30, Damage 142%"/>
-    <string name="h26" value="MP - 30, Damage 144%"/>
-    <string name="h27" value="MP - 30, Damage 146%"/>
-    <string name="h28" value="MP - 30, Damage 148%"/>
-    <string name="h29" value="MP - 30, Damage 149%"/>
-    <string name="h30" value="MP - 30, Damage 150%"/>
+    <string name="h1" value="MP -20; Damage 50% against up to 6 enemies"/>
+    <string name="h2" value="MP -20; Damage 55% against up to 6 enemies"/>
+    <string name="h3" value="MP -20; Damage 60% against up to 6 enemies"/>
+    <string name="h4" value="MP -20; Damage 65% against up to 6 enemies"/>
+    <string name="h5" value="MP -20; Damage 70% against up to 6 enemies"/>
+    <string name="h6" value="MP -20; Damage 75% against up to 6 enemies"/>
+    <string name="h7" value="MP -20; Damage 80% against up to 6 enemies"/>
+    <string name="h8" value="MP -20; Damage 85% against up to 6 enemies"/>
+    <string name="h9" value="MP -20; Damage 90% against up to 6 enemies"/>
+    <string name="h10" value="MP -20; Damage 95% against up to 6 enemies"/>
+    <string name="h11" value="MP -25; Damage 100% against up to 6 enemies"/>
+    <string name="h12" value="MP -25; Damage 103% against up to 6 enemies"/>
+    <string name="h13" value="MP -25; Damage 106% against up to 6 enemies"/>
+    <string name="h14" value="MP -25; Damage 109% against up to 6 enemies"/>
+    <string name="h15" value="MP -25; Damage 112% against up to 6 enemies"/>
+    <string name="h16" value="MP -25; Damage 115% against up to 6 enemies"/>
+    <string name="h17" value="MP -25; Damage 118% against up to 6 enemies"/>
+    <string name="h18" value="MP -25; Damage 121% against up to 6 enemies"/>
+    <string name="h19" value="MP -25; Damage 124% against up to 6 enemies"/>
+    <string name="h20" value="MP -25; Damage 127% against up to 6 enemies"/>
+    <string name="h21" value="MP -30; Damage 130% against up to 6 enemies"/>
+    <string name="h22" value="MP -30; Damage 133% against up to 6 enemies"/>
+    <string name="h23" value="MP -30; Damage 136% against up to 6 enemies"/>
+    <string name="h24" value="MP -30; Damage 139% against up to 6 enemies"/>
+    <string name="h25" value="MP -30; Damage 142% against up to 6 enemies"/>
+    <string name="h26" value="MP -30; Damage 144% against up to 6 enemies"/>
+    <string name="h27" value="MP -30; Damage 146% against up to 6 enemies"/>
+    <string name="h28" value="MP -30; Damage 148% against up to 6 enemies"/>
+    <string name="h29" value="MP -30; Damage 149% against up to 6 enemies"/>
+    <string name="h30" value="MP -30; Damage 150% against up to 6 enemies"/>
   </imgdir>
   <imgdir name="3111004">
     <string name="name" value="Arrow Rain"/>
     <string name="desc" value="[Master Level : 30]\nRains arrows from above to attack up to 6 enemies.\nRequires a bow.\nRequired Skill : #cMortal Blow Lv. 5 or higher#"/>
-    <string name="h1" value="MP - 18, Damage 60%"/>
-    <string name="h2" value="MP - 18, Damage 65%"/>
-    <string name="h3" value="MP - 18, Damage 70%"/>
-    <string name="h4" value="MP - 18, Damage 75%"/>
-    <string name="h5" value="MP - 18, Damage 80%"/>
-    <string name="h6" value="MP - 18, Damage 85%"/>
-    <string name="h7" value="MP - 18, Damage 90%"/>
-    <string name="h8" value="MP - 18, Damage 95%"/>
-    <string name="h9" value="MP - 18, Damage 100%"/>
-    <string name="h10" value="MP - 18, Damage 105%"/>
-    <string name="h11" value="MP - 23, Damage 110%"/>
-    <string name="h12" value="MP - 23, Damage 113%"/>
-    <string name="h13" value="MP - 23, Damage 116%"/>
-    <string name="h14" value="MP - 23, Damage 119%"/>
-    <string name="h15" value="MP - 23, Damage 122%"/>
-    <string name="h16" value="MP - 23, Damage 125%"/>
-    <string name="h17" value="MP - 23, Damage 128%"/>
-    <string name="h18" value="MP - 23, Damage 131%"/>
-    <string name="h19" value="MP - 23, Damage 134%"/>
-    <string name="h20" value="MP - 23, Damage 137%"/>
-    <string name="h21" value="MP - 23, Damage 140%"/>
-    <string name="h22" value="MP - 28, Damage 143%"/>
-    <string name="h23" value="MP - 28, Damage 146%"/>
-    <string name="h24" value="MP - 28, Damage 149%"/>
-    <string name="h25" value="MP - 28, Damage 152%"/>
-    <string name="h26" value="MP - 28, Damage 154%"/>
-    <string name="h27" value="MP - 28, Damage 156%"/>
-    <string name="h28" value="MP - 28, Damage 158%"/>
-    <string name="h29" value="MP - 28, Damage 159%"/>
-    <string name="h30" value="MP - 28, Damage 160%"/>
+    <string name="h1" value="MP -18; Damage 60% against up to 6 enemies"/>
+    <string name="h2" value="MP -18; Damage 65% against up to 6 enemies"/>
+    <string name="h3" value="MP -18; Damage 70% against up to 6 enemies"/>
+    <string name="h4" value="MP -18; Damage 75% against up to 6 enemies"/>
+    <string name="h5" value="MP -18; Damage 80% against up to 6 enemies"/>
+    <string name="h6" value="MP -18; Damage 85% against up to 6 enemies"/>
+    <string name="h7" value="MP -18; Damage 90% against up to 6 enemies"/>
+    <string name="h8" value="MP -18; Damage 95% against up to 6 enemies"/>
+    <string name="h9" value="MP -18; Damage 100% against up to 6 enemies"/>
+    <string name="h10" value="MP -18; Damage 105% against up to 6 enemies"/>
+    <string name="h11" value="MP -23; Damage 110% against up to 6 enemies"/>
+    <string name="h12" value="MP -23; Damage 113% against up to 6 enemies"/>
+    <string name="h13" value="MP -23; Damage 116% against up to 6 enemies"/>
+    <string name="h14" value="MP -23; Damage 119% against up to 6 enemies"/>
+    <string name="h15" value="MP -23; Damage 122% against up to 6 enemies"/>
+    <string name="h16" value="MP -23; Damage 125% against up to 6 enemies"/>
+    <string name="h17" value="MP -23; Damage 128% against up to 6 enemies"/>
+    <string name="h18" value="MP -23; Damage 131% against up to 6 enemies"/>
+    <string name="h19" value="MP -23; Damage 134% against up to 6 enemies"/>
+    <string name="h20" value="MP -23; Damage 137% against up to 6 enemies"/>
+    <string name="h21" value="MP -28; Damage 140% against up to 6 enemies"/>
+    <string name="h22" value="MP -28; Damage 143% against up to 6 enemies"/>
+    <string name="h23" value="MP -28; Damage 146% against up to 6 enemies"/>
+    <string name="h24" value="MP -28; Damage 149% against up to 6 enemies"/>
+    <string name="h25" value="MP -28; Damage 152% against up to 6 enemies"/>
+    <string name="h26" value="MP -28; Damage 154% against up to 6 enemies"/>
+    <string name="h27" value="MP -28; Damage 156% against up to 6 enemies"/>
+    <string name="h28" value="MP -28; Damage 158% against up to 6 enemies"/>
+    <string name="h29" value="MP -28; Damage 159% against up to 6 enemies"/>
+    <string name="h30" value="MP -28; Damage 160% against up to 6 enemies"/>
   </imgdir>
   <imgdir name="3111005">
     <string name="name" value="Silver Hawk"/>
     <string name="desc" value="[Master Level : 30]\nSummons Silver Hawk to attack nearby enemies for a period of time, with a chance to stun.\nRequired Skill : #cPuppet Lv. 5 or higher#"/>
-    <string name="h1" value="MP - 32, use 1 Summoning Rock; summons a hawk for 103 sec.; attack +23 ; 50% chance of stunning"/>
-    <string name="h2" value="MP - 34, use 1 Summoning Rock; summons a hawk for 106 sec.; attack +26 ; 53% chance of stunning"/>
-    <string name="h3" value="MP - 36, use 1 Summoning Rock; summons a hawk for 109 sec.; attack +29 ; 56% chance of stunning"/>
-    <string name="h4" value="MP - 38, use 1 Summoning Rock; summons a hawk for 112 sec.; attack +32 ; 59% chance of stunning"/>
-    <string name="h5" value="MP - 40, use 1 Summoning Rock; summons a hawk for 115 sec.; attack +35 ; 62% chance of stunning"/>
-    <string name="h6" value="MP - 42, use 1 Summoning Rock; summons a hawk for 118 sec.; attack +38 ; 65% chance of stunning"/>
-    <string name="h7" value="MP - 44, use 1 Summoning Rock; summons a hawk for 121 sec.; attack +41 ; 68% chance of stunning"/>
-    <string name="h8" value="MP - 46, use 1 Summoning Rock; summons a hawk for 124 sec.; attack +44 ; 71% chance of stunning"/>
-    <string name="h9" value="MP - 48, use 1 Summoning Rock; summons a hawk for 127 sec.; attack +47 ; 74% chance of stunning"/>
-    <string name="h10" value="MP - 50, use 1 Summoning Rock; summons a hawk for 130 sec.; attack +50 ; 77% chance of stunning"/>
-    <string name="h11" value="MP - 52, use 1 Summoning Rock; summons a hawk for 133 sec.; attack +53 ; 80% chance of stunning"/>
-    <string name="h12" value="MP - 54, use 1 Summoning Rock; summons a hawk for 136 sec.; attack +56 ; 82% chance of stunning"/>
-    <string name="h13" value="MP - 56, use 1 Summoning Rock; summons a hawk for 139 sec.; attack +59 ; 84% chance of stunning"/>
-    <string name="h14" value="MP - 58, use 1 Summoning Rock; summons a hawk for 142 sec.; attack +62 ; 86% chance of stunning"/>
-    <string name="h15" value="MP - 60, use 1 Summoning Rock; summons a hawk for 145 sec.; attack +65 ; 88% chance of stunning"/>
-    <string name="h16" value="MP - 62, use 1 Summoning Rock; summons a hawk for 148 sec.; attack +68 ; 90% chance of stunning"/>
-    <string name="h17" value="MP - 64, use 1 Summoning Rock; summons a hawk for 151 sec.; attack +71 ; 91% chance of stunning"/>
-    <string name="h18" value="MP - 66, use 1 Summoning Rock; summons a hawk for 154 sec.; attack +74 ; 92% chance of stunning"/>
-    <string name="h19" value="MP - 68, use 1 Summoning Rock; summons a hawk for 157 sec.; attack +77 ; 93% chance of stunning"/>
-    <string name="h20" value="MP - 70, use 1 Summoning Rock; summons a hawk for 160 sec.; attack +80 ; 94% chance of stunning"/>
-    <string name="h21" value="MP - 71, use 1 Summoning Rock; summons a hawk for 162 sec.; attack +82 ; 95% chance of stunning"/>
-    <string name="h22" value="MP - 72, use 1 Summoning Rock; summons a hawk for 164 sec.; attack +84 ; 95% chance of stunning"/>
-    <string name="h23" value="MP - 73, use 1 Summoning Rock; summons a hawk for 166 sec.; attack +86 ; 96% chance of stunning"/>
-    <string name="h24" value="MP - 74, use 1 Summoning Rock; summons a hawk for 168 sec.; attack +88 ; 96% chance of stunning"/>
-    <string name="h25" value="MP - 75, use 1 Summoning Rock; summons a hawk for 170 sec.; attack +90 ; 97% chance of stunning"/>
-    <string name="h26" value="MP - 76, use 1 Summoning Rock; summons a hawk for 172 sec.; attack +92 ; 97% chance of stunning"/>
-    <string name="h27" value="MP - 77, use 1 Summoning Rock; summons a hawk for 174 sec. ; attack +94 ; 98% chance of stunning"/>
-    <string name="h28" value="MP - 78, use 1 Summoning Rock; summons a hawk for 176 sec. ; attack +96 ; 98% chance of stunning"/>
-    <string name="h29" value="MP - 79, use 1 Summoning Rock; summons a hawk for 178 sec. ; attack +98 ; 99% chance of stunning"/>
-    <string name="h30" value="MP - 80, use 1 Summoning Rock; summons a hawk for 180 sec. ; attack +100 ; 99% chance of stunning"/>
+    <string name="h1" value="MP -32, 1 Summoning Rock; summons Silver Hawk for 103 sec, attack 23, 50% stun chance"/>
+    <string name="h2" value="MP -34, 1 Summoning Rock; summons Silver Hawk for 106 sec, attack 26, 53% stun chance"/>
+    <string name="h3" value="MP -36, 1 Summoning Rock; summons Silver Hawk for 109 sec, attack 29, 56% stun chance"/>
+    <string name="h4" value="MP -38, 1 Summoning Rock; summons Silver Hawk for 112 sec, attack 32, 59% stun chance"/>
+    <string name="h5" value="MP -40, 1 Summoning Rock; summons Silver Hawk for 115 sec, attack 35, 62% stun chance"/>
+    <string name="h6" value="MP -42, 1 Summoning Rock; summons Silver Hawk for 118 sec, attack 38, 65% stun chance"/>
+    <string name="h7" value="MP -44, 1 Summoning Rock; summons Silver Hawk for 121 sec, attack 41, 68% stun chance"/>
+    <string name="h8" value="MP -46, 1 Summoning Rock; summons Silver Hawk for 124 sec, attack 44, 71% stun chance"/>
+    <string name="h9" value="MP -48, 1 Summoning Rock; summons Silver Hawk for 127 sec, attack 47, 74% stun chance"/>
+    <string name="h10" value="MP -50, 1 Summoning Rock; summons Silver Hawk for 130 sec, attack 50, 77% stun chance"/>
+    <string name="h11" value="MP -52, 1 Summoning Rock; summons Silver Hawk for 133 sec, attack 53, 80% stun chance"/>
+    <string name="h12" value="MP -54, 1 Summoning Rock; summons Silver Hawk for 136 sec, attack 56, 82% stun chance"/>
+    <string name="h13" value="MP -56, 1 Summoning Rock; summons Silver Hawk for 139 sec, attack 59, 84% stun chance"/>
+    <string name="h14" value="MP -58, 1 Summoning Rock; summons Silver Hawk for 142 sec, attack 62, 86% stun chance"/>
+    <string name="h15" value="MP -60, 1 Summoning Rock; summons Silver Hawk for 145 sec, attack 65, 88% stun chance"/>
+    <string name="h16" value="MP -62, 1 Summoning Rock; summons Silver Hawk for 148 sec, attack 68, 90% stun chance"/>
+    <string name="h17" value="MP -64, 1 Summoning Rock; summons Silver Hawk for 151 sec, attack 71, 91% stun chance"/>
+    <string name="h18" value="MP -66, 1 Summoning Rock; summons Silver Hawk for 154 sec, attack 74, 92% stun chance"/>
+    <string name="h19" value="MP -68, 1 Summoning Rock; summons Silver Hawk for 157 sec, attack 77, 93% stun chance"/>
+    <string name="h20" value="MP -70, 1 Summoning Rock; summons Silver Hawk for 160 sec, attack 80, 94% stun chance"/>
+    <string name="h21" value="MP -71, 1 Summoning Rock; summons Silver Hawk for 162 sec, attack 82, 95% stun chance"/>
+    <string name="h22" value="MP -72, 1 Summoning Rock; summons Silver Hawk for 164 sec, attack 84, 95% stun chance"/>
+    <string name="h23" value="MP -73, 1 Summoning Rock; summons Silver Hawk for 166 sec, attack 86, 96% stun chance"/>
+    <string name="h24" value="MP -74, 1 Summoning Rock; summons Silver Hawk for 168 sec, attack 88, 96% stun chance"/>
+    <string name="h25" value="MP -75, 1 Summoning Rock; summons Silver Hawk for 170 sec, attack 90, 97% stun chance"/>
+    <string name="h26" value="MP -76, 1 Summoning Rock; summons Silver Hawk for 172 sec, attack 92, 97% stun chance"/>
+    <string name="h27" value="MP -77, 1 Summoning Rock; summons Silver Hawk for 174 sec, attack 94, 98% stun chance"/>
+    <string name="h28" value="MP -78, 1 Summoning Rock; summons Silver Hawk for 176 sec, attack 96, 98% stun chance"/>
+    <string name="h29" value="MP -79, 1 Summoning Rock; summons Silver Hawk for 178 sec, attack 98, 99% stun chance"/>
+    <string name="h30" value="MP -80, 1 Summoning Rock; summons Silver Hawk for 180 sec, attack 100, 99% stun chance"/>
   </imgdir>
   <imgdir name="3111006">
     <string name="name" value="Strafe"/>
     <string name="desc" value="[Master Level : 30]\nRapidly fires 4 arrows at a single enemy."/>
-    <string name="h1" value="MP - 26, Damage 71%, attack 4 times"/>
-    <string name="h2" value="MP - 26, Damage 72%, attack 4 times"/>
-    <string name="h3" value="MP - 26, Damage 73%, attack 4 times"/>
-    <string name="h4" value="MP - 26, Damage 74%, attack 4 times"/>
-    <string name="h5" value="MP - 26, Damage 75%, attack 4 times"/>
-    <string name="h6" value="MP - 26, Damage 76%, attack 4 times"/>
-    <string name="h7" value="MP - 26, Damage 77%, attack 4 times"/>
-    <string name="h8" value="MP - 26, Damage 78%, attack 4 times"/>
-    <string name="h9" value="MP - 26, Damage 79%, attack 4 times"/>
-    <string name="h10" value="MP - 26, Damage 80%, attack 4 times"/>
-    <string name="h11" value="MP - 26, Damage 81%, attack 4 times"/>
-    <string name="h12" value="MP - 26, Damage 82%, attack 4 times"/>
-    <string name="h13" value="MP - 26, Damage 83%, attack 4 times"/>
-    <string name="h14" value="MP - 26, Damage 84%, attack 4 times"/>
-    <string name="h15" value="MP - 26, Damage 85%, attack 4 times"/>
-    <string name="h16" value="MP - 32, Damage 86%, attack 4 times"/>
-    <string name="h17" value="MP - 32, Damage 87%, attack 4 times"/>
-    <string name="h18" value="MP - 32, Damage 88%, attack 4 times"/>
-    <string name="h19" value="MP - 32, Damage 89%, attack 4 times"/>
-    <string name="h20" value="MP - 32, Damage 90%, attack 4 times"/>
-    <string name="h21" value="MP - 32, Damage 91%, attack 4 times"/>
-    <string name="h22" value="MP - 32, Damage 92%, attack 4 times"/>
-    <string name="h23" value="MP - 32, Damage 93%, attack 4 times"/>
-    <string name="h24" value="MP - 32, Damage 94%, attack 4 times"/>
-    <string name="h25" value="MP - 32, Damage 95%, attack 4 times"/>
-    <string name="h26" value="MP - 32, Damage 96%, attack 4 times"/>
-    <string name="h27" value="MP - 32, Damage 97%, attack 4 times"/>
-    <string name="h28" value="MP - 32, Damage 98%, attack 4 times"/>
-    <string name="h29" value="MP - 32, Damage 99%, attack 4 times"/>
-    <string name="h30" value="MP - 32, Damage 100%, attack 4 times"/>
+    <string name="h1" value="MP -26; Damage 71% per arrow, 4 hits"/>
+    <string name="h2" value="MP -26; Damage 72% per arrow, 4 hits"/>
+    <string name="h3" value="MP -26; Damage 73% per arrow, 4 hits"/>
+    <string name="h4" value="MP -26; Damage 74% per arrow, 4 hits"/>
+    <string name="h5" value="MP -26; Damage 75% per arrow, 4 hits"/>
+    <string name="h6" value="MP -26; Damage 76% per arrow, 4 hits"/>
+    <string name="h7" value="MP -26; Damage 77% per arrow, 4 hits"/>
+    <string name="h8" value="MP -26; Damage 78% per arrow, 4 hits"/>
+    <string name="h9" value="MP -26; Damage 79% per arrow, 4 hits"/>
+    <string name="h10" value="MP -26; Damage 80% per arrow, 4 hits"/>
+    <string name="h11" value="MP -26; Damage 81% per arrow, 4 hits"/>
+    <string name="h12" value="MP -26; Damage 82% per arrow, 4 hits"/>
+    <string name="h13" value="MP -26; Damage 83% per arrow, 4 hits"/>
+    <string name="h14" value="MP -26; Damage 84% per arrow, 4 hits"/>
+    <string name="h15" value="MP -26; Damage 85% per arrow, 4 hits"/>
+    <string name="h16" value="MP -32; Damage 86% per arrow, 4 hits"/>
+    <string name="h17" value="MP -32; Damage 87% per arrow, 4 hits"/>
+    <string name="h18" value="MP -32; Damage 88% per arrow, 4 hits"/>
+    <string name="h19" value="MP -32; Damage 89% per arrow, 4 hits"/>
+    <string name="h20" value="MP -32; Damage 90% per arrow, 4 hits"/>
+    <string name="h21" value="MP -32; Damage 91% per arrow, 4 hits"/>
+    <string name="h22" value="MP -32; Damage 92% per arrow, 4 hits"/>
+    <string name="h23" value="MP -32; Damage 93% per arrow, 4 hits"/>
+    <string name="h24" value="MP -32; Damage 94% per arrow, 4 hits"/>
+    <string name="h25" value="MP -32; Damage 95% per arrow, 4 hits"/>
+    <string name="h26" value="MP -32; Damage 96% per arrow, 4 hits"/>
+    <string name="h27" value="MP -32; Damage 97% per arrow, 4 hits"/>
+    <string name="h28" value="MP -32; Damage 98% per arrow, 4 hits"/>
+    <string name="h29" value="MP -32; Damage 99% per arrow, 4 hits"/>
+    <string name="h30" value="MP -32; Damage 100% per arrow, 4 hits"/>
   </imgdir>
   <imgdir name="321">
     <string name="bookName" value="Sniper&apos;s Scope"/>
@@ -4135,210 +4135,210 @@
   <imgdir name="3210000">
     <string name="name" value="Thrust"/>
     <string name="desc" value="[Master Level : 20]\nIncreases movement speed."/>
-    <string name="h1" value="Speed + 2"/>
-    <string name="h2" value="Speed + 4"/>
-    <string name="h3" value="Speed + 6"/>
-    <string name="h4" value="Speed + 8"/>
-    <string name="h5" value="Speed + 10"/>
-    <string name="h6" value="Speed + 12"/>
-    <string name="h7" value="Speed + 14"/>
-    <string name="h8" value="Speed + 16"/>
-    <string name="h9" value="Speed + 18"/>
-    <string name="h10" value="Speed + 20"/>
-    <string name="h11" value="Speed + 21"/>
-    <string name="h12" value="Speed + 22"/>
-    <string name="h13" value="Speed + 23"/>
-    <string name="h14" value="Speed + 24"/>
-    <string name="h15" value="Speed + 25"/>
-    <string name="h16" value="Speed + 26"/>
-    <string name="h17" value="Speed + 27"/>
-    <string name="h18" value="Speed + 28"/>
-    <string name="h19" value="Speed + 29"/>
-    <string name="h20" value="Speed + 30"/>
+    <string name="h1" value="Speed +2"/>
+    <string name="h2" value="Speed +4"/>
+    <string name="h3" value="Speed +6"/>
+    <string name="h4" value="Speed +8"/>
+    <string name="h5" value="Speed +10"/>
+    <string name="h6" value="Speed +12"/>
+    <string name="h7" value="Speed +14"/>
+    <string name="h8" value="Speed +16"/>
+    <string name="h9" value="Speed +18"/>
+    <string name="h10" value="Speed +20"/>
+    <string name="h11" value="Speed +21"/>
+    <string name="h12" value="Speed +22"/>
+    <string name="h13" value="Speed +23"/>
+    <string name="h14" value="Speed +24"/>
+    <string name="h15" value="Speed +25"/>
+    <string name="h16" value="Speed +26"/>
+    <string name="h17" value="Speed +27"/>
+    <string name="h18" value="Speed +28"/>
+    <string name="h19" value="Speed +29"/>
+    <string name="h20" value="Speed +30"/>
   </imgdir>
   <imgdir name="3210001">
     <string name="name" value="Mortal Blow"/>
     <string name="desc" value="[Master Level : 20]\nAllows crossbow attacks at very close range and grants a chance to inflict a deadly blow."/>
-    <string name="h1" value="32% success rate, Damage 110%; Kills the monster with HP at 20% or lower at 1% success rate"/>
-    <string name="h2" value="34% success rate, Damage 120%; Kills the monster with HP at 23% or lower at 1% success rate"/>
-    <string name="h3" value="36% success rate, Damage 130%; Kills the monster with HP at 23% or lower at 2% success rate"/>
-    <string name="h4" value="38% success rate, Damage 140%; Kills the monster with HP at 26% or lower at 2% success rate"/>
-    <string name="h5" value="40% success rate, Damage 150%; Kills the monster with HP at 26% or lower at 3% success rate"/>
-    <string name="h6" value="42% success rate, Damage 160%; Kills the monster with HP at 29% or lower at 3% success rate"/>
-    <string name="h7" value="44% success rate, Damage 170%; Kills the monster with HP at 29% or lower at 4% success rate"/>
-    <string name="h8" value="46% success rate, Damage 180%; Kills the monster with HP at 32% or lower at 4% success rate"/>
-    <string name="h9" value="48% success rate, Damage 190%; Kills the monster with HP at 32% or lower at 5% success rate"/>
-    <string name="h10" value="50% success rate, Damage 200%; Kills the monster with HP at 35% or lower at 5% success rate"/>
-    <string name="h11" value="52% success rate, Damage 205%; Kills the monster with HP at 35% or lower at 6% success rate"/>
-    <string name="h12" value="54% success rate, Damage 210%; Kills the monster with HP at 38% or lower at 6% success rate"/>
-    <string name="h13" value="56% success rate, Damage 215%; Kills the monster with HP at 38% or lower at 7% success rate"/>
-    <string name="h14" value="58% success rate, Damage 220%; Kills the monster with HP at 41% or lower at 7% success rate"/>
-    <string name="h15" value="60% success rate, Damage 225%; Kills the monster with HP at 41% or lower at 8% success rate"/>
-    <string name="h16" value="62% success rate, Damage 230%; Kills the monster with HP at 44% or lower at 8% success rate"/>
-    <string name="h17" value="64% success rate, Damage 235%; Kills the monster with HP at 44% or lower at 9% success rate"/>
-    <string name="h18" value="66% success rate, Damage 240%; Kills the monster with HP at 47% or lower at 9% success rate"/>
-    <string name="h19" value="68% success rate, Damage 245%; Kills the monster with HP at 47% or lower at 10% success rate"/>
-    <string name="h20" value="70% success rate, Damage 250%; Kills the monster with HP at 50% or lower at 10% success rate"/>
+    <string name="h1" value="33% chance, Damage 110%; 1% chance to instantly defeat enemies at 20% HP or lower"/>
+    <string name="h2" value="36% chance, Damage 120%; 1% chance to instantly defeat enemies at 23% HP or lower"/>
+    <string name="h3" value="39% chance, Damage 130%; 2% chance to instantly defeat enemies at 23% HP or lower"/>
+    <string name="h4" value="42% chance, Damage 140%; 2% chance to instantly defeat enemies at 26% HP or lower"/>
+    <string name="h5" value="45% chance, Damage 150%; 3% chance to instantly defeat enemies at 26% HP or lower"/>
+    <string name="h6" value="48% chance, Damage 160%; 3% chance to instantly defeat enemies at 29% HP or lower"/>
+    <string name="h7" value="51% chance, Damage 170%; 4% chance to instantly defeat enemies at 29% HP or lower"/>
+    <string name="h8" value="54% chance, Damage 180%; 4% chance to instantly defeat enemies at 32% HP or lower"/>
+    <string name="h9" value="57% chance, Damage 190%; 5% chance to instantly defeat enemies at 32% HP or lower"/>
+    <string name="h10" value="60% chance, Damage 200%; 5% chance to instantly defeat enemies at 35% HP or lower"/>
+    <string name="h11" value="63% chance, Damage 205%; 6% chance to instantly defeat enemies at 35% HP or lower"/>
+    <string name="h12" value="66% chance, Damage 210%; 6% chance to instantly defeat enemies at 38% HP or lower"/>
+    <string name="h13" value="69% chance, Damage 215%; 7% chance to instantly defeat enemies at 38% HP or lower"/>
+    <string name="h14" value="72% chance, Damage 220%; 7% chance to instantly defeat enemies at 41% HP or lower"/>
+    <string name="h15" value="75% chance, Damage 225%; 8% chance to instantly defeat enemies at 41% HP or lower"/>
+    <string name="h16" value="78% chance, Damage 230%; 8% chance to instantly defeat enemies at 44% HP or lower"/>
+    <string name="h17" value="81% chance, Damage 235%; 9% chance to instantly defeat enemies at 44% HP or lower"/>
+    <string name="h18" value="84% chance, Damage 240%; 9% chance to instantly defeat enemies at 47% HP or lower"/>
+    <string name="h19" value="87% chance, Damage 245%; 10% chance to instantly defeat enemies at 47% HP or lower"/>
+    <string name="h20" value="90% chance, Damage 250%; 10% chance to instantly defeat enemies at 50% HP or lower"/>
   </imgdir>
   <imgdir name="3211002">
     <string name="name" value="Puppet"/>
     <string name="desc" value="[Master Level : 20]\nSummons a puppet that attracts monster attacks for a period of time."/>
-    <string name="h1" value="MP - 23; For 5 sec., summons HP 500 puppet"/>
-    <string name="h2" value="MP - 23; For 5 sec., summons HP 600 puppet"/>
-    <string name="h3" value="MP - 23; For 10 sec., summons HP 700 puppet"/>
-    <string name="h4" value="MP - 23; For 10 sec., summons HP 800 puppet"/>
-    <string name="h5" value="MP - 23; For 10 sec., summons HP 900 puppet"/>
-    <string name="h6" value="MP - 26; For 20 sec., summons HP 1000 puppet"/>
-    <string name="h7" value="MP - 26; For 20 sec., summons HP 1200 puppet"/>
-    <string name="h8" value="MP - 26; For 20 sec., summons HP 1400 puppet"/>
-    <string name="h9" value="MP - 26; For 30 sec., summons HP 1600 puppet"/>
-    <string name="h10" value="MP - 26; For 30 sec., summons HP 1800 puppet"/>
-    <string name="h11" value="MP - 29; For 30 sec., summons HP 2000 puppet"/>
-    <string name="h12" value="MP - 29; For 40 sec., summons HP 2400 puppet"/>
-    <string name="h13" value="MP - 29; For 40 sec., summons HP 2800 puppet"/>
-    <string name="h14" value="MP - 29; For 40 sec., summons HP 3200 puppet"/>
-    <string name="h15" value="MP - 29; For 50 sec., summons HP 3600 puppet"/>
-    <string name="h16" value="MP - 32; For 50 sec., summons HP 4000 puppet"/>
-    <string name="h17" value="MP - 32; For 50 sec., summons HP 4500 puppet"/>
-    <string name="h18" value="MP - 32; For 60 sec., summons HP 5000 puppet"/>
-    <string name="h19" value="MP - 32; For 60 sec., summons HP 5500 puppet"/>
-    <string name="h20" value="MP - 32; For 60 sec., summons HP 6000 puppet"/>
+    <string name="h1" value="MP -23; summons a puppet with 500 HP for 5 sec"/>
+    <string name="h2" value="MP -23; summons a puppet with 600 HP for 5 sec"/>
+    <string name="h3" value="MP -23; summons a puppet with 700 HP for 10 sec"/>
+    <string name="h4" value="MP -23; summons a puppet with 800 HP for 10 sec"/>
+    <string name="h5" value="MP -23; summons a puppet with 900 HP for 10 sec"/>
+    <string name="h6" value="MP -26; summons a puppet with 1000 HP for 20 sec"/>
+    <string name="h7" value="MP -26; summons a puppet with 1200 HP for 20 sec"/>
+    <string name="h8" value="MP -26; summons a puppet with 1400 HP for 20 sec"/>
+    <string name="h9" value="MP -26; summons a puppet with 1600 HP for 30 sec"/>
+    <string name="h10" value="MP -26; summons a puppet with 1800 HP for 30 sec"/>
+    <string name="h11" value="MP -29; summons a puppet with 2000 HP for 30 sec"/>
+    <string name="h12" value="MP -29; summons a puppet with 2400 HP for 40 sec"/>
+    <string name="h13" value="MP -29; summons a puppet with 2800 HP for 40 sec"/>
+    <string name="h14" value="MP -29; summons a puppet with 3200 HP for 40 sec"/>
+    <string name="h15" value="MP -29; summons a puppet with 3600 HP for 50 sec"/>
+    <string name="h16" value="MP -32; summons a puppet with 4000 HP for 50 sec"/>
+    <string name="h17" value="MP -32; summons a puppet with 4500 HP for 50 sec"/>
+    <string name="h18" value="MP -32; summons a puppet with 5000 HP for 60 sec"/>
+    <string name="h19" value="MP -32; summons a puppet with 5500 HP for 60 sec"/>
+    <string name="h20" value="MP -32; summons a puppet with 6000 HP for 60 sec"/>
   </imgdir>
   <imgdir name="3211003">
     <string name="name" value="Blizzard"/>
     <string name="desc" value="[Master Level : 30]\nAttacks up to 6 enemies with ice arrows, dealing ice-element damage.\nRequires a crossbow."/>
-    <string name="h1" value="MP - 20, Damage 100%, freezes enemies for 1 sec."/>
-    <string name="h2" value="MP - 20, Damage 102%, freezes enemies for 1 sec."/>
-    <string name="h3" value="MP - 20, Damage 104%, freezes enemies for 1 sec."/>
-    <string name="h4" value="MP - 20, Damage 106%, freezes enemies for 1 sec."/>
-    <string name="h5" value="MP - 20, Damage 108%, freezes enemies for 1 sec."/>
-    <string name="h6" value="MP - 20, Damage 110%, freezes enemies for 1 sec."/>
-    <string name="h7" value="MP - 20, Damage 112%, freezes enemies for 1 sec."/>
-    <string name="h8" value="MP - 20, Damage 114%, freezes enemies for 1 sec."/>
-    <string name="h9" value="MP - 20, Damage 116%, freezes enemies for 1 sec."/>
-    <string name="h10" value="MP - 20, Damage 118%, freezes enemies for 1 sec."/>
-    <string name="h11" value="MP - 25, Damage 120%, freezes enemies for 2 sec."/>
-    <string name="h12" value="MP - 25, Damage 122%, freezes enemies for 2 sec."/>
-    <string name="h13" value="MP - 25, Damage 124%, freezes enemies for 2 sec."/>
-    <string name="h14" value="MP - 25, Damage 126%, freezes enemies for 2 sec."/>
-    <string name="h15" value="MP - 25, Damage 128%, freezes enemies for 2 sec."/>
-    <string name="h16" value="MP - 25, Damage 130%, freezes enemies for 2 sec."/>
-    <string name="h17" value="MP - 25, Damage 131%, freezes enemies for 2 sec."/>
-    <string name="h18" value="MP - 25, Damage 132%, freezes enemies for 2 sec."/>
-    <string name="h19" value="MP - 25, Damage 133%, freezes enemies for 2 sec."/>
-    <string name="h20" value="MP - 25, Damage 134%, freezes enemies for 2 sec."/>
-    <string name="h21" value="MP - 30, Damage 135%, freezes enemies for 3 sec."/>
-    <string name="h22" value="MP - 30, Damage 136%, freezes enemies for 3 sec."/>
-    <string name="h23" value="MP - 30, Damage 136%, freezes enemies for 3 sec."/>
-    <string name="h24" value="MP - 30, Damage 137%, freezes enemies for 3 sec."/>
-    <string name="h25" value="MP - 30, Damage 137%, freezes enemies for 3 sec."/>
-    <string name="h26" value="MP - 30, Damage 138%, freezes enemies for 3 sec."/>
-    <string name="h27" value="MP - 30, Damage 138%, freezes enemies for 3 sec."/>
-    <string name="h28" value="MP - 30, Damage 139%, freezes enemies for 3 sec."/>
-    <string name="h29" value="MP - 30, Damage 139%, freezes enemies for 3 sec."/>
-    <string name="h30" value="MP - 30, Damage 140%, freezes enemies for 3 sec."/>
+    <string name="h1" value="MP -20; Damage 100% against up to 6 enemies, freezes for 1 sec"/>
+    <string name="h2" value="MP -20; Damage 102% against up to 6 enemies, freezes for 1 sec"/>
+    <string name="h3" value="MP -20; Damage 104% against up to 6 enemies, freezes for 1 sec"/>
+    <string name="h4" value="MP -20; Damage 106% against up to 6 enemies, freezes for 1 sec"/>
+    <string name="h5" value="MP -20; Damage 108% against up to 6 enemies, freezes for 1 sec"/>
+    <string name="h6" value="MP -20; Damage 110% against up to 6 enemies, freezes for 1 sec"/>
+    <string name="h7" value="MP -20; Damage 112% against up to 6 enemies, freezes for 1 sec"/>
+    <string name="h8" value="MP -20; Damage 114% against up to 6 enemies, freezes for 1 sec"/>
+    <string name="h9" value="MP -20; Damage 116% against up to 6 enemies, freezes for 1 sec"/>
+    <string name="h10" value="MP -20; Damage 118% against up to 6 enemies, freezes for 1 sec"/>
+    <string name="h11" value="MP -25; Damage 120% against up to 6 enemies, freezes for 2 sec"/>
+    <string name="h12" value="MP -25; Damage 122% against up to 6 enemies, freezes for 2 sec"/>
+    <string name="h13" value="MP -25; Damage 124% against up to 6 enemies, freezes for 2 sec"/>
+    <string name="h14" value="MP -25; Damage 126% against up to 6 enemies, freezes for 2 sec"/>
+    <string name="h15" value="MP -25; Damage 128% against up to 6 enemies, freezes for 2 sec"/>
+    <string name="h16" value="MP -25; Damage 130% against up to 6 enemies, freezes for 2 sec"/>
+    <string name="h17" value="MP -25; Damage 131% against up to 6 enemies, freezes for 2 sec"/>
+    <string name="h18" value="MP -25; Damage 132% against up to 6 enemies, freezes for 2 sec"/>
+    <string name="h19" value="MP -25; Damage 133% against up to 6 enemies, freezes for 2 sec"/>
+    <string name="h20" value="MP -30; Damage 134% against up to 6 enemies, freezes for 2 sec"/>
+    <string name="h21" value="MP -30; Damage 135% against up to 6 enemies, freezes for 3 sec"/>
+    <string name="h22" value="MP -30; Damage 136% against up to 6 enemies, freezes for 3 sec"/>
+    <string name="h23" value="MP -30; Damage 136% against up to 6 enemies, freezes for 3 sec"/>
+    <string name="h24" value="MP -30; Damage 137% against up to 6 enemies, freezes for 3 sec"/>
+    <string name="h25" value="MP -30; Damage 137% against up to 6 enemies, freezes for 3 sec"/>
+    <string name="h26" value="MP -30; Damage 138% against up to 6 enemies, freezes for 3 sec"/>
+    <string name="h27" value="MP -30; Damage 138% against up to 6 enemies, freezes for 3 sec"/>
+    <string name="h28" value="MP -30; Damage 139% against up to 6 enemies, freezes for 3 sec"/>
+    <string name="h29" value="MP -30; Damage 139% against up to 6 enemies, freezes for 3 sec"/>
+    <string name="h30" value="MP -30; Damage 140% against up to 6 enemies, freezes for 3 sec"/>
   </imgdir>
   <imgdir name="3211004">
     <string name="name" value="Arrow Eruption"/>
     <string name="desc" value="[Master Level : 30]\nTriggers an erupting arrow attack that hits up to 6 enemies.\nRequires a crossbow.\nRequired Skill : #cMortal Blow Lv. 5 or higher#"/>
-    <string name="h1" value="MP - 18, Damage 60%"/>
-    <string name="h2" value="MP - 18, Damage 65%"/>
-    <string name="h3" value="MP - 18, Damage 70%"/>
-    <string name="h4" value="MP - 18, Damage 75%"/>
-    <string name="h5" value="MP - 18, Damage 80%"/>
-    <string name="h6" value="MP - 18, Damage 85%"/>
-    <string name="h7" value="MP - 18, Damage 90%"/>
-    <string name="h8" value="MP - 18, Damage 95%"/>
-    <string name="h9" value="MP - 18, Damage 100%"/>
-    <string name="h10" value="MP - 18, Damage 105%"/>
-    <string name="h11" value="MP - 23, Damage 110%"/>
-    <string name="h12" value="MP - 23, Damage 113%"/>
-    <string name="h13" value="MP - 23, Damage 116%"/>
-    <string name="h14" value="MP - 23, Damage 119%"/>
-    <string name="h15" value="MP - 23, Damage 122%"/>
-    <string name="h16" value="MP - 23, Damage 125%"/>
-    <string name="h17" value="MP - 23, Damage 128%"/>
-    <string name="h18" value="MP - 23, Damage 131%"/>
-    <string name="h19" value="MP - 23, Damage 134%"/>
-    <string name="h20" value="MP - 23, Damage 137%"/>
-    <string name="h21" value="MP - 28, Damage 140%"/>
-    <string name="h22" value="MP - 28, Damage 143%"/>
-    <string name="h23" value="MP - 28, Damage 146%"/>
-    <string name="h24" value="MP - 28, Damage 149%"/>
-    <string name="h25" value="MP - 28, Damage 152%"/>
-    <string name="h26" value="MP - 28, Damage 154%"/>
-    <string name="h27" value="MP - 28, Damage 156%"/>
-    <string name="h28" value="MP - 28, Damage 158%"/>
-    <string name="h29" value="MP - 28, Damage 159%"/>
-    <string name="h30" value="MP - 28, Damage 160%"/>
+    <string name="h1" value="MP -18; Damage 60% against up to 6 enemies"/>
+    <string name="h2" value="MP -18; Damage 65% against up to 6 enemies"/>
+    <string name="h3" value="MP -18; Damage 70% against up to 6 enemies"/>
+    <string name="h4" value="MP -18; Damage 75% against up to 6 enemies"/>
+    <string name="h5" value="MP -18; Damage 80% against up to 6 enemies"/>
+    <string name="h6" value="MP -18; Damage 85% against up to 6 enemies"/>
+    <string name="h7" value="MP -18; Damage 90% against up to 6 enemies"/>
+    <string name="h8" value="MP -18; Damage 95% against up to 6 enemies"/>
+    <string name="h9" value="MP -18; Damage 100% against up to 6 enemies"/>
+    <string name="h10" value="MP -18; Damage 105% against up to 6 enemies"/>
+    <string name="h11" value="MP -23; Damage 110% against up to 6 enemies"/>
+    <string name="h12" value="MP -23; Damage 113% against up to 6 enemies"/>
+    <string name="h13" value="MP -23; Damage 116% against up to 6 enemies"/>
+    <string name="h14" value="MP -23; Damage 119% against up to 6 enemies"/>
+    <string name="h15" value="MP -23; Damage 122% against up to 6 enemies"/>
+    <string name="h16" value="MP -23; Damage 125% against up to 6 enemies"/>
+    <string name="h17" value="MP -23; Damage 128% against up to 6 enemies"/>
+    <string name="h18" value="MP -23; Damage 131% against up to 6 enemies"/>
+    <string name="h19" value="MP -23; Damage 134% against up to 6 enemies"/>
+    <string name="h20" value="MP -23; Damage 137% against up to 6 enemies"/>
+    <string name="h21" value="MP -28; Damage 140% against up to 6 enemies"/>
+    <string name="h22" value="MP -28; Damage 143% against up to 6 enemies"/>
+    <string name="h23" value="MP -28; Damage 146% against up to 6 enemies"/>
+    <string name="h24" value="MP -28; Damage 149% against up to 6 enemies"/>
+    <string name="h25" value="MP -28; Damage 152% against up to 6 enemies"/>
+    <string name="h26" value="MP -28; Damage 154% against up to 6 enemies"/>
+    <string name="h27" value="MP -28; Damage 156% against up to 6 enemies"/>
+    <string name="h28" value="MP -28; Damage 158% against up to 6 enemies"/>
+    <string name="h29" value="MP -28; Damage 159% against up to 6 enemies"/>
+    <string name="h30" value="MP -28; Damage 160% against up to 6 enemies"/>
   </imgdir>
   <imgdir name="3211005">
     <string name="name" value="Golden Eagle"/>
     <string name="desc" value="[Master Level : 30]\nSummons Golden Eagle to attack nearby enemies for a period of time, with a chance to stun.\nRequired Skill : #cPuppet Lv. 5 or higher#"/>
-    <string name="h1" value="MP - 32, use 1 Summoning Rock; summons an eagle that attacks 13 times in 180 sec.; 50% chance of stunning"/>
-    <string name="h2" value="MP - 34, use 1 Summoning Rock; summons an eagle that attacks 16 times in 180 sec.; 53% chance of stunning"/>
-    <string name="h3" value="MP - 36, use 1 Summoning Rock; summons an eagle that attacks 19 times in 180 sec.; 56% chance of stunning"/>
-    <string name="h4" value="MP - 38, use 1 Summoning Rock; summons an eagle that attacks 22 times in 180 sec.; 59% chance of stunning"/>
-    <string name="h5" value="MP - 40, use 1 Summoning Rock; summons an eagle that attacks 25 times in 180 sec.; 62% chance of stunning"/>
-    <string name="h6" value="MP - 42, use 1 Summoning Rock; summons an eagle that attacks 28 times in 180 sec.; 65% chance of stunning"/>
-    <string name="h7" value="MP - 44, use 1 Summoning Rock; summons an eagle that attacks 31 times in 180 sec.; 68% chance of stunning"/>
-    <string name="h8" value="MP - 46, use 1 Summoning Rock; summons an eagle that attacks 34 times in 180 sec.; 71% chance of stunning"/>
-    <string name="h9" value="MP - 48, use 1 Summoning Rock; summons an eagle that attacks 37 times in 180 sec.; 74% chance of stunning"/>
-    <string name="h10" value="MP - 50, use 1 Summoning Rock; summons an eagle that attacks 40 times in 180 sec.; 77% chance of stunning"/>
-    <string name="h11" value="MP - 52, use 1 Summoning Rock; summons an eagle that attacks 42 times in 180 sec.; 80% chance of stunning"/>
-    <string name="h12" value="MP - 54, use 1 Summoning Rock; summons an eagle that attacks 44 times in 180 sec.; 82% chance of stunning"/>
-    <string name="h13" value="MP - 56, use 1 Summoning Rock; summons an eagle that attacks 46 times in 180 sec.; 84% chance of stunning"/>
-    <string name="h14" value="MP - 58, use 1 Summoning Rock; summons an eagle that attacks 48 times in 180 sec.; 86% chance of stunning"/>
-    <string name="h15" value="MP - 60, use 1 Summoning Rock; summons an eagle that attacks 50 times in 180 sec.; 88% chance of stunning"/>
-    <string name="h16" value="MP - 62, use 1 Summoning Rock; summons an eagle that attacks 52 times in 180 sec.; 90% chance of stunning"/>
-    <string name="h17" value="MP - 64, use 1 Summoning Rock; summons an eagle that attacks 54 times in 180 sec.; 91% chance of stunning"/>
-    <string name="h18" value="MP - 66, use 1 Summoning Rock; summons an eagle that attacks 56 times in 180 sec.; 92% chance of stunning"/>
-    <string name="h19" value="MP - 68, use 1 Summoning Rock; summons an eagle that attacks 58 times in 180 sec.; 93% chance of stunning"/>
-    <string name="h20" value="MP - 70, use 1 Summoning Rock; summons an eagle that attacks 60 times in 180 sec.; 94% chance of stunning"/>
-    <string name="h21" value="MP - 71, use 1 Summoning Rock; summons an eagle that attacks 61 times in 180 sec.; 95% chance of stunning"/>
-    <string name="h22" value="MP - 72, use 1 Summoning Rock; summons an eagle that attacks 62 times in 180 sec.; 95% chance of stunning"/>
-    <string name="h23" value="MP - 73, use 1 Summoning Rock; summons an eagle that attacks 63 times in 180 sec.; 96% chance of stunning"/>
-    <string name="h24" value="MP - 74, use 1 Summoning Rock; summons an eagle that attacks 64 times in 180 sec.; 96% chance of stunning"/>
-    <string name="h25" value="MP - 75, use 1 Summoning Rock; summons an eagle that attacks 65 times in 180 sec.; 97% chance of stunning"/>
-    <string name="h26" value="MP - 76, use 1 Summoning Rock; summons an eagle that attacks 66 times in 180 sec.; 97% chance of stunning"/>
-    <string name="h27" value="MP - 77, use 1 Summoning Rock; summons an eagle that attacks 67 times in 180 sec.; 98% chance of stunning"/>
-    <string name="h28" value="MP - 78, use 1 Summoning Rock; summons an eagle that attacks 68 times in 180 sec.; 98% chance of stunning"/>
-    <string name="h29" value="MP - 79, use 1 Summoning Rock; summons an eagle that attacks 69 times in 180 sec.; 99% chance of stunning"/>
-    <string name="h30" value="MP - 80, use 1 Summoning Rock; summons an eagle that attacks 70 times in 180 sec.; 99% chance of stunning"/>
+    <string name="h1" value="MP -32, 1 Summoning Rock; summons Golden Eagle for 103 sec, attack 23, 50% stun chance"/>
+    <string name="h2" value="MP -34, 1 Summoning Rock; summons Golden Eagle for 106 sec, attack 26, 53% stun chance"/>
+    <string name="h3" value="MP -36, 1 Summoning Rock; summons Golden Eagle for 109 sec, attack 29, 56% stun chance"/>
+    <string name="h4" value="MP -38, 1 Summoning Rock; summons Golden Eagle for 112 sec, attack 32, 59% stun chance"/>
+    <string name="h5" value="MP -40, 1 Summoning Rock; summons Golden Eagle for 115 sec, attack 35, 62% stun chance"/>
+    <string name="h6" value="MP -42, 1 Summoning Rock; summons Golden Eagle for 118 sec, attack 38, 65% stun chance"/>
+    <string name="h7" value="MP -44, 1 Summoning Rock; summons Golden Eagle for 121 sec, attack 41, 68% stun chance"/>
+    <string name="h8" value="MP -46, 1 Summoning Rock; summons Golden Eagle for 124 sec, attack 44, 71% stun chance"/>
+    <string name="h9" value="MP -48, 1 Summoning Rock; summons Golden Eagle for 127 sec, attack 47, 74% stun chance"/>
+    <string name="h10" value="MP -50, 1 Summoning Rock; summons Golden Eagle for 130 sec, attack 50, 77% stun chance"/>
+    <string name="h11" value="MP -52, 1 Summoning Rock; summons Golden Eagle for 133 sec, attack 53, 80% stun chance"/>
+    <string name="h12" value="MP -54, 1 Summoning Rock; summons Golden Eagle for 136 sec, attack 56, 82% stun chance"/>
+    <string name="h13" value="MP -56, 1 Summoning Rock; summons Golden Eagle for 139 sec, attack 59, 84% stun chance"/>
+    <string name="h14" value="MP -58, 1 Summoning Rock; summons Golden Eagle for 142 sec, attack 62, 86% stun chance"/>
+    <string name="h15" value="MP -60, 1 Summoning Rock; summons Golden Eagle for 145 sec, attack 65, 88% stun chance"/>
+    <string name="h16" value="MP -62, 1 Summoning Rock; summons Golden Eagle for 148 sec, attack 68, 90% stun chance"/>
+    <string name="h17" value="MP -64, 1 Summoning Rock; summons Golden Eagle for 151 sec, attack 71, 91% stun chance"/>
+    <string name="h18" value="MP -66, 1 Summoning Rock; summons Golden Eagle for 154 sec, attack 74, 92% stun chance"/>
+    <string name="h19" value="MP -68, 1 Summoning Rock; summons Golden Eagle for 160 sec, attack 77, 93% stun chance"/>
+    <string name="h20" value="MP -70, 1 Summoning Rock; summons Golden Eagle for 162 sec, attack 80, 94% stun chance"/>
+    <string name="h21" value="MP -71, 1 Summoning Rock; summons Golden Eagle for 164 sec, attack 82, 95% stun chance"/>
+    <string name="h22" value="MP -72, 1 Summoning Rock; summons Golden Eagle for 166 sec, attack 84, 95% stun chance"/>
+    <string name="h23" value="MP -73, 1 Summoning Rock; summons Golden Eagle for 168 sec, attack 86, 96% stun chance"/>
+    <string name="h24" value="MP -74, 1 Summoning Rock; summons Golden Eagle for 170 sec, attack 88, 96% stun chance"/>
+    <string name="h25" value="MP -75, 1 Summoning Rock; summons Golden Eagle for 172 sec, attack 90, 97% stun chance"/>
+    <string name="h26" value="MP -76, 1 Summoning Rock; summons Golden Eagle for 174 sec, attack 92, 97% stun chance"/>
+    <string name="h27" value="MP -77, 1 Summoning Rock; summons Golden Eagle for 176 sec, attack 94, 98% stun chance"/>
+    <string name="h28" value="MP -78, 1 Summoning Rock; summons Golden Eagle for 178 sec, attack 96, 98% stun chance"/>
+    <string name="h29" value="MP -79, 1 Summoning Rock; summons Golden Eagle for 180 sec, attack 98, 99% stun chance"/>
+    <string name="h30" value="MP -80, 1 Summoning Rock; summons Golden Eagle for 180 sec, attack 100, 99% stun chance"/>
   </imgdir>
   <imgdir name="3211006">
     <string name="name" value="Strafe"/>
     <string name="desc" value="[Master Level : 30]\nRapidly fires 4 arrows at a single enemy."/>
-    <string name="h1" value="MP - 26, Damage 71%, attack 4 times"/>
-    <string name="h2" value="MP - 26, Damage 72%, attack 4 times"/>
-    <string name="h3" value="MP - 26, Damage 73%, attack 4 times"/>
-    <string name="h4" value="MP - 26, Damage 74%, attack 4 times"/>
-    <string name="h5" value="MP - 26, Damage 75%, attack 4 times"/>
-    <string name="h6" value="MP - 26, Damage 76%, attack 4 times"/>
-    <string name="h7" value="MP - 26, Damage 77%, attack 4 times"/>
-    <string name="h8" value="MP - 26, Damage 78%, attack 4 times"/>
-    <string name="h9" value="MP - 26, Damage 79%, attack 4 times"/>
-    <string name="h10" value="MP - 26, Damage 80%, attack 4 times"/>
-    <string name="h11" value="MP - 26, Damage 81%, attack 4 times"/>
-    <string name="h12" value="MP - 26, Damage 82%, attack 4 times"/>
-    <string name="h13" value="MP - 26, Damage 83%, attack 4 times"/>
-    <string name="h14" value="MP - 26, Damage 84%, attack 4 times"/>
-    <string name="h15" value="MP - 26, Damage 85%, attack 4 times"/>
-    <string name="h16" value="MP - 32, Damage 86%, attack 4 times"/>
-    <string name="h17" value="MP - 32, Damage 87%, attack 4 times"/>
-    <string name="h18" value="MP - 32, Damage 88%, attack 4 times"/>
-    <string name="h19" value="MP - 32, Damage 89%, attack 4 times"/>
-    <string name="h20" value="MP - 32, Damage 90%, attack 4 times"/>
-    <string name="h21" value="MP - 32, Damage 91%, attack 4 times"/>
-    <string name="h22" value="MP - 32, Damage 92%, attack 4 times"/>
-    <string name="h23" value="MP - 32, Damage 93%, attack 4 times"/>
-    <string name="h24" value="MP - 32, Damage 94%, attack 4 times"/>
-    <string name="h25" value="MP - 32, Damage 95%, attack 4 times"/>
-    <string name="h26" value="MP - 32, Damage 96%, attack 4 times"/>
-    <string name="h27" value="MP - 32, Damage 97%, attack 4 times"/>
-    <string name="h28" value="MP - 32, Damage 98%, attack 4 times"/>
-    <string name="h29" value="MP - 32, Damage 99%, attack 4 times"/>
-    <string name="h30" value="MP - 32, Damage 100%, attack 4 times"/>
+    <string name="h1" value="MP -26; Damage 71% per arrow, 4 hits"/>
+    <string name="h2" value="MP -26; Damage 72% per arrow, 4 hits"/>
+    <string name="h3" value="MP -26; Damage 73% per arrow, 4 hits"/>
+    <string name="h4" value="MP -26; Damage 74% per arrow, 4 hits"/>
+    <string name="h5" value="MP -26; Damage 75% per arrow, 4 hits"/>
+    <string name="h6" value="MP -26; Damage 76% per arrow, 4 hits"/>
+    <string name="h7" value="MP -26; Damage 77% per arrow, 4 hits"/>
+    <string name="h8" value="MP -26; Damage 78% per arrow, 4 hits"/>
+    <string name="h9" value="MP -26; Damage 79% per arrow, 4 hits"/>
+    <string name="h10" value="MP -26; Damage 80% per arrow, 4 hits"/>
+    <string name="h11" value="MP -26; Damage 81% per arrow, 4 hits"/>
+    <string name="h12" value="MP -26; Damage 82% per arrow, 4 hits"/>
+    <string name="h13" value="MP -26; Damage 83% per arrow, 4 hits"/>
+    <string name="h14" value="MP -26; Damage 84% per arrow, 4 hits"/>
+    <string name="h15" value="MP -26; Damage 85% per arrow, 4 hits"/>
+    <string name="h16" value="MP -32; Damage 86% per arrow, 4 hits"/>
+    <string name="h17" value="MP -32; Damage 87% per arrow, 4 hits"/>
+    <string name="h18" value="MP -32; Damage 88% per arrow, 4 hits"/>
+    <string name="h19" value="MP -32; Damage 89% per arrow, 4 hits"/>
+    <string name="h20" value="MP -32; Damage 90% per arrow, 4 hits"/>
+    <string name="h21" value="MP -32; Damage 91% per arrow, 4 hits"/>
+    <string name="h22" value="MP -32; Damage 92% per arrow, 4 hits"/>
+    <string name="h23" value="MP -32; Damage 93% per arrow, 4 hits"/>
+    <string name="h24" value="MP -32; Damage 94% per arrow, 4 hits"/>
+    <string name="h25" value="MP -32; Damage 95% per arrow, 4 hits"/>
+    <string name="h26" value="MP -32; Damage 96% per arrow, 4 hits"/>
+    <string name="h27" value="MP -32; Damage 97% per arrow, 4 hits"/>
+    <string name="h28" value="MP -32; Damage 98% per arrow, 4 hits"/>
+    <string name="h29" value="MP -32; Damage 99% per arrow, 4 hits"/>
+    <string name="h30" value="MP -32; Damage 100% per arrow, 4 hits"/>
   </imgdir>
   <imgdir name="411">
     <string name="bookName" value="The Way of Hermit"/>
@@ -5136,7 +5136,7 @@
   </imgdir>
   <imgdir name="1221000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
+    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
     <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
     <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
     <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
@@ -5482,7 +5482,7 @@
   </imgdir>
   <imgdir name="1321000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
+    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
     <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
     <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
     <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
@@ -5770,7 +5770,7 @@
   </imgdir>
   <imgdir name="2121000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
+    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
     <string name="h1" value="MP -10; all stats +1% for 30 sec"/>
     <string name="h2" value="MP -10; all stats +1% for 60 sec"/>
     <string name="h3" value="MP -10; all stats +2% for 90 sec"/>
@@ -6338,7 +6338,7 @@
   </imgdir>
   <imgdir name="2321000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
+    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
     <string name="h1" value="MP -10; all stats +1% for 30 sec"/>
     <string name="h2" value="MP -10; all stats +1% for 60 sec"/>
     <string name="h3" value="MP -10; all stats +2% for 90 sec"/>
@@ -6636,139 +6636,139 @@
   </imgdir>
   <imgdir name="3121000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
-    <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
-    <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
-    <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
-    <string name="h4" value="MP - 10 ,  For 120Secs, all stats + 2% "/>
-    <string name="h5" value="MP - 10 ,  For 150Secs, all stats + 3% "/>
-    <string name="h6" value="MP - 20 ,  For 180Secs, all stats + 3% "/>
-    <string name="h7" value="MP - 20 ,  For 210Secs, all stats + 4% "/>
-    <string name="h8" value="MP - 20 ,  For 240Secs, all stats + 4% "/>
-    <string name="h9" value="MP - 20 ,  For 270Secs, all stats + 5% "/>
-    <string name="h10" value="MP - 20 ,  For 300Secs, all stats + 5% "/>
-    <string name="h11" value="MP - 30 ,  For 330Secs, all stats + 6% "/>
-    <string name="h12" value="MP - 30 ,  For 360Secs, all stats + 6% "/>
-    <string name="h13" value="MP - 30 ,  For 390Secs, all stats + 7% "/>
-    <string name="h14" value="MP - 30 ,  For 420Secs, all stats + 7% "/>
-    <string name="h15" value="MP - 30 ,  For 450Secs, all stats + 8% "/>
-    <string name="h16" value="MP - 40 ,  For 480Secs, all stats + 8% "/>
-    <string name="h17" value="MP - 40 ,  For 510Secs, all stats + 9% "/>
-    <string name="h18" value="MP - 40 ,  For 540Secs, all stats + 9% "/>
-    <string name="h19" value="MP - 40 ,  For 570Secs, all stats + 10% "/>
-    <string name="h20" value="MP - 40 ,  For 600Secs, all stats + 10% "/>
-    <string name="h21" value="MP - 50 ,  For 630Secs, all stats + 11% "/>
-    <string name="h22" value="MP - 50 ,  For 660Secs, all stats + 11% "/>
-    <string name="h23" value="MP - 50 ,  For 690Secs, all stats + 12% "/>
-    <string name="h24" value="MP - 50 ,  For 720Secs, all stats + 12% "/>
-    <string name="h25" value="MP - 50 ,  For 750Secs, all stats + 13% "/>
-    <string name="h26" value="MP - 60 ,  For 780Secs, all stats + 13% "/>
-    <string name="h27" value="MP - 60 ,  For 810Secs, all stats + 14% "/>
-    <string name="h28" value="MP - 60 ,  For 840Secs, all stats + 14% "/>
-    <string name="h29" value="MP - 60 ,  For 870Secs, all stats + 15% "/>
-    <string name="h30" value="MP - 60 ,  For 900Secs, all stats + 15% "/>
+    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
+    <string name="h1" value="MP -10; all stats +1% for 30 sec"/>
+    <string name="h2" value="MP -10; all stats +1% for 60 sec"/>
+    <string name="h3" value="MP -10; all stats +2% for 90 sec"/>
+    <string name="h4" value="MP -10; all stats +2% for 120 sec"/>
+    <string name="h5" value="MP -10; all stats +3% for 150 sec"/>
+    <string name="h6" value="MP -20; all stats +3% for 180 sec"/>
+    <string name="h7" value="MP -20; all stats +4% for 210 sec"/>
+    <string name="h8" value="MP -20; all stats +4% for 240 sec"/>
+    <string name="h9" value="MP -20; all stats +5% for 270 sec"/>
+    <string name="h10" value="MP -20; all stats +5% for 300 sec"/>
+    <string name="h11" value="MP -30; all stats +6% for 330 sec"/>
+    <string name="h12" value="MP -30; all stats +6% for 360 sec"/>
+    <string name="h13" value="MP -30; all stats +7% for 390 sec"/>
+    <string name="h14" value="MP -30; all stats +7% for 420 sec"/>
+    <string name="h15" value="MP -30; all stats +8% for 450 sec"/>
+    <string name="h16" value="MP -40; all stats +8% for 480 sec"/>
+    <string name="h17" value="MP -40; all stats +9% for 510 sec"/>
+    <string name="h18" value="MP -40; all stats +9% for 540 sec"/>
+    <string name="h19" value="MP -40; all stats +10% for 570 sec"/>
+    <string name="h20" value="MP -40; all stats +10% for 600 sec"/>
+    <string name="h21" value="MP -50; all stats +11% for 630 sec"/>
+    <string name="h22" value="MP -50; all stats +11% for 660 sec"/>
+    <string name="h23" value="MP -50; all stats +12% for 690 sec"/>
+    <string name="h24" value="MP -50; all stats +12% for 720 sec"/>
+    <string name="h25" value="MP -50; all stats +13% for 750 sec"/>
+    <string name="h26" value="MP -60; all stats +13% for 780 sec"/>
+    <string name="h27" value="MP -60; all stats +14% for 810 sec"/>
+    <string name="h28" value="MP -60; all stats +14% for 840 sec"/>
+    <string name="h29" value="MP -60; all stats +15% for 870 sec"/>
+    <string name="h30" value="MP -60; all stats +15% for 900 sec"/>
   </imgdir>
   <imgdir name="3121002">
     <string name="name" value="Sharp Eyes"/>
     <string name="desc" value="Temporarily increases Critical Rate and Critical Damage for yourself and party members."/>
-    <string name="h1" value="MP - 29 , for 10secs , Critical rate 1%, Damage + 11% ."/>
-    <string name="h2" value="MP - 29 , for 20secs , Critical rate 1%, Damage + 12% ."/>
-    <string name="h3" value="MP - 29 , for 30secs , Critical rate 2%, Damage + 13% ."/>
-    <string name="h4" value="MP - 29 , for 40secs , Critical rate 2%, Damage + 14% ."/>
-    <string name="h5" value="MP - 29 , for 50secs , Critical rate 3%, Damage + 15% ."/>
-    <string name="h6" value="MP - 29 , for 60secs , Critical rate 3%, Damage + 16% ."/>
-    <string name="h7" value="MP - 29 , for 70secs , Critical rate 4%, Damage + 17% ."/>
-    <string name="h8" value="MP - 29 , for 80secs , Critical rate 4%, Damage + 18% ."/>
-    <string name="h9" value="MP - 29 , for 90secs , Critical rate 5%, Damage + 19% ."/>
-    <string name="h10" value="MP - 29 , for 100secs , Critical rate 5%, Damage + 20% ."/>
-    <string name="h11" value="MP - 37 , for 110secs , Critical rate 6%, Damage + 21% ."/>
-    <string name="h12" value="MP - 37 , for 120secs , Critical rate 6%, Damage + 22% ."/>
-    <string name="h13" value="MP - 37 , for 130secs , Critical rate 7%, Damage + 23% ."/>
-    <string name="h14" value="MP - 37 , for 140secs , Critical rate 7%, Damage + 24% ."/>
-    <string name="h15" value="MP - 37 , for 150secs , Critical rate 8%, Damage + 25% ."/>
-    <string name="h16" value="MP - 37 , for 160secs , Critical rate 8%, Damage + 26% ."/>
-    <string name="h17" value="MP - 37 , for 170secs , Critical rate 9%, Damage + 27% ."/>
-    <string name="h18" value="MP - 37 , for 180secs , Critical rate 9%, Damage + 28% ."/>
-    <string name="h19" value="MP - 37 , for 190secs , Critical rate 10%, Damage + 29% ."/>
-    <string name="h20" value="MP - 37 , for 200secs , Critical rate 10%, Damage + 30% ."/>
-    <string name="h21" value="MP - 45 , for 210secs , Critical rate 11%, Damage + 31% ."/>
-    <string name="h22" value="MP - 45 , for 220secs , Critical rate 11%, Damage + 32% ."/>
-    <string name="h23" value="MP - 45 , for 230secs , Critical rate 12%, Damage + 33% ."/>
-    <string name="h24" value="MP - 45 , for 240secs , Critical rate 12%, Damage + 34% ."/>
-    <string name="h25" value="MP - 45 , for 250secs , Critical rate 13%, Damage + 35% ."/>
-    <string name="h26" value="MP - 44 , for 260secs , Critical rate 13%, Damage + 36% ."/>
-    <string name="h27" value="MP - 43 , for 270secs , Critical rate 14%, Damage + 37% ."/>
-    <string name="h28" value="MP - 42 , for 280secs , Critical rate 14%, Damage + 38% ."/>
-    <string name="h29" value="MP - 41 , for 290secs , Critical rate 15%, Damage + 39% ."/>
-    <string name="h30" value="MP - 40 , for 300secs , Critical rate 15%, Damage + 40% ."/>
+    <string name="h1" value="MP -29; Critical Rate +1% and Critical Damage +11% for 10 sec"/>
+    <string name="h2" value="MP -29; Critical Rate +1% and Critical Damage +12% for 20 sec"/>
+    <string name="h3" value="MP -29; Critical Rate +2% and Critical Damage +13% for 30 sec"/>
+    <string name="h4" value="MP -29; Critical Rate +2% and Critical Damage +14% for 40 sec"/>
+    <string name="h5" value="MP -29; Critical Rate +3% and Critical Damage +15% for 50 sec"/>
+    <string name="h6" value="MP -29; Critical Rate +3% and Critical Damage +16% for 60 sec"/>
+    <string name="h7" value="MP -29; Critical Rate +4% and Critical Damage +17% for 70 sec"/>
+    <string name="h8" value="MP -29; Critical Rate +4% and Critical Damage +18% for 80 sec"/>
+    <string name="h9" value="MP -29; Critical Rate +5% and Critical Damage +19% for 90 sec"/>
+    <string name="h10" value="MP -29; Critical Rate +5% and Critical Damage +20% for 100 sec"/>
+    <string name="h11" value="MP -37; Critical Rate +6% and Critical Damage +21% for 110 sec"/>
+    <string name="h12" value="MP -37; Critical Rate +6% and Critical Damage +22% for 120 sec"/>
+    <string name="h13" value="MP -37; Critical Rate +7% and Critical Damage +23% for 130 sec"/>
+    <string name="h14" value="MP -37; Critical Rate +7% and Critical Damage +24% for 140 sec"/>
+    <string name="h15" value="MP -37; Critical Rate +8% and Critical Damage +25% for 150 sec"/>
+    <string name="h16" value="MP -37; Critical Rate +8% and Critical Damage +26% for 160 sec"/>
+    <string name="h17" value="MP -37; Critical Rate +9% and Critical Damage +27% for 170 sec"/>
+    <string name="h18" value="MP -37; Critical Rate +9% and Critical Damage +28% for 180 sec"/>
+    <string name="h19" value="MP -37; Critical Rate +10% and Critical Damage +29% for 190 sec"/>
+    <string name="h20" value="MP -37; Critical Rate +10% and Critical Damage +30% for 200 sec"/>
+    <string name="h21" value="MP -45; Critical Rate +11% and Critical Damage +31% for 210 sec"/>
+    <string name="h22" value="MP -45; Critical Rate +11% and Critical Damage +32% for 220 sec"/>
+    <string name="h23" value="MP -45; Critical Rate +12% and Critical Damage +33% for 230 sec"/>
+    <string name="h24" value="MP -45; Critical Rate +12% and Critical Damage +34% for 240 sec"/>
+    <string name="h25" value="MP -45; Critical Rate +13% and Critical Damage +35% for 250 sec"/>
+    <string name="h26" value="MP -44; Critical Rate +13% and Critical Damage +36% for 260 sec"/>
+    <string name="h27" value="MP -43; Critical Rate +14% and Critical Damage +37% for 270 sec"/>
+    <string name="h28" value="MP -42; Critical Rate +14% and Critical Damage +38% for 280 sec"/>
+    <string name="h29" value="MP -41; Critical Rate +15% and Critical Damage +39% for 290 sec"/>
+    <string name="h30" value="MP -40; Critical Rate +15% and Critical Damage +40% for 300 sec"/>
   </imgdir>
   <imgdir name="3121003">
     <string name="name" value="Dragon&apos;s Breath"/>
     <string name="desc" value="Unleashes a powerful dragon-infused arrow that attacks multiple enemies ahead and knocks them back."/>
-    <string name="h1" value="MP - 24 , attack 42%, attacks up to 4 enemies"/>
-    <string name="h2" value="MP - 24 , attack 44%, attacks up to 4 enemies"/>
-    <string name="h3" value="MP - 24 , attack 46%, attacks up to 4 enemies"/>
-    <string name="h4" value="MP - 24 , attack 48%, attacks up to 4 enemies"/>
-    <string name="h5" value="MP - 24 , attack 50%, attacks up to 4 enemies"/>
-    <string name="h6" value="MP - 24 , attack 52%, attacks up to 4 enemies"/>
-    <string name="h7" value="MP - 24 , attack 54%, attacks up to 4 enemies"/>
-    <string name="h8" value="MP - 24 , attack 56%, attacks up to 4 enemies"/>
-    <string name="h9" value="MP - 24 , attack 58%, attacks up to 4 enemies"/>
-    <string name="h10" value="MP - 24 , attack 60%, attacks up to 4 enemies"/>
-    <string name="h11" value="MP - 30 , attack 62%, attacks up to 5 enemies"/>
-    <string name="h12" value="MP - 30 , attack 64%, attacks up to 5 enemies"/>
-    <string name="h13" value="MP - 30 , attack 66%, attacks up to 5 enemies"/>
-    <string name="h14" value="MP - 30 , attack 68%, attacks up to 5 enemies"/>
-    <string name="h15" value="MP - 30 , attack 70%, attacks up to 5 enemies"/>
-    <string name="h16" value="MP - 30 , attack 72%, attacks up to 5 enemies"/>
-    <string name="h17" value="MP - 30 , attack 74%, attacks up to 5 enemies"/>
-    <string name="h18" value="MP - 30 , attack 76%, attacks up to 5 enemies"/>
-    <string name="h19" value="MP - 30 , attack 78%, attacks up to 5 enemies"/>
-    <string name="h20" value="MP - 30 , attack 80%, attacks up to 5 enemies"/>
-    <string name="h21" value="MP - 36 , attack 82%, attacks up to 6 enemies"/>
-    <string name="h22" value="MP - 36 , attack 84%, attacks up to 6 enemies"/>
-    <string name="h23" value="MP - 36 , attack 86%, attacks up to 6 enemies"/>
-    <string name="h24" value="MP - 36 , attack 88%, attacks up to 6 enemies"/>
-    <string name="h25" value="MP - 36 , attack 90%, attacks up to 6 enemies"/>
-    <string name="h26" value="MP - 36 , attack 92%, attacks up to 6 enemies"/>
-    <string name="h27" value="MP - 36 , attack 94%, attacks up to 6enemies"/>
-    <string name="h28" value="MP - 36 , attack 96%, attacks up to 6enemies"/>
-    <string name="h29" value="MP - 36 , attack 98%, attacks up to 6enemies"/>
-    <string name="h30" value="MP - 36 , attack 100%, attacks up to 6 enemies"/>
+    <string name="h1" value="MP -24; Damage 42% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h2" value="MP -24; Damage 44% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h3" value="MP -24; Damage 46% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h4" value="MP -24; Damage 48% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h5" value="MP -24; Damage 50% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h6" value="MP -24; Damage 52% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h7" value="MP -24; Damage 54% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h8" value="MP -24; Damage 56% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h9" value="MP -24; Damage 58% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h10" value="MP -24; Damage 60% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h11" value="MP -30; Damage 62% against up to 5 enemies"/>
+    <string name="h12" value="MP -30; Damage 64% against up to 5 enemies"/>
+    <string name="h13" value="MP -30; Damage 66% against up to 5 enemies"/>
+    <string name="h14" value="MP -30; Damage 68% against up to 5 enemies"/>
+    <string name="h15" value="MP -30; Damage 70% against up to 5 enemies"/>
+    <string name="h16" value="MP -30; Damage 72% against up to 5 enemies"/>
+    <string name="h17" value="MP -30; Damage 74% against up to 5 enemies"/>
+    <string name="h18" value="MP -30; Damage 76% against up to 5 enemies"/>
+    <string name="h19" value="MP -30; Damage 78% against up to 5 enemies"/>
+    <string name="h20" value="MP -30; Damage 80% against up to 5 enemies"/>
+    <string name="h21" value="MP -36; Damage 82% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h22" value="MP -36; Damage 84% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h23" value="MP -36; Damage 86% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h24" value="MP -36; Damage 88% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h25" value="MP -36; Damage 90% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h26" value="MP -36; Damage 92% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h27" value="MP -36; Damage 94% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h28" value="MP -36; Damage 96% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h29" value="MP -36; Damage 98% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h30" value="MP -36; Damage 100% against up to 6 enemies, 100% knockback chance"/>
   </imgdir>
   <imgdir name="3121004">
     <string name="name" value="Hurricane"/>
     <string name="desc" value="Fires arrows continuously at tremendous speed while the skill key is held down."/>
-    <string name="h1" value="MP - 6 , Damage 51%"/>
-    <string name="h2" value="MP - 6 , Damage 52%"/>
-    <string name="h3" value="MP - 6 , Damage 53%"/>
-    <string name="h4" value="MP - 6 , Damage 54%"/>
-    <string name="h5" value="MP - 6 , Damage 55%"/>
-    <string name="h6" value="MP - 6 , Damage 56%"/>
-    <string name="h7" value="MP - 6 , Damage 57%"/>
-    <string name="h8" value="MP - 6 , Damage 58%"/>
-    <string name="h9" value="MP - 6 , Damage 59%"/>
-    <string name="h10" value="MP - 6 , Damage 60%"/>
-    <string name="h11" value="MP - 8 , Damage 71%"/>
-    <string name="h12" value="MP - 8 , Damage 72%"/>
-    <string name="h13" value="MP - 8 , Damage 73%"/>
-    <string name="h14" value="MP - 8 , Damage 74%"/>
-    <string name="h15" value="MP - 8 , Damage 75%"/>
-    <string name="h16" value="MP - 8 , Damage 76%"/>
-    <string name="h17" value="MP - 8 , Damage 77%"/>
-    <string name="h18" value="MP - 8 , Damage 78%"/>
-    <string name="h19" value="MP - 8 , Damage 79%"/>
-    <string name="h20" value="MP - 8 , Damage 80%"/>
-    <string name="h21" value="MP - 10 , Damage 91%"/>
-    <string name="h22" value="MP - 10 , Damage 92%"/>
-    <string name="h23" value="MP - 10 , Damage 93%"/>
-    <string name="h24" value="MP - 10 , Damage 94%"/>
-    <string name="h25" value="MP - 10 , Damage 95%"/>
-    <string name="h26" value="MP - 9 , Damage 96%"/>
-    <string name="h27" value="MP - 9 , Damage 97%"/>
-    <string name="h28" value="MP - 9 , Damage 98%"/>
-    <string name="h29" value="MP - 9 , Damage 99%"/>
-    <string name="h30" value="MP - 9 , Damage 100%"/>
+    <string name="h1" value="MP -6; Damage 51% per arrow while held"/>
+    <string name="h2" value="MP -6; Damage 52% per arrow while held"/>
+    <string name="h3" value="MP -6; Damage 53% per arrow while held"/>
+    <string name="h4" value="MP -6; Damage 54% per arrow while held"/>
+    <string name="h5" value="MP -6; Damage 55% per arrow while held"/>
+    <string name="h6" value="MP -6; Damage 56% per arrow while held"/>
+    <string name="h7" value="MP -6; Damage 57% per arrow while held"/>
+    <string name="h8" value="MP -6; Damage 58% per arrow while held"/>
+    <string name="h9" value="MP -6; Damage 59% per arrow while held"/>
+    <string name="h10" value="MP -6; Damage 60% per arrow while held"/>
+    <string name="h11" value="MP -8; Damage 71% per arrow while held"/>
+    <string name="h12" value="MP -8; Damage 72% per arrow while held"/>
+    <string name="h13" value="MP -8; Damage 73% per arrow while held"/>
+    <string name="h14" value="MP -8; Damage 74% per arrow while held"/>
+    <string name="h15" value="MP -8; Damage 75% per arrow while held"/>
+    <string name="h16" value="MP -8; Damage 76% per arrow while held"/>
+    <string name="h17" value="MP -8; Damage 77% per arrow while held"/>
+    <string name="h18" value="MP -8; Damage 78% per arrow while held"/>
+    <string name="h19" value="MP -8; Damage 79% per arrow while held"/>
+    <string name="h20" value="MP -8; Damage 80% per arrow while held"/>
+    <string name="h21" value="MP -10; Damage 91% per arrow while held"/>
+    <string name="h22" value="MP -10; Damage 92% per arrow while held"/>
+    <string name="h23" value="MP -10; Damage 93% per arrow while held"/>
+    <string name="h24" value="MP -10; Damage 94% per arrow while held"/>
+    <string name="h25" value="MP -10; Damage 95% per arrow while held"/>
+    <string name="h26" value="MP -9; Damage 96% per arrow while held"/>
+    <string name="h27" value="MP -9; Damage 97% per arrow while held"/>
+    <string name="h28" value="MP -9; Damage 98% per arrow while held"/>
+    <string name="h29" value="MP -9; Damage 99% per arrow while held"/>
+    <string name="h30" value="MP -9; Damage 100% per arrow while held"/>
   </imgdir>
   <imgdir name="3120005">
     <string name="name" value="Bow Expert"/>
@@ -6807,113 +6807,113 @@
   <imgdir name="3121006">
     <string name="name" value="Phoenix"/>
     <string name="desc" value="Summons Phoenix to attack up to 4 enemies for a period of time.\nRequired Skill : #cSilver Hawk Lv. 15 or higher#"/>
-    <string name="h1" value="MP - 42 , Basic attack 305, for 113secs."/>
-    <string name="h2" value="MP - 44 , Basic attack 310, for 116secs."/>
-    <string name="h3" value="MP - 46 , Basic attack 315, for 119secs."/>
-    <string name="h4" value="MP - 48 , Basic attack 320, for 122secs."/>
-    <string name="h5" value="MP - 50 , Basic attack 325, for 125secs."/>
-    <string name="h6" value="MP - 52 , Basic attack 330, for 128secs."/>
-    <string name="h7" value="MP - 54 , Basic attack 335, for 131secs."/>
-    <string name="h8" value="MP - 56 , Basic attack 340, for 134secs."/>
-    <string name="h9" value="MP - 58 , Basic attack 345, for 137secs."/>
-    <string name="h10" value="MP - 60 , Basic attack 350, for 140secs."/>
-    <string name="h11" value="MP - 62 , Basic attack 405, for 143secs."/>
-    <string name="h12" value="MP - 64 , Basic attack 410, for 146secs."/>
-    <string name="h13" value="MP - 66 , Basic attack 415, for 149secs."/>
-    <string name="h14" value="MP - 68 , Basic attack 420, for 152secs."/>
-    <string name="h15" value="MP - 70 , Basic attack 425, for 155secs."/>
-    <string name="h16" value="MP - 72 , Basic attack 430, for 158secs."/>
-    <string name="h17" value="MP - 74 , Basic attack 435, for 161secs."/>
-    <string name="h18" value="MP - 76 , Basic attack 440, for 164secs."/>
-    <string name="h19" value="MP - 78 , Basic attack 445, for 167secs."/>
-    <string name="h20" value="MP - 80 , Basic attack 450, for 170secs."/>
-    <string name="h21" value="MP - 82 , Basic attack 505, for 173secs."/>
-    <string name="h22" value="MP - 84 , Basic attack 510, for 176secs."/>
-    <string name="h23" value="MP - 86 , Basic attack 515, for 179secs."/>
-    <string name="h24" value="MP - 88 , Basic attack 520, for 182secs."/>
-    <string name="h25" value="MP - 90 , Basic attack 525, for 185secs."/>
-    <string name="h26" value="MP - 92 , Basic attack 530, for 188secs."/>
-    <string name="h27" value="MP - 94 , Basic attack 535, for 191secs."/>
-    <string name="h28" value="MP - 96 , Basic attack 540, for 194secs."/>
-    <string name="h29" value="MP - 98 , Basic attack 545, for 197secs."/>
-    <string name="h30" value="MP - 100, Basic attack 550, for 200secs."/>
+    <string name="h1" value="MP -42; summons Phoenix for 113 sec, attack 305"/>
+    <string name="h2" value="MP -44; summons Phoenix for 116 sec, attack 310"/>
+    <string name="h3" value="MP -46; summons Phoenix for 119 sec, attack 315"/>
+    <string name="h4" value="MP -48; summons Phoenix for 122 sec, attack 320"/>
+    <string name="h5" value="MP -50; summons Phoenix for 125 sec, attack 325"/>
+    <string name="h6" value="MP -52; summons Phoenix for 128 sec, attack 330"/>
+    <string name="h7" value="MP -54; summons Phoenix for 131 sec, attack 335"/>
+    <string name="h8" value="MP -56; summons Phoenix for 134 sec, attack 340"/>
+    <string name="h9" value="MP -58; summons Phoenix for 137 sec, attack 345"/>
+    <string name="h10" value="MP -60; summons Phoenix for 140 sec, attack 350"/>
+    <string name="h11" value="MP -62; summons Phoenix for 143 sec, attack 405"/>
+    <string name="h12" value="MP -64; summons Phoenix for 146 sec, attack 410"/>
+    <string name="h13" value="MP -66; summons Phoenix for 149 sec, attack 415"/>
+    <string name="h14" value="MP -68; summons Phoenix for 152 sec, attack 420"/>
+    <string name="h15" value="MP -70; summons Phoenix for 155 sec, attack 425"/>
+    <string name="h16" value="MP -72; summons Phoenix for 158 sec, attack 430"/>
+    <string name="h17" value="MP -74; summons Phoenix for 161 sec, attack 435"/>
+    <string name="h18" value="MP -76; summons Phoenix for 164 sec, attack 440"/>
+    <string name="h19" value="MP -78; summons Phoenix for 167 sec, attack 445"/>
+    <string name="h20" value="MP -80; summons Phoenix for 170 sec, attack 450"/>
+    <string name="h21" value="MP -82; summons Phoenix for 173 sec, attack 505"/>
+    <string name="h22" value="MP -84; summons Phoenix for 176 sec, attack 510"/>
+    <string name="h23" value="MP -86; summons Phoenix for 179 sec, attack 515"/>
+    <string name="h24" value="MP -88; summons Phoenix for 182 sec, attack 520"/>
+    <string name="h25" value="MP -90; summons Phoenix for 185 sec, attack 525"/>
+    <string name="h26" value="MP -92; summons Phoenix for 188 sec, attack 530"/>
+    <string name="h27" value="MP -94; summons Phoenix for 191 sec, attack 535"/>
+    <string name="h28" value="MP -96; summons Phoenix for 194 sec, attack 540"/>
+    <string name="h29" value="MP -98; summons Phoenix for 197 sec, attack 545"/>
+    <string name="h30" value="MP -100; summons Phoenix for 200 sec, attack 550"/>
   </imgdir>
   <imgdir name="3121007">
     <string name="name" value="Hamstring"/>
     <string name="desc" value="Has a chance to cripple an enemy&apos;s leg, slowing its movement speed for a period of time."/>
-    <string name="h1" value="MP - 12 , within 35secs , with success rate 11%, decreases enemy&apos;s speed by 2 for 5secs"/>
-    <string name="h2" value="MP - 12 , within 40secs , with success rate 12%, decreases enemy&apos;s speed by 4 for 5secs"/>
-    <string name="h3" value="MP - 12 , within 45secs , with success rate 13%, decreases enemy&apos;s speed by 6 for 5secs"/>
-    <string name="h4" value="MP - 12 , within 50secs , with success rate 14%, decreases enemy&apos;s speed by 8 for 5secs"/>
-    <string name="h5" value="MP - 12 , within 55secs , with success rate 15%, decreases enemy&apos;s speed by 10 for 5secs"/>
-    <string name="h6" value="MP - 12 , within 60secs , with success rate 16%, decreases enemy&apos;s speed by 12 for 5secs"/>
-    <string name="h7" value="MP - 12 , within 65secs , with success rate 17%, decreases enemy&apos;s speed by 14 for 5secs"/>
-    <string name="h8" value="MP - 12 , within 70secs , with success rate 18%, decreases enemy&apos;s speed by 16 for 5secs"/>
-    <string name="h9" value="MP - 12 , within 75secs , with success rate 19%, decreases enemy&apos;s speed by 18 for 5secs"/>
-    <string name="h10" value="MP - 12 , within 80secs , with success rate 20%, decreases enemy&apos;s speed by 20 for 5secs"/>
-    <string name="h11" value="MP - 24 , within 85secs , with success rate 21%, decreases enemy&apos;s speed by 22 for 10secs"/>
-    <string name="h12" value="MP - 24 , within 90secs , with success rate 22%, decreases enemy&apos;s speed by 24 for 10secs"/>
-    <string name="h13" value="MP - 24 , within 95secs , with success rate 23%, decreases enemy&apos;s speed by 26 for 10secs"/>
-    <string name="h14" value="MP - 24 , within 100secs , with success rate 24%, decreases enemy&apos;s speed by 28 for 10secs"/>
-    <string name="h15" value="MP - 24 , within 105secs , with success rate 25%, decreases enemy&apos;s speed by 30 for 10secs"/>
-    <string name="h16" value="MP - 24 , within 110secs , with success rate 26%, decreases enemy&apos;s speed by 32 for 10secs"/>
-    <string name="h17" value="MP - 24 , within 115secs , with success rate 27%, decreases enemy&apos;s speed by 34 for 10secs"/>
-    <string name="h18" value="MP - 24 , within 120secs , with success rate 28%, decreases enemy&apos;s speed by 36 for 10secs"/>
-    <string name="h19" value="MP - 24 , within 125secs , with success rate 29%, decreases enemy&apos;s speed by 38 for 10secs"/>
-    <string name="h20" value="MP - 24 , within 130secs , with success rate 30%, decreases enemy&apos;s speed by 40 for 10secs"/>
-    <string name="h21" value="MP - 36 , within 135secs , with success rate 31%, decreases enemy&apos;s speed by 42 for 15secs"/>
-    <string name="h22" value="MP - 36 , within 140secs , with success rate 32%, decreases enemy&apos;s speed by 44 for 15secs"/>
-    <string name="h23" value="MP - 36 , within 145secs , with success rate 33%, decreases enemy&apos;s speed by 46 for 15secs"/>
-    <string name="h24" value="MP - 36 , within 150secs , with success rate 34%, decreases enemy&apos;s speed by 48 for 15secs"/>
-    <string name="h25" value="MP - 36 , within 155secs , with success rate 35%, decreases enemy&apos;s speed by 50 for 15secs"/>
-    <string name="h26" value="MP - 36 , within 160secs , with success rate 36%, decreases enemy&apos;s speed by 52 for 15secs"/>
-    <string name="h27" value="MP - 36 , within 165secs , with success rate 37%, decreases enemy&apos;s speed by 54 for 15secs"/>
-    <string name="h28" value="MP - 36 , within 170secs , with success rate 38%, decreases enemy&apos;s speed by 56 for 15secs"/>
-    <string name="h29" value="MP - 36 , within 175secs , with success rate 39%, decreases enemy&apos;s speed by 58 for 15secs"/>
-    <string name="h30" value="MP - 36 , within 180secs , with success rate 40%, decreases enemy&apos;s speed by 60 for 15secs"/>
+    <string name="h1" value="MP -12; for 35 sec, 11% chance to reduce enemy Speed by 2 for 5 sec"/>
+    <string name="h2" value="MP -12; for 40 sec, 12% chance to reduce enemy Speed by 4 for 5 sec"/>
+    <string name="h3" value="MP -12; for 45 sec, 13% chance to reduce enemy Speed by 6 for 5 sec"/>
+    <string name="h4" value="MP -12; for 50 sec, 14% chance to reduce enemy Speed by 8 for 5 sec"/>
+    <string name="h5" value="MP -12; for 55 sec, 15% chance to reduce enemy Speed by 10 for 5 sec"/>
+    <string name="h6" value="MP -12; for 60 sec, 16% chance to reduce enemy Speed by 12 for 5 sec"/>
+    <string name="h7" value="MP -12; for 65 sec, 17% chance to reduce enemy Speed by 14 for 5 sec"/>
+    <string name="h8" value="MP -12; for 70 sec, 18% chance to reduce enemy Speed by 16 for 5 sec"/>
+    <string name="h9" value="MP -12; for 75 sec, 19% chance to reduce enemy Speed by 18 for 5 sec"/>
+    <string name="h10" value="MP -12; for 80 sec, 20% chance to reduce enemy Speed by 20 for 5 sec"/>
+    <string name="h11" value="MP -24; for 85 sec, 21% chance to reduce enemy Speed by 22 for 10 sec"/>
+    <string name="h12" value="MP -24; for 90 sec, 22% chance to reduce enemy Speed by 24 for 10 sec"/>
+    <string name="h13" value="MP -24; for 95 sec, 23% chance to reduce enemy Speed by 26 for 10 sec"/>
+    <string name="h14" value="MP -24; for 100 sec, 24% chance to reduce enemy Speed by 28 for 10 sec"/>
+    <string name="h15" value="MP -24; for 105 sec, 25% chance to reduce enemy Speed by 30 for 10 sec"/>
+    <string name="h16" value="MP -24; for 110 sec, 26% chance to reduce enemy Speed by 32 for 10 sec"/>
+    <string name="h17" value="MP -24; for 115 sec, 27% chance to reduce enemy Speed by 34 for 10 sec"/>
+    <string name="h18" value="MP -24; for 120 sec, 28% chance to reduce enemy Speed by 36 for 10 sec"/>
+    <string name="h19" value="MP -24; for 125 sec, 29% chance to reduce enemy Speed by 38 for 10 sec"/>
+    <string name="h20" value="MP -24; for 130 sec, 30% chance to reduce enemy Speed by 40 for 10 sec"/>
+    <string name="h21" value="MP -36; for 135 sec, 31% chance to reduce enemy Speed by 42 for 15 sec"/>
+    <string name="h22" value="MP -36; for 140 sec, 32% chance to reduce enemy Speed by 44 for 15 sec"/>
+    <string name="h23" value="MP -36; for 145 sec, 33% chance to reduce enemy Speed by 46 for 15 sec"/>
+    <string name="h24" value="MP -36; for 150 sec, 34% chance to reduce enemy Speed by 48 for 15 sec"/>
+    <string name="h25" value="MP -35; for 155 sec, 35% chance to reduce enemy Speed by 50 for 15 sec"/>
+    <string name="h26" value="MP -34; for 160 sec, 36% chance to reduce enemy Speed by 52 for 15 sec"/>
+    <string name="h27" value="MP -33; for 165 sec, 37% chance to reduce enemy Speed by 54 for 15 sec"/>
+    <string name="h28" value="MP -32; for 170 sec, 38% chance to reduce enemy Speed by 56 for 15 sec"/>
+    <string name="h29" value="MP -31; for 175 sec, 39% chance to reduce enemy Speed by 58 for 15 sec"/>
+    <string name="h30" value="MP -30; for 180 sec, 40% chance to reduce enemy Speed by 60 for 15 sec"/>
   </imgdir>
   <imgdir name="3121008">
     <string name="name" value="Concentrate"/>
     <string name="desc" value="Temporarily increases Weapon Attack and reduces skill MP cost.\n#cCooldown : 6 minutes#"/>
-    <string name="h1" value="MP - 11 , Weapon Attack increases by 11, Mana spend -2%, for 120secs"/>
-    <string name="h2" value="MP - 12 , Weapon Attack increases by 12, Mana spend -4%, for 120secs"/>
-    <string name="h3" value="MP - 13 , Weapon Attack increases by 12, Mana spend -6%, for 120secs"/>
-    <string name="h4" value="MP - 14 , Weapon Attack increases by 13, Mana spend -8%, for 120secs"/>
-    <string name="h5" value="MP - 15 , Weapon Attack increases by 13, Mana spend -10%, for 120secs"/>
-    <string name="h6" value="MP - 16 , Weapon Attack increases by 14, Mana spend -12%, for 120secs"/>
-    <string name="h7" value="MP - 17 , Weapon Attack increases by 14, Mana spend -14%, for 120secs"/>
-    <string name="h8" value="MP - 18 , Weapon Attack increases by 15, Mana spend -16%, for 120secs"/>
-    <string name="h9" value="MP - 19 , Weapon Attack increases by 15, Mana spend -18%, for 120secs"/>
-    <string name="h10" value="MP - 20 , Weapon Attack increases by 16, Mana spend -20%, for 120secs"/>
-    <string name="h11" value="MP - 21 , Weapon Attack increases by 16, Mana spend -22%, for 180secs"/>
-    <string name="h12" value="MP - 22 , Weapon Attack increases by 17, Mana spend -24%, for 180secs"/>
-    <string name="h13" value="MP - 23 , Weapon Attack increases by 17, Mana spend -26%, for 180secs"/>
-    <string name="h14" value="MP - 24 , Weapon Attack increases by 18, Mana spend -28%, for 180secs"/>
-    <string name="h15" value="MP - 25 , Weapon Attack increases by 18, Mana spend -30%, for 180secs"/>
-    <string name="h16" value="MP - 26 , Weapon Attack increases by 19, Mana spend -32%, for 180secs"/>
-    <string name="h17" value="MP - 27 , Weapon Attack increases by 19, Mana spend -34%, for 180secs"/>
-    <string name="h18" value="MP - 28 , Weapon Attack increases by 20, Mana spend -36%, for 180secs"/>
-    <string name="h19" value="MP - 29 , Weapon Attack increases by 20, Mana spend -38%, for 180secs"/>
-    <string name="h20" value="MP - 30 , Weapon Attack increases by 21, Mana spend -40%, for 180secs"/>
-    <string name="h21" value="MP - 31 , Weapon Attack increases by 21, Mana spend -41%, for 240secs"/>
-    <string name="h22" value="MP - 32 , Weapon Attack increases by 22, Mana spend -42%, for 240secs"/>
-    <string name="h23" value="MP - 33 , Weapon Attack increases by 22, Mana spend -43%, for 240secs"/>
-    <string name="h24" value="MP - 34 , Weapon Attack increases by 23, Mana spend -44%, for 240secs"/>
-    <string name="h25" value="MP - 35 , Weapon Attack increases by 23, Mana spend -45%, for 240secs"/>
-    <string name="h26" value="MP - 36 , Weapon Attack increases by 24, Mana spend -46%, for 240secs"/>
-    <string name="h27" value="MP - 37 , Weapon Attack increases by 24, Mana spend -47%, for 240secs"/>
-    <string name="h28" value="MP - 38 , Weapon Attack increases by 25, Mana spend -48%, for 240secs"/>
-    <string name="h29" value="MP - 39 , Weapon Attack increases by 25, Mana spend -49%, for 240secs"/>
-    <string name="h30" value="MP - 40 , Weapon Attack increases by 26, Mana spend -50%, for 240secs"/>
+    <string name="h1" value="MP -11; Weapon Attack +11, MP cost -2% for 120 sec, cooldown 360 sec"/>
+    <string name="h2" value="MP -12; Weapon Attack +12, MP cost -4% for 120 sec, cooldown 360 sec"/>
+    <string name="h3" value="MP -13; Weapon Attack +12, MP cost -6% for 120 sec, cooldown 360 sec"/>
+    <string name="h4" value="MP -14; Weapon Attack +13, MP cost -8% for 120 sec, cooldown 360 sec"/>
+    <string name="h5" value="MP -15; Weapon Attack +13, MP cost -10% for 120 sec, cooldown 360 sec"/>
+    <string name="h6" value="MP -16; Weapon Attack +14, MP cost -12% for 120 sec, cooldown 360 sec"/>
+    <string name="h7" value="MP -17; Weapon Attack +14, MP cost -14% for 120 sec, cooldown 360 sec"/>
+    <string name="h8" value="MP -18; Weapon Attack +15, MP cost -16% for 120 sec, cooldown 360 sec"/>
+    <string name="h9" value="MP -19; Weapon Attack +15, MP cost -18% for 120 sec, cooldown 360 sec"/>
+    <string name="h10" value="MP -20; Weapon Attack +16, MP cost -20% for 120 sec, cooldown 360 sec"/>
+    <string name="h11" value="MP -21; Weapon Attack +16, MP cost -22% for 180 sec, cooldown 360 sec"/>
+    <string name="h12" value="MP -22; Weapon Attack +17, MP cost -24% for 180 sec, cooldown 360 sec"/>
+    <string name="h13" value="MP -23; Weapon Attack +17, MP cost -26% for 180 sec, cooldown 360 sec"/>
+    <string name="h14" value="MP -24; Weapon Attack +18, MP cost -28% for 180 sec, cooldown 360 sec"/>
+    <string name="h15" value="MP -25; Weapon Attack +18, MP cost -30% for 180 sec, cooldown 360 sec"/>
+    <string name="h16" value="MP -26; Weapon Attack +19, MP cost -32% for 180 sec, cooldown 360 sec"/>
+    <string name="h17" value="MP -27; Weapon Attack +19, MP cost -34% for 180 sec, cooldown 360 sec"/>
+    <string name="h18" value="MP -28; Weapon Attack +20, MP cost -36% for 180 sec, cooldown 360 sec"/>
+    <string name="h19" value="MP -29; Weapon Attack +20, MP cost -38% for 180 sec, cooldown 360 sec"/>
+    <string name="h20" value="MP -30; Weapon Attack +21, MP cost -40% for 180 sec, cooldown 360 sec"/>
+    <string name="h21" value="MP -31; Weapon Attack +21, MP cost -41% for 240 sec, cooldown 360 sec"/>
+    <string name="h22" value="MP -32; Weapon Attack +22, MP cost -42% for 240 sec, cooldown 360 sec"/>
+    <string name="h23" value="MP -33; Weapon Attack +22, MP cost -43% for 240 sec, cooldown 360 sec"/>
+    <string name="h24" value="MP -34; Weapon Attack +23, MP cost -44% for 240 sec, cooldown 360 sec"/>
+    <string name="h25" value="MP -35; Weapon Attack +23, MP cost -45% for 240 sec, cooldown 360 sec"/>
+    <string name="h26" value="MP -36; Weapon Attack +24, MP cost -46% for 240 sec, cooldown 360 sec"/>
+    <string name="h27" value="MP -37; Weapon Attack +24, MP cost -47% for 240 sec, cooldown 360 sec"/>
+    <string name="h28" value="MP -38; Weapon Attack +25, MP cost -48% for 240 sec, cooldown 360 sec"/>
+    <string name="h29" value="MP -39; Weapon Attack +25, MP cost -49% for 240 sec, cooldown 360 sec"/>
+    <string name="h30" value="MP -40; Weapon Attack +26, MP cost -50% for 240 sec, cooldown 360 sec"/>
   </imgdir>
   <imgdir name="3121009">
     <string name="name" value="Hero&apos;s Will"/>
     <string name="desc" value="Removes abnormal status effects. Cooldown decreases as the skill level increases."/>
-    <string name="h1" value="MP - 30 escape from abnormal condition, Terms between skills 600secs"/>
-    <string name="h2" value="MP - 30 escape from abnormal condition, Terms between skills 540secs"/>
-    <string name="h3" value="MP - 30 escape from abnormal condition, Terms between skills 480secs"/>
-    <string name="h4" value="MP - 30 escape from abnormal condition, Terms between skills 420secs"/>
-    <string name="h5" value="MP - 30 escape from abnormal condition, Terms between skills 360secs"/>
+    <string name="h1" value="MP -30; removes abnormal status effects, cooldown 600 sec"/>
+    <string name="h2" value="MP -30; removes abnormal status effects, cooldown 540 sec"/>
+    <string name="h3" value="MP -30; removes abnormal status effects, cooldown 480 sec"/>
+    <string name="h4" value="MP -30; removes abnormal status effects, cooldown 420 sec"/>
+    <string name="h5" value="MP -30; removes abnormal status effects, cooldown 360 sec"/>
   </imgdir>
   <imgdir name="322">
     <string name="bookName" value="Marksman"/>
@@ -6921,138 +6921,138 @@
   <imgdir name="3221000">
     <string name="name" value="Maple Warrior"/>
     <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
-    <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
-    <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
-    <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
-    <string name="h4" value="MP - 10 ,  For 120Secs, all stats + 2% "/>
-    <string name="h5" value="MP - 10 ,  For 150Secs, all stats + 3% "/>
-    <string name="h6" value="MP - 20 ,  For 180Secs, all stats + 3% "/>
-    <string name="h7" value="MP - 20 ,  For 210Secs, all stats + 4% "/>
-    <string name="h8" value="MP - 20 ,  For 240Secs, all stats + 4% "/>
-    <string name="h9" value="MP - 20 ,  For 270Secs, all stats + 5% "/>
-    <string name="h10" value="MP - 20 ,  For 300Secs, all stats + 5% "/>
-    <string name="h11" value="MP - 30 ,  For 330Secs, all stats + 6% "/>
-    <string name="h12" value="MP - 30 ,  For 360Secs, all stats + 6% "/>
-    <string name="h13" value="MP - 30 ,  For 390Secs, all stats + 7% "/>
-    <string name="h14" value="MP - 30 ,  For 420Secs, all stats + 7% "/>
-    <string name="h15" value="MP - 30 ,  For 450Secs, all stats + 8% "/>
-    <string name="h16" value="MP - 40 ,  For 480Secs, all stats + 8% "/>
-    <string name="h17" value="MP - 40 ,  For 510Secs, all stats + 9% "/>
-    <string name="h18" value="MP - 40 ,  For 540Secs, all stats + 9% "/>
-    <string name="h19" value="MP - 40 ,  For 570Secs, all stats + 10% "/>
-    <string name="h20" value="MP - 40 ,  For 600Secs, all stats + 10% "/>
-    <string name="h21" value="MP - 50 ,  For 630Secs, all stats + 11% "/>
-    <string name="h22" value="MP - 50 ,  For 660Secs, all stats + 11% "/>
-    <string name="h23" value="MP - 50 ,  For 690Secs, all stats + 12% "/>
-    <string name="h24" value="MP - 50 ,  For 720Secs, all stats + 12% "/>
-    <string name="h25" value="MP - 50 ,  For 750Secs, all stats + 13% "/>
-    <string name="h26" value="MP - 60 ,  For 780Secs, all stats + 13% "/>
-    <string name="h27" value="MP - 60 ,  For 810Secs, all stats + 14% "/>
-    <string name="h28" value="MP - 60 ,  For 840Secs, all stats + 14% "/>
-    <string name="h29" value="MP - 60 ,  For 870Secs, all stats + 15% "/>
-    <string name="h30" value="MP - 60 ,  For 900Secs, all stats + 15% "/>
+    <string name="h1" value="MP -10; all stats +1% for 30 sec"/>
+    <string name="h2" value="MP -10; all stats +1% for 60 sec"/>
+    <string name="h3" value="MP -10; all stats +2% for 90 sec"/>
+    <string name="h4" value="MP -10; all stats +2% for 120 sec"/>
+    <string name="h5" value="MP -10; all stats +3% for 150 sec"/>
+    <string name="h6" value="MP -20; all stats +3% for 180 sec"/>
+    <string name="h7" value="MP -20; all stats +4% for 210 sec"/>
+    <string name="h8" value="MP -20; all stats +4% for 240 sec"/>
+    <string name="h9" value="MP -20; all stats +5% for 270 sec"/>
+    <string name="h10" value="MP -20; all stats +5% for 300 sec"/>
+    <string name="h11" value="MP -30; all stats +6% for 330 sec"/>
+    <string name="h12" value="MP -30; all stats +6% for 360 sec"/>
+    <string name="h13" value="MP -30; all stats +7% for 390 sec"/>
+    <string name="h14" value="MP -30; all stats +7% for 420 sec"/>
+    <string name="h15" value="MP -30; all stats +8% for 450 sec"/>
+    <string name="h16" value="MP -40; all stats +8% for 480 sec"/>
+    <string name="h17" value="MP -40; all stats +9% for 510 sec"/>
+    <string name="h18" value="MP -40; all stats +9% for 540 sec"/>
+    <string name="h19" value="MP -40; all stats +10% for 570 sec"/>
+    <string name="h20" value="MP -40; all stats +10% for 600 sec"/>
+    <string name="h21" value="MP -50; all stats +11% for 630 sec"/>
+    <string name="h22" value="MP -50; all stats +11% for 660 sec"/>
+    <string name="h23" value="MP -50; all stats +12% for 690 sec"/>
+    <string name="h24" value="MP -50; all stats +12% for 720 sec"/>
+    <string name="h25" value="MP -50; all stats +13% for 750 sec"/>
+    <string name="h26" value="MP -60; all stats +13% for 780 sec"/>
+    <string name="h27" value="MP -60; all stats +14% for 810 sec"/>
+    <string name="h28" value="MP -60; all stats +14% for 840 sec"/>
+    <string name="h29" value="MP -60; all stats +15% for 870 sec"/>
+    <string name="h30" value="MP -60; all stats +15% for 900 sec"/>
   </imgdir>
   <imgdir name="3221001">
     <string name="name" value="Piercing Arrow"/>
     <string name="desc" value="Fires a chargeable piercing arrow that passes through multiple enemies; its power increases as it pierces more targets."/>
-    <string name="h1" value="MP - 18 , Max Attacks 320%, Attacks up to 4 enemies"/>
-    <string name="h2" value="MP - 18 , Max Attacks 340%, Attacks up to 4 enemies"/>
-    <string name="h3" value="MP - 18 , Max Attacks 360%, Attacks up to 4 enemies"/>
-    <string name="h4" value="MP - 18 , Max Attacks 380%, Attacks up to 4 enemies"/>
-    <string name="h5" value="MP - 18 , Max Attacks 400%, Attacks up to 4 enemies"/>
-    <string name="h6" value="MP - 18 , Max Attacks 420%, Attacks up to 4 enemies"/>
-    <string name="h7" value="MP - 18 , Max Attacks 440%, Attacks up to 4 enemies"/>
-    <string name="h8" value="MP - 18 , Max Attacks 460%, Attacks up to 4 enemies"/>
-    <string name="h9" value="MP - 18 , Max Attacks 480%, Attacks up to 4 enemies"/>
-    <string name="h10" value="MP - 18 , Max Attacks 500%, Attacks up to 4 enemies"/>
-    <string name="h11" value="MP - 28 , Max Attacks 520%, Attacks up to 5 enemies"/>
-    <string name="h12" value="MP - 28 , Max Attacks 540%, Attacks up to 5 enemies"/>
-    <string name="h13" value="MP - 28 , Max Attacks 560%, Attacks up to 5 enemies"/>
-    <string name="h14" value="MP - 28 , Max Attacks 580%, Attacks up to 5 enemies"/>
-    <string name="h15" value="MP - 28 , Max Attacks 600%, Attacks up to 5 enemies"/>
-    <string name="h16" value="MP - 28 , Max Attacks 620%, Attacks up to 5 enemies"/>
-    <string name="h17" value="MP - 28 , Max Attacks 640%, Attacks up to 5 enemies"/>
-    <string name="h18" value="MP - 28 , Max Attacks 660%, Attacks up to 5 enemies"/>
-    <string name="h19" value="MP - 28 , Max Attacks 680%, Attacks up to 5 enemies"/>
-    <string name="h20" value="MP - 28 , Max Attacks 700%, Attacks up to 5 enemies"/>
-    <string name="h21" value="MP - 38 , Max Attacks 715%, Attacks up to 6 enemies"/>
-    <string name="h22" value="MP - 38 , Max Attacks 730%, Attacks up to 6 enemies"/>
-    <string name="h23" value="MP - 38 , Max Attacks 745%, Attacks up to 6 enemies"/>
-    <string name="h24" value="MP - 38 , Max Attacks 760%, Attacks up to 6 enemies"/>
-    <string name="h25" value="MP - 38 , Max Attacks 775%, Attacks up to 6 enemies"/>
-    <string name="h26" value="MP - 37 , Max Attacks 790%, Attacks up to 6 enemies"/>
-    <string name="h27" value="MP - 36 , Max Attacks 805%, Attacks up to 6 enemies"/>
-    <string name="h28" value="MP - 35 , Max Attacks 820%, Attacks up to 6 enemies"/>
-    <string name="h29" value="MP - 34 , Max Attacks 835%, Attacks up to 6 enemies"/>
-    <string name="h30" value="MP - 33 , Max Attacks 850%, Attacks up to 6 enemies"/>
+    <string name="h1" value="MP -18; charged damage up to 320% against up to 4 enemies"/>
+    <string name="h2" value="MP -18; charged damage up to 340% against up to 4 enemies"/>
+    <string name="h3" value="MP -18; charged damage up to 360% against up to 4 enemies"/>
+    <string name="h4" value="MP -18; charged damage up to 380% against up to 4 enemies"/>
+    <string name="h5" value="MP -18; charged damage up to 400% against up to 4 enemies"/>
+    <string name="h6" value="MP -18; charged damage up to 420% against up to 4 enemies"/>
+    <string name="h7" value="MP -18; charged damage up to 440% against up to 4 enemies"/>
+    <string name="h8" value="MP -18; charged damage up to 460% against up to 4 enemies"/>
+    <string name="h9" value="MP -18; charged damage up to 480% against up to 4 enemies"/>
+    <string name="h10" value="MP -18; charged damage up to 500% against up to 4 enemies"/>
+    <string name="h11" value="MP -28; charged damage up to 520% against up to 5 enemies"/>
+    <string name="h12" value="MP -28; charged damage up to 540% against up to 5 enemies"/>
+    <string name="h13" value="MP -28; charged damage up to 560% against up to 5 enemies"/>
+    <string name="h14" value="MP -28; charged damage up to 580% against up to 5 enemies"/>
+    <string name="h15" value="MP -28; charged damage up to 600% against up to 5 enemies"/>
+    <string name="h16" value="MP -28; charged damage up to 620% against up to 5 enemies"/>
+    <string name="h17" value="MP -28; charged damage up to 640% against up to 5 enemies"/>
+    <string name="h18" value="MP -28; charged damage up to 660% against up to 5 enemies"/>
+    <string name="h19" value="MP -28; charged damage up to 680% against up to 5 enemies"/>
+    <string name="h20" value="MP -28; charged damage up to 700% against up to 5 enemies"/>
+    <string name="h21" value="MP -38; charged damage up to 715% against up to 6 enemies"/>
+    <string name="h22" value="MP -38; charged damage up to 730% against up to 6 enemies"/>
+    <string name="h23" value="MP -38; charged damage up to 745% against up to 6 enemies"/>
+    <string name="h24" value="MP -38; charged damage up to 760% against up to 6 enemies"/>
+    <string name="h25" value="MP -38; charged damage up to 775% against up to 6 enemies"/>
+    <string name="h26" value="MP -37; charged damage up to 790% against up to 6 enemies"/>
+    <string name="h27" value="MP -36; charged damage up to 805% against up to 6 enemies"/>
+    <string name="h28" value="MP -35; charged damage up to 820% against up to 6 enemies"/>
+    <string name="h29" value="MP -34; charged damage up to 835% against up to 6 enemies"/>
+    <string name="h30" value="MP -33; charged damage up to 850% against up to 6 enemies"/>
   </imgdir>
   <imgdir name="3221002">
     <string name="name" value="Sharp Eyes"/>
     <string name="desc" value="Temporarily increases Critical Rate and Critical Damage for yourself and party members."/>
-    <string name="h1" value="MP - 29 , for 10secs, critical rate 1%, Damage 11% ."/>
-    <string name="h2" value="MP - 29 , for 20secs, critical rate 1%, Damage 12% ."/>
-    <string name="h3" value="MP - 29 , for 30secs, critical rate 2%, Damage 13% ."/>
-    <string name="h4" value="MP - 29 , for 40secs, critical rate 2%, Damage 14% ."/>
-    <string name="h5" value="MP - 29 , for 50secs, critical rate 3%, Damage 15% ."/>
-    <string name="h6" value="MP - 29 , for 60secs, critical rate 3%, Damage 16% ."/>
-    <string name="h7" value="MP - 29 , for 70secs, critical rate 4%, Damage 17% ."/>
-    <string name="h8" value="MP - 29 , for 80secs, critical rate 4%, Damage 18% ."/>
-    <string name="h9" value="MP - 29 , for 90secs, critical rate 5%, Damage 19% ."/>
-    <string name="h10" value="MP - 29 , for 100secs, critical rate 5%, Damage 20% ."/>
-    <string name="h11" value="MP - 37 , for 110secs, critical rate 6%, Damage 21% ."/>
-    <string name="h12" value="MP - 37 , for 120secs, critical rate 6%, Damage 22% ."/>
-    <string name="h13" value="MP - 37 , for 130secs, critical rate 7%, Damage 23% ."/>
-    <string name="h14" value="MP - 37 , for 140secs, critical rate 7%, Damage 24% ."/>
-    <string name="h15" value="MP - 37 , for 150secs, critical rate 8%, Damage 25% ."/>
-    <string name="h16" value="MP - 37 , for 160secs, critical rate 8%, Damage 26% ."/>
-    <string name="h17" value="MP - 37 , for 170secs, critical rate 9%, Damage 27% ."/>
-    <string name="h18" value="MP - 37 , for 180secs, critical rate 9%, Damage 28% ."/>
-    <string name="h19" value="MP - 37 , for 190secs, critical rate 10%, Damage 29% ."/>
-    <string name="h20" value="MP - 37 , for 200secs, critical rate 10%, Damage 30% ."/>
-    <string name="h21" value="MP - 45 , for 210secs, critical rate 11%, Damage 31% ."/>
-    <string name="h22" value="MP - 45 , for 220secs, critical rate 11%, Damage 32% ."/>
-    <string name="h23" value="MP - 45 , for 230secs, critical rate 12%, Damage 33% ."/>
-    <string name="h24" value="MP - 45 , for 240secs, critical rate 12%, Damage 34% ."/>
-    <string name="h25" value="MP - 45 , for 250secs, critical rate 13%, Damage 35% ."/>
-    <string name="h26" value="MP - 44 , for 260secs, critical rate 13%, Damage 36% ."/>
-    <string name="h27" value="MP - 43 , for 270secs, critical rate 14%, Damage 37% ."/>
-    <string name="h28" value="MP - 42 , for 280secs, critical rate 14%, Damage 38% ."/>
-    <string name="h29" value="MP - 41 , for 290secs, critical rate 15%, Damage 39% ."/>
-    <string name="h30" value="MP - 40 , for 300secs, critical rate 15%, Damage 40% ."/>
+    <string name="h1" value="MP -29; Critical Rate +1% and Critical Damage +11% for 10 sec"/>
+    <string name="h2" value="MP -29; Critical Rate +1% and Critical Damage +12% for 20 sec"/>
+    <string name="h3" value="MP -29; Critical Rate +2% and Critical Damage +13% for 30 sec"/>
+    <string name="h4" value="MP -29; Critical Rate +2% and Critical Damage +14% for 40 sec"/>
+    <string name="h5" value="MP -29; Critical Rate +3% and Critical Damage +15% for 50 sec"/>
+    <string name="h6" value="MP -29; Critical Rate +3% and Critical Damage +16% for 60 sec"/>
+    <string name="h7" value="MP -29; Critical Rate +4% and Critical Damage +17% for 70 sec"/>
+    <string name="h8" value="MP -29; Critical Rate +4% and Critical Damage +18% for 80 sec"/>
+    <string name="h9" value="MP -29; Critical Rate +5% and Critical Damage +19% for 90 sec"/>
+    <string name="h10" value="MP -29; Critical Rate +5% and Critical Damage +20% for 100 sec"/>
+    <string name="h11" value="MP -37; Critical Rate +6% and Critical Damage +21% for 110 sec"/>
+    <string name="h12" value="MP -37; Critical Rate +6% and Critical Damage +22% for 120 sec"/>
+    <string name="h13" value="MP -37; Critical Rate +7% and Critical Damage +23% for 130 sec"/>
+    <string name="h14" value="MP -37; Critical Rate +7% and Critical Damage +24% for 140 sec"/>
+    <string name="h15" value="MP -37; Critical Rate +8% and Critical Damage +25% for 150 sec"/>
+    <string name="h16" value="MP -37; Critical Rate +8% and Critical Damage +26% for 160 sec"/>
+    <string name="h17" value="MP -37; Critical Rate +9% and Critical Damage +27% for 170 sec"/>
+    <string name="h18" value="MP -37; Critical Rate +9% and Critical Damage +28% for 180 sec"/>
+    <string name="h19" value="MP -37; Critical Rate +10% and Critical Damage +29% for 190 sec"/>
+    <string name="h20" value="MP -37; Critical Rate +10% and Critical Damage +30% for 200 sec"/>
+    <string name="h21" value="MP -45; Critical Rate +11% and Critical Damage +31% for 210 sec"/>
+    <string name="h22" value="MP -45; Critical Rate +11% and Critical Damage +32% for 220 sec"/>
+    <string name="h23" value="MP -45; Critical Rate +12% and Critical Damage +33% for 230 sec"/>
+    <string name="h24" value="MP -45; Critical Rate +12% and Critical Damage +34% for 240 sec"/>
+    <string name="h25" value="MP -45; Critical Rate +13% and Critical Damage +35% for 250 sec"/>
+    <string name="h26" value="MP -44; Critical Rate +13% and Critical Damage +36% for 260 sec"/>
+    <string name="h27" value="MP -43; Critical Rate +14% and Critical Damage +37% for 270 sec"/>
+    <string name="h28" value="MP -42; Critical Rate +14% and Critical Damage +38% for 280 sec"/>
+    <string name="h29" value="MP -41; Critical Rate +15% and Critical Damage +39% for 290 sec"/>
+    <string name="h30" value="MP -40; Critical Rate +15% and Critical Damage +40% for 300 sec"/>
   </imgdir>
   <imgdir name="3221003">
     <string name="name" value="Dragon&apos;s Breath"/>
     <string name="desc" value="Unleashes a powerful dragon-infused arrow that attacks multiple enemies ahead and knocks them back."/>
-    <string name="h1" value="MP - 24 , Attacks 42%, Attacks up to  4 enemies"/>
-    <string name="h2" value="MP - 24 , Attacks 44%, Attacks up to  4 enemies"/>
-    <string name="h3" value="MP - 24 , Attacks 46%, Attacks up to  4 enemies"/>
-    <string name="h4" value="MP - 24 , Attacks 48%, Attacks up to  4 enemies"/>
-    <string name="h5" value="MP - 24 , Attacks 50%, Attacks up to  4 enemies"/>
-    <string name="h6" value="MP - 24 , Attacks 52%, Attacks up to  4 enemies"/>
-    <string name="h7" value="MP - 24 , Attacks 54%, Attacks up to  4 enemies"/>
-    <string name="h8" value="MP - 24 , Attacks 56%, Attacks up to  4 enemies"/>
-    <string name="h9" value="MP - 24 , Attacks 58%, Attacks up to  4 enemies"/>
-    <string name="h10" value="MP - 24 , Attacks 60%, Attacks up to  4 enemies"/>
-    <string name="h11" value="MP - 30 , Attacks 62%, Attacks up to  5 enemies"/>
-    <string name="h12" value="MP - 30 , Attacks 64%, Attacks up to  5 enemies"/>
-    <string name="h13" value="MP - 30 , Attacks 66%, Attacks up to  5 enemies"/>
-    <string name="h14" value="MP - 30 , Attacks 68%, Attacks up to  5 enemies"/>
-    <string name="h15" value="MP - 30 , Attacks 70%, Attacks up to  5 enemies"/>
-    <string name="h16" value="MP - 30 , Attacks 72%, Attacks up to  5 enemies"/>
-    <string name="h17" value="MP - 30 , Attacks 74%, Attacks up to  5 enemies"/>
-    <string name="h18" value="MP - 30 , Attacks 76%, Attacks up to  5 enemies"/>
-    <string name="h19" value="MP - 30 , Attacks 78%, Attacks up to  5 enemies"/>
-    <string name="h20" value="MP - 30 , Attacks 80%, Attacks up to  5 enemies"/>
-    <string name="h21" value="MP - 36 , Attacks 82%, Attacks up to  6 enemies"/>
-    <string name="h22" value="MP - 36 , Attacks 84%, Attacks up to  6 enemies"/>
-    <string name="h23" value="MP - 36 , Attacks 86%, Attacks up to  6 enemies"/>
-    <string name="h24" value="MP - 36 , Attacks 88%, Attacks up to  6 enemies"/>
-    <string name="h25" value="MP - 36 , Attacks 90%, Attacks up to  6 enemies"/>
-    <string name="h26" value="MP - 36 , Attacks 92%, Attacks up to  6 enemies"/>
-    <string name="h27" value="MP - 36 , Attacks 94%, Attacks up to  6 enemies"/>
-    <string name="h28" value="MP - 36 , Attacks 96%, Attacks up to  6 enemies"/>
-    <string name="h29" value="MP - 36 , Attacks 98%, Attacks up to  6 enemies"/>
-    <string name="h30" value="MP - 36 , Attacks 100%, Attacks up to  6 enemies"/>
+    <string name="h1" value="MP -24; Damage 42% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h2" value="MP -24; Damage 44% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h3" value="MP -24; Damage 46% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h4" value="MP -24; Damage 48% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h5" value="MP -24; Damage 50% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h6" value="MP -24; Damage 52% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h7" value="MP -24; Damage 54% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h8" value="MP -24; Damage 56% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h9" value="MP -24; Damage 58% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h10" value="MP -24; Damage 60% against up to 4 enemies, 100% knockback chance"/>
+    <string name="h11" value="MP -30; Damage 62% against up to 5 enemies"/>
+    <string name="h12" value="MP -30; Damage 64% against up to 5 enemies"/>
+    <string name="h13" value="MP -30; Damage 66% against up to 5 enemies"/>
+    <string name="h14" value="MP -30; Damage 68% against up to 5 enemies"/>
+    <string name="h15" value="MP -30; Damage 70% against up to 5 enemies"/>
+    <string name="h16" value="MP -30; Damage 72% against up to 5 enemies"/>
+    <string name="h17" value="MP -30; Damage 74% against up to 5 enemies"/>
+    <string name="h18" value="MP -30; Damage 76% against up to 5 enemies"/>
+    <string name="h19" value="MP -30; Damage 78% against up to 5 enemies"/>
+    <string name="h20" value="MP -30; Damage 80% against up to 5 enemies"/>
+    <string name="h21" value="MP -36; Damage 82% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h22" value="MP -36; Damage 84% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h23" value="MP -36; Damage 86% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h24" value="MP -36; Damage 88% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h25" value="MP -36; Damage 90% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h26" value="MP -36; Damage 92% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h27" value="MP -36; Damage 94% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h28" value="MP -36; Damage 96% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h29" value="MP -36; Damage 98% against up to 6 enemies, 100% knockback chance"/>
+    <string name="h30" value="MP -36; Damage 100% against up to 6 enemies, 100% knockback chance"/>
   </imgdir>
   <imgdir name="3220004">
     <string name="name" value="Marksman Boost"/>
@@ -7091,113 +7091,113 @@
   <imgdir name="3221005">
     <string name="name" value="Frostprey"/>
     <string name="desc" value="Summons Frostprey to attack up to 4 enemies for a period of time.\nRequired Skill : #cGolden Eagle Lv. 15 or higher#"/>
-    <string name="h1" value="MP - 42 , Attack 255%, for 113secs"/>
-    <string name="h2" value="MP - 44 , Attack 260%, for 116secs"/>
-    <string name="h3" value="MP - 46 , Attack 265%, for 119secs"/>
-    <string name="h4" value="MP - 48 , Attack 270%, for 122secs"/>
-    <string name="h5" value="MP - 50 , Attack 275%, for 125secs"/>
-    <string name="h6" value="MP - 52 , Attack 280%, for 128secs"/>
-    <string name="h7" value="MP - 54 , Attack 285%, for 131secs"/>
-    <string name="h8" value="MP - 56 , Attack 290%, for 134secs"/>
-    <string name="h9" value="MP - 58 , Attack 295%, for 137secs"/>
-    <string name="h10" value="MP - 60 , Attack 300%, for 140secs"/>
-    <string name="h11" value="MP - 62 , Attack 355%, for 143secs"/>
-    <string name="h12" value="MP - 64 , Attack 360%, for 146secs"/>
-    <string name="h13" value="MP - 66 , Attack 365%, for 149secs"/>
-    <string name="h14" value="MP - 68 , Attack 370%, for 152secs"/>
-    <string name="h15" value="MP - 70 , Attack 375%, for 155secs"/>
-    <string name="h16" value="MP - 72 , Attack 380%, for 158secs"/>
-    <string name="h17" value="MP - 74 , Attack 385%, for 161secs"/>
-    <string name="h18" value="MP - 76 , Attack 390%, for 164secs"/>
-    <string name="h19" value="MP - 78 , Attack 395%, for 167secs"/>
-    <string name="h20" value="MP - 80 , Attack 400%, for 170secs"/>
-    <string name="h21" value="MP - 82 , Attack 455%, for 173secs"/>
-    <string name="h22" value="MP - 84 , Attack 460%, for 176secs"/>
-    <string name="h23" value="MP - 86 , Attack 465%, for 179secs"/>
-    <string name="h24" value="MP - 88 , Attack 470%, for 182secs"/>
-    <string name="h25" value="MP - 90 , Attack 475%, for 185secs"/>
-    <string name="h26" value="MP - 92 , Attack 480%, for 188secs"/>
-    <string name="h27" value="MP - 94 , Attack 485%, for 191secs"/>
-    <string name="h28" value="MP - 96 , Attack 490%, for 194secs"/>
-    <string name="h29" value="MP - 98 , Attack 495%, for 197secs"/>
-    <string name="h30" value="MP - 100 , Attack 500%, for 200secs"/>
+    <string name="h1" value="MP -42; summons Frostprey for 113 sec, attack 255"/>
+    <string name="h2" value="MP -44; summons Frostprey for 116 sec, attack 260"/>
+    <string name="h3" value="MP -46; summons Frostprey for 119 sec, attack 265"/>
+    <string name="h4" value="MP -48; summons Frostprey for 122 sec, attack 270"/>
+    <string name="h5" value="MP -50; summons Frostprey for 125 sec, attack 275"/>
+    <string name="h6" value="MP -52; summons Frostprey for 128 sec, attack 280"/>
+    <string name="h7" value="MP -54; summons Frostprey for 131 sec, attack 285"/>
+    <string name="h8" value="MP -56; summons Frostprey for 134 sec, attack 290"/>
+    <string name="h9" value="MP -58; summons Frostprey for 137 sec, attack 295"/>
+    <string name="h10" value="MP -60; summons Frostprey for 140 sec, attack 300"/>
+    <string name="h11" value="MP -62; summons Frostprey for 143 sec, attack 355"/>
+    <string name="h12" value="MP -64; summons Frostprey for 146 sec, attack 360"/>
+    <string name="h13" value="MP -66; summons Frostprey for 149 sec, attack 365"/>
+    <string name="h14" value="MP -68; summons Frostprey for 152 sec, attack 370"/>
+    <string name="h15" value="MP -70; summons Frostprey for 155 sec, attack 375"/>
+    <string name="h16" value="MP -72; summons Frostprey for 158 sec, attack 380"/>
+    <string name="h17" value="MP -74; summons Frostprey for 161 sec, attack 385"/>
+    <string name="h18" value="MP -76; summons Frostprey for 164 sec, attack 390"/>
+    <string name="h19" value="MP -78; summons Frostprey for 167 sec, attack 395"/>
+    <string name="h20" value="MP -80; summons Frostprey for 170 sec, attack 400"/>
+    <string name="h21" value="MP -82; summons Frostprey for 173 sec, attack 455"/>
+    <string name="h22" value="MP -84; summons Frostprey for 176 sec, attack 460"/>
+    <string name="h23" value="MP -86; summons Frostprey for 179 sec, attack 465"/>
+    <string name="h24" value="MP -88; summons Frostprey for 182 sec, attack 470"/>
+    <string name="h25" value="MP -90; summons Frostprey for 185 sec, attack 475"/>
+    <string name="h26" value="MP -92; summons Frostprey for 188 sec, attack 480"/>
+    <string name="h27" value="MP -94; summons Frostprey for 191 sec, attack 485"/>
+    <string name="h28" value="MP -96; summons Frostprey for 194 sec, attack 490"/>
+    <string name="h29" value="MP -98; summons Frostprey for 197 sec, attack 495"/>
+    <string name="h30" value="MP -100; summons Frostprey for 200 sec, attack 500"/>
   </imgdir>
   <imgdir name="3221006">
     <string name="name" value="Blind"/>
     <string name="desc" value="Has a chance to impair an enemy&apos;s sight, reducing its Accuracy for a period of time."/>
-    <string name="h1" value="MP - 12 , For 35secs, with success rate  11%, enemy&apos;s accuracy decreases by 1% for 5secs"/>
-    <string name="h2" value="MP - 12 , For 40secs, with success rate 12%, enemy&apos;s accuracy decreases by 2% for 5secs"/>
-    <string name="h3" value="MP - 12 , For 45secs, with success rate 13%, enemy&apos;s accuracy decreases by 3% for 5secs"/>
-    <string name="h4" value="MP - 12 , For 50secs, with success rate 14%, enemy&apos;s accuracy decreases by 4% for 5secs"/>
-    <string name="h5" value="MP - 12 , For 55secs, with success rate 15%, enemy&apos;s accuracy decreases by 5% for 5secs"/>
-    <string name="h6" value="MP - 12 , For 60secs, with success rate 16%, enemy&apos;s accuracy decreases by 6% for 5secs"/>
-    <string name="h7" value="MP - 12 , For 65secs, with success rate 17%, enemy&apos;s accuracy decreases by 7% for 5secs"/>
-    <string name="h8" value="MP - 12 , For 70secs, with success rate 18%, enemy&apos;s accuracy decreases by 8% for 5secs"/>
-    <string name="h9" value="MP - 12 , For 75secs, with success rate 19%, enemy&apos;s accuracy decreases by 9% for 5secs"/>
-    <string name="h10" value="MP - 12 , For 80secs, with success rate 20%, enemy&apos;s accuracy decreases by 10% for 5secs"/>
-    <string name="h11" value="MP - 24 , For 85secs, with success rate 21%, enemy&apos;s accuracy decreases by 11% for 10secs"/>
-    <string name="h12" value="MP - 24 , For 90secs, with success rate 22%, enemy&apos;s accuracy decreases by 12% for 10secs"/>
-    <string name="h13" value="MP - 24 , For 95secs, with success rate 23%, enemy&apos;s accuracy decreases by 13% for 10secs"/>
-    <string name="h14" value="MP - 24 , For 100secs, with success rate 24%, enemy&apos;s accuracy decreases by 14% for 10secs"/>
-    <string name="h15" value="MP - 24 , For 105secs, with success rate 25%, enemy&apos;s accuracy decreases by 15% for 10secs"/>
-    <string name="h16" value="MP - 24 , For 110secs, with success rate 26%, enemy&apos;s accuracy decreases by 16% for 10secs"/>
-    <string name="h17" value="MP - 24 , For 115secs, with success rate 27%, enemy&apos;s accuracy decreases by 17% for 10secs"/>
-    <string name="h18" value="MP - 24 , For 120secs, with success rate 28%, enemy&apos;s accuracy decreases by 18% for 10secs"/>
-    <string name="h19" value="MP - 24 , For 125secs, with success rate 29%, enemy&apos;s accuracy decreases by 19% for 10secs"/>
-    <string name="h20" value="MP - 24 , For 130secs, with success rate 30%, enemy&apos;s accuracy decreases by 20% for 10secs"/>
-    <string name="h21" value="MP - 36 , For 135secs, with success rate 31%, enemy&apos;s accuracy decreases by 21% for 15secs"/>
-    <string name="h22" value="MP - 36 , For 140secs, with success rate 32%, enemy&apos;s accuracy decreases by 22% for 15secs"/>
-    <string name="h23" value="MP - 36 , For 145secs, with success rate 33%, enemy&apos;s accuracy decreases by 23% for 15secs"/>
-    <string name="h24" value="MP - 36 , For 150secs, with success rate 34%, enemy&apos;s accuracy decreases by 24% for 15secs"/>
-    <string name="h25" value="MP - 36 , For 155secs, with success rate 35%, enemy&apos;s accuracy decreases by 25% for 15secs"/>
-    <string name="h26" value="MP - 36 , For 160secs, with success rate 36%, enemy&apos;s accuracy decreases by 26% for 15secs"/>
-    <string name="h27" value="MP - 36 , For 165secs, with success rate 37%, enemy&apos;s accuracy decreases by 27% for 15secs"/>
-    <string name="h28" value="MP - 36 , For 170secs, with success rate 38%, enemy&apos;s accuracy decreases by 28% for 15secs"/>
-    <string name="h29" value="MP - 36 , For 175secs, with success rate 39%, enemy&apos;s accuracy decreases by 29% for 15secs"/>
-    <string name="h30" value="MP - 36 , For 180secs, with success rate 40%, enemy&apos;s accuracy decreases by 30% for 15secs"/>
+    <string name="h1" value="MP -12; for 35 sec, 11% chance to reduce enemy Accuracy by 1% for 5 sec"/>
+    <string name="h2" value="MP -12; for 40 sec, 12% chance to reduce enemy Accuracy by 2% for 5 sec"/>
+    <string name="h3" value="MP -12; for 45 sec, 13% chance to reduce enemy Accuracy by 3% for 5 sec"/>
+    <string name="h4" value="MP -12; for 50 sec, 14% chance to reduce enemy Accuracy by 4% for 5 sec"/>
+    <string name="h5" value="MP -12; for 55 sec, 15% chance to reduce enemy Accuracy by 5% for 5 sec"/>
+    <string name="h6" value="MP -12; for 60 sec, 16% chance to reduce enemy Accuracy by 6% for 5 sec"/>
+    <string name="h7" value="MP -12; for 65 sec, 17% chance to reduce enemy Accuracy by 7% for 5 sec"/>
+    <string name="h8" value="MP -12; for 70 sec, 18% chance to reduce enemy Accuracy by 8% for 5 sec"/>
+    <string name="h9" value="MP -12; for 75 sec, 19% chance to reduce enemy Accuracy by 9% for 5 sec"/>
+    <string name="h10" value="MP -12; for 80 sec, 20% chance to reduce enemy Accuracy by 10% for 5 sec"/>
+    <string name="h11" value="MP -24; for 85 sec, 21% chance to reduce enemy Accuracy by 11% for 10 sec"/>
+    <string name="h12" value="MP -24; for 90 sec, 22% chance to reduce enemy Accuracy by 12% for 10 sec"/>
+    <string name="h13" value="MP -24; for 95 sec, 23% chance to reduce enemy Accuracy by 13% for 10 sec"/>
+    <string name="h14" value="MP -24; for 100 sec, 24% chance to reduce enemy Accuracy by 14% for 10 sec"/>
+    <string name="h15" value="MP -24; for 105 sec, 25% chance to reduce enemy Accuracy by 15% for 10 sec"/>
+    <string name="h16" value="MP -24; for 110 sec, 26% chance to reduce enemy Accuracy by 16% for 10 sec"/>
+    <string name="h17" value="MP -24; for 115 sec, 27% chance to reduce enemy Accuracy by 17% for 10 sec"/>
+    <string name="h18" value="MP -24; for 120 sec, 28% chance to reduce enemy Accuracy by 18% for 10 sec"/>
+    <string name="h19" value="MP -24; for 125 sec, 29% chance to reduce enemy Accuracy by 19% for 10 sec"/>
+    <string name="h20" value="MP -24; for 130 sec, 30% chance to reduce enemy Accuracy by 20% for 10 sec"/>
+    <string name="h21" value="MP -36; for 135 sec, 31% chance to reduce enemy Accuracy by 21% for 15 sec"/>
+    <string name="h22" value="MP -36; for 140 sec, 32% chance to reduce enemy Accuracy by 22% for 15 sec"/>
+    <string name="h23" value="MP -36; for 145 sec, 33% chance to reduce enemy Accuracy by 23% for 15 sec"/>
+    <string name="h24" value="MP -36; for 150 sec, 34% chance to reduce enemy Accuracy by 24% for 15 sec"/>
+    <string name="h25" value="MP -35; for 155 sec, 35% chance to reduce enemy Accuracy by 25% for 15 sec"/>
+    <string name="h26" value="MP -34; for 160 sec, 36% chance to reduce enemy Accuracy by 26% for 15 sec"/>
+    <string name="h27" value="MP -33; for 165 sec, 37% chance to reduce enemy Accuracy by 27% for 15 sec"/>
+    <string name="h28" value="MP -32; for 170 sec, 38% chance to reduce enemy Accuracy by 28% for 15 sec"/>
+    <string name="h29" value="MP -31; for 175 sec, 39% chance to reduce enemy Accuracy by 29% for 15 sec"/>
+    <string name="h30" value="MP -30; for 180 sec, 40% chance to reduce enemy Accuracy by 30% for 15 sec"/>
   </imgdir>
   <imgdir name="3221007">
     <string name="name" value="Snipe"/>
-    <string name="desc" value="Aims for the enemy&apos;s weak point to deliver a near-unerring lethal strike with very high fixed damage."/>
-    <string name="h1" value="MP - 40 , Terms between skills 250secs"/>
-    <string name="h2" value="MP - 39 , Terms between skills 240secs"/>
-    <string name="h3" value="MP - 38 , Terms between skills 230secs"/>
-    <string name="h4" value="MP - 37 , Terms between skills 220secs"/>
-    <string name="h5" value="MP - 36 , Terms between skills 210secs"/>
-    <string name="h6" value="MP - 35 , Terms between skills 200secs"/>
-    <string name="h7" value="MP - 34 , Terms between skills 190secs"/>
-    <string name="h8" value="MP - 33 , Terms between skills 180secs"/>
-    <string name="h9" value="MP - 32 , Terms between skills 170secs"/>
-    <string name="h10" value="MP - 31 , Terms between skills 160secs"/>
-    <string name="h11" value="MP - 30 , Terms between skills 150secs"/>
-    <string name="h12" value="MP - 29 , Terms between skills 140secs"/>
-    <string name="h13" value="MP - 28 , Terms between skills 130secs"/>
-    <string name="h14" value="MP - 27 , Terms between skills 120secs"/>
-    <string name="h15" value="MP - 26 , Terms between skills 110secs"/>
-    <string name="h16" value="MP - 25 , Terms between skills 100secs"/>
-    <string name="h17" value="MP - 24 , Terms between skills 90secs"/>
-    <string name="h18" value="MP - 23 , Terms between skills 80secs"/>
-    <string name="h19" value="MP - 22 , Terms between skills 70secs"/>
-    <string name="h20" value="MP - 21 , Terms between skills 60secs"/>
-    <string name="h21" value="MP - 20 , Terms between skills 50secs"/>
-    <string name="h22" value="MP - 19 , Terms between skills 45secs"/>
-    <string name="h23" value="MP - 18 , Terms between skills 40secs"/>
-    <string name="h24" value="MP - 17 , Terms between skills 35secs"/>
-    <string name="h25" value="MP - 16 , Terms between skills 30secs"/>
-    <string name="h26" value="MP - 15 , Terms between skills 25secs"/>
-    <string name="h27" value="MP - 14 , Terms between skills 20secs"/>
-    <string name="h28" value="MP - 13 , Terms between skills 15secs"/>
-    <string name="h29" value="MP - 12 , Terms between skills 10secs"/>
-    <string name="h30" value="MP - 11 , Terms between skills 5secs"/>
+    <string name="desc" value="Aims for the enemy&apos;s weak point to deliver a fixed-damage strike for 195000-199999 damage."/>
+    <string name="h1" value="MP -40; fixed damage 195000-199999, cooldown 250 sec"/>
+    <string name="h2" value="MP -39; fixed damage 195000-199999, cooldown 240 sec"/>
+    <string name="h3" value="MP -38; fixed damage 195000-199999, cooldown 230 sec"/>
+    <string name="h4" value="MP -37; fixed damage 195000-199999, cooldown 220 sec"/>
+    <string name="h5" value="MP -36; fixed damage 195000-199999, cooldown 210 sec"/>
+    <string name="h6" value="MP -35; fixed damage 195000-199999, cooldown 200 sec"/>
+    <string name="h7" value="MP -34; fixed damage 195000-199999, cooldown 190 sec"/>
+    <string name="h8" value="MP -33; fixed damage 195000-199999, cooldown 180 sec"/>
+    <string name="h9" value="MP -32; fixed damage 195000-199999, cooldown 170 sec"/>
+    <string name="h10" value="MP -31; fixed damage 195000-199999, cooldown 160 sec"/>
+    <string name="h11" value="MP -30; fixed damage 195000-199999, cooldown 150 sec"/>
+    <string name="h12" value="MP -29; fixed damage 195000-199999, cooldown 140 sec"/>
+    <string name="h13" value="MP -28; fixed damage 195000-199999, cooldown 130 sec"/>
+    <string name="h14" value="MP -27; fixed damage 195000-199999, cooldown 120 sec"/>
+    <string name="h15" value="MP -26; fixed damage 195000-199999, cooldown 110 sec"/>
+    <string name="h16" value="MP -25; fixed damage 195000-199999, cooldown 100 sec"/>
+    <string name="h17" value="MP -24; fixed damage 195000-199999, cooldown 90 sec"/>
+    <string name="h18" value="MP -23; fixed damage 195000-199999, cooldown 80 sec"/>
+    <string name="h19" value="MP -22; fixed damage 195000-199999, cooldown 70 sec"/>
+    <string name="h20" value="MP -21; fixed damage 195000-199999, cooldown 60 sec"/>
+    <string name="h21" value="MP -20; fixed damage 195000-199999, cooldown 50 sec"/>
+    <string name="h22" value="MP -19; fixed damage 195000-199999, cooldown 45 sec"/>
+    <string name="h23" value="MP -18; fixed damage 195000-199999, cooldown 40 sec"/>
+    <string name="h24" value="MP -17; fixed damage 195000-199999, cooldown 35 sec"/>
+    <string name="h25" value="MP -16; fixed damage 195000-199999, cooldown 30 sec"/>
+    <string name="h26" value="MP -15; fixed damage 195000-199999, cooldown 25 sec"/>
+    <string name="h27" value="MP -14; fixed damage 195000-199999, cooldown 20 sec"/>
+    <string name="h28" value="MP -13; fixed damage 195000-199999, cooldown 15 sec"/>
+    <string name="h29" value="MP -12; fixed damage 195000-199999, cooldown 10 sec"/>
+    <string name="h30" value="MP -11; fixed damage 195000-199999, cooldown 4 sec"/>
   </imgdir>
   <imgdir name="3221008">
     <string name="name" value="Hero&apos;s Will"/>
     <string name="desc" value="Removes abnormal status effects. Cooldown decreases as the skill level increases."/>
-    <string name="h1" value="MP - 30 escape from abnormal condition, Terms between skills 600secs"/>
-    <string name="h2" value="MP - 30 escape from abnormal condition, Terms between skills 540secs"/>
-    <string name="h3" value="MP - 30 escape from abnormal condition, Terms between skills 480secs"/>
-    <string name="h4" value="MP - 30 escape from abnormal condition, Terms between skills 420secs"/>
-    <string name="h5" value="MP - 30 escape from abnormal condition, Terms between skills 360secs"/>
+    <string name="h1" value="MP -30; removes abnormal status effects, cooldown 600 sec"/>
+    <string name="h2" value="MP -30; removes abnormal status effects, cooldown 540 sec"/>
+    <string name="h3" value="MP -30; removes abnormal status effects, cooldown 480 sec"/>
+    <string name="h4" value="MP -30; removes abnormal status effects, cooldown 420 sec"/>
+    <string name="h5" value="MP -30; removes abnormal status effects, cooldown 360 sec"/>
   </imgdir>
   <imgdir name="412">
     <string name="bookName" value="Secret Skills of Nights Lord"/>
@@ -8599,7 +8599,7 @@
   </imgdir>
   <imgdir name="5121000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
+    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
     <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
     <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
     <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
@@ -8892,7 +8892,7 @@
   </imgdir>
   <imgdir name="5221000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
+    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
     <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
     <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
     <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>

--- a/gms-server/wz/String.wz/Skill.img.xml
+++ b/gms-server/wz/String.wz/Skill.img.xml
@@ -309,7 +309,7 @@
   </imgdir>
   <imgdir name="3000000">
     <string name="name" value="The Blessing of Amazon"/>
-    <string name="desc" value="[Master Level : 16]\nIncreases accuracy."/>
+    <string name="desc" value="[Master Level : 16]\nIncreases Accuracy."/>
     <string name="h1" value="Accuracy +1"/>
     <string name="h2" value="Accuracy +2"/>
     <string name="h3" value="Accuracy +3"/>
@@ -329,7 +329,7 @@
   </imgdir>
   <imgdir name="3000001">
     <string name="name" value="Critical Shot"/>
-    <string name="desc" value="[Master Level : 20]\nLaunches a critical attack with a given success rate."/>
+    <string name="desc" value="[Master Level : 20]\nGrants a chance to inflict a critical hit, increasing damage."/>
     <string name="h1" value="12% success rate, critical damage 105%"/>
     <string name="h2" value="14% success rate, critical damage 110%"/>
     <string name="h3" value="16% success rate, critical damage 115%"/>
@@ -353,7 +353,7 @@
   </imgdir>
   <imgdir name="3000002">
     <string name="name" value="The Eye of Amazon"/>
-    <string name="desc" value="[Master Level : 8]\nIncreases the range of attack for bows and crossbows.\nRequired Skill : #cAt least Level 3 on The Blessing of Amazon#"/>
+    <string name="desc" value="[Master Level : 8]\nIncreases the attack range of bows and crossbows.\nRequired Skill : #cThe Blessing of Amazon Lv. 3 or higher#"/>
     <string name="h1" value="Range of attack for bows and crossbows: +15"/>
     <string name="h2" value="Range of attack for bows and crossbows: +30"/>
     <string name="h3" value="Range of attack for bows and crossbows: +45"/>
@@ -365,7 +365,7 @@
   </imgdir>
   <imgdir name="3001003">
     <string name="name" value="Focus"/>
-    <string name="desc" value="[Master Level : 20]\nFocusing to temporarily increase accuracy and avoidability.\nRequired Skill : #cAt least Level 3 on The Blessing of Amazon#"/>
+    <string name="desc" value="[Master Level : 20]\nTemporarily increases Accuracy and Avoidability.\nRequired Skill : #cThe Blessing of Amazon Lv. 3 or higher#"/>
     <string name="h1" value="MP -8; accuracy +1, avoidability +1 for 70 sec. "/>
     <string name="h2" value="MP -8; accuracy +2, avoidability +2 for 80 sec. "/>
     <string name="h3" value="MP -8; accuracy +3, avoidability +3 for 90 sec. "/>
@@ -389,7 +389,7 @@
   </imgdir>
   <imgdir name="3001004">
     <string name="name" value="Arrow Blow"/>
-    <string name="desc" value="[Master Level : 20]\nFires an arrow with authority. Applies more damage than usual."/>
+    <string name="desc" value="[Master Level : 20]\nFires a powerful arrow at 1 enemy for increased damage."/>
     <string name="h1" value="MP -7; damage 141%"/>
     <string name="h2" value="MP -7; damage 146%"/>
     <string name="h3" value="MP -7; damage 151%"/>
@@ -413,7 +413,7 @@
   </imgdir>
   <imgdir name="3001005">
     <string name="name" value="Double Shot"/>
-    <string name="desc" value="[Master Level : 20]\nFires two arrows at once to attack an enemy twice.\nRequired Skill : #cAt least Level 1 on Arrow Blow#"/>
+    <string name="desc" value="[Master Level : 20]\nFires 2 arrows at once, hitting 1 enemy twice.\nRequired Skill : #cArrow Blow Lv. 1 or higher#"/>
     <string name="h1" value="MP -10; damage 92%"/>
     <string name="h2" value="MP -10; damage 94%"/>
     <string name="h3" value="MP -10; damage 96%"/>
@@ -1751,7 +1751,7 @@
   </imgdir>
   <imgdir name="3100000">
     <string name="name" value="Bow Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the bow mastery and accuracy. It only applies when a bow is in hand."/>
+    <string name="desc" value="[Master Level : 20]\nIncreases Bow Mastery and Accuracy. Requires a bow."/>
     <string name="h1" value="+15% bow mastery, +1 accuracy"/>
     <string name="h2" value="+15% bow mastery, +2 accuracy"/>
     <string name="h3" value="+20% bow mastery, +3 accuracy"/>
@@ -1774,8 +1774,8 @@
     <string name="h20" value="+60% bow mastery, +20 accuracy"/>
   </imgdir>
   <imgdir name="3100001">
-    <string name="name" value="Final Attack : Bow"/>
-    <string name="desc" value="[Master Level : 30]\nStrikes an another, far deadlier blow following the initial attack with a given success rate. It works only when holding a bow.\nRequired Skill : #cAt least Level 3 on Bow Mastery#"/>
+    <string name="name" value="Final Attack: Bow"/>
+    <string name="desc" value="[Master Level : 30]\nAfter using a bow attack skill, there is a chance to trigger an additional Final Attack.\nRequires a bow.\nRequired Skill : #cBow Mastery Lv. 3 or higher#"/>
     <string name="h1" value="2% Success rate, final attack with bow damage 105% "/>
     <string name="h2" value="4% Success rate, final attack with bow damage 110% "/>
     <string name="h3" value="6% Success rate, final attack with bow damage 115% "/>
@@ -1809,7 +1809,7 @@
   </imgdir>
   <imgdir name="3101002">
     <string name="name" value="Bow Booster"/>
-    <string name="desc" value="[Master Level : 20]\nUses HP and MP to temporarily boost up the attacking speed of the bow. It only works with a bow in hand.\nRequired Skill : #cAt least Level 5 on Bow Mastery#"/>
+    <string name="desc" value="[Master Level : 20]\nConsumes HP and MP to increase Bow attack speed by 2 stages for a period of time.\nRequires a bow.\nRequired Skill : #cBow Mastery Lv. 5 or higher#"/>
     <string name="h1" value="HP -29, MP -29; increase in bow attacking speed for 10 sec."/>
     <string name="h2" value="HP -28, MP -28; increase in bow attacking speed for 20 sec."/>
     <string name="h3" value="HP -27, MP -27; increase in bow attacking speed for 30 sec."/>
@@ -1833,7 +1833,7 @@
   </imgdir>
   <imgdir name="3101003">
     <string name="name" value="Power Knock-Back"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the success rate for pushing off the monsters when swinging a bow.  As the level rises, the number of monsters that one can push off with one swing increases."/>
+    <string name="desc" value="[Master Level : 20]\nSwings the bow at close range to damage and knock back multiple enemies with a certain success rate."/>
     <string name="h1" value="MP -8; knock-back +2%, damage 105%, knock-back 2 enemies."/>
     <string name="h2" value="MP -8; knock-back +4%, damage 110%, knock-back 2 enemies."/>
     <string name="h3" value="MP -8; knock-back +6%, damage 115%, knock-back 2 enemies."/>
@@ -1856,8 +1856,8 @@
     <string name="h20" value="MP -15; knock-back +40%, damage 200%, knock-back 6 enemies."/>
   </imgdir>
   <imgdir name="3101004">
-    <string name="name" value="Soul Arrow : Bow"/>
-    <string name="desc" value="[Master Level : 20]\nTemporarily allows the character to fire bow arrows without using up the arrows. Only works with a bow in hand.\nRequired Skill : #cAt least Level 5 on Bow Booster#"/>
+    <string name="name" value="Soul Arrow: Bow"/>
+    <string name="desc" value="[Master Level : 20]\nTemporarily allows bow attacks without consuming arrows.\nRequires a bow.\nRequired Skill : #cBow Booster Lv. 5 or higher#"/>
     <string name="h1" value="MP -15; attack for 30 sec without using up an arrow."/>
     <string name="h2" value="MP -15, attack for 60 sec without using up an arrow."/>
     <string name="h3" value="MP -15, attack for 90 sec without using up an arrow."/>
@@ -1880,8 +1880,8 @@
     <string name="h20" value="MP -20, attack for 600 sec without using up an arrow."/>
   </imgdir>
   <imgdir name="3101005">
-    <string name="name" value="Arrow Bomb : Bow"/>
-    <string name="desc" value="[Master Level : 30]\nFires arrows with bombs attached to it. If struck cleanly, the bomb explodes on the enemy, knocking out some of the enemies around with a certain success rate. Can&apos;t attack more than 6 at once, and it only works with a bow in hand."/>
+    <string name="name" value="Arrow Bomb: Bow"/>
+    <string name="desc" value="[Master Level : 30]\nFires an explosive arrow at 1 enemy, damaging up to 6 nearby enemies and possibly stunning them.\nRequires a bow."/>
     <string name="h1" value="MP -14, stunner 31%, damage 72%"/>
     <string name="h2" value="MP -14, stunner 32%, damage 74%"/>
     <string name="h3" value="MP -14, stunner 33%, damage 76%"/>
@@ -1918,7 +1918,7 @@
   </imgdir>
   <imgdir name="3200000">
     <string name="name" value="Crossbow Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the crossbow mastery and accuracy. It only applies when a crossbow is in hand."/>
+    <string name="desc" value="[Master Level : 20]\nIncreases Crossbow Mastery and Accuracy. Requires a crossbow."/>
     <string name="h1" value="Crossbow mastery +15%, accuracy +1"/>
     <string name="h2" value="Crossbow mastery +15%, accuracy +2"/>
     <string name="h3" value="Crossbow mastery +20%, accuracy +3"/>
@@ -1941,8 +1941,8 @@
     <string name="h20" value="Crossbow mastery +60%, accuracy +20"/>
   </imgdir>
   <imgdir name="3200001">
-    <string name="name" value="Final Attack : Crossbow"/>
-    <string name="desc" value="[Master Level : 30]\nStrikes an another, far deadlier blow following the initial attack with a given success rate. It works only when holding a crossbow.\nRequired Skill : #cAt least Level 3 on Crossbow Mastery#"/>
+    <string name="name" value="Final Attack: Crossbow"/>
+    <string name="desc" value="[Master Level : 30]\nAfter using a crossbow attack skill, there is a chance to trigger an additional Final Attack.\nRequires a crossbow.\nRequired Skill : #cCrossbow Mastery Lv. 3 or higher#"/>
     <string name="h1" value="2% Success rate,\r\nfinal attack with crossbow damage 105% "/>
     <string name="h2" value="4% Success rate,\r\nfinal attack with crossbow damage 110% "/>
     <string name="h3" value="6% Success rate,\r\nfinal attack with crossbow damage 115% "/>
@@ -1976,7 +1976,7 @@
   </imgdir>
   <imgdir name="3201002">
     <string name="name" value="Crossbow Booster"/>
-    <string name="desc" value="[Master Level : 20]\nUses HP and MP to temporarily boost up the attacking speed of the crossbow. It only works with a crossbow in hand.\nRequired Skill : #cAt least Level 5 on Crossbow Mastery#"/>
+    <string name="desc" value="[Master Level : 20]\nConsumes HP and MP to increase Crossbow attack speed by 2 stages for a period of time.\nRequires a crossbow.\nRequired Skill : #cCrossbow Mastery Lv. 5 or higher#"/>
     <string name="h1" value="HP -29, MP -29; improves crossbow speed for 10 sec."/>
     <string name="h2" value="HP -28, MP -28; improves crossbow speed for 20 sec."/>
     <string name="h3" value="HP -27, MP -27; improves crossbow speed for 30 sec."/>
@@ -2000,7 +2000,7 @@
   </imgdir>
   <imgdir name="3201003">
     <string name="name" value="Power Knock-Back"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the success rate for pushing off the monsters when swinging a crossbow.  As the level rises, the number of monsters that one can push off with one swing increases."/>
+    <string name="desc" value="[Master Level : 20]\nSwings the crossbow at close range to damage and knock back multiple enemies with a certain success rate."/>
     <string name="h1" value="MP -8; knock-back +2%, damage 105%, knock-back 2 enemies."/>
     <string name="h2" value="MP -8; knock-back +4%, damage 110%, knock-back 2 enemies."/>
     <string name="h3" value="MP -8; knock-back +6%, damage 115%, knock-back 2 enemies."/>
@@ -2023,8 +2023,8 @@
     <string name="h20" value="MP -15; knock-back +40%, damage 200%, knock-back 6 enemies."/>
   </imgdir>
   <imgdir name="3201004">
-    <string name="name" value="Soul Arrow : Crossbow"/>
-    <string name="desc" value="[Master Level : 20]\nTemporarily allows the character to fire crossbow arrows without using up the arrows. Only works with a crossbow in hand.\nRequired Skill : #cAt least Level 5 on Bow Booster#"/>
+    <string name="name" value="Soul Arrow: Crossbow"/>
+    <string name="desc" value="[Master Level : 20]\nTemporarily allows crossbow attacks without consuming arrows.\nRequires a crossbow.\nRequired Skill : #cCrossbow Booster Lv. 5 or higher#"/>
     <string name="h1" value="MP -15; attack for 30 sec without using up an arrow."/>
     <string name="h2" value="MP -15; attack for 60 sec without using up an arrow."/>
     <string name="h3" value="MP -15; attack for 90 sec without using up an arrow."/>
@@ -2047,8 +2047,8 @@
     <string name="h20" value="MP -20; attack for 600 sec without using up an arrow."/>
   </imgdir>
   <imgdir name="3201005">
-    <string name="name" value="Iron Arrow : Crossbow"/>
-    <string name="desc" value="[Master Level : 30]\nAttacks up to 6 monsters at once with a powerful arrow, which penetrates through them. Damage decreases as the arrow flies through."/>
+    <string name="name" value="Iron Arrow: Crossbow"/>
+    <string name="desc" value="[Master Level : 30]\nFires a powerful piercing arrow that can hit up to 6 enemies; damage decreases as it pierces through targets."/>
     <string name="h1" value="MP -25, damage 64%"/>
     <string name="h2" value="MP -25, damage 68%"/>
     <string name="h3" value="MP -25, damage 72%"/>
@@ -3923,7 +3923,7 @@
   </imgdir>
   <imgdir name="3110000">
     <string name="name" value="Thrust"/>
-    <string name="desc" value="[Master Level : 20]\nBoosts up the moving speed."/>
+    <string name="desc" value="[Master Level : 20]\nIncreases movement speed."/>
     <string name="h1" value="Speed + 2"/>
     <string name="h2" value="Speed + 4"/>
     <string name="h3" value="Speed + 6"/>
@@ -3947,7 +3947,7 @@
   </imgdir>
   <imgdir name="3110001">
     <string name="name" value="Mortal Blow"/>
-    <string name="desc" value="[Master Level : 20]\nEnables to shoot monsters within a very close range with a given success rate. Even kills a monster with a single shot every once in a while."/>
+    <string name="desc" value="[Master Level : 20]\nAllows attacks at very close range and grants a chance to inflict a deadly blow."/>
     <string name="h1" value="32% success rate, Damage 110%; Kills the monster with HP at 20% or lower at 1% success rate"/>
     <string name="h2" value="34% success rate, Damage 120%; Kills the monster with HP at 23% or lower at 1% success rate"/>
     <string name="h3" value="36% success rate, Damage 130%; Kills the monster with HP at 23% or lower at 2% success rate"/>
@@ -3971,7 +3971,7 @@
   </imgdir>
   <imgdir name="3111002">
     <string name="name" value="Puppet"/>
-    <string name="desc" value="[Master Level : 20]\nTemporarily summons a puppet, which takes all the attacks from the monsters instead. "/>
+    <string name="desc" value="[Master Level : 20]\nSummons a puppet that attracts monster attacks for a period of time."/>
     <string name="h1" value="MP - 23; For 5 sec., summons HP 500 puppet"/>
     <string name="h2" value="MP - 23; For 5 sec., summons HP 600 puppet"/>
     <string name="h3" value="MP - 23; For 10 sec., summons HP 700 puppet"/>
@@ -3995,7 +3995,7 @@
   </imgdir>
   <imgdir name="3111003">
     <string name="name" value="Inferno"/>
-    <string name="desc" value="[Master Level : 30]\nUses fire-based arrows to attack up to 6 monsters at once. Only works when equipped with a bow."/>
+    <string name="desc" value="[Master Level : 30]\nAttacks up to 6 enemies with fire arrows, dealing fire-element damage.\nRequires a bow."/>
     <string name="h1" value="MP - 20, Damage 50%"/>
     <string name="h2" value="MP - 20, Damage 55%"/>
     <string name="h3" value="MP - 20, Damage 60%"/>
@@ -4029,7 +4029,7 @@
   </imgdir>
   <imgdir name="3111004">
     <string name="name" value="Arrow Rain"/>
-    <string name="desc" value="[Master Level : 30]\nFires a number of arrows into the sky, attacking upto 6 monsters at once on its way down. Only available when equipped with a bow.\nRequired Skill : #cAt least Level 5 on Mortal Blow#"/>
+    <string name="desc" value="[Master Level : 30]\nRains arrows from above to attack up to 6 enemies.\nRequires a bow.\nRequired Skill : #cMortal Blow Lv. 5 or higher#"/>
     <string name="h1" value="MP - 18, Damage 60%"/>
     <string name="h2" value="MP - 18, Damage 65%"/>
     <string name="h3" value="MP - 18, Damage 70%"/>
@@ -4063,7 +4063,7 @@
   </imgdir>
   <imgdir name="3111005">
     <string name="name" value="Silver Hawk"/>
-    <string name="desc" value="[Master Level : 30]\nSummons a silver hawk. The hawk will be hovering around you, attacking monsters nearby.\nRequired Skill : #cAt least Level 5 on Puppet#"/>
+    <string name="desc" value="[Master Level : 30]\nSummons Silver Hawk to attack nearby enemies for a period of time, with a chance to stun.\nRequired Skill : #cPuppet Lv. 5 or higher#"/>
     <string name="h1" value="MP - 32, use 1 Summoning Rock; summons a hawk for 103 sec.; attack +23 ; 50% chance of stunning"/>
     <string name="h2" value="MP - 34, use 1 Summoning Rock; summons a hawk for 106 sec.; attack +26 ; 53% chance of stunning"/>
     <string name="h3" value="MP - 36, use 1 Summoning Rock; summons a hawk for 109 sec.; attack +29 ; 56% chance of stunning"/>
@@ -4097,7 +4097,7 @@
   </imgdir>
   <imgdir name="3111006">
     <string name="name" value="Strafe"/>
-    <string name="desc" value="[Master Level : 30]\nFires 4 arrows at an enemy."/>
+    <string name="desc" value="[Master Level : 30]\nRapidly fires 4 arrows at a single enemy."/>
     <string name="h1" value="MP - 26, Damage 71%, attack 4 times"/>
     <string name="h2" value="MP - 26, Damage 72%, attack 4 times"/>
     <string name="h3" value="MP - 26, Damage 73%, attack 4 times"/>
@@ -4134,7 +4134,7 @@
   </imgdir>
   <imgdir name="3210000">
     <string name="name" value="Thrust"/>
-    <string name="desc" value="[Master Level : 20]\nBoosts up the moving speed."/>
+    <string name="desc" value="[Master Level : 20]\nIncreases movement speed."/>
     <string name="h1" value="Speed + 2"/>
     <string name="h2" value="Speed + 4"/>
     <string name="h3" value="Speed + 6"/>
@@ -4158,7 +4158,7 @@
   </imgdir>
   <imgdir name="3210001">
     <string name="name" value="Mortal Blow"/>
-    <string name="desc" value="[Master Level : 20]\nFor a certain rate, allows you to fire crossbow arrows even at a very close range. Even kills a monster with one shot every once in a while."/>
+    <string name="desc" value="[Master Level : 20]\nAllows crossbow attacks at very close range and grants a chance to inflict a deadly blow."/>
     <string name="h1" value="32% success rate, Damage 110%; Kills the monster with HP at 20% or lower at 1% success rate"/>
     <string name="h2" value="34% success rate, Damage 120%; Kills the monster with HP at 23% or lower at 1% success rate"/>
     <string name="h3" value="36% success rate, Damage 130%; Kills the monster with HP at 23% or lower at 2% success rate"/>
@@ -4182,7 +4182,7 @@
   </imgdir>
   <imgdir name="3211002">
     <string name="name" value="Puppet"/>
-    <string name="desc" value="[Master Level : 20]\nSummons a puppet (your other self) for a certain amount of time. While the puppet is around, the monsters will attack the puppet, not you."/>
+    <string name="desc" value="[Master Level : 20]\nSummons a puppet that attracts monster attacks for a period of time."/>
     <string name="h1" value="MP - 23; For 5 sec., summons HP 500 puppet"/>
     <string name="h2" value="MP - 23; For 5 sec., summons HP 600 puppet"/>
     <string name="h3" value="MP - 23; For 10 sec., summons HP 700 puppet"/>
@@ -4206,7 +4206,7 @@
   </imgdir>
   <imgdir name="3211003">
     <string name="name" value="Blizzard"/>
-    <string name="desc" value="[Master Level : 30]\nUses ice-based arrows to attack up to 6 monsters at once. Only works when equipped with a bow."/>
+    <string name="desc" value="[Master Level : 30]\nAttacks up to 6 enemies with ice arrows, dealing ice-element damage.\nRequires a crossbow."/>
     <string name="h1" value="MP - 20, Damage 100%, freezes enemies for 1 sec."/>
     <string name="h2" value="MP - 20, Damage 102%, freezes enemies for 1 sec."/>
     <string name="h3" value="MP - 20, Damage 104%, freezes enemies for 1 sec."/>
@@ -4240,7 +4240,7 @@
   </imgdir>
   <imgdir name="3211004">
     <string name="name" value="Arrow Eruption"/>
-    <string name="desc" value="[Master Level : 30]\nAttacks up to 6 monsters simultaneously by shooting multiple arrows.  Only works with a crossbow equipped."/>
+    <string name="desc" value="[Master Level : 30]\nTriggers an erupting arrow attack that hits up to 6 enemies.\nRequires a crossbow.\nRequired Skill : #cMortal Blow Lv. 5 or higher#"/>
     <string name="h1" value="MP - 18, Damage 60%"/>
     <string name="h2" value="MP - 18, Damage 65%"/>
     <string name="h3" value="MP - 18, Damage 70%"/>
@@ -4274,7 +4274,7 @@
   </imgdir>
   <imgdir name="3211005">
     <string name="name" value="Golden Eagle"/>
-    <string name="desc" value="[Master Level : 30]\nSummons a golden eagle. The eagle will be hovering around you, attacking monsters nearby.\nRequired Skill : #cAt least Level 5 on Puppet#"/>
+    <string name="desc" value="[Master Level : 30]\nSummons Golden Eagle to attack nearby enemies for a period of time, with a chance to stun.\nRequired Skill : #cPuppet Lv. 5 or higher#"/>
     <string name="h1" value="MP - 32, use 1 Summoning Rock; summons an eagle that attacks 13 times in 180 sec.; 50% chance of stunning"/>
     <string name="h2" value="MP - 34, use 1 Summoning Rock; summons an eagle that attacks 16 times in 180 sec.; 53% chance of stunning"/>
     <string name="h3" value="MP - 36, use 1 Summoning Rock; summons an eagle that attacks 19 times in 180 sec.; 56% chance of stunning"/>
@@ -4308,7 +4308,7 @@
   </imgdir>
   <imgdir name="3211006">
     <string name="name" value="Strafe"/>
-    <string name="desc" value="[Master Level : 30]\nFires 4 arrows at an enemy."/>
+    <string name="desc" value="[Master Level : 30]\nRapidly fires 4 arrows at a single enemy."/>
     <string name="h1" value="MP - 26, Damage 71%, attack 4 times"/>
     <string name="h2" value="MP - 26, Damage 72%, attack 4 times"/>
     <string name="h3" value="MP - 26, Damage 73%, attack 4 times"/>
@@ -4818,7 +4818,7 @@
   </imgdir>
   <imgdir name="1121000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
+    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
     <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
     <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
     <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
@@ -6670,7 +6670,7 @@
   </imgdir>
   <imgdir name="3121002">
     <string name="name" value="Sharp Eyes"/>
-    <string name="desc" value="Grants party members the ability to locate enemy weaknesses, and in turn inflict more damage by exploiting them."/>
+    <string name="desc" value="Temporarily increases Critical Rate and Critical Damage for yourself and party members."/>
     <string name="h1" value="MP - 29 , for 10secs , Critical rate 1%, Damage + 11% ."/>
     <string name="h2" value="MP - 29 , for 20secs , Critical rate 1%, Damage + 12% ."/>
     <string name="h3" value="MP - 29 , for 30secs , Critical rate 2%, Damage + 13% ."/>
@@ -6704,7 +6704,7 @@
   </imgdir>
   <imgdir name="3121003">
     <string name="name" value="Dragon&apos;s Breath"/>
-    <string name="desc" value="Drawing upon the spirit of the dragon, fires a powerful arrow of tremendous force that will knock back the target a long distance."/>
+    <string name="desc" value="Unleashes a powerful dragon-infused arrow that attacks multiple enemies ahead and knocks them back."/>
     <string name="h1" value="MP - 24 , attack 42%, attacks up to 4 enemies"/>
     <string name="h2" value="MP - 24 , attack 44%, attacks up to 4 enemies"/>
     <string name="h3" value="MP - 24 , attack 46%, attacks up to 4 enemies"/>
@@ -6738,7 +6738,7 @@
   </imgdir>
   <imgdir name="3121004">
     <string name="name" value="Hurricane"/>
-    <string name="desc" value="Fires away arrows at a tremendous speed, as chaotic as a nasty rainstorm."/>
+    <string name="desc" value="Fires arrows continuously at tremendous speed while the skill key is held down."/>
     <string name="h1" value="MP - 6 , Damage 51%"/>
     <string name="h2" value="MP - 6 , Damage 52%"/>
     <string name="h3" value="MP - 6 , Damage 53%"/>
@@ -6772,7 +6772,7 @@
   </imgdir>
   <imgdir name="3120005">
     <string name="name" value="Bow Expert"/>
-    <string name="desc" value="Increases the bow mastery as well as weapon attack. Only applied with a bow equipped."/>
+    <string name="desc" value="Further increases Bow Mastery and Weapon Attack.\nRequires a bow."/>
     <string name="h1" value="Bow Mastery 65%"/>
     <string name="h2" value="Bow Mastery 65%"/>
     <string name="h3" value="Bow Mastery 65%, Weapon attack + 1 ."/>
@@ -6806,7 +6806,7 @@
   </imgdir>
   <imgdir name="3121006">
     <string name="name" value="Phoenix"/>
-    <string name="desc" value="Temporarily summons the Phoenix, who is a fire-based ally. Attacks up to 4 monsters."/>
+    <string name="desc" value="Summons Phoenix to attack up to 4 enemies for a period of time.\nRequired Skill : #cSilver Hawk Lv. 15 or higher#"/>
     <string name="h1" value="MP - 42 , Basic attack 305, for 113secs."/>
     <string name="h2" value="MP - 44 , Basic attack 310, for 116secs."/>
     <string name="h3" value="MP - 46 , Basic attack 315, for 119secs."/>
@@ -6840,7 +6840,7 @@
   </imgdir>
   <imgdir name="3121007">
     <string name="name" value="Hamstring"/>
-    <string name="desc" value="Attacks a monster&apos;s leg with a given success rate, slowing it down tremendously in the process"/>
+    <string name="desc" value="Has a chance to cripple an enemy&apos;s leg, slowing its movement speed for a period of time."/>
     <string name="h1" value="MP - 12 , within 35secs , with success rate 11%, decreases enemy&apos;s speed by 2 for 5secs"/>
     <string name="h2" value="MP - 12 , within 40secs , with success rate 12%, decreases enemy&apos;s speed by 4 for 5secs"/>
     <string name="h3" value="MP - 12 , within 45secs , with success rate 13%, decreases enemy&apos;s speed by 6 for 5secs"/>
@@ -6874,7 +6874,7 @@
   </imgdir>
   <imgdir name="3121008">
     <string name="name" value="Concentrate"/>
-    <string name="desc" value="Temporarily increases weapon attack, while simultaneously decreases skill-based MP usage.\n#c Terms between skills : 6 Minutes#"/>
+    <string name="desc" value="Temporarily increases Weapon Attack and reduces skill MP cost.\n#cCooldown : 6 minutes#"/>
     <string name="h1" value="MP - 11 , Weapon Attack increases by 11, Mana spend -2%, for 120secs"/>
     <string name="h2" value="MP - 12 , Weapon Attack increases by 12, Mana spend -4%, for 120secs"/>
     <string name="h3" value="MP - 13 , Weapon Attack increases by 12, Mana spend -6%, for 120secs"/>
@@ -6908,7 +6908,7 @@
   </imgdir>
   <imgdir name="3121009">
     <string name="name" value="Hero&apos;s Will"/>
-    <string name="desc" value="Enables one to shrug off abnormal conditions. The higher the skill level, the more types of abnormal conditions one can nullify."/>
+    <string name="desc" value="Removes abnormal status effects. Cooldown decreases as the skill level increases."/>
     <string name="h1" value="MP - 30 escape from abnormal condition, Terms between skills 600secs"/>
     <string name="h2" value="MP - 30 escape from abnormal condition, Terms between skills 540secs"/>
     <string name="h3" value="MP - 30 escape from abnormal condition, Terms between skills 480secs"/>
@@ -6920,7 +6920,7 @@
   </imgdir>
   <imgdir name="3221000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Increase all players&apos; stats within a party by certain percentage "/>
+    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
     <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
     <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
     <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
@@ -6954,7 +6954,7 @@
   </imgdir>
   <imgdir name="3221001">
     <string name="name" value="Piercing Arrow"/>
-    <string name="desc" value="Fires a special arrow that penetrates through monsters. The arrow&apos;s power increases with each monster it pierces, inflicting more damage to each consecutive monster."/>
+    <string name="desc" value="Fires a chargeable piercing arrow that passes through multiple enemies; its power increases as it pierces more targets."/>
     <string name="h1" value="MP - 18 , Max Attacks 320%, Attacks up to 4 enemies"/>
     <string name="h2" value="MP - 18 , Max Attacks 340%, Attacks up to 4 enemies"/>
     <string name="h3" value="MP - 18 , Max Attacks 360%, Attacks up to 4 enemies"/>
@@ -6988,7 +6988,7 @@
   </imgdir>
   <imgdir name="3221002">
     <string name="name" value="Sharp Eyes"/>
-    <string name="desc" value="Grants party members the ability to locate enemy weaknesses, and in turn inflict more damage by exploiting them."/>
+    <string name="desc" value="Temporarily increases Critical Rate and Critical Damage for yourself and party members."/>
     <string name="h1" value="MP - 29 , for 10secs, critical rate 1%, Damage 11% ."/>
     <string name="h2" value="MP - 29 , for 20secs, critical rate 1%, Damage 12% ."/>
     <string name="h3" value="MP - 29 , for 30secs, critical rate 2%, Damage 13% ."/>
@@ -7022,7 +7022,7 @@
   </imgdir>
   <imgdir name="3221003">
     <string name="name" value="Dragon&apos;s Breath"/>
-    <string name="desc" value="Drawing upon the spirit of the dragon, fires a powerful arrow of tremendous force that will knock back the target a long distance."/>
+    <string name="desc" value="Unleashes a powerful dragon-infused arrow that attacks multiple enemies ahead and knocks them back."/>
     <string name="h1" value="MP - 24 , Attacks 42%, Attacks up to  4 enemies"/>
     <string name="h2" value="MP - 24 , Attacks 44%, Attacks up to  4 enemies"/>
     <string name="h3" value="MP - 24 , Attacks 46%, Attacks up to  4 enemies"/>
@@ -7056,7 +7056,7 @@
   </imgdir>
   <imgdir name="3220004">
     <string name="name" value="Marksman Boost"/>
-    <string name="desc" value="Increases the crossbow mastery as well as weapon attack.  Only applied with a crossbow equipped."/>
+    <string name="desc" value="Further increases Crossbow Mastery and Weapon Attack.\nRequires a crossbow."/>
     <string name="h1" value="Cross bow Mastery 65%"/>
     <string name="h2" value="Cross bow Mastery 65%"/>
     <string name="h3" value="Cross bow Mastery 65%, Weapon attack + 1 ."/>
@@ -7090,7 +7090,7 @@
   </imgdir>
   <imgdir name="3221005">
     <string name="name" value="Frostprey"/>
-    <string name="desc" value="Temporarily summons the Frostprey, an ice-based hawk. Attacks up to 4 monsters."/>
+    <string name="desc" value="Summons Frostprey to attack up to 4 enemies for a period of time.\nRequired Skill : #cGolden Eagle Lv. 15 or higher#"/>
     <string name="h1" value="MP - 42 , Attack 255%, for 113secs"/>
     <string name="h2" value="MP - 44 , Attack 260%, for 116secs"/>
     <string name="h3" value="MP - 46 , Attack 265%, for 119secs"/>
@@ -7124,7 +7124,7 @@
   </imgdir>
   <imgdir name="3221006">
     <string name="name" value="Blind"/>
-    <string name="desc" value="Delivers a blinding strike that impairs a monster&apos;s vision with a certain success rate, decreasing its accuracy."/>
+    <string name="desc" value="Has a chance to impair an enemy&apos;s sight, reducing its Accuracy for a period of time."/>
     <string name="h1" value="MP - 12 , For 35secs, with success rate  11%, enemy&apos;s accuracy decreases by 1% for 5secs"/>
     <string name="h2" value="MP - 12 , For 40secs, with success rate 12%, enemy&apos;s accuracy decreases by 2% for 5secs"/>
     <string name="h3" value="MP - 12 , For 45secs, with success rate 13%, enemy&apos;s accuracy decreases by 3% for 5secs"/>
@@ -7158,7 +7158,7 @@
   </imgdir>
   <imgdir name="3221007">
     <string name="name" value="Snipe"/>
-    <string name="desc" value="Delivers a lethal blow to a monster by aiming for its weak spot."/>
+    <string name="desc" value="Aims for the enemy&apos;s weak point to deliver a near-unerring lethal strike with very high fixed damage."/>
     <string name="h1" value="MP - 40 , Terms between skills 250secs"/>
     <string name="h2" value="MP - 39 , Terms between skills 240secs"/>
     <string name="h3" value="MP - 38 , Terms between skills 230secs"/>
@@ -7192,7 +7192,7 @@
   </imgdir>
   <imgdir name="3221008">
     <string name="name" value="Hero&apos;s Will"/>
-    <string name="desc" value="Enables one to shrug off abnormal conditions. The higher the skill level, the more types of abnormal conditions one can nullify."/>
+    <string name="desc" value="Removes abnormal status effects. Cooldown decreases as the skill level increases."/>
     <string name="h1" value="MP - 30 escape from abnormal condition, Terms between skills 600secs"/>
     <string name="h2" value="MP - 30 escape from abnormal condition, Terms between skills 540secs"/>
     <string name="h3" value="MP - 30 escape from abnormal condition, Terms between skills 480secs"/>


### PR DESCRIPTION
改动内容
- 校正冒险家弓箭手一转至四转技能名称、技能说明和逐级数值说明，覆盖弓手系与弩手系文本。
- 按 `Skill.wz` 中的实际等级字段修正伤害、命中、回避、移动速度、暴击率、暴击伤害、攻击次数、目标数、持续时间、成功率、冷却时间、MP/HP 消耗等逐级文本。
- 按服务端伤害处理逻辑补充“一击要害箭 / Snipe”的固定伤害范围 `195000-199999`，并修正满级冷却为 4 秒。
- 中文目录保留经典技能名用法，将“贯穿箭”“击退箭”恢复为原有命名，并同步修正关联前置技能说明。
- 清理弓箭手英文技能文本中的异常标点组合，例如 `sec.,`、`sec.;`、`.;`、`.,`、`% ;` 等。
- 本次改动仅涉及技能文本资源，不涉及任务、NPC、道具或地图。

影响范围
- 同时影响服务端资源与客户端显示文本。
- 由于改动包含 `String.wz` 相关 XML，后续需要同步客户端资源包。

验证情况
- 已通过代理同步最新 `upstream/master` 与 `origin`。
- 已检查当前分支相对 `upstream/master` 的 diff，仅包含本次技能文本修复文件。
- 已按冒险家弓箭手技能 ID 范围校验英文异常标点，未发现 `sec.,`、`sec.;`、`secs`、`.;`、`.,`、`% ;` 残留。
- 已执行 XML 解析检查，确认修改后的中英文 `Skill.img.xml` 可正常解析。
- 已执行乱码检查，确认本次提交信息、PR 文本与变更文件中的中文说明未引入异常乱码字符。
- 已检查未混入测试产物、日志、压缩包、Jar 包等无关文件。

客户端资源
- 本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。
