### PR TITLE
fix: 校正海盗职业技能说明

### DIFF
--- a/gms-server/wz-zh-CN/String.wz/Skill.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Skill.img.xml
@@ -11304,31 +11304,40 @@
     </imgdir>
     <imgdir name="5000000">
         <string name="name" value="快动作"/>
-        <string name="h1" value="增加命中率 1，回避率 1"/>
-        <string name="h10" value="增加命中率 10，回避率 10"/>
-        <string name="h11" value="增加命中率 11，回避率 11"/>
-        <string name="h12" value="增加命中率 12，回避率 12"/>
-        <string name="h13" value="增加命中率 13，回避率 13"/>
-        <string name="h14" value="增加命中率 14，回避率 14"/>
-        <string name="h15" value="增加命中率 15，回避率 15"/>
-        <string name="h16" value="增加命中率 16，回避率 16"/>
-        <string name="h17" value="增加命中率 17，回避率 17"/>
-        <string name="h18" value="增加命中率 18，回避率 18"/>
-        <string name="h19" value="增加命中率 19，回避率 19"/>
-        <string name="h2" value="增加命中率 2，回避率 2"/>
-        <string name="h20" value="增加命中率 20，回避率 20"/>
-        <string name="h3" value="增加命中率 3，回避率 3"/>
-        <string name="h4" value="增加命中率 4，回避率 4"/>
-        <string name="h5" value="增加命中率 5，回避率 5"/>
-        <string name="h6" value="增加命中率 6，回避率 6"/>
-        <string name="h7" value="增加命中率 7，回避率 7"/>
-        <string name="h8" value="增加命中率 8，回避率 8"/>
-        <string name="h9" value="增加命中率 9，回避率 9"/>
-        <string name="desc" value="[最高等级 : 20]\n增加命中率和回避率"/>
+        <string name="desc" value="[最高等级：20]\n提高命中率和回避率。"/>
+        <string name="h1" value="命中率 +1，回避率 +1"/>
+        <string name="h2" value="命中率 +2，回避率 +2"/>
+        <string name="h3" value="命中率 +3，回避率 +3"/>
+        <string name="h4" value="命中率 +4，回避率 +4"/>
+        <string name="h5" value="命中率 +5，回避率 +5"/>
+        <string name="h6" value="命中率 +6，回避率 +6"/>
+        <string name="h7" value="命中率 +7，回避率 +7"/>
+        <string name="h8" value="命中率 +8，回避率 +8"/>
+        <string name="h9" value="命中率 +9，回避率 +9"/>
+        <string name="h10" value="命中率 +10，回避率 +10"/>
+        <string name="h11" value="命中率 +11，回避率 +11"/>
+        <string name="h12" value="命中率 +12，回避率 +12"/>
+        <string name="h13" value="命中率 +13，回避率 +13"/>
+        <string name="h14" value="命中率 +14，回避率 +14"/>
+        <string name="h15" value="命中率 +15，回避率 +15"/>
+        <string name="h16" value="命中率 +16，回避率 +16"/>
+        <string name="h17" value="命中率 +17，回避率 +17"/>
+        <string name="h18" value="命中率 +18，回避率 +18"/>
+        <string name="h19" value="命中率 +19，回避率 +19"/>
+        <string name="h20" value="命中率 +20，回避率 +20"/>
     </imgdir>
     <imgdir name="5001001">
         <string name="name" value="百裂拳"/>
+        <string name="desc" value="[最高等级：20]\n消耗MP，快速拳击1个敌人。"/>
         <string name="h1" value="消耗MP 6，伤害 156%"/>
+        <string name="h2" value="消耗MP 6，伤害 162%"/>
+        <string name="h3" value="消耗MP 6，伤害 168%"/>
+        <string name="h4" value="消耗MP 6，伤害 174%"/>
+        <string name="h5" value="消耗MP 7，伤害 180%"/>
+        <string name="h6" value="消耗MP 7，伤害 186%"/>
+        <string name="h7" value="消耗MP 7，伤害 192%"/>
+        <string name="h8" value="消耗MP 8，伤害 198%"/>
+        <string name="h9" value="消耗MP 8，伤害 204%"/>
         <string name="h10" value="消耗MP 9，伤害 210%"/>
         <string name="h11" value="消耗MP 9，伤害 216%"/>
         <string name="h12" value="消耗MP 10，伤害 222%"/>
@@ -11339,1379 +11348,1379 @@
         <string name="h17" value="消耗MP 12，伤害 252%"/>
         <string name="h18" value="消耗MP 13，伤害 258%"/>
         <string name="h19" value="消耗MP 13，伤害 264%"/>
-        <string name="h2" value="消耗MP 6，伤害 162%"/>
         <string name="h20" value="消耗MP 14，伤害 270%"/>
-        <string name="h3" value="消耗MP 6，伤害 168%"/>
-        <string name="h4" value="消耗MP 6，伤害 174%"/>
-        <string name="h5" value="消耗MP 7，伤害 180%"/>
-        <string name="h6" value="消耗MP 7，伤害 186%"/>
-        <string name="h7" value="消耗MP 7，伤害 192%"/>
-        <string name="h8" value="消耗MP 8，伤害 198%"/>
-        <string name="h9" value="消耗MP 8，伤害 204%"/>
-        <string name="desc" value="[最高等级 : 20]\n消耗MP，用拳头快速攻击敌人"/>
     </imgdir>
     <imgdir name="5001002">
         <string name="name" value="半月踢"/>
-        <string name="h1" value="消耗MP 8，伤害 114%，最多攻击 3只"/>
-        <string name="h10" value="消耗MP 11，伤害 150%，最多攻击 4只"/>
-        <string name="h11" value="消耗MP 11，伤害 154%，最多攻击 5只"/>
-        <string name="h12" value="消耗MP 12，伤害 158%，最多攻击 5只"/>
-        <string name="h13" value="消耗MP 12，伤害 162%，最多攻击 5只"/>
-        <string name="h14" value="消耗MP 13，伤害 166%，最多攻击 5只"/>
-        <string name="h15" value="消耗MP 13，伤害 170%，最多攻击 5只"/>
-        <string name="h16" value="消耗MP 14，伤害 174%，最多攻击 6只"/>
-        <string name="h17" value="消耗MP 14，伤害 178%，最多攻击 6只"/>
-        <string name="h18" value="消耗MP 15，伤害 182%，最多攻击 6只"/>
-        <string name="h19" value="消耗MP 15，伤害 186%，最多攻击 6只"/>
-        <string name="h2" value="消耗MP 8，伤害 118%，最多攻击 3只"/>
-        <string name="h20" value="消耗MP 16，伤害 190%，最多攻击 6只"/>
-        <string name="h3" value="消耗MP 8，伤害 122%，最多攻击 3只"/>
-        <string name="h4" value="消耗MP 8，伤害 126%，最多攻击 3只"/>
-        <string name="h5" value="消耗MP 9，伤害 130%，最多攻击 3只"/>
-        <string name="h6" value="消耗MP 9，伤害 134%，最多攻击 4只"/>
-        <string name="h7" value="消耗MP 9，伤害 138%，最多攻击 4只"/>
-        <string name="h8" value="消耗MP 10，伤害 142%，最多攻击 4只"/>
-        <string name="h9" value="消耗MP 10，伤害 146%，最多攻击 4只"/>
-        <string name="desc" value="[最高等级 : 20]\n后旋跳，用腿给周围多数的敌人击退攻击"/>
+        <string name="desc" value="[最高等级：20]\n以后空翻踢攻击周围敌人。"/>
+        <string name="h1" value="消耗MP 8，伤害 114%，最多攻击 3 个敌人"/>
+        <string name="h2" value="消耗MP 8，伤害 118%，最多攻击 3 个敌人"/>
+        <string name="h3" value="消耗MP 8，伤害 122%，最多攻击 3 个敌人"/>
+        <string name="h4" value="消耗MP 8，伤害 126%，最多攻击 3 个敌人"/>
+        <string name="h5" value="消耗MP 9，伤害 130%，最多攻击 3 个敌人"/>
+        <string name="h6" value="消耗MP 9，伤害 134%，最多攻击 4 个敌人"/>
+        <string name="h7" value="消耗MP 9，伤害 138%，最多攻击 4 个敌人"/>
+        <string name="h8" value="消耗MP 10，伤害 142%，最多攻击 4 个敌人"/>
+        <string name="h9" value="消耗MP 10，伤害 146%，最多攻击 4 个敌人"/>
+        <string name="h10" value="消耗MP 11，伤害 150%，最多攻击 4 个敌人"/>
+        <string name="h11" value="消耗MP 11，伤害 154%，最多攻击 5 个敌人"/>
+        <string name="h12" value="消耗MP 12，伤害 158%，最多攻击 5 个敌人"/>
+        <string name="h13" value="消耗MP 12，伤害 162%，最多攻击 5 个敌人"/>
+        <string name="h14" value="消耗MP 13，伤害 166%，最多攻击 5 个敌人"/>
+        <string name="h15" value="消耗MP 13，伤害 170%，最多攻击 5 个敌人"/>
+        <string name="h16" value="消耗MP 14，伤害 174%，最多攻击 6 个敌人"/>
+        <string name="h17" value="消耗MP 14，伤害 178%，最多攻击 6 个敌人"/>
+        <string name="h18" value="消耗MP 15，伤害 182%，最多攻击 6 个敌人"/>
+        <string name="h19" value="消耗MP 15，伤害 186%，最多攻击 6 个敌人"/>
+        <string name="h20" value="消耗MP 16，伤害 190%，最多攻击 6 个敌人"/>
     </imgdir>
     <imgdir name="5001003">
         <string name="name" value="双弹射击"/>
-        <string name="h1" value="消耗MP 4，伤害 92%"/>
-        <string name="h10" value="消耗MP 5，伤害 110%"/>
-        <string name="h11" value="消耗MP 6，伤害 112%"/>
-        <string name="h12" value="消耗MP 6，伤害 114%"/>
-        <string name="h13" value="消耗MP 6，伤害 116%"/>
-        <string name="h14" value="消耗MP 6，伤害 118%"/>
-        <string name="h15" value="消耗MP 6，伤害 120%"/>
-        <string name="h16" value="消耗MP 7，伤害 122%"/>
-        <string name="h17" value="消耗MP 7，伤害 124%"/>
-        <string name="h18" value="消耗MP 7，伤害 126%"/>
-        <string name="h19" value="消耗MP 7，伤害 128%"/>
-        <string name="h2" value="消耗MP 4，伤害 94%"/>
-        <string name="h20" value="消耗MP 7，伤害 130%"/>
-        <string name="h3" value="消耗MP 4，伤害 96%"/>
-        <string name="h4" value="消耗MP 4，伤害 98%"/>
-        <string name="h5" value="消耗MP 4，伤害 100%"/>
-        <string name="h6" value="消耗MP 5，伤害 102%"/>
-        <string name="h7" value="消耗MP 5，伤害 104%"/>
-        <string name="h8" value="消耗MP 5，伤害 106%"/>
-        <string name="h9" value="消耗MP 5，伤害 108%"/>
-        <string name="desc" value="[最高等级 : 20]\n同时发射二颗子弹，攻击敌人"/>
+        <string name="desc" value="[最高等级：20]\n向1个敌人发射2发子弹。需要装备手枪和子弹。"/>
+        <string name="h1" value="消耗MP 4，每发伤害 61%，发射 2 发"/>
+        <string name="h2" value="消耗MP 4，每发伤害 62%，发射 2 发"/>
+        <string name="h3" value="消耗MP 4，每发伤害 63%，发射 2 发"/>
+        <string name="h4" value="消耗MP 4，每发伤害 64%，发射 2 发"/>
+        <string name="h5" value="消耗MP 4，每发伤害 65%，发射 2 发"/>
+        <string name="h6" value="消耗MP 5，每发伤害 66%，发射 2 发"/>
+        <string name="h7" value="消耗MP 5，每发伤害 67%，发射 2 发"/>
+        <string name="h8" value="消耗MP 5，每发伤害 68%，发射 2 发"/>
+        <string name="h9" value="消耗MP 5，每发伤害 69%，发射 2 发"/>
+        <string name="h10" value="消耗MP 5，每发伤害 70%，发射 2 发"/>
+        <string name="h11" value="消耗MP 6，每发伤害 71%，发射 2 发"/>
+        <string name="h12" value="消耗MP 6，每发伤害 72%，发射 2 发"/>
+        <string name="h13" value="消耗MP 6，每发伤害 73%，发射 2 发"/>
+        <string name="h14" value="消耗MP 6，每发伤害 74%，发射 2 发"/>
+        <string name="h15" value="消耗MP 6，每发伤害 75%，发射 2 发"/>
+        <string name="h16" value="消耗MP 7，每发伤害 76%，发射 2 发"/>
+        <string name="h17" value="消耗MP 7，每发伤害 77%，发射 2 发"/>
+        <string name="h18" value="消耗MP 7，每发伤害 78%，发射 2 发"/>
+        <string name="h19" value="消耗MP 7，每发伤害 79%，发射 2 发"/>
+        <string name="h20" value="消耗MP 7，每发伤害 80%，发射 2 发"/>
     </imgdir>
     <imgdir name="5001005">
         <string name="name" value="疾驰"/>
-        <string name="h1" value="消耗MP 14，持续时间 4秒"/>
-        <string name="h10" value="消耗MP 5，持续时间 20秒"/>
-        <string name="h2" value="消耗MP 13，持续时间 4秒"/>
-        <string name="h3" value="消耗MP 12，持续时间 8秒"/>
-        <string name="h4" value="消耗MP 11，持续时间 8秒"/>
-        <string name="h5" value="消耗MP 10，持续时间 12秒"/>
-        <string name="h6" value="消耗MP 9，持续时间 12秒"/>
-        <string name="h7" value="消耗MP 8，持续时间 16秒"/>
-        <string name="h8" value="消耗MP 7，持续时间 16秒"/>
-        <string name="h9" value="消耗MP 6，持续时间 20秒"/>
-        <string name="desc" value="[最高等级 : 10]\n连续两次敲打左右方向键中的某一个，\n瞬间提高移动速度和跳跃力"/>
+        <string name="desc" value="[最高等级：10]\n连续按两次方向键，暂时提高移动速度和跳跃力。"/>
+        <string name="h1" value="消耗MP 14，移动速度 +12，跳跃力 +1，持续 4 秒"/>
+        <string name="h2" value="消耗MP 13，移动速度 +14，跳跃力 +2，持续 4 秒"/>
+        <string name="h3" value="消耗MP 12，移动速度 +16，跳跃力 +3，持续 8 秒"/>
+        <string name="h4" value="消耗MP 11，移动速度 +18，跳跃力 +4，持续 8 秒"/>
+        <string name="h5" value="消耗MP 10，移动速度 +20，跳跃力 +5，持续 12 秒"/>
+        <string name="h6" value="消耗MP 9，移动速度 +22，跳跃力 +6，持续 12 秒"/>
+        <string name="h7" value="消耗MP 8，移动速度 +24，跳跃力 +7，持续 16 秒"/>
+        <string name="h8" value="消耗MP 7，移动速度 +26，跳跃力 +8，持续 16 秒"/>
+        <string name="h9" value="消耗MP 6，移动速度 +28，跳跃力 +9，持续 20 秒"/>
+        <string name="h10" value="消耗MP 5，移动速度 +30，跳跃力 +10，持续 20 秒"/>
     </imgdir>
     <imgdir name="510">
         <string name="bookName" value="拳手介绍书"/>
     </imgdir>
     <imgdir name="5100000">
         <string name="name" value="强体术"/>
-        <string name="h1" value="MaxHP 升级时 3，AP 增加时2 追加向上"/>
-        <string name="h10" value="MaxHP 升级时 30，AP 增加时20 追加向上"/>
-        <string name="h2" value="MaxHP 升级时 6，AP 增加时4 追加向上"/>
-        <string name="h3" value="MaxHP 升级时 9，AP 增加时6 追加向上"/>
-        <string name="h4" value="MaxHP 升级时 12，AP 增加时8 追加向上"/>
-        <string name="h5" value="MaxHP 升级时 15，AP 增加时10 追加向上"/>
-        <string name="h6" value="MaxHP 升级时 18，AP 增加时12 追加向上"/>
-        <string name="h7" value="MaxHP 升级时 21，AP 增加时14 追加向上"/>
-        <string name="h8" value="MaxHP 升级时 24，AP 增加时16 追加向上"/>
-        <string name="h9" value="MaxHP 升级时 27，AP 增加时18 追加向上"/>
-        <string name="desc" value="[最高等级 : 10]\n升级时，最大HP上使用AP时，\n提高最大Hp的增加量"/>
+        <string name="desc" value="[最高等级：10]\n提高升级和用AP增加最大HP时获得的最大HP。"/>
+        <string name="h1" value="升级时最大HP +3，用AP增加最大HP时 +2"/>
+        <string name="h2" value="升级时最大HP +6，用AP增加最大HP时 +4"/>
+        <string name="h3" value="升级时最大HP +9，用AP增加最大HP时 +6"/>
+        <string name="h4" value="升级时最大HP +12，用AP增加最大HP时 +8"/>
+        <string name="h5" value="升级时最大HP +15，用AP增加最大HP时 +10"/>
+        <string name="h6" value="升级时最大HP +18，用AP增加最大HP时 +12"/>
+        <string name="h7" value="升级时最大HP +21，用AP增加最大HP时 +14"/>
+        <string name="h8" value="升级时最大HP +24，用AP增加最大HP时 +16"/>
+        <string name="h9" value="升级时最大HP +27，用AP增加最大HP时 +18"/>
+        <string name="h10" value="升级时最大HP +30，用AP增加最大HP时 +20"/>
     </imgdir>
     <imgdir name="5100001">
         <string name="name" value="精准拳"/>
-        <string name="h1" value="拳甲系列武器熟练度15%，命中率1上升"/>
-        <string name="h10" value="拳甲系列武器熟练度35%，命中率 10 上升"/>
-        <string name="h11" value="拳甲系列武器熟练度40%，命中率 11 上升"/>
-        <string name="h12" value="拳甲系列武器熟练度40%，命中率 12 上升"/>
-        <string name="h13" value="拳甲系列武器熟练度45%，命中率 13 上升"/>
-        <string name="h14" value="拳甲系列武器熟练度45%，命中率 14 上升"/>
-        <string name="h15" value="拳甲系列武器熟练度50%，命中率 15 上升"/>
-        <string name="h16" value="拳甲系列武器熟练度50%，命中率 16 上升"/>
-        <string name="h17" value="拳甲系列武器熟练度55%，命中率 17 上升"/>
-        <string name="h18" value="拳甲系列武器熟练度55%，命中率 18 上升"/>
-        <string name="h19" value="拳甲系列武器熟练度60%，命中率 19 上升"/>
-        <string name="h2" value="拳甲系列武器熟练度15%，命中率 2 上升"/>
-        <string name="h20" value="拳甲系列武器熟练度60%，命中率 20 上升"/>
-        <string name="h3" value="拳甲系列武器熟练度20%，命中率 3 上升"/>
-        <string name="h4" value="拳甲系列武器熟练度20%，命中率 4 上升"/>
-        <string name="h5" value="拳甲系列武器熟练度25%，命中率 5 上升"/>
-        <string name="h6" value="拳甲系列武器熟练度25%，命中率 6 上升"/>
-        <string name="h7" value="拳甲系列武器熟练度30%，命中率 7 上升"/>
-        <string name="h8" value="拳甲系列武器熟练度30%，命中率 8 上升"/>
-        <string name="h9" value="拳甲系列武器熟练度35%，命中率 9 上升"/>
-        <string name="desc" value="[最高等级 : 20]\n提高拳甲系武器的熟练度和命中率。\n只有佩戴拳甲时才可适用"/>
+        <string name="desc" value="[最高等级：20]\n装备拳甲时，提高拳甲熟练度和命中率。"/>
+        <string name="h1" value="拳甲熟练度 +15%，命中率 +1"/>
+        <string name="h2" value="拳甲熟练度 +15%，命中率 +2"/>
+        <string name="h3" value="拳甲熟练度 +20%，命中率 +3"/>
+        <string name="h4" value="拳甲熟练度 +20%，命中率 +4"/>
+        <string name="h5" value="拳甲熟练度 +25%，命中率 +5"/>
+        <string name="h6" value="拳甲熟练度 +25%，命中率 +6"/>
+        <string name="h7" value="拳甲熟练度 +30%，命中率 +7"/>
+        <string name="h8" value="拳甲熟练度 +30%，命中率 +8"/>
+        <string name="h9" value="拳甲熟练度 +35%，命中率 +9"/>
+        <string name="h10" value="拳甲熟练度 +35%，命中率 +10"/>
+        <string name="h11" value="拳甲熟练度 +40%，命中率 +11"/>
+        <string name="h12" value="拳甲熟练度 +40%，命中率 +12"/>
+        <string name="h13" value="拳甲熟练度 +45%，命中率 +13"/>
+        <string name="h14" value="拳甲熟练度 +45%，命中率 +14"/>
+        <string name="h15" value="拳甲熟练度 +50%，命中率 +15"/>
+        <string name="h16" value="拳甲熟练度 +50%，命中率 +16"/>
+        <string name="h17" value="拳甲熟练度 +55%，命中率 +17"/>
+        <string name="h18" value="拳甲熟练度 +55%，命中率 +18"/>
+        <string name="h19" value="拳甲熟练度 +60%，命中率 +19"/>
+        <string name="h20" value="拳甲熟练度 +60%，命中率 +20"/>
     </imgdir>
     <imgdir name="5101002">
         <string name="name" value="回马"/>
-        <string name="h1" value="消耗MP 12，伤害 128%，最多攻击 3只"/>
-        <string name="h10" value="消耗MP 20，伤害 200%，最多攻击 3只"/>
-        <string name="h11" value="消耗MP 22，伤害 208%，最多攻击 3只"/>
-        <string name="h12" value="消耗MP 22，伤害 216%，最多攻击 3只"/>
-        <string name="h13" value="消耗MP 24，伤害 224%，最多攻击 3只"/>
-        <string name="h14" value="消耗MP 24，伤害 232%，最多攻击 3只"/>
-        <string name="h15" value="消耗MP 26，伤害 240%，最多攻击 3只"/>
-        <string name="h16" value="消耗MP 26，伤害 248%，最多攻击 3只"/>
-        <string name="h17" value="消耗MP 28，伤害 256%，最多攻击 3只"/>
-        <string name="h18" value="消耗MP 28，伤害 264%，最多攻击 3只"/>
-        <string name="h19" value="消耗MP 30，伤害 272%，最多攻击 3只"/>
-        <string name="h2" value="消耗MP 12，伤害 136%，最多攻击 3只"/>
-        <string name="h20" value="消耗MP 30，伤害 280%，最多攻击 3只"/>
-        <string name="h3" value="消耗MP 14，伤害 144%，最多攻击 3只"/>
-        <string name="h4" value="消耗MP 14，伤害 152%，最多攻击 3只"/>
-        <string name="h5" value="消耗MP 16，伤害 160%，最多攻击 3只"/>
-        <string name="h6" value="消耗MP 16，伤害 168%，最多攻击 3只"/>
-        <string name="h7" value="消耗MP 18，伤害 176%，最多攻击 3只"/>
-        <string name="h8" value="消耗MP 18，伤害 184%，最多攻击 3只"/>
-        <string name="h9" value="消耗MP 20，伤害 192%，最多攻击 3只"/>
-        <string name="desc" value="[最高等级 : 20]\n快速滑向后方，给与背后多数的敌人伤害. "/>
+        <string name="desc" value="[最高等级：20]\n向后滑行攻击多个敌人，并使其眩晕。"/>
+        <string name="h1" value="消耗MP 12，伤害 88%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h2" value="消耗MP 12，伤害 96%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h3" value="消耗MP 14，伤害 104%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h4" value="消耗MP 14，伤害 112%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h5" value="消耗MP 16，伤害 120%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h6" value="消耗MP 16，伤害 128%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h7" value="消耗MP 18，伤害 136%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h8" value="消耗MP 18，伤害 144%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h9" value="消耗MP 20，伤害 152%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h10" value="消耗MP 20，伤害 160%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h11" value="消耗MP 22，伤害 168%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h12" value="消耗MP 22，伤害 176%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h13" value="消耗MP 24，伤害 184%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h14" value="消耗MP 24，伤害 192%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h15" value="消耗MP 26，伤害 200%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h16" value="消耗MP 26，伤害 208%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h17" value="消耗MP 28，伤害 216%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h18" value="消耗MP 28，伤害 224%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h19" value="消耗MP 30，伤害 232%，攻击 1 次，眩晕 1 秒"/>
+        <string name="h20" value="消耗MP 30，伤害 240%，攻击 1 次，眩晕 1 秒"/>
     </imgdir>
     <imgdir name="5101003">
         <string name="name" value="升龙连击"/>
-        <string name="h1" value="消耗MP 15，伤害 160%"/>
-        <string name="h10" value="消耗MP 20，伤害 250%"/>
-        <string name="h11" value="消耗MP 25，伤害 260%"/>
-        <string name="h12" value="消耗MP 25，伤害 270%"/>
-        <string name="h13" value="消耗MP 25，伤害 280%"/>
-        <string name="h14" value="消耗MP 25，伤害 290%"/>
-        <string name="h15" value="消耗MP 25，伤害 300%"/>
-        <string name="h16" value="消耗MP 30，伤害 310%"/>
-        <string name="h17" value="消耗MP 30，伤害 320%"/>
-        <string name="h18" value="消耗MP 30，伤害 330%"/>
-        <string name="h19" value="消耗MP 30，伤害 340%"/>
-        <string name="h2" value="消耗MP 15，伤害 170%"/>
-        <string name="h20" value="消耗MP 30，伤害 350%"/>
-        <string name="h3" value="消耗MP 15，伤害 180%"/>
-        <string name="h4" value="消耗MP 15，伤害 190%"/>
-        <string name="h5" value="消耗MP 15，伤害 200%"/>
-        <string name="h6" value="消耗MP 20，伤害 210%"/>
-        <string name="h7" value="消耗MP 20，伤害 220%"/>
-        <string name="h8" value="消耗MP 20，伤害 230%"/>
-        <string name="h9" value="消耗MP 20，伤害 240%"/>
-        <string name="desc" value="[最高等级 : 20]\n用拳头二度连续攻击，使敌人重伤"/>
+        <string name="desc" value="[最高等级：20]\n连续攻击1个敌人2次，并使其眩晕。"/>
+        <string name="h1" value="消耗MP 15，伤害 100%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h2" value="消耗MP 15，伤害 110%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h3" value="消耗MP 15，伤害 120%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h4" value="消耗MP 15，伤害 130%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h5" value="消耗MP 15，伤害 140%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h6" value="消耗MP 20，伤害 150%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h7" value="消耗MP 20，伤害 160%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h8" value="消耗MP 20，伤害 170%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h9" value="消耗MP 20，伤害 180%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h10" value="消耗MP 20，伤害 190%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h11" value="消耗MP 25，伤害 200%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h12" value="消耗MP 25，伤害 210%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h13" value="消耗MP 25，伤害 220%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h14" value="消耗MP 25，伤害 230%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h15" value="消耗MP 25，伤害 240%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h16" value="消耗MP 30，伤害 250%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h17" value="消耗MP 30，伤害 260%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h18" value="消耗MP 30，伤害 270%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h19" value="消耗MP 30，伤害 280%，攻击 2 次，眩晕 1 秒"/>
+        <string name="h20" value="消耗MP 30，伤害 290%，攻击 2 次，眩晕 1 秒"/>
     </imgdir>
     <imgdir name="5101004">
         <string name="name" value="贯骨击"/>
-        <string name="h1" value="消耗MP 20，伤害 135%，最多攻击 3只"/>
-        <string name="h10" value="消耗MP 28，伤害 270%，最多攻击 3只"/>
-        <string name="h11" value="消耗MP 28，伤害 285%，最多攻击 3只"/>
-        <string name="h12" value="消耗MP 28，伤害 300%，最多攻击 3只"/>
-        <string name="h13" value="消耗MP 32，伤害 315%，最多攻击 3只"/>
-        <string name="h14" value="消耗MP 32，伤害 330%，最多攻击 3只"/>
-        <string name="h15" value="消耗MP 32，伤害 345%，最多攻击 3只"/>
-        <string name="h16" value="消耗MP 32，伤害 360%，最多攻击 3只"/>
-        <string name="h17" value="消耗MP 36，伤害 375%，最多攻击 3只"/>
-        <string name="h18" value="消耗MP 36，伤害 390%，最多攻击 3只"/>
-        <string name="h19" value="消耗MP 36，伤害 405%，最多攻击 3只"/>
-        <string name="h2" value="消耗MP 20，伤害 150%，最多攻击 3只"/>
-        <string name="h20" value="消耗MP 36，伤害 420%，最多攻击 3只"/>
-        <string name="h3" value="消耗MP 20，伤害 165%，最多攻击 3只"/>
-        <string name="h4" value="消耗MP 20，伤害 180%，最多攻击 3只"/>
-        <string name="h5" value="消耗MP 24，伤害 195%，最多攻击 3只"/>
-        <string name="h6" value="消耗MP 24，伤害 210%，最多攻击 3只"/>
-        <string name="h7" value="消耗MP 24，伤害 225%，最多攻击 3只"/>
-        <string name="h8" value="消耗MP 24，伤害 240%，最多攻击 3只"/>
-        <string name="h9" value="消耗MP 28，伤害 255%，最多攻击 3只"/>
-        <string name="desc" value="[最高等级 : 20]\n向前方的多数敌人施加拳击"/>
+        <string name="desc" value="[最高等级：20]\n向前突进，用拳头攻击多个敌人。"/>
+        <string name="h1" value="消耗MP 20，伤害 135%，最多攻击 3 个敌人"/>
+        <string name="h2" value="消耗MP 20，伤害 150%，最多攻击 3 个敌人"/>
+        <string name="h3" value="消耗MP 20，伤害 165%，最多攻击 3 个敌人"/>
+        <string name="h4" value="消耗MP 20，伤害 180%，最多攻击 3 个敌人"/>
+        <string name="h5" value="消耗MP 24，伤害 195%，最多攻击 3 个敌人"/>
+        <string name="h6" value="消耗MP 24，伤害 210%，最多攻击 3 个敌人"/>
+        <string name="h7" value="消耗MP 24，伤害 225%，最多攻击 3 个敌人"/>
+        <string name="h8" value="消耗MP 24，伤害 240%，最多攻击 3 个敌人"/>
+        <string name="h9" value="消耗MP 28，伤害 255%，最多攻击 3 个敌人"/>
+        <string name="h10" value="消耗MP 28，伤害 270%，最多攻击 3 个敌人"/>
+        <string name="h11" value="消耗MP 28，伤害 285%，最多攻击 3 个敌人"/>
+        <string name="h12" value="消耗MP 28，伤害 300%，最多攻击 3 个敌人"/>
+        <string name="h13" value="消耗MP 32，伤害 315%，最多攻击 3 个敌人"/>
+        <string name="h14" value="消耗MP 32，伤害 330%，最多攻击 3 个敌人"/>
+        <string name="h15" value="消耗MP 32，伤害 345%，最多攻击 3 个敌人"/>
+        <string name="h16" value="消耗MP 32，伤害 360%，最多攻击 3 个敌人"/>
+        <string name="h17" value="消耗MP 36，伤害 375%，最多攻击 3 个敌人"/>
+        <string name="h18" value="消耗MP 36，伤害 390%，最多攻击 3 个敌人"/>
+        <string name="h19" value="消耗MP 36，伤害 405%，最多攻击 3 个敌人"/>
+        <string name="h20" value="消耗MP 36，伤害 420%，最多攻击 3 个敌人"/>
     </imgdir>
     <imgdir name="5101005">
         <string name="name" value="生命分流"/>
-        <string name="h1" value="消耗MaxHP的10%，恢复消耗的 HP的 55% MP，冷却时间 70秒"/>
-        <string name="h10" value="消耗MaxHP的10%，恢复消耗的 HP的 100% MP，冷却时间 25秒"/>
-        <string name="h2" value="消耗MaxHP的10%，恢复消耗的 HP的 60% MP，冷却时间 65秒"/>
-        <string name="h3" value="消耗MaxHP的10%，恢复消耗的 HP的 65% MP，冷却时间 60秒"/>
-        <string name="h4" value="消耗MaxHP的10%，恢复消耗的 HP的 70% MP，冷却时间 55秒"/>
-        <string name="h5" value="消耗MaxHP的10%，恢复消耗的 HP的 75% MP，冷却时间 50秒"/>
-        <string name="h6" value="消耗MaxHP的10%，恢复消耗的 HP的 80% MP，冷却时间 45秒"/>
-        <string name="h7" value="消耗MaxHP的10%，恢复消耗的 HP的 85% MP，冷却时间 40秒"/>
-        <string name="h8" value="消耗MaxHP的10%，恢复消耗的 HP的 90% MP，冷却时间 35秒"/>
-        <string name="h9" value="消耗MaxHP的10%，恢复消耗的 HP的 95% MP，冷却时间 30秒"/>
-        <string name="desc" value="[最高等级 : 10]\n消耗自己的HP使之恢复MP"/>
+        <string name="desc" value="[最高等级：10]\n消耗HP恢复MP，有冷却时间。"/>
+        <string name="h1" value="消耗 10% HP，恢复 55% MP，冷却 70 秒"/>
+        <string name="h2" value="消耗 10% HP，恢复 60% MP，冷却 65 秒"/>
+        <string name="h3" value="消耗 10% HP，恢复 65% MP，冷却 60 秒"/>
+        <string name="h4" value="消耗 10% HP，恢复 70% MP，冷却 55 秒"/>
+        <string name="h5" value="消耗 10% HP，恢复 75% MP，冷却 50 秒"/>
+        <string name="h6" value="消耗 10% HP，恢复 80% MP，冷却 45 秒"/>
+        <string name="h7" value="消耗 10% HP，恢复 85% MP，冷却 40 秒"/>
+        <string name="h8" value="消耗 10% HP，恢复 90% MP，冷却 35 秒"/>
+        <string name="h9" value="消耗 10% HP，恢复 95% MP，冷却 30 秒"/>
+        <string name="h10" value="消耗 10% HP，恢复 100% MP，冷却 25 秒"/>
     </imgdir>
     <imgdir name="5101006">
         <string name="name" value="急速拳"/>
-        <string name="h1" value="消耗HP29，MP 29  10秒内提高指节的攻击速度"/>
-        <string name="h10" value="消耗HP20，MP 20  100秒内提高指节的攻击速度"/>
-        <string name="h11" value="消耗HP19，MP 19  110秒内提高指节的攻击速度"/>
-        <string name="h12" value="消耗HP18，MP 18  120秒内提高指节的攻击速度"/>
-        <string name="h13" value="消耗HP17，MP 17  130秒内提高指节的攻击速度"/>
-        <string name="h14" value="消耗HP16，MP 16  140秒内提高指节的攻击速度"/>
-        <string name="h15" value="消耗HP15，MP 15  150秒内提高指节的攻击速度"/>
-        <string name="h16" value="消耗HP14，MP 14  160秒内提高指节的攻击速度"/>
-        <string name="h17" value="消耗HP13，MP 13  170秒内提高指节的攻击速度"/>
-        <string name="h18" value="消耗HP12，MP 12  180秒内提高指节的攻击速度"/>
-        <string name="h19" value="消耗HP11，MP 11  190秒内提高指节的攻击速度"/>
-        <string name="h2" value="消耗HP28，MP 28  20秒内提高指节的攻击速度"/>
-        <string name="h20" value="消耗HP10，MP 10  200秒内提高指节的攻击速度"/>
-        <string name="h3" value="消耗HP27，MP 27  30秒内提高指节的攻击速度"/>
-        <string name="h4" value="消耗HP26，MP 26  40秒内提高指节的攻击速度"/>
-        <string name="h5" value="消耗HP25，MP 25  50秒内提高指节的攻击速度"/>
-        <string name="h6" value="消耗HP24，MP 24  60秒内提高指节的攻击速度"/>
-        <string name="h7" value="消耗HP23，MP 23  70秒内提高指节的攻击速度"/>
-        <string name="h8" value="消耗HP22，MP 22  80秒内提高指节的攻击速度"/>
-        <string name="h9" value="消耗HP21，MP 21  90秒内提高指节的攻击速度"/>
-        <string name="desc" value="[最高等级 : 20]\n消耗HP,MP，一定时间内使拳的攻击速度提升。\n只有佩戴指节时才可发动技能.\n必要技能 : #c精准拳5级以上"/>
+        <string name="desc" value="[最高等级：20]\n消耗HP和MP，使拳甲攻击速度提高2个阶段。需要精准拳5级以上。"/>
+        <string name="h1" value="消耗HP 29，消耗MP 29，攻击速度 +2 阶段，持续 10 秒"/>
+        <string name="h2" value="消耗HP 28，消耗MP 28，攻击速度 +2 阶段，持续 20 秒"/>
+        <string name="h3" value="消耗HP 27，消耗MP 27，攻击速度 +2 阶段，持续 30 秒"/>
+        <string name="h4" value="消耗HP 26，消耗MP 26，攻击速度 +2 阶段，持续 40 秒"/>
+        <string name="h5" value="消耗HP 25，消耗MP 25，攻击速度 +2 阶段，持续 50 秒"/>
+        <string name="h6" value="消耗HP 24，消耗MP 24，攻击速度 +2 阶段，持续 60 秒"/>
+        <string name="h7" value="消耗HP 23，消耗MP 23，攻击速度 +2 阶段，持续 70 秒"/>
+        <string name="h8" value="消耗HP 22，消耗MP 22，攻击速度 +2 阶段，持续 80 秒"/>
+        <string name="h9" value="消耗HP 21，消耗MP 21，攻击速度 +2 阶段，持续 90 秒"/>
+        <string name="h10" value="消耗HP 20，消耗MP 20，攻击速度 +2 阶段，持续 100 秒"/>
+        <string name="h11" value="消耗HP 19，消耗MP 19，攻击速度 +2 阶段，持续 110 秒"/>
+        <string name="h12" value="消耗HP 18，消耗MP 18，攻击速度 +2 阶段，持续 120 秒"/>
+        <string name="h13" value="消耗HP 17，消耗MP 17，攻击速度 +2 阶段，持续 130 秒"/>
+        <string name="h14" value="消耗HP 16，消耗MP 16，攻击速度 +2 阶段，持续 140 秒"/>
+        <string name="h15" value="消耗HP 15，消耗MP 15，攻击速度 +2 阶段，持续 150 秒"/>
+        <string name="h16" value="消耗HP 14，消耗MP 14，攻击速度 +2 阶段，持续 160 秒"/>
+        <string name="h17" value="消耗HP 13，消耗MP 13，攻击速度 +2 阶段，持续 170 秒"/>
+        <string name="h18" value="消耗HP 12，消耗MP 12，攻击速度 +2 阶段，持续 180 秒"/>
+        <string name="h19" value="消耗HP 11，消耗MP 11，攻击速度 +2 阶段，持续 190 秒"/>
+        <string name="h20" value="消耗HP 10，消耗MP 10，攻击速度 +2 阶段，持续 200 秒"/>
     </imgdir>
     <imgdir name="5101007">
         <string name="name" value="橡木伪装"/>
-        <string name="h1" value="消耗MP 12，持续时间 12秒，冷却时间 35秒，37%的几率解除"/>
-        <string name="h10" value="消耗MP 20，持续时间 30秒，冷却时间 15秒，10%的几率解除"/>
-        <string name="h2" value="消耗MP 12，持续时间 14秒，冷却时间 35秒，34%的几率解除"/>
-        <string name="h3" value="消耗MP 14，持续时间 16秒，冷却时间 30秒，31%的几率解除"/>
-        <string name="h4" value="消耗MP 14，持续时间 18秒，冷却时间 30秒，28%的几率解除"/>
-        <string name="h5" value="消耗MP 16，持续时间 20秒，冷却时间 25秒，25%的几率解除"/>
-        <string name="h6" value="消耗MP 16，持续时间 22秒，冷却时间 25秒，22%的几率解除"/>
-        <string name="h7" value="消耗MP 18，持续时间 24秒，冷却时间 20秒，19%的几率解除"/>
-        <string name="h8" value="消耗MP 18，持续时间 26秒，冷却时间 20秒，16%的几率解除"/>
-        <string name="h9" value="消耗MP 20，持续时间 28秒，冷却时间 15秒，13%的几率解除"/>
-        <string name="desc" value="[最高等级 : 10]\n为了不受怪物攻击地移动，戴上橡木桶变装。\n有时可能会被好奇的怪物发现，所以要格外小心。\n俯卧时被发现的概率减少"/>
+        <string name="desc" value="[最高等级：10]\n伪装成橡木桶，降低被怪物发现的概率，有冷却时间。"/>
+        <string name="h1" value="消耗MP 11，伪装 12 秒，被发现概率 37%，冷却 35 秒"/>
+        <string name="h2" value="消耗MP 12，伪装 14 秒，被发现概率 34%，冷却 35 秒"/>
+        <string name="h3" value="消耗MP 13，伪装 16 秒，被发现概率 31%，冷却 30 秒"/>
+        <string name="h4" value="消耗MP 14，伪装 18 秒，被发现概率 28%，冷却 30 秒"/>
+        <string name="h5" value="消耗MP 15，伪装 20 秒，被发现概率 25%，冷却 25 秒"/>
+        <string name="h6" value="消耗MP 16，伪装 22 秒，被发现概率 22%，冷却 25 秒"/>
+        <string name="h7" value="消耗MP 17，伪装 24 秒，被发现概率 19%，冷却 20 秒"/>
+        <string name="h8" value="消耗MP 18，伪装 26 秒，被发现概率 16%，冷却 20 秒"/>
+        <string name="h9" value="消耗MP 19，伪装 28 秒，被发现概率 13%，冷却 15 秒"/>
+        <string name="h10" value="消耗MP 20，伪装 30 秒，被发现概率 10%，冷却 15 秒"/>
     </imgdir>
     <imgdir name="511">
         <string name="bookName" value="斗士之路"/>
     </imgdir>
     <imgdir name="5110000">
-        <string name="name" value="迷惑攻击"/>
-        <string name="h1" value="22%的几率追加 3%的伤害"/>
-        <string name="h10" value="40%的几率追加 30%的伤害"/>
-        <string name="h11" value="42%的几率追加 33%的伤害"/>
-        <string name="h12" value="44%的几率追加 36%的伤害"/>
-        <string name="h13" value="46%的几率追加 39%的伤害"/>
-        <string name="h14" value="48%的几率追加 42%的伤害"/>
-        <string name="h15" value="50%的几率追加 45%的伤害"/>
-        <string name="h16" value="52%的几率追加 48%的伤害"/>
-        <string name="h17" value="54%的几率追加 51%的伤害"/>
-        <string name="h18" value="56%的几率追加 54%的伤害"/>
-        <string name="h19" value="58%的几率追加 57%的伤害"/>
-        <string name="h2" value="24%的几率追加 6%的伤害"/>
-        <string name="h20" value="60%的几率追加 60%的伤害"/>
-        <string name="h3" value="26%的几率追加 9%的伤害"/>
-        <string name="h4" value="28%的几率追加 12%的伤害"/>
-        <string name="h5" value="30%的几率追加 15%的伤害"/>
-        <string name="h6" value="32%的几率追加 18%的伤害"/>
-        <string name="h7" value="34%的几率追加 21%的伤害"/>
-        <string name="h8" value="36%的几率追加 24%的伤害"/>
-        <string name="h9" value="38%的几率追加 27%的伤害"/>
-        <string name="desc" value="[最高等级 : 20]\n攻击迷惑状态的敌人时，\n以一定的概率出现爆击"/>
+        <string name="name" value="眩晕精通"/>
+        <string name="desc" value="[最高等级：20]\n攻击眩晕状态的敌人时，有一定概率造成额外暴击伤害。"/>
+        <string name="h1" value="攻击眩晕敌人时，22% 概率造成 +103% 暴击伤害"/>
+        <string name="h2" value="攻击眩晕敌人时，24% 概率造成 +106% 暴击伤害"/>
+        <string name="h3" value="攻击眩晕敌人时，26% 概率造成 +109% 暴击伤害"/>
+        <string name="h4" value="攻击眩晕敌人时，28% 概率造成 +112% 暴击伤害"/>
+        <string name="h5" value="攻击眩晕敌人时，30% 概率造成 +115% 暴击伤害"/>
+        <string name="h6" value="攻击眩晕敌人时，32% 概率造成 +118% 暴击伤害"/>
+        <string name="h7" value="攻击眩晕敌人时，34% 概率造成 +121% 暴击伤害"/>
+        <string name="h8" value="攻击眩晕敌人时，36% 概率造成 +124% 暴击伤害"/>
+        <string name="h9" value="攻击眩晕敌人时，38% 概率造成 +127% 暴击伤害"/>
+        <string name="h10" value="攻击眩晕敌人时，40% 概率造成 +130% 暴击伤害"/>
+        <string name="h11" value="攻击眩晕敌人时，42% 概率造成 +133% 暴击伤害"/>
+        <string name="h12" value="攻击眩晕敌人时，44% 概率造成 +136% 暴击伤害"/>
+        <string name="h13" value="攻击眩晕敌人时，46% 概率造成 +139% 暴击伤害"/>
+        <string name="h14" value="攻击眩晕敌人时，48% 概率造成 +142% 暴击伤害"/>
+        <string name="h15" value="攻击眩晕敌人时，50% 概率造成 +145% 暴击伤害"/>
+        <string name="h16" value="攻击眩晕敌人时，52% 概率造成 +148% 暴击伤害"/>
+        <string name="h17" value="攻击眩晕敌人时，54% 概率造成 +151% 暴击伤害"/>
+        <string name="h18" value="攻击眩晕敌人时，56% 概率造成 +154% 暴击伤害"/>
+        <string name="h19" value="攻击眩晕敌人时，58% 概率造成 +157% 暴击伤害"/>
+        <string name="h20" value="攻击眩晕敌人时，60% 概率造成 +160% 暴击伤害"/>
     </imgdir>
     <imgdir name="5110001">
         <string name="name" value="能量获得"/>
-        <string name="h1" value="发动时 持续时间31秒，命中率和回避率+1"/>
-        <string name="h10" value="发动时 持续时间35秒，命中率和回避率+5，物理攻击力+12"/>
-        <string name="h11" value="发动时 持续时间36秒，命中率和回避率+6，物理攻击力+12"/>
-        <string name="h12" value="发动时 持续时间36秒，命中率和回避率+6，物理攻击力+13"/>
-        <string name="h13" value="发动时 持续时间37秒，命中率和回避率+7，物理攻击力+13"/>
-        <string name="h14" value="发动时 持续时间37秒，命中率和回避率+7，物理攻击力+13"/>
-        <string name="h15" value="发动时 持续时间38秒，命中率和回避率+8，物理攻击力+13"/>
-        <string name="h16" value="发动时 持续时间38秒，命中率和回避率+8，物理攻击力+14"/>
-        <string name="h17" value="发动时 持续时间39秒，命中率和回避率+9，物理攻击力+14"/>
-        <string name="h18" value="发动时 持续时间39秒，命中率和回避率+9，物理攻击力+14"/>
-        <string name="h19" value="发动时 持续时间40秒，命中率和回避率+10，物理攻击力+14"/>
-        <string name="h2" value="发动时 持续时间31秒，命中率和回避率+1"/>
-        <string name="h20" value="发动时 持续时间40秒，命中率和回避率+10，物理攻击力+15"/>
-        <string name="h21" value="发动时 持续时间41秒，命中率和回避率+11，物理攻击力+15"/>
-        <string name="h22" value="发动时 持续时间41秒，命中率和回避率+11，物理攻击力+15"/>
-        <string name="h23" value="发动时 持续时间42秒，命中率和回避率+12，物理攻击力+15"/>
-        <string name="h24" value="发动时 持续时间42秒，命中率和回避率+12，物理攻击力+16"/>
-        <string name="h25" value="发动时 持续时间43秒，命中率和回避率+13，物理攻击力+16"/>
-        <string name="h26" value="发动时 持续时间43秒，命中率和回避率+13，物理攻击力+16"/>
-        <string name="h27" value="发动时 持续时间44秒，命中率和回避率+14，物理攻击力+16"/>
-        <string name="h28" value="发动时 持续时间44秒，命中率和回避率+14，物理攻击力+17"/>
-        <string name="h29" value="发动时 持续时间45秒，命中率和回避率+15，物理攻击力+17"/>
-        <string name="h3" value="发动时 持续时间32秒，命中率和回避率+2"/>
-        <string name="h30" value="发动时 持续时间45秒，命中率和回避率+15，物理攻击力+17"/>
-        <string name="h31" value="发动时 持续时间46秒，命中率和回避率+16，物理攻击力+17"/>
-        <string name="h32" value="发动时 持续时间46秒，命中率和回避率+16，物理攻击力+18"/>
-        <string name="h33" value="发动时 持续时间47秒，命中率和回避率+17，物理攻击力+18"/>
-        <string name="h35" value="发动时 持续时间48秒，命中率和回避率+18，物理攻击力+18"/>
-        <string name="h36" value="发动时 持续时间48秒，命中率和回避率+18，物理攻击力+19"/>
-        <string name="h37" value="发动时 持续时间49秒，命中率和回避率+19，物理攻击力+19"/>
-        <string name="h38" value="发动时 持续时间49秒，命中率和回避率+19，物理攻击力+19"/>
-        <string name="h39" value="发动时 持续时间50秒，命中率和回避率+20，物理攻击力+19"/>
-        <string name="h4" value="发动时 持续时间32秒，命中率和回避率+2，物理攻击力+11"/>
-        <string name="h40" value="发动时 持续时间50秒，命中率和回避率+20，物理攻击力+20"/>
-        <string name="h5" value="发动时 持续时间33秒，命中率和回避率+3，物理攻击力+11"/>
-        <string name="h6" value="发动时 持续时间33秒，命中率和回避率+3，物理攻击力+11"/>
-        <string name="h7" value="发动时 持续时间34秒，命中率和回避率+4，物理攻击力+11"/>
-        <string name="h8" value="发动时 持续时间34秒，命中率和回避率+4，物理攻击力+12"/>
-        <string name="h9" value="发动时 持续时间35秒，命中率和回避率+5，物理攻击力+12"/>
-        <string name="desc" value="[最高等级 : 40]\n攻击时获得一定量的能量补充，\n能量充沛时就会自动启动攻击和阿基里斯\n效果使之可以使用利用能量的技能"/>
+        <string name="desc" value="[最高等级：40]\n有效攻击会积累能量。每次命中增加102点能量，达到10000后进入能量充满状态，持续时间按等级决定。"/>
+        <string name="h1" value="能量充满状态持续 31 秒，伤害 +5%，攻击力 +0，命中率 +1，回避率 +1，稳如泰山/碰撞攻击概率 11%"/>
+        <string name="h2" value="能量充满状态持续 31 秒，伤害 +10%，攻击力 +0，命中率 +1，回避率 +1，稳如泰山/碰撞攻击概率 12%"/>
+        <string name="h3" value="能量充满状态持续 32 秒，伤害 +15%，攻击力 +0，命中率 +2，回避率 +2，稳如泰山/碰撞攻击概率 13%"/>
+        <string name="h4" value="能量充满状态持续 32 秒，伤害 +20%，攻击力 +11，命中率 +2，回避率 +2，稳如泰山/碰撞攻击概率 14%"/>
+        <string name="h5" value="能量充满状态持续 33 秒，伤害 +25%，攻击力 +11，命中率 +3，回避率 +3，稳如泰山/碰撞攻击概率 15%"/>
+        <string name="h6" value="能量充满状态持续 33 秒，伤害 +30%，攻击力 +11，命中率 +3，回避率 +3，稳如泰山/碰撞攻击概率 16%"/>
+        <string name="h7" value="能量充满状态持续 34 秒，伤害 +35%，攻击力 +11，命中率 +4，回避率 +4，稳如泰山/碰撞攻击概率 17%"/>
+        <string name="h8" value="能量充满状态持续 34 秒，伤害 +40%，攻击力 +12，命中率 +4，回避率 +4，稳如泰山/碰撞攻击概率 18%"/>
+        <string name="h9" value="能量充满状态持续 35 秒，伤害 +45%，攻击力 +12，命中率 +5，回避率 +5，稳如泰山/碰撞攻击概率 19%"/>
+        <string name="h10" value="能量充满状态持续 35 秒，伤害 +50%，攻击力 +12，命中率 +5，回避率 +5，稳如泰山/碰撞攻击概率 20%"/>
+        <string name="h11" value="能量充满状态持续 36 秒，伤害 +55%，攻击力 +12，命中率 +6，回避率 +6，稳如泰山/碰撞攻击概率 21%"/>
+        <string name="h12" value="能量充满状态持续 36 秒，伤害 +60%，攻击力 +13，命中率 +6，回避率 +6，稳如泰山/碰撞攻击概率 22%"/>
+        <string name="h13" value="能量充满状态持续 37 秒，伤害 +65%，攻击力 +13，命中率 +7，回避率 +7，稳如泰山/碰撞攻击概率 23%"/>
+        <string name="h14" value="能量充满状态持续 37 秒，伤害 +70%，攻击力 +13，命中率 +7，回避率 +7，稳如泰山/碰撞攻击概率 24%"/>
+        <string name="h15" value="能量充满状态持续 38 秒，伤害 +75%，攻击力 +13，命中率 +8，回避率 +8，稳如泰山/碰撞攻击概率 25%"/>
+        <string name="h16" value="能量充满状态持续 38 秒，伤害 +80%，攻击力 +14，命中率 +8，回避率 +8，稳如泰山/碰撞攻击概率 26%"/>
+        <string name="h17" value="能量充满状态持续 39 秒，伤害 +85%，攻击力 +14，命中率 +9，回避率 +9，稳如泰山/碰撞攻击概率 27%"/>
+        <string name="h18" value="能量充满状态持续 39 秒，伤害 +90%，攻击力 +14，命中率 +9，回避率 +9，稳如泰山/碰撞攻击概率 28%"/>
+        <string name="h19" value="能量充满状态持续 40 秒，伤害 +95%，攻击力 +14，命中率 +10，回避率 +10，稳如泰山/碰撞攻击概率 29%"/>
+        <string name="h20" value="能量充满状态持续 40 秒，伤害 +100%，攻击力 +15，命中率 +10，回避率 +10，稳如泰山/碰撞攻击概率 30%"/>
+        <string name="h21" value="能量充满状态持续 41 秒，伤害 +105%，攻击力 +15，命中率 +11，回避率 +11，稳如泰山/碰撞攻击概率 31%"/>
+        <string name="h22" value="能量充满状态持续 41 秒，伤害 +110%，攻击力 +15，命中率 +11，回避率 +11，稳如泰山/碰撞攻击概率 32%"/>
+        <string name="h23" value="能量充满状态持续 42 秒，伤害 +115%，攻击力 +15，命中率 +12，回避率 +12，稳如泰山/碰撞攻击概率 33%"/>
+        <string name="h24" value="能量充满状态持续 42 秒，伤害 +120%，攻击力 +16，命中率 +12，回避率 +12，稳如泰山/碰撞攻击概率 34%"/>
+        <string name="h25" value="能量充满状态持续 43 秒，伤害 +125%，攻击力 +16，命中率 +13，回避率 +13，稳如泰山/碰撞攻击概率 35%"/>
+        <string name="h26" value="能量充满状态持续 43 秒，伤害 +130%，攻击力 +16，命中率 +13，回避率 +13，稳如泰山/碰撞攻击概率 36%"/>
+        <string name="h27" value="能量充满状态持续 44 秒，伤害 +135%，攻击力 +16，命中率 +14，回避率 +14，稳如泰山/碰撞攻击概率 37%"/>
+        <string name="h28" value="能量充满状态持续 44 秒，伤害 +140%，攻击力 +17，命中率 +14，回避率 +14，稳如泰山/碰撞攻击概率 38%"/>
+        <string name="h29" value="能量充满状态持续 45 秒，伤害 +145%，攻击力 +17，命中率 +15，回避率 +15，稳如泰山/碰撞攻击概率 39%"/>
+        <string name="h30" value="能量充满状态持续 45 秒，伤害 +150%，攻击力 +17，命中率 +15，回避率 +15，稳如泰山/碰撞攻击概率 40%"/>
+        <string name="h31" value="能量充满状态持续 46 秒，伤害 +155%，攻击力 +17，命中率 +16，回避率 +16，稳如泰山/碰撞攻击概率 41%"/>
+        <string name="h32" value="能量充满状态持续 46 秒，伤害 +160%，攻击力 +18，命中率 +16，回避率 +16，稳如泰山/碰撞攻击概率 42%"/>
+        <string name="h33" value="能量充满状态持续 47 秒，伤害 +165%，攻击力 +18，命中率 +17，回避率 +17，稳如泰山/碰撞攻击概率 43%"/>
+        <string name="h34" value="能量充满状态持续 47 秒，伤害 +170%，攻击力 +18，命中率 +17，回避率 +17，稳如泰山/碰撞攻击概率 44%"/>
+        <string name="h35" value="能量充满状态持续 48 秒，伤害 +175%，攻击力 +18，命中率 +18，回避率 +18，稳如泰山/碰撞攻击概率 45%"/>
+        <string name="h36" value="能量充满状态持续 48 秒，伤害 +180%，攻击力 +19，命中率 +18，回避率 +18，稳如泰山/碰撞攻击概率 46%"/>
+        <string name="h37" value="能量充满状态持续 49 秒，伤害 +185%，攻击力 +19，命中率 +19，回避率 +19，稳如泰山/碰撞攻击概率 47%"/>
+        <string name="h38" value="能量充满状态持续 49 秒，伤害 +190%，攻击力 +19，命中率 +19，回避率 +19，稳如泰山/碰撞攻击概率 48%"/>
+        <string name="h39" value="能量充满状态持续 50 秒，伤害 +195%，攻击力 +19，命中率 +20，回避率 +20，稳如泰山/碰撞攻击概率 49%"/>
+        <string name="h40" value="能量充满状态持续 50 秒，伤害 +200%，攻击力 +20，命中率 +20，回避率 +20，稳如泰山/碰撞攻击概率 50%"/>
     </imgdir>
     <imgdir name="5111002">
         <string name="name" value="能量爆破"/>
-        <string name="h1" value="伤害 246%，最多攻击 2只 攻击"/>
-        <string name="h10" value="伤害 300%，最多攻击 2只 攻击"/>
-        <string name="h11" value="伤害 306%，最多攻击 3只 攻击"/>
-        <string name="h12" value="伤害 312%，最多攻击 3只 攻击"/>
-        <string name="h13" value="伤害 318%，最多攻击 3只 攻击"/>
-        <string name="h14" value="伤害 324%，最多攻击 3只 攻击"/>
-        <string name="h15" value="伤害 330%，最多攻击 3只 攻击"/>
-        <string name="h16" value="伤害 336%，最多攻击 3只 攻击"/>
-        <string name="h17" value="伤害 342%，最多攻击 3只 攻击"/>
-        <string name="h18" value="伤害 348%，最多攻击 3只 攻击"/>
-        <string name="h19" value="伤害 354%，最多攻击 3只 攻击"/>
-        <string name="h2" value="伤害 252%，最多攻击 2只 攻击"/>
-        <string name="h20" value="伤害 360%，最多攻击 3只 攻击"/>
-        <string name="h21" value="伤害 366%，最多攻击 4只 攻击"/>
-        <string name="h22" value="伤害 372%，最多攻击 4只 攻击"/>
-        <string name="h23" value="伤害 378%，最多攻击 4只 攻击"/>
-        <string name="h24" value="伤害 384%，最多攻击 4只 攻击"/>
-        <string name="h25" value="伤害 390%，最多攻击 4只 攻击"/>
-        <string name="h26" value="伤害 396%，最多攻击 4只 攻击"/>
-        <string name="h27" value="伤害 402%，最多攻击 4只 攻击"/>
-        <string name="h28" value="伤害 408%，最多攻击 4只 攻击"/>
-        <string name="h29" value="伤害 414%，最多攻击 4只 攻击"/>
-        <string name="h3" value="伤害 258%，最多攻击 2只 攻击"/>
-        <string name="h30" value="伤害 420%，最多攻击 4只 攻击"/>
-        <string name="h4" value="伤害 264%，最多攻击 2只 攻击"/>
-        <string name="h5" value="伤害 270%，最多攻击 2只 攻击"/>
-        <string name="h6" value="伤害 276%，最多攻击 2只 攻击"/>
-        <string name="h7" value="伤害 282%，最多攻击 2只 攻击"/>
-        <string name="h8" value="伤害 288%，最多攻击 2只 攻击"/>
-        <string name="h9" value="伤害 294%，最多攻击 2只 攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n散发能量，使近距离的多数怪物收到伤害。\n只有 #c能量充沛#的状态下才可以使用。\n必要技能 : #c能量获得1级以上#"/>
+        <string name="desc" value="[最高等级：30]\n释放能量攻击多个敌人。只能在能量充满状态下使用。"/>
+        <string name="h1" value="能量充满时可用，伤害 246%，最多攻击 2 个敌人"/>
+        <string name="h2" value="能量充满时可用，伤害 252%，最多攻击 2 个敌人"/>
+        <string name="h3" value="能量充满时可用，伤害 258%，最多攻击 2 个敌人"/>
+        <string name="h4" value="能量充满时可用，伤害 264%，最多攻击 2 个敌人"/>
+        <string name="h5" value="能量充满时可用，伤害 270%，最多攻击 2 个敌人"/>
+        <string name="h6" value="能量充满时可用，伤害 276%，最多攻击 2 个敌人"/>
+        <string name="h7" value="能量充满时可用，伤害 282%，最多攻击 2 个敌人"/>
+        <string name="h8" value="能量充满时可用，伤害 288%，最多攻击 2 个敌人"/>
+        <string name="h9" value="能量充满时可用，伤害 294%，最多攻击 2 个敌人"/>
+        <string name="h10" value="能量充满时可用，伤害 300%，最多攻击 2 个敌人"/>
+        <string name="h11" value="能量充满时可用，伤害 306%，最多攻击 3 个敌人"/>
+        <string name="h12" value="能量充满时可用，伤害 312%，最多攻击 3 个敌人"/>
+        <string name="h13" value="能量充满时可用，伤害 318%，最多攻击 3 个敌人"/>
+        <string name="h14" value="能量充满时可用，伤害 324%，最多攻击 3 个敌人"/>
+        <string name="h15" value="能量充满时可用，伤害 330%，最多攻击 3 个敌人"/>
+        <string name="h16" value="能量充满时可用，伤害 336%，最多攻击 3 个敌人"/>
+        <string name="h17" value="能量充满时可用，伤害 342%，最多攻击 3 个敌人"/>
+        <string name="h18" value="能量充满时可用，伤害 348%，最多攻击 3 个敌人"/>
+        <string name="h19" value="能量充满时可用，伤害 354%，最多攻击 3 个敌人"/>
+        <string name="h20" value="能量充满时可用，伤害 360%，最多攻击 3 个敌人"/>
+        <string name="h21" value="能量充满时可用，伤害 366%，最多攻击 4 个敌人"/>
+        <string name="h22" value="能量充满时可用，伤害 372%，最多攻击 4 个敌人"/>
+        <string name="h23" value="能量充满时可用，伤害 378%，最多攻击 4 个敌人"/>
+        <string name="h24" value="能量充满时可用，伤害 384%，最多攻击 4 个敌人"/>
+        <string name="h25" value="能量充满时可用，伤害 390%，最多攻击 4 个敌人"/>
+        <string name="h26" value="能量充满时可用，伤害 396%，最多攻击 4 个敌人"/>
+        <string name="h27" value="能量充满时可用，伤害 402%，最多攻击 4 个敌人"/>
+        <string name="h28" value="能量充满时可用，伤害 408%，最多攻击 4 个敌人"/>
+        <string name="h29" value="能量充满时可用，伤害 414%，最多攻击 4 个敌人"/>
+        <string name="h30" value="能量充满时可用，伤害 420%，最多攻击 4 个敌人"/>
     </imgdir>
     <imgdir name="5111004">
         <string name="name" value="能量耗转"/>
-        <string name="h1" value="伤害 265%，伤害的11% 恢复体力"/>
-        <string name="h10" value="伤害 310%，伤害的15% 恢复体力"/>
-        <string name="h11" value="伤害 315%，伤害的16% 恢复体力"/>
-        <string name="h12" value="伤害 320%，伤害的16% 恢复体力"/>
-        <string name="h13" value="伤害 325%，伤害的17% 恢复体力"/>
-        <string name="h14" value="伤害 330%，伤害的17% 恢复体力"/>
-        <string name="h15" value="伤害 335%，伤害的18% 恢复体力"/>
-        <string name="h16" value="伤害 340%，伤害的18% 恢复体力"/>
-        <string name="h17" value="伤害 345%，伤害的19% 恢复体力"/>
-        <string name="h18" value="伤害 350%，伤害的19% 恢复体力"/>
-        <string name="h19" value="伤害 355%，伤害的20% 恢复体力"/>
-        <string name="h2" value="伤害 270%，伤害的11% 恢复体力"/>
-        <string name="h20" value="伤害 360%，伤害的20% 恢复体力"/>
-        <string name="h3" value="伤害 275%，伤害的12% 恢复体力"/>
-        <string name="h4" value="伤害 280%，伤害的12% 恢复体力"/>
-        <string name="h5" value="伤害 285%，伤害的13% 恢复体力"/>
-        <string name="h6" value="伤害 290%，伤害的13% 恢复体力"/>
-        <string name="h7" value="伤害 295%，伤害的14% 恢复体力"/>
-        <string name="h8" value="伤害 300%，伤害的14% 恢复体力"/>
-        <string name="h9" value="伤害 305%，伤害的15% 恢复体力"/>
-        <string name="desc" value="[最高等级 : 20]\n利用能量，使敌人的一些HP变为自己的HP。\n只有#c能量充沛#的状态下才可以使用。\n必要技能 : #c能量获得1级以上#"/>
+        <string name="desc" value="[最高等级：20]\n消耗能量攻击1个敌人，并按伤害的一部分恢复HP。只能在能量充满状态下使用。"/>
+        <string name="h1" value="伤害 265%，按伤害的 11% 恢复HP"/>
+        <string name="h2" value="伤害 270%，按伤害的 11% 恢复HP"/>
+        <string name="h3" value="伤害 275%，按伤害的 12% 恢复HP"/>
+        <string name="h4" value="伤害 280%，按伤害的 12% 恢复HP"/>
+        <string name="h5" value="伤害 285%，按伤害的 13% 恢复HP"/>
+        <string name="h6" value="伤害 290%，按伤害的 13% 恢复HP"/>
+        <string name="h7" value="伤害 295%，按伤害的 14% 恢复HP"/>
+        <string name="h8" value="伤害 300%，按伤害的 14% 恢复HP"/>
+        <string name="h9" value="伤害 305%，按伤害的 15% 恢复HP"/>
+        <string name="h10" value="伤害 310%，按伤害的 15% 恢复HP"/>
+        <string name="h11" value="伤害 315%，按伤害的 16% 恢复HP"/>
+        <string name="h12" value="伤害 320%，按伤害的 16% 恢复HP"/>
+        <string name="h13" value="伤害 325%，按伤害的 17% 恢复HP"/>
+        <string name="h14" value="伤害 330%，按伤害的 17% 恢复HP"/>
+        <string name="h15" value="伤害 335%，按伤害的 18% 恢复HP"/>
+        <string name="h16" value="伤害 340%，按伤害的 18% 恢复HP"/>
+        <string name="h17" value="伤害 345%，按伤害的 19% 恢复HP"/>
+        <string name="h18" value="伤害 350%，按伤害的 19% 恢复HP"/>
+        <string name="h19" value="伤害 355%，按伤害的 20% 恢复HP"/>
+        <string name="h20" value="伤害 360%，按伤害的 20% 恢复HP"/>
     </imgdir>
     <imgdir name="5111005">
         <string name="name" value="超人变形"/>
-        <string name="h1" value="消耗MP 22 和 魔法石 1个，物理，魔力防御力 2 增加"/>
-        <string name="h10" value="消耗MP 40 和 魔法石 1个，物理，魔力防御力 20 增加"/>
-        <string name="h11" value="消耗MP 42 和 魔法石 1个，物理，魔力防御力 22 增加"/>
-        <string name="h12" value="消耗MP 44 和 魔法石 1个，物理，魔力防御力 24 增加"/>
-        <string name="h13" value="消耗MP 46 和 魔法石 1个，物理，魔力防御力 26 增加"/>
-        <string name="h14" value="消耗MP 48 和 魔法石 1个，物理，魔力防御力 28 增加"/>
-        <string name="h15" value="消耗MP 50 和 魔法石 1个，物理，魔力防御力 30 增加"/>
-        <string name="h16" value="消耗MP 52 和 魔法石 1个，物理，魔力防御力 32 增加"/>
-        <string name="h17" value="消耗MP 54 和 魔法石 1个，物理，魔力防御力 34 增加"/>
-        <string name="h18" value="消耗MP 56 和 魔法石 1个，物理，魔力防御力 36 增加"/>
-        <string name="h19" value="消耗MP 58 和 魔法石 1个，物理，魔力防御力 38 增加"/>
-        <string name="h2" value="消耗MP 24 和 魔法石 1个，物理，魔力防御力 4 增加"/>
-        <string name="h20" value="消耗MP 60 和 魔法石 1个，物理，魔力防御力 40 增加"/>
-        <string name="h3" value="消耗MP 26 和 魔法石 1个，物理，魔力防御力 6 增加"/>
-        <string name="h4" value="消耗MP 28 和 魔法石 1个，物理，魔力防御力 8 增加"/>
-        <string name="h5" value="消耗MP 30 和 魔法石 1个，物理，魔力防御力 10 增加"/>
-        <string name="h6" value="消耗MP 32 和 魔法石 1个，物理，魔力防御力 12 增加"/>
-        <string name="h7" value="消耗MP 34 和 魔法石 1个，物理，魔力防御力 14 增加"/>
-        <string name="h8" value="消耗MP 36 和 魔法石 1个，物理，魔力防御力 16 增加"/>
-        <string name="h9" value="消耗MP 38 和 魔法石 1个，物理，魔力防御力 18 增加"/>
-        <string name="desc" value="[最高等级 : 20]\n在120秒内保持超人变形状态。 \n限制使用的技能: 双弹射击，橡木伪装，金手指，索命"/>
+        <string name="desc" value="[最高等级：20]\n变身120秒，提高力量、物理防御、魔法防御、移动速度和跳跃力，有冷却时间。"/>
+        <string name="h1" value="消耗MP 22，力量 +1，物理防御 +2，魔法防御 +2，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 550 秒"/>
+        <string name="h2" value="消耗MP 24，力量 +2，物理防御 +4，魔法防御 +4，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 540 秒"/>
+        <string name="h3" value="消耗MP 26，力量 +3，物理防御 +6，魔法防御 +6，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 530 秒"/>
+        <string name="h4" value="消耗MP 28，力量 +4，物理防御 +8，魔法防御 +8，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 520 秒"/>
+        <string name="h5" value="消耗MP 30，力量 +5，物理防御 +10，魔法防御 +10，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 510 秒"/>
+        <string name="h6" value="消耗MP 32，力量 +6，物理防御 +12，魔法防御 +12，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 500 秒"/>
+        <string name="h7" value="消耗MP 34，力量 +7，物理防御 +14，魔法防御 +14，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 490 秒"/>
+        <string name="h8" value="消耗MP 36，力量 +8，物理防御 +16，魔法防御 +16，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 480 秒"/>
+        <string name="h9" value="消耗MP 38，力量 +9，物理防御 +18，魔法防御 +18，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 470 秒"/>
+        <string name="h10" value="消耗MP 40，力量 +10，物理防御 +20，魔法防御 +20，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 460 秒"/>
+        <string name="h11" value="消耗MP 42，力量 +11，物理防御 +22，魔法防御 +22，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 450 秒"/>
+        <string name="h12" value="消耗MP 44，力量 +12，物理防御 +24，魔法防御 +24，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 440 秒"/>
+        <string name="h13" value="消耗MP 46，力量 +13，物理防御 +26，魔法防御 +26，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 430 秒"/>
+        <string name="h14" value="消耗MP 48，力量 +14，物理防御 +28，魔法防御 +28，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 420 秒"/>
+        <string name="h15" value="消耗MP 50，力量 +15，物理防御 +30，魔法防御 +30，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 410 秒"/>
+        <string name="h16" value="消耗MP 52，力量 +16，物理防御 +32，魔法防御 +32，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 400 秒"/>
+        <string name="h17" value="消耗MP 54，力量 +17，物理防御 +34，魔法防御 +34，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 390 秒"/>
+        <string name="h18" value="消耗MP 56，力量 +18，物理防御 +36，魔法防御 +36，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 380 秒"/>
+        <string name="h19" value="消耗MP 58，力量 +19，物理防御 +38，魔法防御 +38，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 370 秒"/>
+        <string name="h20" value="消耗MP 60，力量 +20，物理防御 +40，魔法防御 +40，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 360 秒"/>
     </imgdir>
     <imgdir name="5111006">
         <string name="name" value="碎石乱击"/>
-        <string name="h1" value="消耗MP 18，伤害 265%，最多攻击 4只 攻击"/>
-        <string name="h10" value="消耗MP 22，伤害 400%，最多攻击 4只 攻击"/>
-        <string name="h11" value="消耗MP 26，伤害 415%，最多攻击 5只 攻击"/>
-        <string name="h12" value="消耗MP 26，伤害 430%，最多攻击 5只 攻击"/>
-        <string name="h13" value="消耗MP 26，伤害 445%，最多攻击 5只 攻击"/>
-        <string name="h14" value="消耗MP 26，伤害 460%，最多攻击 5只 攻击"/>
-        <string name="h15" value="消耗MP 26，伤害 475%，最多攻击 5只 攻击"/>
-        <string name="h16" value="消耗MP 30，伤害 490%，最多攻击 5只 攻击"/>
-        <string name="h17" value="消耗MP 30，伤害 505%，最多攻击 5只 攻击"/>
-        <string name="h18" value="消耗MP 30，伤害 520%，最多攻击 5只 攻击"/>
-        <string name="h19" value="消耗MP 30，伤害 535%，最多攻击 5只 攻击"/>
-        <string name="h2" value="消耗MP 18，伤害 280%，最多攻击 4只 攻击"/>
-        <string name="h20" value="消耗MP 30，伤害 550%，最多攻击 5只 攻击"/>
-        <string name="h21" value="消耗MP 34，伤害 565%，最多攻击 6只 攻击"/>
-        <string name="h22" value="消耗MP 34，伤害 580%，最多攻击 6只 攻击"/>
-        <string name="h23" value="消耗MP 34，伤害 595%，最多攻击 6只 攻击"/>
-        <string name="h24" value="消耗MP 34，伤害 610%，最多攻击 6只 攻击"/>
-        <string name="h25" value="消耗MP 34，伤害 625%，最多攻击 6只 攻击"/>
-        <string name="h26" value="消耗MP 38，伤害 640%，最多攻击 6只 攻击"/>
-        <string name="h27" value="消耗MP 38，伤害 655%，最多攻击 6只 攻击"/>
-        <string name="h28" value="消耗MP 38，伤害 670%，最多攻击 6只 攻击"/>
-        <string name="h29" value="消耗MP 38，伤害 685%，最多攻击 6只 攻击"/>
-        <string name="h3" value="消耗MP 18，伤害 295%，最多攻击 4只 攻击"/>
-        <string name="h30" value="消耗MP 38，伤害 700%，最多攻击 6只 攻击"/>
-        <string name="h4" value="消耗MP 18，伤害 310%，最多攻击 4只 攻击"/>
-        <string name="h5" value="消耗MP 18，伤害 325%，最多攻击 4只 攻击"/>
-        <string name="h6" value="消耗MP 22，伤害 340%，最多攻击 4只 攻击"/>
-        <string name="h7" value="消耗MP 22，伤害 355%，最多攻击 4只 攻击"/>
-        <string name="h8" value="消耗MP 22，伤害 370%，最多攻击 4只 攻击"/>
-        <string name="h9" value="消耗MP 22，伤害 385%，最多攻击 4只 攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n猛烈地撞击大地引起冲击，伤害多个怪物。\n只有在 #c超人变形，超级变身# 状态下使用.\n必要技能 : #c超人变形 1级以上#"/>
+        <string name="desc" value="[最高等级：30]\n猛烈撞击地面攻击多个敌人。需要处于超人变形或超级变身状态。"/>
+        <string name="h1" value="消耗MP 18，伤害 265%，最多攻击 4 个敌人"/>
+        <string name="h2" value="消耗MP 18，伤害 280%，最多攻击 4 个敌人"/>
+        <string name="h3" value="消耗MP 18，伤害 295%，最多攻击 4 个敌人"/>
+        <string name="h4" value="消耗MP 18，伤害 310%，最多攻击 4 个敌人"/>
+        <string name="h5" value="消耗MP 18，伤害 325%，最多攻击 4 个敌人"/>
+        <string name="h6" value="消耗MP 22，伤害 340%，最多攻击 4 个敌人"/>
+        <string name="h7" value="消耗MP 22，伤害 355%，最多攻击 4 个敌人"/>
+        <string name="h8" value="消耗MP 22，伤害 370%，最多攻击 4 个敌人"/>
+        <string name="h9" value="消耗MP 22，伤害 385%，最多攻击 4 个敌人"/>
+        <string name="h10" value="消耗MP 22，伤害 400%，最多攻击 4 个敌人"/>
+        <string name="h11" value="消耗MP 26，伤害 415%，最多攻击 5 个敌人"/>
+        <string name="h12" value="消耗MP 26，伤害 430%，最多攻击 5 个敌人"/>
+        <string name="h13" value="消耗MP 26，伤害 445%，最多攻击 5 个敌人"/>
+        <string name="h14" value="消耗MP 26，伤害 460%，最多攻击 5 个敌人"/>
+        <string name="h15" value="消耗MP 26，伤害 475%，最多攻击 5 个敌人"/>
+        <string name="h16" value="消耗MP 30，伤害 490%，最多攻击 5 个敌人"/>
+        <string name="h17" value="消耗MP 30，伤害 505%，最多攻击 5 个敌人"/>
+        <string name="h18" value="消耗MP 30，伤害 520%，最多攻击 5 个敌人"/>
+        <string name="h19" value="消耗MP 30，伤害 535%，最多攻击 5 个敌人"/>
+        <string name="h20" value="消耗MP 30，伤害 550%，最多攻击 5 个敌人"/>
+        <string name="h21" value="消耗MP 34，伤害 565%，最多攻击 6 个敌人"/>
+        <string name="h22" value="消耗MP 34，伤害 580%，最多攻击 6 个敌人"/>
+        <string name="h23" value="消耗MP 34，伤害 595%，最多攻击 6 个敌人"/>
+        <string name="h24" value="消耗MP 34，伤害 610%，最多攻击 6 个敌人"/>
+        <string name="h25" value="消耗MP 34，伤害 625%，最多攻击 6 个敌人"/>
+        <string name="h26" value="消耗MP 38，伤害 640%，最多攻击 6 个敌人"/>
+        <string name="h27" value="消耗MP 38，伤害 655%，最多攻击 6 个敌人"/>
+        <string name="h28" value="消耗MP 38，伤害 670%，最多攻击 6 个敌人"/>
+        <string name="h29" value="消耗MP 38，伤害 685%，最多攻击 6 个敌人"/>
+        <string name="h30" value="消耗MP 38，伤害 700%，最多攻击 6 个敌人"/>
     </imgdir>
     <imgdir name="512">
         <string name="bookName" value="冲锋队长的达成"/>
     </imgdir>
     <imgdir name="5121000">
         <string name="name" value="冒险岛勇士"/>
-        <string name="h1" value="消耗MP10  30秒内所有的属性点提高1%"/>
-        <string name="h10" value="消耗MP20  300秒内所有的属性点提高5%"/>
-        <string name="h11" value="消耗MP30  330秒内所有的属性点提高6%"/>
-        <string name="h12" value="消耗MP30  360秒内所有的属性点提高6%"/>
-        <string name="h13" value="消耗MP30  390秒内所有的属性点提高7%"/>
-        <string name="h14" value="消耗MP30  420秒内所有的属性点提高7%"/>
-        <string name="h15" value="消耗MP30  450秒内所有的属性点提高8%"/>
-        <string name="h16" value="消耗MP40  480秒内所有的属性点提高8%"/>
-        <string name="h17" value="消耗MP40  510秒内所有的属性点提高9%"/>
-        <string name="h18" value="消耗MP40  540秒内所有的属性点提高9%"/>
-        <string name="h19" value="消耗MP40  570秒内所有的属性点提高10%"/>
-        <string name="h2" value="消耗MP10  60秒内所有的属性点提高1%"/>
-        <string name="h20" value="消耗MP40  600秒内所有的属性点提高10%"/>
-        <string name="h21" value="消耗MP 50，630秒内所有的属性点提高 11%"/>
-        <string name="h22" value="消耗MP 50，660秒内所有的属性点提高 11%"/>
-        <string name="h23" value="消耗MP 50，690秒内所有的属性点提高 12%"/>
-        <string name="h24" value="消耗MP 50，720秒内所有的属性点提高 12%"/>
-        <string name="h25" value="消耗MP 50，750秒内所有的属性点提高 13%"/>
-        <string name="h26" value="消耗MP 60，780秒内所有的属性点提高 13%"/>
-        <string name="h27" value="消耗MP 60，810秒内所有的属性点提高 14%"/>
-        <string name="h28" value="消耗MP 60，840秒内所有的属性点提高 14%"/>
-        <string name="h29" value="消耗MP 60，870秒内所有的属性点提高 15%"/>
-        <string name="h3" value="消耗MP10  90秒内所有的属性点提高2%"/>
-        <string name="h30" value="消耗MP 60，900秒内所有的属性点提高 15%"/>
-        <string name="h4" value="消耗MP10  120秒内所有的属性点提高2%"/>
-        <string name="h5" value="消耗MP10  150秒内所有的属性点提高3%"/>
-        <string name="h6" value="消耗MP20  180秒内所有的属性点提高3%"/>
-        <string name="h7" value="消耗MP20  210秒内所有的属性点提高4%"/>
-        <string name="h8" value="消耗MP20  240秒内所有的属性点提高4%"/>
-        <string name="h9" value="消耗MP20  270秒内所有的属性点提高5%"/>
-        <string name="desc" value="一定时间内把组队成员的所有属性点提高\n一定的百分比"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内按百分比提高自身及周围队员的所有属性。"/>
+        <string name="h1" value="消耗MP 10，所有属性 +1%，持续30秒"/>
+        <string name="h2" value="消耗MP 10，所有属性 +1%，持续60秒"/>
+        <string name="h3" value="消耗MP 10，所有属性 +2%，持续90秒"/>
+        <string name="h4" value="消耗MP 10，所有属性 +2%，持续120秒"/>
+        <string name="h5" value="消耗MP 10，所有属性 +3%，持续150秒"/>
+        <string name="h6" value="消耗MP 20，所有属性 +3%，持续180秒"/>
+        <string name="h7" value="消耗MP 20，所有属性 +4%，持续210秒"/>
+        <string name="h8" value="消耗MP 20，所有属性 +4%，持续240秒"/>
+        <string name="h9" value="消耗MP 20，所有属性 +5%，持续270秒"/>
+        <string name="h10" value="消耗MP 20，所有属性 +5%，持续300秒"/>
+        <string name="h11" value="消耗MP 30，所有属性 +6%，持续330秒"/>
+        <string name="h12" value="消耗MP 30，所有属性 +6%，持续360秒"/>
+        <string name="h13" value="消耗MP 30，所有属性 +7%，持续390秒"/>
+        <string name="h14" value="消耗MP 30，所有属性 +7%，持续420秒"/>
+        <string name="h15" value="消耗MP 30，所有属性 +8%，持续450秒"/>
+        <string name="h16" value="消耗MP 40，所有属性 +8%，持续480秒"/>
+        <string name="h17" value="消耗MP 40，所有属性 +9%，持续510秒"/>
+        <string name="h18" value="消耗MP 40，所有属性 +9%，持续540秒"/>
+        <string name="h19" value="消耗MP 40，所有属性 +10%，持续570秒"/>
+        <string name="h20" value="消耗MP 40，所有属性 +10%，持续600秒"/>
+        <string name="h21" value="消耗MP 50，所有属性 +11%，持续630秒"/>
+        <string name="h22" value="消耗MP 50，所有属性 +11%，持续660秒"/>
+        <string name="h23" value="消耗MP 50，所有属性 +12%，持续690秒"/>
+        <string name="h24" value="消耗MP 50，所有属性 +12%，持续720秒"/>
+        <string name="h25" value="消耗MP 50，所有属性 +13%，持续750秒"/>
+        <string name="h26" value="消耗MP 60，所有属性 +13%，持续780秒"/>
+        <string name="h27" value="消耗MP 60，所有属性 +14%，持续810秒"/>
+        <string name="h28" value="消耗MP 60，所有属性 +14%，持续840秒"/>
+        <string name="h29" value="消耗MP 60，所有属性 +15%，持续870秒"/>
+        <string name="h30" value="消耗MP 60，所有属性 +15%，持续900秒"/>
     </imgdir>
     <imgdir name="5121001">
         <string name="name" value="潜龙出渊"/>
-        <string name="h1" value="消耗MP 21，伤害 275%，4只 攻击"/>
-		<string name="h10" value="消耗MP 25，伤害 410%，4只 攻击"/>
-		<string name="h11" value="消耗MP 26，伤害 475%，5只 攻击"/>
-		<string name="h12" value="消耗MP 26，伤害 490%，5只 攻击"/>
-		<string name="h13" value="消耗MP 27，伤害 505%，5只 攻击"/>
-		<string name="h14" value="消耗MP 27，伤害 520%，5只 攻击"/>
-		<string name="h15" value="消耗MP 28，伤害 535%，5只 攻击"/>
-		<string name="h16" value="消耗MP 28，伤害 550%，5只 攻击"/>
-		<string name="h17" value="消耗MP 29，伤害 565%，5只 攻击"/>
-		<string name="h18" value="消耗MP 29，伤害 580%，5只 攻击"/>
-		<string name="h19" value="消耗MP 30，伤害 595%，5只 攻击"/>
-		<string name="h2" value="消耗MP 21，伤害 290%，4只 攻击"/>
-		<string name="h20" value="消耗MP 30，伤害 610%，5只 攻击"/>
-		<string name="h21" value="消耗MP 31，伤害 675%，6只 攻击"/>
-		<string name="h22" value="消耗MP 31，伤害 690%，6只 攻击"/>
-		<string name="h23" value="消耗MP 32，伤害 705%，6只 攻击"/>
-		<string name="h24" value="消耗MP 32，伤害 720%，6只 攻击"/>
-		<string name="h25" value="消耗MP 33，伤害 735%，6只 攻击"/>
-		<string name="h26" value="消耗MP 33，伤害 750%，6只 攻击"/>
-		<string name="h27" value="消耗MP 34，伤害 765%，6只 攻击"/>
-		<string name="h28" value="消耗MP 34，伤害 780%，6只 攻击"/>
-		<string name="h29" value="消耗MP 35，伤害 795%，6只 攻击"/>
-		<string name="h3" value="消耗MP 22，伤害 305%，4只 攻击"/>
-		<string name="h30" value="消耗MP 35，伤害 810%，6只 攻击"/>
-		<string name="h4" value="消耗MP 22，伤害 320%，4只 攻击"/>
-		<string name="h5" value="消耗MP 23，伤害 335%，4只 攻击"/>
-		<string name="h6" value="消耗MP 23，伤害 350%，4只 攻击"/>
-		<string name="h7" value="消耗MP 24，伤害 365%，4只 攻击"/>
-		<string name="h8" value="消耗MP 24，伤害 380%，4只 攻击"/>
-		<string name="h9" value="消耗MP 25，伤害 395%，4只 攻击"/>
-        <string name="desc" value="召唤沉睡的龙，给与多数的敌人伤害"/>
+        <string name="desc" value="[最高等级：30]\n召唤潜伏地下的龙攻击多个敌人。"/>
+        <string name="h1" value="消耗MP 21，伤害 275%，最多攻击 4 个敌人"/>
+        <string name="h2" value="消耗MP 21，伤害 290%，最多攻击 4 个敌人"/>
+        <string name="h3" value="消耗MP 22，伤害 305%，最多攻击 4 个敌人"/>
+        <string name="h4" value="消耗MP 22，伤害 320%，最多攻击 4 个敌人"/>
+        <string name="h5" value="消耗MP 23，伤害 335%，最多攻击 4 个敌人"/>
+        <string name="h6" value="消耗MP 23，伤害 350%，最多攻击 4 个敌人"/>
+        <string name="h7" value="消耗MP 24，伤害 365%，最多攻击 4 个敌人"/>
+        <string name="h8" value="消耗MP 24，伤害 380%，最多攻击 4 个敌人"/>
+        <string name="h9" value="消耗MP 25，伤害 395%，最多攻击 4 个敌人"/>
+        <string name="h10" value="消耗MP 25，伤害 410%，最多攻击 4 个敌人"/>
+        <string name="h11" value="消耗MP 26，伤害 475%，最多攻击 5 个敌人"/>
+        <string name="h12" value="消耗MP 26，伤害 490%，最多攻击 5 个敌人"/>
+        <string name="h13" value="消耗MP 27，伤害 505%，最多攻击 5 个敌人"/>
+        <string name="h14" value="消耗MP 27，伤害 520%，最多攻击 5 个敌人"/>
+        <string name="h15" value="消耗MP 28，伤害 535%，最多攻击 5 个敌人"/>
+        <string name="h16" value="消耗MP 28，伤害 550%，最多攻击 5 个敌人"/>
+        <string name="h17" value="消耗MP 29，伤害 565%，最多攻击 5 个敌人"/>
+        <string name="h18" value="消耗MP 29，伤害 580%，最多攻击 5 个敌人"/>
+        <string name="h19" value="消耗MP 30，伤害 595%，最多攻击 5 个敌人"/>
+        <string name="h20" value="消耗MP 30，伤害 610%，最多攻击 5 个敌人"/>
+        <string name="h21" value="消耗MP 31，伤害 675%，最多攻击 6 个敌人"/>
+        <string name="h22" value="消耗MP 31，伤害 690%，最多攻击 6 个敌人"/>
+        <string name="h23" value="消耗MP 32，伤害 705%，最多攻击 6 个敌人"/>
+        <string name="h24" value="消耗MP 32，伤害 720%，最多攻击 6 个敌人"/>
+        <string name="h25" value="消耗MP 33，伤害 735%，最多攻击 6 个敌人"/>
+        <string name="h26" value="消耗MP 33，伤害 750%，最多攻击 6 个敌人"/>
+        <string name="h27" value="消耗MP 34，伤害 765%，最多攻击 6 个敌人"/>
+        <string name="h28" value="消耗MP 34，伤害 780%，最多攻击 6 个敌人"/>
+        <string name="h29" value="消耗MP 35，伤害 795%，最多攻击 6 个敌人"/>
+        <string name="h30" value="消耗MP 35，伤害 810%，最多攻击 6 个敌人"/>
     </imgdir>
     <imgdir name="5121002">
         <string name="name" value="超能量"/>
-        <string name="h1" value="伤害 300%，2只 攻击"/>
-        <string name="h10" value="伤害 480%，3只 攻击"/>
-        <string name="h11" value="伤害 510%，3只 攻击"/>
-        <string name="h12" value="伤害 530%，3只 攻击"/>
-        <string name="h13" value="伤害 550%，4只 攻击"/>
-        <string name="h14" value="伤害 570%，4只 攻击"/>
-        <string name="h15" value="伤害 590%，4只 攻击"/>
-        <string name="h16" value="伤害 610%，4只 攻击"/>
-        <string name="h17" value="伤害 630%，4只 攻击"/>
-        <string name="h18" value="伤害 650%，4只 攻击"/>
-        <string name="h19" value="伤害 670%，5只 攻击"/>
-        <string name="h2" value="伤害 320%，2只 攻击"/>
-        <string name="h20" value="伤害 690%，5只 攻击"/>
-        <string name="h21" value="伤害 720%，5只 攻击"/>
-        <string name="h22" value="伤害 740%，5只 攻击"/>
-        <string name="h23" value="伤害 760%，5只 攻击"/>
-        <string name="h24" value="伤害 780%，5只 攻击"/>
-        <string name="h25" value="伤害 800%，6只 攻击"/>
-        <string name="h26" value="伤害 820%，6只 攻击"/>
-        <string name="h27" value="伤害 840%，6只 攻击"/>
-        <string name="h28" value="伤害 860%，6只 攻击"/>
-        <string name="h29" value="伤害 880%，6只 攻击"/>
-        <string name="h3" value="伤害 340%，2只 攻击"/>
-        <string name="h30" value="伤害 900%，6只 攻击"/>
-        <string name="h4" value="伤害 360%，2只 攻击"/>
-        <string name="h5" value="伤害 380%，2只 攻击"/>
-        <string name="h6" value="伤害 400%，2只 攻击"/>
-        <string name="h7" value="伤害 420%，3只 攻击"/>
-        <string name="h8" value="伤害 440%，3只 攻击"/>
-        <string name="h9" value="伤害 460%，3只 攻击"/>
-        <string name="desc" value="爆发聚集的能量攻击敌人，如果周围有其\n他怪物，超能量会转移给与怪物累计伤害\n只能#c能量充沛#的状态下使用\n必要技能 : #c能量获得1级以上#"/>
+        <string name="desc" value="[最高等级：30]\n发射能量球攻击敌人，并可连锁攻击附近敌人。只能在能量充满状态下使用。"/>
+        <string name="h1" value="，伤害 300%，最多攻击 2 个敌人"/>
+        <string name="h2" value="，伤害 320%，最多攻击 2 个敌人"/>
+        <string name="h3" value="，伤害 340%，最多攻击 2 个敌人"/>
+        <string name="h4" value="，伤害 360%，最多攻击 2 个敌人"/>
+        <string name="h5" value="，伤害 380%，最多攻击 2 个敌人"/>
+        <string name="h6" value="，伤害 400%，最多攻击 2 个敌人"/>
+        <string name="h7" value="，伤害 420%，最多攻击 3 个敌人"/>
+        <string name="h8" value="，伤害 440%，最多攻击 3 个敌人"/>
+        <string name="h9" value="，伤害 460%，最多攻击 3 个敌人"/>
+        <string name="h10" value="，伤害 480%，最多攻击 3 个敌人"/>
+        <string name="h11" value="，伤害 510%，最多攻击 3 个敌人"/>
+        <string name="h12" value="，伤害 530%，最多攻击 3 个敌人"/>
+        <string name="h13" value="，伤害 550%，最多攻击 4 个敌人"/>
+        <string name="h14" value="，伤害 570%，最多攻击 4 个敌人"/>
+        <string name="h15" value="，伤害 590%，最多攻击 4 个敌人"/>
+        <string name="h16" value="，伤害 610%，最多攻击 4 个敌人"/>
+        <string name="h17" value="，伤害 630%，最多攻击 4 个敌人"/>
+        <string name="h18" value="，伤害 650%，最多攻击 4 个敌人"/>
+        <string name="h19" value="，伤害 670%，最多攻击 5 个敌人"/>
+        <string name="h20" value="，伤害 690%，最多攻击 5 个敌人"/>
+        <string name="h21" value="，伤害 720%，最多攻击 5 个敌人"/>
+        <string name="h22" value="，伤害 740%，最多攻击 5 个敌人"/>
+        <string name="h23" value="，伤害 760%，最多攻击 5 个敌人"/>
+        <string name="h24" value="，伤害 780%，最多攻击 5 个敌人"/>
+        <string name="h25" value="，伤害 800%，最多攻击 6 个敌人"/>
+        <string name="h26" value="，伤害 820%，最多攻击 6 个敌人"/>
+        <string name="h27" value="，伤害 840%，最多攻击 6 个敌人"/>
+        <string name="h28" value="，伤害 860%，最多攻击 6 个敌人"/>
+        <string name="h29" value="，伤害 880%，最多攻击 6 个敌人"/>
+        <string name="h30" value="，伤害 900%，最多攻击 6 个敌人"/>
     </imgdir>
     <imgdir name="5121003">
         <string name="name" value="超级变身"/>
-        <string name="h1" value="消耗MP22和魔法石1个，防御力+41"/>
-		<string name="h10" value="消耗MP40和魔法石1个，防御力+50"/>
-		<string name="h11" value="消耗MP42和魔法石1个，防御力+51"/>
-		<string name="h12" value="消耗MP44和魔法石1个，防御力+52"/>
-		<string name="h13" value="消耗MP46和魔法石1个，防御力+53"/>
-		<string name="h14" value="消耗MP48和魔法石1个，防御力+54"/>
-		<string name="h15" value="消耗MP50和魔法石1个，防御力+55"/>
-		<string name="h16" value="消耗MP52和魔法石1个，防御力+56"/>
-		<string name="h17" value="消耗MP54和魔法石1个，防御力+57"/>
-		<string name="h18" value="消耗MP56和魔法石1个，防御力+58"/>
-		<string name="h19" value="消耗MP58和魔法石1个，防御力+59"/>
-		<string name="h2" value="消耗MP24和魔法石1个，防御力+42"/>
-		<string name="h20" value="消耗MP60和魔法石1个，防御力+60"/>
-		<string name="h3" value="消耗MP26和魔法石1个，防御力+43"/>
-		<string name="h4" value="消耗MP28和魔法石1个，防御力+44"/>
-		<string name="h5" value="消耗MP30和魔法石1个，防御力+45"/>
-		<string name="h6" value="消耗MP32和魔法石1个，防御力+46"/>
-		<string name="h7" value="消耗MP34和魔法石1个，防御力+47"/>
-		<string name="h8" value="消耗MP36和魔法石1个，防御力+48"/>
-		<string name="h9" value="消耗MP38和魔法石1个，防御力+49"/>
-		<string name="desc" value="在120秒内保持超人变形状态。\n限制技能 : 双弹射击和橡木伪装都无法使用。\n必要技能 : #c变身 20级以上#"/>
+        <string name="desc" value="[最高等级：20]\n进入更强的变身状态120秒，提高力量、物理防御、魔法防御、移动速度和跳跃力。需要超人变形20级。"/>
+        <string name="h1" value="消耗MP 22，力量 +21，物理防御 +41，魔法防御 +41，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 430 秒"/>
+        <string name="h2" value="消耗MP 24，力量 +21，物理防御 +42，魔法防御 +42，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 420 秒"/>
+        <string name="h3" value="消耗MP 26，力量 +22，物理防御 +43，魔法防御 +43，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 410 秒"/>
+        <string name="h4" value="消耗MP 28，力量 +22，物理防御 +44，魔法防御 +44，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 400 秒"/>
+        <string name="h5" value="消耗MP 30，力量 +23，物理防御 +45，魔法防御 +45，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 390 秒"/>
+        <string name="h6" value="消耗MP 32，力量 +23，物理防御 +46，魔法防御 +46，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 380 秒"/>
+        <string name="h7" value="消耗MP 34，力量 +24，物理防御 +47，魔法防御 +47，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 370 秒"/>
+        <string name="h8" value="消耗MP 36，力量 +24，物理防御 +48，魔法防御 +48，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 360 秒"/>
+        <string name="h9" value="消耗MP 38，力量 +25，物理防御 +49，魔法防御 +49，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 350 秒"/>
+        <string name="h10" value="消耗MP 40，力量 +25，物理防御 +50，魔法防御 +50，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 340 秒"/>
+        <string name="h11" value="消耗MP 42，力量 +26，物理防御 +51，魔法防御 +51，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 330 秒"/>
+        <string name="h12" value="消耗MP 44，力量 +26，物理防御 +52，魔法防御 +52，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 320 秒"/>
+        <string name="h13" value="消耗MP 46，力量 +27，物理防御 +53，魔法防御 +53，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 310 秒"/>
+        <string name="h14" value="消耗MP 48，力量 +27，物理防御 +54，魔法防御 +54，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 300 秒"/>
+        <string name="h15" value="消耗MP 50，力量 +28，物理防御 +55，魔法防御 +55，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 290 秒"/>
+        <string name="h16" value="消耗MP 52，力量 +28，物理防御 +56，魔法防御 +56，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 280 秒"/>
+        <string name="h17" value="消耗MP 54，力量 +29，物理防御 +57，魔法防御 +57，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 270 秒"/>
+        <string name="h18" value="消耗MP 56，力量 +29，物理防御 +58，魔法防御 +58，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 260 秒"/>
+        <string name="h19" value="消耗MP 58，力量 +30，物理防御 +59，魔法防御 +59，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 250 秒"/>
+        <string name="h20" value="消耗MP 60，力量 +30，物理防御 +60，魔法防御 +60，移动速度 +40，跳跃力 +20，持续 120 秒，冷却 240 秒"/>
     </imgdir>
     <imgdir name="5121004">
         <string name="name" value="金手指"/>
-        <string name="h1" value="消耗MP 20，以伤害 90% 攻击敌人8次"/>
-		<string name="h10" value="消耗MP 20，以伤害 180% 攻击敌人8次"/>
-		<string name="h11" value="消耗MP 35，以伤害 200% 攻击敌人8次"/>
-		<string name="h12" value="消耗MP 35，以伤害 210% 攻击敌人8次"/>
-		<string name="h13" value="消耗MP 35，以伤害 220% 攻击敌人8次"/>
-		<string name="h14" value="消耗MP 35，以伤害 230% 攻击敌人8次"/>
-		<string name="h15" value="消耗MP 35，以伤害 240% 攻击敌人8次"/>
-		<string name="h16" value="消耗MP 35，以伤害 250% 攻击敌人8次"/>
-		<string name="h17" value="消耗MP 35，以伤害 260% 攻击敌人8次"/>
-		<string name="h18" value="消耗MP 35，以伤害 270% 攻击敌人8次"/>
-		<string name="h19" value="消耗MP 35，以伤害 280% 攻击敌人8次"/>
-		<string name="h2" value="消耗MP 20，以伤害 100% 攻击敌人8次"/>
-		<string name="h20" value="消耗MP 35，以伤害 290% 攻击敌人8次"/>
-		<string name="h21" value="消耗MP 50，以伤害 310% 攻击敌人8次"/>
-		<string name="h22" value="消耗MP 50，以伤害 320% 攻击敌人8次"/>
-		<string name="h23" value="消耗MP 50，以伤害 330% 攻击敌人8次"/>
-		<string name="h24" value="消耗MP 50，以伤害 340% 攻击敌人8次"/>
-		<string name="h25" value="消耗MP 50，以伤害 350% 攻击敌人8次"/>
-		<string name="h26" value="消耗MP 50，以伤害 360% 攻击敌人8次"/>
-		<string name="h27" value="消耗MP 50，以伤害 370% 攻击敌人8次"/>
-		<string name="h28" value="消耗MP 50，以伤害 380% 攻击敌人8次"/>
-		<string name="h29" value="消耗MP 50，以伤害 390% 攻击敌人8次"/>
-		<string name="h3" value="消耗MP 20，以伤害 110% 攻击敌人8次"/>
-		<string name="h30" value="消耗MP 50，以伤害 400% 攻击敌人8次"/>
-		<string name="h4" value="消耗MP 20，以伤害 120% 攻击敌人8次"/>
-		<string name="h5" value="消耗MP 20，以伤害 130% 攻击敌人8次"/>
-		<string name="h6" value="消耗MP 20，以伤害 140% 攻击敌人8次"/>
-		<string name="h7" value="消耗MP 20，以伤害 150% 攻击敌人8次"/>
-		<string name="h8" value="消耗MP 20，以伤害 160% 攻击敌人8次"/>
-		<string name="h9" value="消耗MP 20，以伤害 170% 攻击敌人8次"/>
-        <string name="desc" value="超越极限的快速攻击，给一个敌人带来大的\n伤害，只能在超级变身状态下使用，具有眩\n晕效果。只有在 #c超级变身# 状态下才可以使用.\n必要技能 : #c超级变身 1级以上#"/>
+        <string name="desc" value="[最高等级：30]\n攻击1个敌人8次并使其眩晕。只能在超级变身状态下使用。"/>
+        <string name="h1" value="消耗MP 20，伤害 90% x 8 次，眩晕 1 秒"/>
+        <string name="h2" value="消耗MP 20，伤害 100% x 8 次，眩晕 1 秒"/>
+        <string name="h3" value="消耗MP 20，伤害 110% x 8 次，眩晕 1 秒"/>
+        <string name="h4" value="消耗MP 20，伤害 120% x 8 次，眩晕 1 秒"/>
+        <string name="h5" value="消耗MP 20，伤害 130% x 8 次，眩晕 1 秒"/>
+        <string name="h6" value="消耗MP 20，伤害 140% x 8 次，眩晕 1 秒"/>
+        <string name="h7" value="消耗MP 20，伤害 150% x 8 次，眩晕 1 秒"/>
+        <string name="h8" value="消耗MP 20，伤害 160% x 8 次，眩晕 1 秒"/>
+        <string name="h9" value="消耗MP 20，伤害 170% x 8 次，眩晕 1 秒"/>
+        <string name="h10" value="消耗MP 20，伤害 180% x 8 次，眩晕 1 秒"/>
+        <string name="h11" value="消耗MP 35，伤害 200% x 8 次，眩晕 1 秒"/>
+        <string name="h12" value="消耗MP 35，伤害 210% x 8 次，眩晕 1 秒"/>
+        <string name="h13" value="消耗MP 35，伤害 220% x 8 次，眩晕 1 秒"/>
+        <string name="h14" value="消耗MP 35，伤害 230% x 8 次，眩晕 1 秒"/>
+        <string name="h15" value="消耗MP 35，伤害 240% x 8 次，眩晕 1 秒"/>
+        <string name="h16" value="消耗MP 35，伤害 250% x 8 次，眩晕 1 秒"/>
+        <string name="h17" value="消耗MP 35，伤害 260% x 8 次，眩晕 1 秒"/>
+        <string name="h18" value="消耗MP 35，伤害 270% x 8 次，眩晕 1 秒"/>
+        <string name="h19" value="消耗MP 35，伤害 280% x 8 次，眩晕 1 秒"/>
+        <string name="h20" value="消耗MP 35，伤害 290% x 8 次，眩晕 1 秒"/>
+        <string name="h21" value="消耗MP 50，伤害 310% x 8 次，眩晕 1 秒"/>
+        <string name="h22" value="消耗MP 50，伤害 320% x 8 次，眩晕 1 秒"/>
+        <string name="h23" value="消耗MP 50，伤害 330% x 8 次，眩晕 1 秒"/>
+        <string name="h24" value="消耗MP 50，伤害 340% x 8 次，眩晕 1 秒"/>
+        <string name="h25" value="消耗MP 50，伤害 350% x 8 次，眩晕 1 秒"/>
+        <string name="h26" value="消耗MP 50，伤害 360% x 8 次，眩晕 1 秒"/>
+        <string name="h27" value="消耗MP 50，伤害 370% x 8 次，眩晕 1 秒"/>
+        <string name="h28" value="消耗MP 50，伤害 380% x 8 次，眩晕 1 秒"/>
+        <string name="h29" value="消耗MP 50，伤害 390% x 8 次，眩晕 1 秒"/>
+        <string name="h30" value="消耗MP 50，伤害 400% x 8 次，眩晕 1 秒"/>
     </imgdir>
     <imgdir name="5121005">
         <string name="name" value="索命"/>
-        <string name="h1" value="消耗MP 11，伤害 210%，2只 攻击"/>
-        <string name="h10" value="消耗MP 20，伤害 300%，3只 攻击"/>
-        <string name="h11" value="消耗MP 21，伤害 360%，3只 攻击"/>
-        <string name="h12" value="消耗MP 22，伤害 370%，3只 攻击"/>
-        <string name="h13" value="消耗MP 23，伤害 380%，4只 攻击"/>
-        <string name="h14" value="消耗MP 24，伤害 390%，4只 攻击"/>
-        <string name="h15" value="消耗MP 25，伤害 400%，4只 攻击"/>
-        <string name="h16" value="消耗MP 26，伤害 410%，4只 攻击"/>
-        <string name="h17" value="消耗MP 27，伤害 420%，4只 攻击"/>
-        <string name="h18" value="消耗MP 28，伤害 430%，4只 攻击"/>
-        <string name="h19" value="消耗MP 29，伤害 440%，5只 攻击"/>
-        <string name="h2" value="消耗MP 12，伤害 220%，2只 攻击"/>
-        <string name="h20" value="消耗MP 30，伤害 450%，5只 攻击"/>
-        <string name="h21" value="消耗MP 31，伤害 510%，5只 攻击"/>
-        <string name="h22" value="消耗MP 32，伤害 520%，5只 攻击"/>
-        <string name="h23" value="消耗MP 33，伤害 530%，5只 攻击"/>
-        <string name="h24" value="消耗MP 34，伤害 540%，5只 攻击"/>
-        <string name="h25" value="消耗MP 35，伤害 550%，6只 攻击"/>
-        <string name="h26" value="消耗MP 36，伤害 560%，6只 攻击"/>
-        <string name="h27" value="消耗MP 37，伤害 570%，6只 攻击"/>
-        <string name="h28" value="消耗MP 38，伤害 580%，6只 攻击"/>
-        <string name="h29" value="消耗MP 39，伤害 590%，6只 攻击"/>
-        <string name="h3" value="消耗MP 13，伤害 230%，2只 攻击"/>
-        <string name="h30" value="消耗MP 40，伤害 600%，6只 攻击"/>
-        <string name="h4" value="消耗MP 14，伤害 240%，2只 攻击"/>
-        <string name="h5" value="消耗MP 15，伤害 250%，2只 攻击"/>
-        <string name="h6" value="消耗MP 16，伤害 260%，2只 攻击"/>
-        <string name="h7" value="消耗MP 17，伤害 270%，3只 攻击"/>
-        <string name="h8" value="消耗MP 18，伤害 280%，3只 攻击"/>
-        <string name="h9" value="消耗MP 19，伤害 290%，3只 攻击"/>
-        <string name="desc" value="给与远距离怪物伤害，并身体向前移动，\n只有在 #c超级变身# 状态下使用。\n必要技能 : #c超级变身 1级以上#"/>
+        <string name="desc" value="[最高等级：30]\n攻击远处敌人并将其拉近，同时造成眩晕。只能在超级变身状态下使用。"/>
+        <string name="h1" value="消耗MP 11，伤害 210%，最多攻击 2 个敌人"/>
+        <string name="h2" value="消耗MP 12，伤害 220%，最多攻击 2 个敌人"/>
+        <string name="h3" value="消耗MP 13，伤害 230%，最多攻击 2 个敌人"/>
+        <string name="h4" value="消耗MP 14，伤害 240%，最多攻击 2 个敌人"/>
+        <string name="h5" value="消耗MP 15，伤害 250%，最多攻击 2 个敌人"/>
+        <string name="h6" value="消耗MP 16，伤害 260%，最多攻击 2 个敌人"/>
+        <string name="h7" value="消耗MP 17，伤害 270%，最多攻击 3 个敌人"/>
+        <string name="h8" value="消耗MP 18，伤害 280%，最多攻击 3 个敌人"/>
+        <string name="h9" value="消耗MP 19，伤害 290%，最多攻击 3 个敌人"/>
+        <string name="h10" value="消耗MP 20，伤害 300%，最多攻击 3 个敌人"/>
+        <string name="h11" value="消耗MP 21，伤害 360%，最多攻击 3 个敌人"/>
+        <string name="h12" value="消耗MP 22，伤害 370%，最多攻击 3 个敌人"/>
+        <string name="h13" value="消耗MP 23，伤害 380%，最多攻击 4 个敌人"/>
+        <string name="h14" value="消耗MP 24，伤害 390%，最多攻击 4 个敌人"/>
+        <string name="h15" value="消耗MP 25，伤害 400%，最多攻击 4 个敌人"/>
+        <string name="h16" value="消耗MP 26，伤害 410%，最多攻击 4 个敌人"/>
+        <string name="h17" value="消耗MP 27，伤害 420%，最多攻击 4 个敌人"/>
+        <string name="h18" value="消耗MP 28，伤害 430%，最多攻击 4 个敌人"/>
+        <string name="h19" value="消耗MP 29，伤害 440%，最多攻击 5 个敌人"/>
+        <string name="h20" value="消耗MP 30，伤害 450%，最多攻击 5 个敌人"/>
+        <string name="h21" value="消耗MP 31，伤害 510%，最多攻击 5 个敌人"/>
+        <string name="h22" value="消耗MP 32，伤害 520%，最多攻击 5 个敌人"/>
+        <string name="h23" value="消耗MP 33，伤害 530%，最多攻击 5 个敌人"/>
+        <string name="h24" value="消耗MP 34，伤害 540%，最多攻击 5 个敌人"/>
+        <string name="h25" value="消耗MP 35，伤害 550%，最多攻击 6 个敌人"/>
+        <string name="h26" value="消耗MP 36，伤害 560%，最多攻击 6 个敌人"/>
+        <string name="h27" value="消耗MP 37，伤害 570%，最多攻击 6 个敌人"/>
+        <string name="h28" value="消耗MP 38，伤害 580%，最多攻击 6 个敌人"/>
+        <string name="h29" value="消耗MP 39，伤害 590%，最多攻击 6 个敌人"/>
+        <string name="h30" value="消耗MP 40，伤害 600%，最多攻击 6 个敌人"/>
     </imgdir>
     <imgdir name="5121007">
         <string name="name" value="光速拳"/>
-        <string name="h1" value="消耗MP 21，伤害 94%"/>
-		<string name="h10" value="消耗MP 25，伤害 130%"/>
-		<string name="h11" value="消耗MP 26，伤害 144%"/>
-		<string name="h12" value="消耗MP 26，伤害 148%"/>
-		<string name="h13" value="消耗MP 27，伤害 152%"/>
-		<string name="h14" value="消耗MP 27，伤害 156%"/>
-		<string name="h15" value="消耗MP 28，伤害 160%"/>
-		<string name="h16" value="消耗MP 28，伤害 164%"/>
-		<string name="h17" value="消耗MP 29，伤害 168%"/>
-		<string name="h18" value="消耗MP 29，伤害 172%"/>
-		<string name="h19" value="消耗MP 30，伤害 176%"/>
-		<string name="h2" value="消耗MP 21，伤害 98%"/>
-		<string name="h20" value="消耗MP 30，伤害 180%"/>
-		<string name="h21" value="消耗MP 31，伤害 194%"/>
-		<string name="h22" value="消耗MP 31，伤害 198%"/>
-		<string name="h23" value="消耗MP 32，伤害 202%"/>
-		<string name="h24" value="消耗MP 32，伤害 206%"/>
-		<string name="h25" value="消耗MP 33，伤害 210%"/>
-		<string name="h26" value="消耗MP 33，伤害 214%"/>
-		<string name="h27" value="消耗MP 34，伤害 218%"/>
-		<string name="h28" value="消耗MP 34，伤害 222%"/>
-		<string name="h29" value="消耗MP 35，伤害 226%"/>
-		<string name="h3" value="消耗MP 22，伤害 102%"/>
-		<string name="h30" value="消耗MP 35，伤害 230%"/>
-		<string name="h4" value="消耗MP 22，伤害 106%"/>
-		<string name="h5" value="消耗MP 23，伤害 110%"/>
-		<string name="h6" value="消耗MP 23，伤害 114%"/>
-		<string name="h7" value="消耗MP 24，伤害 118%"/>
-		<string name="h8" value="消耗MP 24，伤害 122%"/>
-		<string name="h9" value="消耗MP 25，伤害 126%"/>
-        <string name="desc" value="极快的速度在近距离的一个怪物攻击6下"/>
+        <string name="desc" value="[最高等级：30]\n快速攻击近距离1个敌人6次。最后两击有服务端额外伤害倍率。"/>
+        <string name="h1" value="消耗MP 21，伤害 94% x 6 次"/>
+        <string name="h2" value="消耗MP 21，伤害 98% x 6 次"/>
+        <string name="h3" value="消耗MP 22，伤害 102% x 6 次"/>
+        <string name="h4" value="消耗MP 22，伤害 106% x 6 次"/>
+        <string name="h5" value="消耗MP 23，伤害 110% x 6 次"/>
+        <string name="h6" value="消耗MP 23，伤害 114% x 6 次"/>
+        <string name="h7" value="消耗MP 24，伤害 118% x 6 次"/>
+        <string name="h8" value="消耗MP 24，伤害 122% x 6 次"/>
+        <string name="h9" value="消耗MP 25，伤害 126% x 6 次"/>
+        <string name="h10" value="消耗MP 25，伤害 130% x 6 次"/>
+        <string name="h11" value="消耗MP 26，伤害 144% x 6 次"/>
+        <string name="h12" value="消耗MP 26，伤害 148% x 6 次"/>
+        <string name="h13" value="消耗MP 27，伤害 152% x 6 次"/>
+        <string name="h14" value="消耗MP 27，伤害 156% x 6 次"/>
+        <string name="h15" value="消耗MP 28，伤害 160% x 6 次"/>
+        <string name="h16" value="消耗MP 28，伤害 164% x 6 次"/>
+        <string name="h17" value="消耗MP 29，伤害 168% x 6 次"/>
+        <string name="h18" value="消耗MP 29，伤害 172% x 6 次"/>
+        <string name="h19" value="消耗MP 30，伤害 176% x 6 次"/>
+        <string name="h20" value="消耗MP 30，伤害 180% x 6 次"/>
+        <string name="h21" value="消耗MP 31，伤害 194% x 6 次"/>
+        <string name="h22" value="消耗MP 31，伤害 198% x 6 次"/>
+        <string name="h23" value="消耗MP 32，伤害 202% x 6 次"/>
+        <string name="h24" value="消耗MP 32，伤害 206% x 6 次"/>
+        <string name="h25" value="消耗MP 33，伤害 210% x 6 次"/>
+        <string name="h26" value="消耗MP 33，伤害 214% x 6 次"/>
+        <string name="h27" value="消耗MP 34，伤害 218% x 6 次"/>
+        <string name="h28" value="消耗MP 34，伤害 222% x 6 次"/>
+        <string name="h29" value="消耗MP 35，伤害 226% x 6 次"/>
+        <string name="h30" value="消耗MP 35，伤害 230% x 6 次"/>
     </imgdir>
     <imgdir name="5121008">
         <string name="name" value="勇士的意志"/>
-        <string name="h1" value="消耗MP 30，解除诱惑异常状态，冷却时间10分钟"/>
-        <string name="desc" value="从异常状态中恢复. \n随着等级的上升,冷却时间逐渐缩短"/>
+        <string name="desc" value="[最高等级：5]\n解除自身诱惑状态。冷却时间随等级降低。"/>
+        <string name="h1" value="消耗MP 30，冷却 600 秒"/>
+        <string name="h2" value="消耗MP 30，冷却 540 秒"/>
+        <string name="h3" value="消耗MP 30，冷却 480 秒"/>
+        <string name="h4" value="消耗MP 30，冷却 420 秒"/>
+        <string name="h5" value="消耗MP 30，冷却 360 秒"/>
     </imgdir>
     <imgdir name="5121009">
         <string name="name" value="极速领域"/>
-        <string name="h1" value="消耗HP 78，MP 78  110秒内提升武器的攻击速度"/>
-        <string name="h10" value="消耗HP 60，MP 60  200秒内提升武器的攻击速度"/>
-        <string name="h11" value="消耗HP 58，MP 58  210秒内提升武器的攻击速度"/>
-        <string name="h12" value="消耗HP 56，MP 56  220秒内提升武器的攻击速度"/>
-        <string name="h13" value="消耗HP 54，MP 54  230秒内提升武器的攻击速度"/>
-        <string name="h14" value="消耗HP 52，MP 52  240秒内提升武器的攻击速度"/>
-        <string name="h15" value="消耗HP 50，MP 50  250秒内提升武器的攻击速度"/>
-        <string name="h16" value="消耗HP 48，MP 48  260秒内提升武器的攻击速度"/>
-        <string name="h17" value="消耗HP 46，MP 46  270秒内提升武器的攻击速度"/>
-        <string name="h18" value="消耗HP 44，MP 44  280秒内提升武器的攻击速度"/>
-        <string name="h19" value="消耗HP 42，MP 42  290秒内提升武器的攻击速度"/>
-        <string name="h2" value="消耗HP 76，MP 76  120秒内提升武器的攻击速度"/>
-        <string name="h20" value="消耗HP 40，MP 40  300秒内提升武器的攻击速度"/>
-        <string name="h3" value="消耗HP 74，MP 74  130秒内提升武器的攻击速度"/>
-        <string name="h4" value="消耗HP 72，MP 72  140秒内提升武器的攻击速度"/>
-        <string name="h5" value="消耗HP 70，MP 70  150秒内提升武器的攻击速度"/>
-        <string name="h6" value="消耗HP 68，MP 68  160秒内提升武器的攻击速度"/>
-        <string name="h7" value="消耗HP 66，MP 66  170秒内提升武器的攻击速度"/>
-        <string name="h8" value="消耗HP 64，MP 64  180秒内提升武器的攻击速度"/>
-        <string name="h9" value="消耗HP 62，MP 62  190秒内提升武器的攻击速度"/>
-        <string name="desc" value="一定时间内提升武器的攻击速度。可与其他\n武器速度提升技能叠加，对全部组队成员有效。\n必要技能 : #c急速拳 20级以上#"/>
+        <string name="desc" value="[最高等级：20]\n消耗HP和MP，使全队武器攻击速度提高1到2个阶段，可与加速类技能叠加。需要急速拳20级。"/>
+        <string name="h1" value="消耗HP 78，消耗MP 78，武器攻击速度 +1 阶段，持续 110 秒"/>
+        <string name="h2" value="消耗HP 76，消耗MP 76，武器攻击速度 +1 阶段，持续 120 秒"/>
+        <string name="h3" value="消耗HP 74，消耗MP 74，武器攻击速度 +1 阶段，持续 130 秒"/>
+        <string name="h4" value="消耗HP 72，消耗MP 72，武器攻击速度 +1 阶段，持续 140 秒"/>
+        <string name="h5" value="消耗HP 70，消耗MP 70，武器攻击速度 +1 阶段，持续 150 秒"/>
+        <string name="h6" value="消耗HP 68，消耗MP 68，武器攻击速度 +1 阶段，持续 160 秒"/>
+        <string name="h7" value="消耗HP 66，消耗MP 66，武器攻击速度 +1 阶段，持续 170 秒"/>
+        <string name="h8" value="消耗HP 64，消耗MP 64，武器攻击速度 +1 阶段，持续 180 秒"/>
+        <string name="h9" value="消耗HP 62，消耗MP 62，武器攻击速度 +1 阶段，持续 190 秒"/>
+        <string name="h10" value="消耗HP 60，消耗MP 60，武器攻击速度 +1 阶段，持续 200 秒"/>
+        <string name="h11" value="消耗HP 58，消耗MP 58，武器攻击速度 +2 阶段，持续 210 秒"/>
+        <string name="h12" value="消耗HP 56，消耗MP 56，武器攻击速度 +2 阶段，持续 220 秒"/>
+        <string name="h13" value="消耗HP 54，消耗MP 54，武器攻击速度 +2 阶段，持续 230 秒"/>
+        <string name="h14" value="消耗HP 52，消耗MP 52，武器攻击速度 +2 阶段，持续 240 秒"/>
+        <string name="h15" value="消耗HP 50，消耗MP 50，武器攻击速度 +2 阶段，持续 250 秒"/>
+        <string name="h16" value="消耗HP 48，消耗MP 48，武器攻击速度 +2 阶段，持续 260 秒"/>
+        <string name="h17" value="消耗HP 46，消耗MP 46，武器攻击速度 +2 阶段，持续 270 秒"/>
+        <string name="h18" value="消耗HP 44，消耗MP 44，武器攻击速度 +2 阶段，持续 280 秒"/>
+        <string name="h19" value="消耗HP 42，消耗MP 42，武器攻击速度 +2 阶段，持续 290 秒"/>
+        <string name="h20" value="消耗HP 40，消耗MP 40，武器攻击速度 +2 阶段，持续 300 秒"/>
     </imgdir>
     <imgdir name="5121010">
         <string name="name" value="伺机待发"/>
-        <string name="h1" value="消耗MP 195，冷却时间 49分"/>
-        <string name="h10" value="消耗MP 150，冷却时间 40分"/>
-        <string name="h11" value="消耗MP 145，冷却时间 39分"/>
-        <string name="h12" value="消耗MP 140，冷却时间 38分"/>
-        <string name="h13" value="消耗MP 135，冷却时间 37分"/>
-        <string name="h14" value="消耗MP 130，冷却时间 36分"/>
-        <string name="h15" value="消耗MP 125，冷却时间 35分"/>
-        <string name="h16" value="消耗MP 120，冷却时间 34分"/>
-        <string name="h17" value="消耗MP 115，冷却时间 33分"/>
-        <string name="h18" value="消耗MP 110，冷却时间 32分"/>
-        <string name="h19" value="消耗MP 105，冷却时间 31分"/>
-        <string name="h2" value="消耗MP 190，冷却时间 48分"/>
-        <string name="h20" value="消耗MP 100，冷却时间 30分"/>
-        <string name="h21" value="消耗MP 95，冷却时间 29分"/>
-        <string name="h22" value="消耗MP 90，冷却时间 28分"/>
-        <string name="h23" value="消耗MP 85，冷却时间 27分"/>
-        <string name="h24" value="消耗MP 80，冷却时间 26分"/>
-        <string name="h26" value="消耗MP 70，冷却时间 24分"/>
-        <string name="h27" value="消耗MP 65，冷却时间 23分"/>
-        <string name="h28" value="消耗MP 60，冷却时间 22分"/>
-        <string name="h29" value="消耗MP 55，冷却时间 21分"/>
-        <string name="h3" value="消耗MP 185，冷却时间 47分"/>
-        <string name="h30" value="消耗MP 50，冷却时间 20分"/>
-        <string name="h4" value="消耗MP 180，冷却时间 46分"/>
-        <string name="h5" value="消耗MP 175，冷却时间 45分"/>
-        <string name="h6" value="消耗MP 170，冷却时间 44分"/>
-        <string name="h7" value="消耗MP 165，冷却时间 43分"/>
-        <string name="h8" value="消耗MP 160，冷却时间 42分"/>
-        <string name="h9" value="消耗MP 155，冷却时间 41分"/>
-        <string name="desc" value="初始化自己和团队使用的全部的技能和冷却\n时间。只是本技能的冷却时间不能初始化"/>
+        <string name="desc" value="[最高等级：30]\n重置自己和队伍成员的技能冷却时间，但不重置伺机待发本身。"/>
+        <string name="h1" value="消耗MP 195，冷却 49 分钟"/>
+        <string name="h2" value="消耗MP 190，冷却 48 分钟"/>
+        <string name="h3" value="消耗MP 185，冷却 47 分钟"/>
+        <string name="h4" value="消耗MP 180，冷却 46 分钟"/>
+        <string name="h5" value="消耗MP 175，冷却 45 分钟"/>
+        <string name="h6" value="消耗MP 170，冷却 44 分钟"/>
+        <string name="h7" value="消耗MP 165，冷却 43 分钟"/>
+        <string name="h8" value="消耗MP 160，冷却 42 分钟"/>
+        <string name="h9" value="消耗MP 155，冷却 41 分钟"/>
+        <string name="h10" value="消耗MP 150，冷却 40 分钟"/>
+        <string name="h11" value="消耗MP 145，冷却 39 分钟"/>
+        <string name="h12" value="消耗MP 140，冷却 38 分钟"/>
+        <string name="h13" value="消耗MP 135，冷却 37 分钟"/>
+        <string name="h14" value="消耗MP 130，冷却 36 分钟"/>
+        <string name="h15" value="消耗MP 125，冷却 35 分钟"/>
+        <string name="h16" value="消耗MP 120，冷却 34 分钟"/>
+        <string name="h17" value="消耗MP 115，冷却 33 分钟"/>
+        <string name="h18" value="消耗MP 110，冷却 32 分钟"/>
+        <string name="h19" value="消耗MP 105，冷却 31 分钟"/>
+        <string name="h20" value="消耗MP 100，冷却 30 分钟"/>
+        <string name="h21" value="消耗MP 95，冷却 29 分钟"/>
+        <string name="h22" value="消耗MP 90，冷却 28 分钟"/>
+        <string name="h23" value="消耗MP 85，冷却 27 分钟"/>
+        <string name="h24" value="消耗MP 80，冷却 26 分钟"/>
+        <string name="h25" value="消耗MP 75，冷却 25 分钟"/>
+        <string name="h26" value="消耗MP 70，冷却 24 分钟"/>
+        <string name="h27" value="消耗MP 65，冷却 23 分钟"/>
+        <string name="h28" value="消耗MP 60，冷却 22 分钟"/>
+        <string name="h29" value="消耗MP 55，冷却 21 分钟"/>
+        <string name="h30" value="消耗MP 50，冷却 20 分钟"/>
     </imgdir>
     <imgdir name="520">
         <string name="bookName" value="火枪手介绍书"/>
     </imgdir>
     <imgdir name="5200000">
         <string name="name" value="精准枪"/>
-        <string name="h1" value="提高枪系武器的熟练度15%，命中率 1 上升，枪弹数10 上升"/>
-        <string name="h10" value="提高枪系武器的熟练度35%，命中率 10 上升，枪弹数100 上升"/>
-        <string name="h11" value="提高枪系武器的熟练度40%，命中率 11 上升，枪弹数110 上升"/>
-        <string name="h12" value="提高枪系武器的熟练度40%，命中率 12 上升，枪弹数120 上升"/>
-        <string name="h13" value="提高枪系武器的熟练度45%，命中率 13 上升，枪弹数130 上升"/>
-        <string name="h14" value="提高枪系武器的熟练度45%，命中率 14 上升，枪弹数140 上升"/>
-        <string name="h15" value="提高枪系武器的熟练度50%，命中率 15 上升，枪弹数150 上升"/>
-        <string name="h16" value="提高枪系武器的熟练度50%，命中率 16 上升，枪弹数160 上升"/>
-        <string name="h17" value="提高枪系武器的熟练度55%，命中率 17 上升，枪弹数170 上升"/>
-        <string name="h18" value="提高枪系武器的熟练度55%，命中率 18 上升，枪弹数180 上升"/>
-        <string name="h19" value="提高枪系武器的熟练度60%，命中率 19 上升，枪弹数190 上升"/>
-        <string name="h2" value="提高枪系武器的熟练度15%，命中率 2 上升，枪弹数20 上升"/>
-        <string name="h20" value="提高枪系武器的熟练度60%，命中率 20 上升，枪弹数200 上升"/>
-        <string name="h3" value="提高枪系武器的熟练度20%，命中率 3 上升，枪弹数30 上升"/>
-        <string name="h4" value="提高枪系武器的熟练度20%，命中率 4 上升，枪弹数40 上升"/>
-        <string name="h5" value="提高枪系武器的熟练度25%，命中率 5 上升，枪弹数50 上升"/>
-        <string name="h6" value="提高枪系武器的熟练度25%，命中率 6 上升，枪弹数60 上升"/>
-        <string name="h7" value="提高枪系武器的熟练度30%，命中率 7 上升，枪弹数70 上升"/>
-        <string name="h8" value="提高枪系武器的熟练度30%，命中率 8 上升，枪弹数80 上升"/>
-        <string name="h9" value="提高枪系武器的熟练度35%，命中率 9 上升，枪弹数90 上升"/>
-        <string name="desc" value="[最高等级 : 20]\n提升枪系武器的熟练度和命中率。\n只适用于有装备枪的时候"/>
+        <string name="desc" value="[最高等级：20]\n装备手枪时，提高手枪熟练度、命中率和子弹容量。"/>
+        <string name="h1" value="手枪熟练度 +15%，命中率 +1，子弹容量 +10"/>
+        <string name="h2" value="手枪熟练度 +15%，命中率 +2，子弹容量 +20"/>
+        <string name="h3" value="手枪熟练度 +20%，命中率 +3，子弹容量 +30"/>
+        <string name="h4" value="手枪熟练度 +20%，命中率 +4，子弹容量 +40"/>
+        <string name="h5" value="手枪熟练度 +25%，命中率 +5，子弹容量 +50"/>
+        <string name="h6" value="手枪熟练度 +25%，命中率 +6，子弹容量 +60"/>
+        <string name="h7" value="手枪熟练度 +30%，命中率 +7，子弹容量 +70"/>
+        <string name="h8" value="手枪熟练度 +30%，命中率 +8，子弹容量 +80"/>
+        <string name="h9" value="手枪熟练度 +35%，命中率 +9，子弹容量 +90"/>
+        <string name="h10" value="手枪熟练度 +35%，命中率 +10，子弹容量 +100"/>
+        <string name="h11" value="手枪熟练度 +40%，命中率 +11，子弹容量 +110"/>
+        <string name="h12" value="手枪熟练度 +40%，命中率 +12，子弹容量 +120"/>
+        <string name="h13" value="手枪熟练度 +45%，命中率 +13，子弹容量 +130"/>
+        <string name="h14" value="手枪熟练度 +45%，命中率 +14，子弹容量 +140"/>
+        <string name="h15" value="手枪熟练度 +50%，命中率 +15，子弹容量 +150"/>
+        <string name="h16" value="手枪熟练度 +50%，命中率 +16，子弹容量 +160"/>
+        <string name="h17" value="手枪熟练度 +55%，命中率 +17，子弹容量 +170"/>
+        <string name="h18" value="手枪熟练度 +55%，命中率 +18，子弹容量 +180"/>
+        <string name="h19" value="手枪熟练度 +60%，命中率 +19，子弹容量 +190"/>
+        <string name="h20" value="手枪熟练度 +60%，命中率 +20，子弹容量 +200"/>
     </imgdir>
     <imgdir name="5201001">
         <string name="name" value="快枪手"/>
-        <string name="h1" value="消耗MP 10，伤害 125%，最多攻击 3只"/>
-        <string name="h10" value="消耗MP 15，伤害 170%，最多攻击 3只"/>
-        <string name="h11" value="消耗MP 20，伤害 175%，最多攻击 3只"/>
-        <string name="h12" value="消耗MP 20，伤害 180%，最多攻击 3只"/>
-        <string name="h13" value="消耗MP 20，伤害 185%，最多攻击 3只"/>
-        <string name="h14" value="消耗MP 20，伤害 190%，最多攻击 3只"/>
-        <string name="h15" value="消耗MP 20，伤害 195%，最多攻击 3只"/>
-        <string name="h16" value="消耗MP 25，伤害 200%，最多攻击 3只"/>
-        <string name="h17" value="消耗MP 25，伤害 205%，最多攻击 3只"/>
-        <string name="h18" value="消耗MP 25，伤害 210%，最多攻击 3只"/>
-        <string name="h19" value="消耗MP 25，伤害 215%，最多攻击 3只"/>
-        <string name="h2" value="消耗MP 10，伤害 130%，最多攻击 3只"/>
-        <string name="h20" value="消耗MP 25，伤害 220%，最多攻击 3只"/>
-        <string name="h3" value="消耗MP 10，伤害 135%，最多攻击 3只"/>
-        <string name="h4" value="消耗MP 10，伤害 140%，最多攻击 3只"/>
-        <string name="h5" value="消耗MP 10，伤害 145%，最多攻击 3只"/>
-        <string name="h6" value="消耗MP 15，伤害 150%，最多攻击 3只"/>
-        <string name="h7" value="消耗MP 15，伤害 155%，最多攻击 3只"/>
-        <string name="h8" value="消耗MP 15，伤害 160%，最多攻击 3只"/>
-        <string name="h9" value="消耗MP 15，伤害 165%，最多攻击 3只"/>
-        <string name="desc" value="[最高等级 : 20]\n极短的时间内开枪，攻击多数敌人"/>
+        <string name="desc" value="[最高等级：20]\n快速射击攻击多个敌人。"/>
+        <string name="h1" value="消耗MP 10，伤害 75%，最多攻击 3 个敌人"/>
+        <string name="h2" value="消耗MP 10，伤害 80%，最多攻击 3 个敌人"/>
+        <string name="h3" value="消耗MP 10，伤害 85%，最多攻击 3 个敌人"/>
+        <string name="h4" value="消耗MP 10，伤害 90%，最多攻击 3 个敌人"/>
+        <string name="h5" value="消耗MP 10，伤害 95%，最多攻击 3 个敌人"/>
+        <string name="h6" value="消耗MP 15，伤害 100%，最多攻击 3 个敌人"/>
+        <string name="h7" value="消耗MP 15，伤害 105%，最多攻击 3 个敌人"/>
+        <string name="h8" value="消耗MP 15，伤害 110%，最多攻击 3 个敌人"/>
+        <string name="h9" value="消耗MP 15，伤害 115%，最多攻击 3 个敌人"/>
+        <string name="h10" value="消耗MP 15，伤害 120%，最多攻击 3 个敌人"/>
+        <string name="h11" value="消耗MP 20，伤害 125%，最多攻击 3 个敌人"/>
+        <string name="h12" value="消耗MP 20，伤害 130%，最多攻击 3 个敌人"/>
+        <string name="h13" value="消耗MP 20，伤害 135%，最多攻击 3 个敌人"/>
+        <string name="h14" value="消耗MP 20，伤害 140%，最多攻击 3 个敌人"/>
+        <string name="h15" value="消耗MP 20，伤害 145%，最多攻击 3 个敌人"/>
+        <string name="h16" value="消耗MP 25，伤害 150%，最多攻击 3 个敌人"/>
+        <string name="h17" value="消耗MP 25，伤害 155%，最多攻击 3 个敌人"/>
+        <string name="h18" value="消耗MP 25，伤害 160%，最多攻击 3 个敌人"/>
+        <string name="h19" value="消耗MP 25，伤害 165%，最多攻击 3 个敌人"/>
+        <string name="h20" value="消耗MP 25，伤害 170%，最多攻击 3 个敌人"/>
     </imgdir>
     <imgdir name="5201002">
         <string name="name" value="投弹攻击"/>
-        <string name="h1" value="消耗MP 15，伤害 45%，攻击3只"/>
-        <string name="h10" value="消耗MP 19，伤害 90%，攻击4只"/>
-        <string name="h11" value="消耗MP 23，伤害 95%，攻击5只"/>
-        <string name="h12" value="消耗MP 23，伤害 100%，攻击5只"/>
-        <string name="h13" value="消耗MP 23，伤害 105%，攻击5只"/>
-        <string name="h14" value="消耗MP 23，伤害 110%，攻击5只"/>
-        <string name="h15" value="消耗MP 23，伤害 115%，攻击5只"/>
-        <string name="h16" value="消耗MP 27，伤害 120%，攻击6只"/>
-        <string name="h17" value="消耗MP 27，伤害 125%，攻击6只"/>
-        <string name="h18" value="消耗MP 27，伤害 130%，攻击6只"/>
-        <string name="h19" value="消耗MP 27，伤害 135%，攻击6只"/>
-        <string name="h2" value="消耗MP 15，伤害 50%，攻击3只"/>
-        <string name="h20" value="消耗MP 27，伤害 140%，攻击6只"/>
-        <string name="h3" value="消耗MP 15，伤害 55%，攻击3只"/>
-        <string name="h4" value="消耗MP 15，伤害 60%，攻击3只"/>
-        <string name="h5" value="消耗MP 15，伤害 65%，攻击3只"/>
-        <string name="h6" value="消耗MP 19，伤害 70%，攻击4只"/>
-        <string name="h7" value="消耗MP 19，伤害 75%，攻击4只"/>
-        <string name="h8" value="消耗MP 19，伤害 80%，攻击4只"/>
-        <string name="h9" value="消耗MP 19，伤害 85%，攻击4只"/>
-        <string name="desc" value="[最高等级 : 20]\n扔炸弹攻击敌人，根据按键时间决定射程"/>
+        <string name="desc" value="[最高等级：20]\n投掷炸弹攻击敌人，按键时间影响投掷距离。"/>
+        <string name="h1" value="消耗MP 15，伤害 45%，最多攻击 3 个敌人"/>
+        <string name="h2" value="消耗MP 15，伤害 50%，最多攻击 3 个敌人"/>
+        <string name="h3" value="消耗MP 15，伤害 55%，最多攻击 3 个敌人"/>
+        <string name="h4" value="消耗MP 15，伤害 60%，最多攻击 3 个敌人"/>
+        <string name="h5" value="消耗MP 15，伤害 65%，最多攻击 3 个敌人"/>
+        <string name="h6" value="消耗MP 19，伤害 70%，最多攻击 4 个敌人"/>
+        <string name="h7" value="消耗MP 19，伤害 75%，最多攻击 4 个敌人"/>
+        <string name="h8" value="消耗MP 19，伤害 80%，最多攻击 4 个敌人"/>
+        <string name="h9" value="消耗MP 19，伤害 85%，最多攻击 4 个敌人"/>
+        <string name="h10" value="消耗MP 19，伤害 90%，最多攻击 4 个敌人"/>
+        <string name="h11" value="消耗MP 23，伤害 95%，最多攻击 5 个敌人"/>
+        <string name="h12" value="消耗MP 23，伤害 100%，最多攻击 5 个敌人"/>
+        <string name="h13" value="消耗MP 23，伤害 105%，最多攻击 5 个敌人"/>
+        <string name="h14" value="消耗MP 23，伤害 110%，最多攻击 5 个敌人"/>
+        <string name="h15" value="消耗MP 23，伤害 115%，最多攻击 5 个敌人"/>
+        <string name="h16" value="消耗MP 27，伤害 120%，最多攻击 6 个敌人"/>
+        <string name="h17" value="消耗MP 27，伤害 125%，最多攻击 6 个敌人"/>
+        <string name="h18" value="消耗MP 27，伤害 130%，最多攻击 6 个敌人"/>
+        <string name="h19" value="消耗MP 27，伤害 135%，最多攻击 6 个敌人"/>
+        <string name="h20" value="消耗MP 27，伤害 140%，最多攻击 6 个敌人"/>
     </imgdir>
     <imgdir name="5201003">
         <string name="name" value="速射"/>
-        <string name="h1" value="消耗HP 29，MP 29  10秒内的攻击速度提升"/>
-        <string name="h10" value="消耗HP 20，MP 20  100秒内的攻击速度提升"/>
-        <string name="h11" value="消耗HP 19，MP 19  110秒内的攻击速度提升"/>
-        <string name="h12" value="消耗HP 18，MP 18  120秒内的攻击速度提升"/>
-        <string name="h13" value="消耗HP 17，MP 17  130秒内的攻击速度提升"/>
-        <string name="h14" value="消耗HP 16，MP 16  140秒内的攻击速度提升"/>
-        <string name="h15" value="消耗HP 15，MP 15  150秒内的攻击速度提升"/>
-        <string name="h16" value="消耗HP 14，MP 14  160秒内的攻击速度提升"/>
-        <string name="h17" value="消耗HP 13，MP 13  170秒内的攻击速度提升"/>
-        <string name="h18" value="消耗HP 12，MP 12  180秒内的攻击速度提升"/>
-        <string name="h19" value="消耗HP 11，MP 11  190秒内的攻击速度提升"/>
-        <string name="h2" value="消耗HP 28，MP 28  20秒内的攻击速度提升"/>
-        <string name="h20" value="消耗HP 10，MP 10  200秒内的攻击速度提升"/>
-        <string name="h3" value="消耗HP 27，MP 27  30秒内的攻击速度提升"/>
-        <string name="h4" value="消耗HP 26，MP 26  40秒内的攻击速度提升"/>
-        <string name="h5" value="消耗HP 25，MP 25  50秒内的攻击速度提升"/>
-        <string name="h6" value="消耗HP 24，MP 24  60秒内的攻击速度提升"/>
-        <string name="h7" value="消耗HP 23，MP 23  70秒内的攻击速度提升"/>
-        <string name="h8" value="消耗HP 22，MP 22  80秒内的攻击速度提升"/>
-        <string name="h9" value="消耗HP 21，MP 21  90秒内的攻击速度提升"/>
-        <string name="desc" value="[最高等级 : 20]\n消耗HP,MP，在一定时间内提升枪的攻击速度。\n只适用于装备枪的时候。\n必要技能 : #c精准枪5级以上#"/>
+        <string name="desc" value="[最高等级：20]\n消耗HP和MP，使手枪攻击速度提高2个阶段。需要精准枪5级以上。"/>
+        <string name="h1" value="消耗HP 29，消耗MP 29，攻击速度 +2 阶段，持续 10 秒"/>
+        <string name="h2" value="消耗HP 28，消耗MP 28，攻击速度 +2 阶段，持续 20 秒"/>
+        <string name="h3" value="消耗HP 27，消耗MP 27，攻击速度 +2 阶段，持续 30 秒"/>
+        <string name="h4" value="消耗HP 26，消耗MP 26，攻击速度 +2 阶段，持续 40 秒"/>
+        <string name="h5" value="消耗HP 25，消耗MP 25，攻击速度 +2 阶段，持续 50 秒"/>
+        <string name="h6" value="消耗HP 24，消耗MP 24，攻击速度 +2 阶段，持续 60 秒"/>
+        <string name="h7" value="消耗HP 23，消耗MP 23，攻击速度 +2 阶段，持续 70 秒"/>
+        <string name="h8" value="消耗HP 22，消耗MP 22，攻击速度 +2 阶段，持续 80 秒"/>
+        <string name="h9" value="消耗HP 21，消耗MP 21，攻击速度 +2 阶段，持续 90 秒"/>
+        <string name="h10" value="消耗HP 20，消耗MP 20，攻击速度 +2 阶段，持续 100 秒"/>
+        <string name="h11" value="消耗HP 19，消耗MP 19，攻击速度 +2 阶段，持续 110 秒"/>
+        <string name="h12" value="消耗HP 18，消耗MP 18，攻击速度 +2 阶段，持续 120 秒"/>
+        <string name="h13" value="消耗HP 17，消耗MP 17，攻击速度 +2 阶段，持续 130 秒"/>
+        <string name="h14" value="消耗HP 16，消耗MP 16，攻击速度 +2 阶段，持续 140 秒"/>
+        <string name="h15" value="消耗HP 15，消耗MP 15，攻击速度 +2 阶段，持续 150 秒"/>
+        <string name="h16" value="消耗HP 14，消耗MP 14，攻击速度 +2 阶段，持续 160 秒"/>
+        <string name="h17" value="消耗HP 13，消耗MP 13，攻击速度 +2 阶段，持续 170 秒"/>
+        <string name="h18" value="消耗HP 12，消耗MP 12，攻击速度 +2 阶段，持续 180 秒"/>
+        <string name="h19" value="消耗HP 11，消耗MP 11，攻击速度 +2 阶段，持续 190 秒"/>
+        <string name="h20" value="消耗HP 10，消耗MP 10，攻击速度 +2 阶段，持续 200 秒"/>
     </imgdir>
     <imgdir name="5201004">
         <string name="name" value="迷惑射击"/>
-        <string name="h1" value="消耗MP 10，伤害 63%，43%的几率眩晕1秒"/>
-        <string name="h10" value="消耗MP 15，伤害 90%，70%的几率眩晕2秒"/>
-        <string name="h11" value="消耗MP 20，伤害 93%，73%的几率眩晕3秒"/>
-        <string name="h12" value="消耗MP 20，伤害 96%，76%的几率眩晕3秒"/>
-        <string name="h13" value="消耗MP 20，伤害 99%，79%的几率眩晕3秒"/>
-        <string name="h14" value="消耗MP 20，伤害 102%，82%的几率眩晕3秒"/>
-        <string name="h15" value="消耗MP 20，伤害 105%，85%的几率眩晕3秒"/>
-        <string name="h16" value="消耗MP 25，伤害 108%，88%的几率眩晕4秒"/>
-        <string name="h17" value="消耗MP 25，伤害 111%，91%的几率眩晕4秒"/>
-        <string name="h18" value="消耗MP 25，伤害 114%，94%的几率眩晕4秒"/>
-        <string name="h19" value="消耗MP 25，伤害 117%，97%的几率眩晕4秒"/>
-        <string name="h2" value="消耗MP 10，伤害 66%，46%的几率眩晕1秒"/>
-        <string name="h20" value="消耗MP 25，伤害 120%，100%的几率眩晕4秒"/>
-        <string name="h3" value="消耗MP 10，伤害 69%，49%的几率眩晕1秒"/>
-        <string name="h4" value="消耗MP 10，伤害 72%，52%的几率眩晕1秒"/>
-        <string name="h5" value="消耗MP 10，伤害 75%，55%的几率眩晕1秒"/>
-        <string name="h6" value="消耗MP 15，伤害 78%，58%的几率眩晕2秒"/>
-        <string name="h7" value="消耗MP 15，伤害 81%，61%的几率眩晕2秒"/>
-        <string name="h8" value="消耗MP 15，伤害 84%，64%的几率眩晕2秒"/>
-        <string name="h9" value="消耗MP 15，伤害 87%，67%的几率眩晕2秒"/>
-        <string name="desc" value="[最高等级 : 20]\n假装射击的同时发射迷惑旗，使多数怪物\n们惊慌。同时能攻击3只以下的怪物"/>
+        <string name="desc" value="[最高等级：20]\n发射迷惑射击，攻击并眩晕最多3个敌人。"/>
+        <string name="h1" value="消耗MP 10，伤害 63%，最多攻击 3 个敌人，43% 概率眩晕 1 秒"/>
+        <string name="h2" value="消耗MP 10，伤害 66%，最多攻击 3 个敌人，46% 概率眩晕 1 秒"/>
+        <string name="h3" value="消耗MP 10，伤害 69%，最多攻击 3 个敌人，49% 概率眩晕 1 秒"/>
+        <string name="h4" value="消耗MP 10，伤害 72%，最多攻击 3 个敌人，52% 概率眩晕 1 秒"/>
+        <string name="h5" value="消耗MP 10，伤害 75%，最多攻击 3 个敌人，55% 概率眩晕 1 秒"/>
+        <string name="h6" value="消耗MP 15，伤害 78%，最多攻击 3 个敌人，58% 概率眩晕 2 秒"/>
+        <string name="h7" value="消耗MP 15，伤害 81%，最多攻击 3 个敌人，61% 概率眩晕 2 秒"/>
+        <string name="h8" value="消耗MP 15，伤害 84%，最多攻击 3 个敌人，64% 概率眩晕 2 秒"/>
+        <string name="h9" value="消耗MP 15，伤害 87%，最多攻击 3 个敌人，67% 概率眩晕 2 秒"/>
+        <string name="h10" value="消耗MP 15，伤害 90%，最多攻击 3 个敌人，70% 概率眩晕 2 秒"/>
+        <string name="h11" value="消耗MP 20，伤害 93%，最多攻击 3 个敌人，73% 概率眩晕 3 秒"/>
+        <string name="h12" value="消耗MP 20，伤害 96%，最多攻击 3 个敌人，76% 概率眩晕 3 秒"/>
+        <string name="h13" value="消耗MP 20，伤害 99%，最多攻击 3 个敌人，79% 概率眩晕 3 秒"/>
+        <string name="h14" value="消耗MP 20，伤害 102%，最多攻击 3 个敌人，82% 概率眩晕 3 秒"/>
+        <string name="h15" value="消耗MP 20，伤害 105%，最多攻击 3 个敌人，85% 概率眩晕 3 秒"/>
+        <string name="h16" value="消耗MP 25，伤害 108%，最多攻击 3 个敌人，88% 概率眩晕 4 秒"/>
+        <string name="h17" value="消耗MP 25，伤害 111%，最多攻击 3 个敌人，91% 概率眩晕 4 秒"/>
+        <string name="h18" value="消耗MP 25，伤害 114%，最多攻击 3 个敌人，94% 概率眩晕 4 秒"/>
+        <string name="h19" value="消耗MP 25，伤害 117%，最多攻击 3 个敌人，97% 概率眩晕 4 秒"/>
+        <string name="h20" value="消耗MP 25，伤害 120%，最多攻击 3 个敌人，100% 概率眩晕 4 秒"/>
     </imgdir>
     <imgdir name="5201005">
         <string name="name" value="轻羽鞋"/>
-        <string name="h1" value="消耗MP 50，降落速度 280"/>
-        <string name="h10" value="消耗MP 14，降落速度 100"/>
-        <string name="h2" value="消耗MP 46，降落速度 260"/>
-        <string name="h3" value="消耗MP 42，降落速度 240"/>
-        <string name="h4" value="消耗MP 38，降落速度 220"/>
-        <string name="h5" value="消耗MP 34，降落速度 200"/>
-        <string name="h6" value="消耗MP 30，降落速度 180"/>
-        <string name="h7" value="消耗MP 26，降落速度 160"/>
-        <string name="h8" value="消耗MP 22，降落速度 140"/>
-        <string name="h9" value="消耗MP 18，降落速度 120"/>
-        <string name="desc" value="[最高等级 : 10]\n比目前的跳跃滞空时间更久的跳跃"/>
+        <string name="desc" value="[最高等级：10]\n消耗MP，使跳跃后的滞空时间更长。"/>
+        <string name="h1" value="消耗MP 50，滞空控制 5 秒，下落速度 280"/>
+        <string name="h2" value="消耗MP 46，滞空控制 5 秒，下落速度 260"/>
+        <string name="h3" value="消耗MP 42，滞空控制 5 秒，下落速度 240"/>
+        <string name="h4" value="消耗MP 38，滞空控制 5 秒，下落速度 220"/>
+        <string name="h5" value="消耗MP 34，滞空控制 5 秒，下落速度 200"/>
+        <string name="h6" value="消耗MP 30，滞空控制 5 秒，下落速度 180"/>
+        <string name="h7" value="消耗MP 26，滞空控制 5 秒，下落速度 160"/>
+        <string name="h8" value="消耗MP 22，滞空控制 5 秒，下落速度 140"/>
+        <string name="h9" value="消耗MP 18，滞空控制 5 秒，下落速度 120"/>
+        <string name="h10" value="消耗MP 14，滞空控制 5 秒，下落速度 100"/>
     </imgdir>
     <imgdir name="5201006">
         <string name="name" value="激退射杀"/>
-        <string name="h1" value="消耗MP 14，伤害 70%"/>
-        <string name="h10" value="消耗MP 18，伤害 160%"/>
-        <string name="h11" value="消耗MP 22，伤害 170%"/>
-        <string name="h12" value="消耗MP 22，伤害 180%"/>
-        <string name="h13" value="消耗MP 22，伤害 190%"/>
-        <string name="h14" value="消耗MP 22，伤害 200%"/>
-        <string name="h15" value="消耗MP 22，伤害 210%"/>
-        <string name="h16" value="消耗MP 26，伤害 220%"/>
-        <string name="h17" value="消耗MP 26，伤害 230%"/>
-        <string name="h18" value="消耗MP 26，伤害 240%"/>
-        <string name="h19" value="消耗MP 26，伤害 250%"/>
-        <string name="h2" value="消耗MP 14，伤害 80%"/>
-        <string name="h20" value="消耗MP 26，伤害 260%"/>
-        <string name="h3" value="消耗MP 14，伤害 90%"/>
-        <string name="h4" value="消耗MP 14，伤害 100%"/>
-        <string name="h5" value="消耗MP 14，伤害 110%"/>
-        <string name="h6" value="消耗MP 18，伤害 120%"/>
-        <string name="h7" value="消耗MP 18，伤害 130%"/>
-        <string name="h8" value="消耗MP 18，伤害 140%"/>
-        <string name="h9" value="消耗MP 18，伤害 150%"/>
-        <string name="desc" value="[最高等级 : 20]\n利用枪的后座力，\n一边射击，一边向后方移动。\n必要技能 : #c轻羽鞋5级以上#"/>
+        <string name="desc" value="[最高等级：20]\n利用手枪后坐力一边射击一边后退。需要轻羽鞋5级以上。"/>
+        <string name="h1" value="消耗MP 14，伤害 70%，后退距离 115"/>
+        <string name="h2" value="消耗MP 14，伤害 80%，后退距离 115"/>
+        <string name="h3" value="消耗MP 14，伤害 90%，后退距离 130"/>
+        <string name="h4" value="消耗MP 14，伤害 100%，后退距离 130"/>
+        <string name="h5" value="消耗MP 14，伤害 110%，后退距离 145"/>
+        <string name="h6" value="消耗MP 18，伤害 120%，后退距离 145"/>
+        <string name="h7" value="消耗MP 18，伤害 130%，后退距离 160"/>
+        <string name="h8" value="消耗MP 18，伤害 140%，后退距离 160"/>
+        <string name="h9" value="消耗MP 18，伤害 150%，后退距离 175"/>
+        <string name="h10" value="消耗MP 18，伤害 160%，后退距离 175"/>
+        <string name="h11" value="消耗MP 22，伤害 170%，后退距离 190"/>
+        <string name="h12" value="消耗MP 22，伤害 180%，后退距离 190"/>
+        <string name="h13" value="消耗MP 22，伤害 190%，后退距离 205"/>
+        <string name="h14" value="消耗MP 22，伤害 200%，后退距离 205"/>
+        <string name="h15" value="消耗MP 22，伤害 210%，后退距离 220"/>
+        <string name="h16" value="消耗MP 26，伤害 220%，后退距离 220"/>
+        <string name="h17" value="消耗MP 26，伤害 230%，后退距离 235"/>
+        <string name="h18" value="消耗MP 26，伤害 240%，后退距离 235"/>
+        <string name="h19" value="消耗MP 26，伤害 250%，后退距离 250"/>
+        <string name="h20" value="消耗MP 26，伤害 260%，后退距离 250"/>
     </imgdir>
     <imgdir name="521">
         <string name="bookName" value="大副之路"/>
     </imgdir>
     <imgdir name="5210000">
         <string name="name" value="三连射杀"/>
-        <string name="h1" value="消耗MP 13，伤害 135%"/>
-        <string name="h10" value="消耗MP 17，伤害 180%"/>
-        <string name="h11" value="消耗MP 18，伤害 185%"/>
-        <string name="h12" value="消耗MP 18，伤害 190%"/>
-        <string name="h13" value="消耗MP 19，伤害 195%"/>
-        <string name="h14" value="消耗MP 19，伤害 200%"/>
-        <string name="h15" value="消耗MP 20，伤害 205%"/>
-        <string name="h16" value="消耗MP 20，伤害 210%"/>
-        <string name="h17" value="消耗MP 21，伤害 215%"/>
-        <string name="h18" value="消耗MP 21，伤害 220%"/>
-        <string name="h19" value="消耗MP 22，伤害 225%"/>
-        <string name="h2" value="消耗MP 13，伤害 140%"/>
-        <string name="h20" value="消耗MP 22，伤害 230%"/>
-        <string name="h3" value="消耗MP 14，伤害 145%"/>
-        <string name="h4" value="消耗MP 14，伤害 150%"/>
-        <string name="h5" value="消耗MP 15，伤害 155%"/>
-        <string name="h6" value="消耗MP 15，伤害 160%"/>
-        <string name="h7" value="消耗MP 16，伤害 165%"/>
-        <string name="h8" value="消耗MP 16，伤害 170%"/>
-        <string name="h9" value="消耗MP 17，伤害 175%"/>
-        <string name="desc" value="[最高等级 : 20]\n双弹射杀使用时的弹数和攻击力增加。\n必要技能 : #c双弹射击 20等级#   "/>
+        <string name="desc" value="[最高等级：20]\n将双弹射击强化为3连射。需要双弹射击20级。"/>
+        <string name="h1" value="消耗MP 13，每发伤害 115%，发射 3 发"/>
+        <string name="h2" value="消耗MP 13，每发伤害 120%，发射 3 发"/>
+        <string name="h3" value="消耗MP 14，每发伤害 125%，发射 3 发"/>
+        <string name="h4" value="消耗MP 14，每发伤害 130%，发射 3 发"/>
+        <string name="h5" value="消耗MP 15，每发伤害 135%，发射 3 发"/>
+        <string name="h6" value="消耗MP 15，每发伤害 140%，发射 3 发"/>
+        <string name="h7" value="消耗MP 16，每发伤害 145%，发射 3 发"/>
+        <string name="h8" value="消耗MP 16，每发伤害 150%，发射 3 发"/>
+        <string name="h9" value="消耗MP 17，每发伤害 155%，发射 3 发"/>
+        <string name="h10" value="消耗MP 17，每发伤害 160%，发射 3 发"/>
+        <string name="h11" value="消耗MP 18，每发伤害 165%，发射 3 发"/>
+        <string name="h12" value="消耗MP 18，每发伤害 170%，发射 3 发"/>
+        <string name="h13" value="消耗MP 19，每发伤害 175%，发射 3 发"/>
+        <string name="h14" value="消耗MP 19，每发伤害 180%，发射 3 发"/>
+        <string name="h15" value="消耗MP 20，每发伤害 185%，发射 3 发"/>
+        <string name="h16" value="消耗MP 20，每发伤害 190%，发射 3 发"/>
+        <string name="h17" value="消耗MP 21，每发伤害 195%，发射 3 发"/>
+        <string name="h18" value="消耗MP 21，每发伤害 200%，发射 3 发"/>
+        <string name="h19" value="消耗MP 22，每发伤害 205%，发射 3 发"/>
+        <string name="h20" value="消耗MP 22，每发伤害 210%，发射 3 发"/>
     </imgdir>
     <imgdir name="5211001">
         <string name="name" value="章鱼炮台"/>
-        <string name="h1" value="消耗MP 11，攻击力 84，持续时间 10秒"/>
-        <string name="h10" value="消耗MP 15，攻击力 120，持续时间 10秒"/>
-        <string name="h11" value="消耗MP 16，攻击力 124，持续时间 20秒"/>
-        <string name="h12" value="消耗MP 16，攻击力 128，持续时间 20秒"/>
-        <string name="h13" value="消耗MP 17，攻击力 132，持续时间 20秒"/>
-        <string name="h14" value="消耗MP 17，攻击力 136，持续时间 20秒"/>
-        <string name="h15" value="消耗MP 18，攻击力 140，持续时间 20秒"/>
-        <string name="h16" value="消耗MP 18，攻击力 144，持续时间 20秒"/>
-        <string name="h17" value="消耗MP 19，攻击力 148，持续时间 20秒"/>
-        <string name="h18" value="消耗MP 19，攻击力 152，持续时间 20秒"/>
-        <string name="h19" value="消耗MP 20，攻击力 156，持续时间 20秒"/>
-        <string name="h2" value="消耗MP 11，攻击力 88，持续时间 10秒"/>
-        <string name="h20" value="消耗MP 20，攻击力 160，持续时间 20秒"/>
-        <string name="h21" value="消耗MP 21，攻击力 164，持续时间 30秒"/>
-        <string name="h22" value="消耗MP 21，攻击力 168，持续时间 30秒"/>
-        <string name="h23" value="消耗MP 22，攻击力 172，持续时间 30秒"/>
-        <string name="h24" value="消耗MP 22，攻击力 176，持续时间 30秒"/>
-        <string name="h25" value="消耗MP 23，攻击力 180，持续时间 30秒"/>
-        <string name="h26" value="消耗MP 23，攻击力 184，持续时间 30秒"/>
-        <string name="h27" value="消耗MP 24，攻击力 188，持续时间 30秒"/>
-        <string name="h28" value="消耗MP 24，攻击力 192，持续时间 30秒"/>
-        <string name="h29" value="消耗MP 25，攻击力 196，持续时间 30秒"/>
-        <string name="h3" value="消耗MP 12，攻击力 92，持续时间 10秒"/>
-        <string name="h30" value="消耗MP 25，攻击力 200，持续时间 30秒"/>
-        <string name="h4" value="消耗MP 12，攻击力 96，持续时间 10秒"/>
-        <string name="h5" value="消耗MP 13，攻击力 100，持续时间 10秒"/>
-        <string name="h6" value="消耗MP 13，攻击力 104，持续时间 10秒"/>
-        <string name="h7" value="消耗MP 14，攻击力 108，持续时间 10秒"/>
-        <string name="h8" value="消耗MP 14，攻击力 112，持续时间 10秒"/>
-        <string name="h9" value="消耗MP 15，攻击力 116，持续时间 10秒"/>
-        <string name="desc" value="[最高等级 : 30]\n召唤帮助攻击的章鱼。但召唤的章鱼不会动。\n#c冷却时间 : 10秒#"/>
+        <string name="desc" value="[最高等级：30]\n召唤固定位置的章鱼炮台攻击敌人，有冷却时间。"/>
+        <string name="h1" value="消耗MP 11，召唤攻击力 84，持续 10 秒，冷却 10 秒"/>
+        <string name="h2" value="消耗MP 11，召唤攻击力 88，持续 10 秒，冷却 10 秒"/>
+        <string name="h3" value="消耗MP 12，召唤攻击力 92，持续 10 秒，冷却 10 秒"/>
+        <string name="h4" value="消耗MP 12，召唤攻击力 96，持续 10 秒，冷却 10 秒"/>
+        <string name="h5" value="消耗MP 13，召唤攻击力 100，持续 10 秒，冷却 10 秒"/>
+        <string name="h6" value="消耗MP 13，召唤攻击力 104，持续 10 秒，冷却 10 秒"/>
+        <string name="h7" value="消耗MP 14，召唤攻击力 108，持续 10 秒，冷却 10 秒"/>
+        <string name="h8" value="消耗MP 14，召唤攻击力 112，持续 10 秒，冷却 10 秒"/>
+        <string name="h9" value="消耗MP 15，召唤攻击力 116，持续 10 秒，冷却 10 秒"/>
+        <string name="h10" value="消耗MP 15，召唤攻击力 120，持续 10 秒，冷却 10 秒"/>
+        <string name="h11" value="消耗MP 16，召唤攻击力 124，持续 20 秒，冷却 10 秒"/>
+        <string name="h12" value="消耗MP 16，召唤攻击力 128，持续 20 秒，冷却 10 秒"/>
+        <string name="h13" value="消耗MP 17，召唤攻击力 132，持续 20 秒，冷却 10 秒"/>
+        <string name="h14" value="消耗MP 17，召唤攻击力 136，持续 20 秒，冷却 10 秒"/>
+        <string name="h15" value="消耗MP 18，召唤攻击力 140，持续 20 秒，冷却 10 秒"/>
+        <string name="h16" value="消耗MP 18，召唤攻击力 144，持续 20 秒，冷却 10 秒"/>
+        <string name="h17" value="消耗MP 19，召唤攻击力 148，持续 20 秒，冷却 10 秒"/>
+        <string name="h18" value="消耗MP 19，召唤攻击力 152，持续 20 秒，冷却 10 秒"/>
+        <string name="h19" value="消耗MP 20，召唤攻击力 156，持续 20 秒，冷却 10 秒"/>
+        <string name="h20" value="消耗MP 20，召唤攻击力 160，持续 20 秒，冷却 10 秒"/>
+        <string name="h21" value="消耗MP 21，召唤攻击力 164，持续 30 秒，冷却 10 秒"/>
+        <string name="h22" value="消耗MP 21，召唤攻击力 168，持续 30 秒，冷却 10 秒"/>
+        <string name="h23" value="消耗MP 22，召唤攻击力 172，持续 30 秒，冷却 10 秒"/>
+        <string name="h24" value="消耗MP 22，召唤攻击力 176，持续 30 秒，冷却 10 秒"/>
+        <string name="h25" value="消耗MP 23，召唤攻击力 180，持续 30 秒，冷却 10 秒"/>
+        <string name="h26" value="消耗MP 23，召唤攻击力 184，持续 30 秒，冷却 10 秒"/>
+        <string name="h27" value="消耗MP 24，召唤攻击力 188，持续 30 秒，冷却 10 秒"/>
+        <string name="h28" value="消耗MP 24，召唤攻击力 192，持续 30 秒，冷却 10 秒"/>
+        <string name="h29" value="消耗MP 25，召唤攻击力 196，持续 30 秒，冷却 10 秒"/>
+        <string name="h30" value="消耗MP 25，召唤攻击力 200，持续 30 秒，冷却 10 秒"/>
     </imgdir>
     <imgdir name="5211002">
         <string name="name" value="海鸥空袭"/>
-        <string name="h1" value="消耗MP 11，攻击力 218，持续时间 10秒"/>
-        <string name="h10" value="消耗MP 14，攻击力 290，持续时间 10秒"/>
-        <string name="h11" value="消耗MP 14，攻击力 298，持续时间 20秒"/>
-        <string name="h12" value="消耗MP 14，攻击力 306，持续时间 20秒"/>
-        <string name="h13" value="消耗MP 15，攻击力 314，持续时间 20秒"/>
-        <string name="h14" value="消耗MP 15，攻击力 322，持续时间 20秒"/>
-        <string name="h15" value="消耗MP 15，攻击力 330，持续时间 20秒"/>
-        <string name="h16" value="消耗MP 16，攻击力 338，持续时间 20秒"/>
-        <string name="h17" value="消耗MP 16，攻击力 346，持续时间 20秒"/>
-        <string name="h18" value="消耗MP 16，攻击力 354，持续时间 20秒"/>
-        <string name="h19" value="消耗MP 17，攻击力 362，持续时间 20秒"/>
-        <string name="h2" value="消耗MP 11，攻击力 226，持续时间 10秒"/>
-        <string name="h20" value="消耗MP 17，攻击力 370，持续时间 20秒"/>
-        <string name="h21" value="消耗MP 17，攻击力 378，持续时间 30秒"/>
-        <string name="h22" value="消耗MP 18，攻击力 386，持续时间 30秒"/>
-        <string name="h23" value="消耗MP 18，攻击力 394，持续时间 30秒"/>
-        <string name="h24" value="消耗MP 18，攻击力 402，持续时间 30秒"/>
-        <string name="h25" value="消耗MP 19，攻击力 410，持续时间 30秒"/>
-        <string name="h26" value="消耗MP 19，攻击力 418，持续时间 30秒"/>
-        <string name="h27" value="消耗MP 19，攻击力 426，持续时间 30秒"/>
-        <string name="h28" value="消耗MP 20，攻击力 434，持续时间 30秒"/>
-        <string name="h29" value="消耗MP 20，攻击力 442，持续时间 30秒"/>
-        <string name="h3" value="消耗MP 11，攻击力 234，持续时间 10秒"/>
-        <string name="h30" value="消耗MP 20，攻击力 450，持续时间 30秒"/>
-        <string name="h4" value="消耗MP 12，攻击力 242，持续时间 10秒"/>
-        <string name="h5" value="消耗MP 12，攻击力 250，持续时间 10秒"/>
-        <string name="h6" value="消耗MP 12，攻击力 258，持续时间 10秒"/>
-        <string name="h7" value="消耗MP 13，攻击力 266，持续时间 10秒"/>
-        <string name="h8" value="消耗MP 13，攻击力 274，持续时间 10秒"/>
-        <string name="h9" value="消耗MP 13，攻击力 282，持续时间 10秒"/>
-        <string name="desc" value="[最高等级 : 30]\n召唤能向敌人扔炸弹的海鸥。\n海鸥一旦发现敌人就会仍炸弹。\n#c冷却时间 : 5秒#"/>
+        <string name="desc" value="[最高等级：30]\n召唤海鸥寻找敌人、投掷炸弹后消失，有冷却时间。"/>
+        <string name="h1" value="消耗MP 11，召唤攻击力 218，持续 10 秒，冷却 5 秒"/>
+        <string name="h2" value="消耗MP 11，召唤攻击力 226，持续 10 秒，冷却 5 秒"/>
+        <string name="h3" value="消耗MP 11，召唤攻击力 234，持续 10 秒，冷却 5 秒"/>
+        <string name="h4" value="消耗MP 12，召唤攻击力 242，持续 10 秒，冷却 5 秒"/>
+        <string name="h5" value="消耗MP 12，召唤攻击力 250，持续 10 秒，冷却 5 秒"/>
+        <string name="h6" value="消耗MP 12，召唤攻击力 258，持续 10 秒，冷却 5 秒"/>
+        <string name="h7" value="消耗MP 13，召唤攻击力 266，持续 10 秒，冷却 5 秒"/>
+        <string name="h8" value="消耗MP 13，召唤攻击力 274，持续 10 秒，冷却 5 秒"/>
+        <string name="h9" value="消耗MP 13，召唤攻击力 282，持续 10 秒，冷却 5 秒"/>
+        <string name="h10" value="消耗MP 14，召唤攻击力 290，持续 10 秒，冷却 5 秒"/>
+        <string name="h11" value="消耗MP 14，召唤攻击力 298，持续 20 秒，冷却 5 秒"/>
+        <string name="h12" value="消耗MP 14，召唤攻击力 306，持续 20 秒，冷却 5 秒"/>
+        <string name="h13" value="消耗MP 15，召唤攻击力 314，持续 20 秒，冷却 5 秒"/>
+        <string name="h14" value="消耗MP 15，召唤攻击力 322，持续 20 秒，冷却 5 秒"/>
+        <string name="h15" value="消耗MP 15，召唤攻击力 330，持续 20 秒，冷却 5 秒"/>
+        <string name="h16" value="消耗MP 16，召唤攻击力 338，持续 20 秒，冷却 5 秒"/>
+        <string name="h17" value="消耗MP 16，召唤攻击力 346，持续 20 秒，冷却 5 秒"/>
+        <string name="h18" value="消耗MP 16，召唤攻击力 354，持续 20 秒，冷却 5 秒"/>
+        <string name="h19" value="消耗MP 17，召唤攻击力 362，持续 20 秒，冷却 5 秒"/>
+        <string name="h20" value="消耗MP 17，召唤攻击力 370，持续 20 秒，冷却 5 秒"/>
+        <string name="h21" value="消耗MP 17，召唤攻击力 378，持续 30 秒，冷却 5 秒"/>
+        <string name="h22" value="消耗MP 18，召唤攻击力 386，持续 30 秒，冷却 5 秒"/>
+        <string name="h23" value="消耗MP 18，召唤攻击力 394，持续 30 秒，冷却 5 秒"/>
+        <string name="h24" value="消耗MP 18，召唤攻击力 402，持续 30 秒，冷却 5 秒"/>
+        <string name="h25" value="消耗MP 19，召唤攻击力 410，持续 30 秒，冷却 5 秒"/>
+        <string name="h26" value="消耗MP 19，召唤攻击力 418，持续 30 秒，冷却 5 秒"/>
+        <string name="h27" value="消耗MP 19，召唤攻击力 426，持续 30 秒，冷却 5 秒"/>
+        <string name="h28" value="消耗MP 20，召唤攻击力 434，持续 30 秒，冷却 5 秒"/>
+        <string name="h29" value="消耗MP 20，召唤攻击力 442，持续 30 秒，冷却 5 秒"/>
+        <string name="h30" value="消耗MP 20，召唤攻击力 450，持续 30 秒，冷却 5 秒"/>
     </imgdir>
     <imgdir name="5211004">
         <string name="name" value="烈焰喷射"/>
-        <string name="h1" value="消耗MP 25，伤害 113%，6只 攻击"/>
-        <string name="h10" value="消耗MP 25，伤害 140%，6只 攻击"/>
-        <string name="h11" value="消耗MP 30，伤害 143%，6只 攻击"/>
-        <string name="h12" value="消耗MP 30，伤害 146%，6只 攻击"/>
-        <string name="h13" value="消耗MP 30，伤害 149%，6只 攻击"/>
-        <string name="h14" value="消耗MP 30，伤害 152%，6只 攻击"/>
-        <string name="h15" value="消耗MP 30，伤害 155%，6只 攻击"/>
-        <string name="h16" value="消耗MP 30，伤害 158%，6只 攻击"/>
-        <string name="h17" value="消耗MP 30，伤害 161%，6只 攻击"/>
-        <string name="h18" value="消耗MP 30，伤害 164%，6只 攻击"/>
-        <string name="h19" value="消耗MP 30，伤害 167%，6只 攻击"/>
-        <string name="h2" value="消耗MP 25，伤害 116%，6只 攻击"/>
-        <string name="h20" value="消耗MP 30，伤害 170%，6只 攻击"/>
-        <string name="h21" value="消耗MP 35，伤害 173%，6只 攻击"/>
-        <string name="h22" value="消耗MP 35，伤害 176%，6只 攻击"/>
-        <string name="h23" value="消耗MP 35，伤害 179%，6只 攻击"/>
-        <string name="h24" value="消耗MP 35，伤害 182%，6只 攻击"/>
-        <string name="h25" value="消耗MP 35，伤害 185%，6只 攻击"/>
-        <string name="h26" value="消耗MP 35，伤害 188%，6只 攻击"/>
-        <string name="h27" value="消耗MP 35，伤害 191%，6只 攻击"/>
-        <string name="h28" value="消耗MP 35，伤害 194%，6只 攻击"/>
-        <string name="h29" value="消耗MP 35，伤害 197%，6只 攻击"/>
-        <string name="h3" value="消耗MP 25，伤害 119%，6只 攻击"/>
-        <string name="h30" value="消耗MP 35，伤害 200%，6只 攻击"/>
-        <string name="h4" value="消耗MP 25，伤害 122%，6只 攻击"/>
-        <string name="h5" value="消耗MP 25，伤害 125%，6只 攻击"/>
-        <string name="h6" value="消耗MP 25，伤害 128%，6只 攻击"/>
-        <string name="h7" value="消耗MP 25，伤害 131%，6只 攻击"/>
-        <string name="h8" value="消耗MP 25，伤害 134%，6只 攻击"/>
-        <string name="h9" value="消耗MP 25，伤害 137%，6只 攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n给近距离的敌人火属性攻击。\n受到攻击的敌人在一定时间受到连续伤害"/>
+        <string name="desc" value="[最高等级：30]\n用火焰攻击近距离敌人，非首领敌人会受到持续火焰伤害。"/>
+        <string name="h1" value="消耗MP 25，伤害 73%，最多攻击 2 个敌人，灼烧 3 秒"/>
+        <string name="h2" value="消耗MP 25，伤害 76%，最多攻击 2 个敌人，灼烧 3 秒"/>
+        <string name="h3" value="消耗MP 25，伤害 79%，最多攻击 2 个敌人，灼烧 3 秒"/>
+        <string name="h4" value="消耗MP 25，伤害 82%，最多攻击 2 个敌人，灼烧 3 秒"/>
+        <string name="h5" value="消耗MP 25，伤害 85%，最多攻击 2 个敌人，灼烧 3 秒"/>
+        <string name="h6" value="消耗MP 25，伤害 88%，最多攻击 2 个敌人，灼烧 3 秒"/>
+        <string name="h7" value="消耗MP 25，伤害 91%，最多攻击 3 个敌人，灼烧 3 秒"/>
+        <string name="h8" value="消耗MP 25，伤害 94%，最多攻击 3 个敌人，灼烧 3 秒"/>
+        <string name="h9" value="消耗MP 25，伤害 97%，最多攻击 3 个敌人，灼烧 3 秒"/>
+        <string name="h10" value="消耗MP 25，伤害 100%，最多攻击 3 个敌人，灼烧 3 秒"/>
+        <string name="h11" value="消耗MP 30，伤害 103%，最多攻击 3 个敌人，灼烧 4 秒"/>
+        <string name="h12" value="消耗MP 30，伤害 106%，最多攻击 3 个敌人，灼烧 4 秒"/>
+        <string name="h13" value="消耗MP 30，伤害 109%，最多攻击 4 个敌人，灼烧 4 秒"/>
+        <string name="h14" value="消耗MP 30，伤害 112%，最多攻击 4 个敌人，灼烧 4 秒"/>
+        <string name="h15" value="消耗MP 30，伤害 115%，最多攻击 4 个敌人，灼烧 4 秒"/>
+        <string name="h16" value="消耗MP 30，伤害 118%，最多攻击 4 个敌人，灼烧 4 秒"/>
+        <string name="h17" value="消耗MP 30，伤害 121%，最多攻击 4 个敌人，灼烧 4 秒"/>
+        <string name="h18" value="消耗MP 30，伤害 124%，最多攻击 4 个敌人，灼烧 4 秒"/>
+        <string name="h19" value="消耗MP 30，伤害 127%，最多攻击 5 个敌人，灼烧 4 秒"/>
+        <string name="h20" value="消耗MP 30，伤害 130%，最多攻击 5 个敌人，灼烧 4 秒"/>
+        <string name="h21" value="消耗MP 35，伤害 133%，最多攻击 5 个敌人，灼烧 5 秒"/>
+        <string name="h22" value="消耗MP 35，伤害 136%，最多攻击 5 个敌人，灼烧 5 秒"/>
+        <string name="h23" value="消耗MP 35，伤害 139%，最多攻击 5 个敌人，灼烧 5 秒"/>
+        <string name="h24" value="消耗MP 35，伤害 142%，最多攻击 5 个敌人，灼烧 5 秒"/>
+        <string name="h25" value="消耗MP 35，伤害 145%，最多攻击 6 个敌人，灼烧 5 秒"/>
+        <string name="h26" value="消耗MP 35，伤害 148%，最多攻击 6 个敌人，灼烧 5 秒"/>
+        <string name="h27" value="消耗MP 35，伤害 151%，最多攻击 6 个敌人，灼烧 5 秒"/>
+        <string name="h28" value="消耗MP 35，伤害 154%，最多攻击 6 个敌人，灼烧 5 秒"/>
+        <string name="h29" value="消耗MP 35，伤害 157%，最多攻击 6 个敌人，灼烧 5 秒"/>
+        <string name="h30" value="消耗MP 35，伤害 160%，最多攻击 6 个敌人，灼烧 5 秒"/>
     </imgdir>
     <imgdir name="5211005">
         <string name="name" value="寒冰喷射"/>
-        <string name="h1" value="消耗MP 25，伤害 122%，6只 攻击"/>
-        <string name="h10" value="消耗MP 25，伤害 140%，6只 攻击"/>
-        <string name="h11" value="消耗MP 30，伤害 142%，6只 攻击"/>
-        <string name="h12" value="消耗MP 30，伤害 144%，6只 攻击"/>
-        <string name="h13" value="消耗MP 30，伤害 146%，6只 攻击"/>
-        <string name="h14" value="消耗MP 30，伤害 148%，6只 攻击"/>
-        <string name="h15" value="消耗MP 30，伤害 150%，6只 攻击"/>
-        <string name="h16" value="消耗MP 30，伤害 152%，6只 攻击"/>
-        <string name="h17" value="消耗MP 30，伤害 154%，6只 攻击"/>
-        <string name="h18" value="消耗MP 30，伤害 156%，6只 攻击"/>
-        <string name="h19" value="消耗MP 30，伤害 158%，6只 攻击"/>
-        <string name="h2" value="消耗MP 25，伤害 124%，6只 攻击"/>
-        <string name="h20" value="消耗MP 30，伤害 160%，6只 攻击"/>
-        <string name="h21" value="消耗MP 35，伤害 162%，6只 攻击"/>
-        <string name="h22" value="消耗MP 35，伤害 164%，6只 攻击"/>
-        <string name="h23" value="消耗MP 35，伤害 166%，6只 攻击"/>
-        <string name="h24" value="消耗MP 35，伤害 168%，6只 攻击"/>
-        <string name="h25" value="消耗MP 35，伤害 170%，6只 攻击"/>
-        <string name="h26" value="消耗MP 35，伤害 172%，6只 攻击"/>
-        <string name="h27" value="消耗MP 35，伤害 174%，6只 攻击"/>
-        <string name="h28" value="消耗MP 35，伤害 176%，6只 攻击"/>
-        <string name="h29" value="消耗MP 35，伤害 178%，6只 攻击"/>
-        <string name="h3" value="消耗MP 25，伤害 126%，6只 攻击"/>
-        <string name="h30" value="消耗MP 35，伤害 180%，6只 攻击"/>
-        <string name="h4" value="消耗MP 25，伤害 128%，6只 攻击"/>
-        <string name="h5" value="消耗MP 25，伤害 130%，6只 攻击"/>
-        <string name="h6" value="消耗MP 25，伤害 132%，6只 攻击"/>
-        <string name="h7" value="消耗MP 25，伤害 134%，6只 攻击"/>
-        <string name="h8" value="消耗MP 25，伤害 136%，6只 攻击"/>
-        <string name="h9" value="消耗MP 25，伤害 138%，6只 攻击"/>
-        <string name="desc" value="[最高等级 : 30]\n给近距离的敌人冷属性攻击。\n受到攻击的敌人在一定时间内处于结冰状态"/>
+        <string name="desc" value="[最高等级：30]\n用寒冰攻击近距离敌人并使其冻结。服务端冻结时间为技能时间的2倍。"/>
+        <string name="h1" value="消耗MP 25，伤害 72%，最多攻击 2 个敌人，冻结 2 秒"/>
+        <string name="h2" value="消耗MP 25，伤害 74%，最多攻击 2 个敌人，冻结 2 秒"/>
+        <string name="h3" value="消耗MP 25，伤害 76%，最多攻击 2 个敌人，冻结 2 秒"/>
+        <string name="h4" value="消耗MP 25，伤害 78%，最多攻击 2 个敌人，冻结 2 秒"/>
+        <string name="h5" value="消耗MP 25，伤害 80%，最多攻击 2 个敌人，冻结 2 秒"/>
+        <string name="h6" value="消耗MP 25，伤害 82%，最多攻击 2 个敌人，冻结 2 秒"/>
+        <string name="h7" value="消耗MP 25，伤害 84%，最多攻击 3 个敌人，冻结 2 秒"/>
+        <string name="h8" value="消耗MP 25，伤害 86%，最多攻击 3 个敌人，冻结 2 秒"/>
+        <string name="h9" value="消耗MP 25，伤害 88%，最多攻击 3 个敌人，冻结 2 秒"/>
+        <string name="h10" value="消耗MP 25，伤害 90%，最多攻击 3 个敌人，冻结 2 秒"/>
+        <string name="h11" value="消耗MP 30，伤害 92%，最多攻击 3 个敌人，冻结 4 秒"/>
+        <string name="h12" value="消耗MP 30，伤害 94%，最多攻击 3 个敌人，冻结 4 秒"/>
+        <string name="h13" value="消耗MP 30，伤害 96%，最多攻击 4 个敌人，冻结 4 秒"/>
+        <string name="h14" value="消耗MP 30，伤害 98%，最多攻击 4 个敌人，冻结 4 秒"/>
+        <string name="h15" value="消耗MP 30，伤害 100%，最多攻击 4 个敌人，冻结 4 秒"/>
+        <string name="h16" value="消耗MP 30，伤害 102%，最多攻击 4 个敌人，冻结 4 秒"/>
+        <string name="h17" value="消耗MP 30，伤害 104%，最多攻击 4 个敌人，冻结 4 秒"/>
+        <string name="h18" value="消耗MP 30，伤害 106%，最多攻击 4 个敌人，冻结 4 秒"/>
+        <string name="h19" value="消耗MP 30，伤害 108%，最多攻击 5 个敌人，冻结 4 秒"/>
+        <string name="h20" value="消耗MP 30，伤害 110%，最多攻击 5 个敌人，冻结 4 秒"/>
+        <string name="h21" value="消耗MP 35，伤害 112%，最多攻击 5 个敌人，冻结 6 秒"/>
+        <string name="h22" value="消耗MP 35，伤害 114%，最多攻击 5 个敌人，冻结 6 秒"/>
+        <string name="h23" value="消耗MP 35，伤害 116%，最多攻击 5 个敌人，冻结 6 秒"/>
+        <string name="h24" value="消耗MP 35，伤害 118%，最多攻击 5 个敌人，冻结 6 秒"/>
+        <string name="h25" value="消耗MP 35，伤害 120%，最多攻击 6 个敌人，冻结 6 秒"/>
+        <string name="h26" value="消耗MP 35，伤害 122%，最多攻击 6 个敌人，冻结 6 秒"/>
+        <string name="h27" value="消耗MP 35，伤害 124%，最多攻击 6 个敌人，冻结 6 秒"/>
+        <string name="h28" value="消耗MP 35，伤害 126%，最多攻击 6 个敌人，冻结 6 秒"/>
+        <string name="h29" value="消耗MP 35，伤害 128%，最多攻击 6 个敌人，冻结 6 秒"/>
+        <string name="h30" value="消耗MP 35，伤害 130%，最多攻击 6 个敌人，冻结 6 秒"/>
     </imgdir>
     <imgdir name="5211006">
         <string name="name" value="导航"/>
-        <string name="h1" value="消耗MP 20，伤害 148%"/>
-        <string name="h10" value="消耗MP 20，伤害 220%"/>
-        <string name="h11" value="消耗MP 25，伤害 228%"/>
-        <string name="h12" value="消耗MP 25，伤害 236%"/>
-        <string name="h13" value="消耗MP 25，伤害 244%"/>
-        <string name="h14" value="消耗MP 25，伤害 252%"/>
-        <string name="h15" value="消耗MP 25，伤害 260%"/>
-        <string name="h16" value="消耗MP 25，伤害 268%"/>
-        <string name="h17" value="消耗MP 25，伤害 276%"/>
-        <string name="h18" value="消耗MP 25，伤害 284%"/>
-        <string name="h19" value="消耗MP 25，伤害 292%"/>
-        <string name="h2" value="消耗MP 20，伤害 156%"/>
-        <string name="h20" value="消耗MP 25，伤害 300%"/>
-        <string name="h21" value="消耗MP 30，伤害 308%"/>
-        <string name="h22" value="消耗MP 30，伤害 316%"/>
-        <string name="h23" value="消耗MP 30，伤害 324%"/>
-        <string name="h24" value="消耗MP 30，伤害 332%"/>
-        <string name="h25" value="消耗MP 30，伤害 340%"/>
-        <string name="h26" value="消耗MP 30，伤害 348%"/>
-        <string name="h27" value="消耗MP 30，伤害 356%"/>
-        <string name="h28" value="消耗MP 30，伤害 364%"/>
-        <string name="h29" value="消耗MP 30，伤害 372%"/>
-        <string name="h3" value="消耗MP 20，伤害 164%"/>
-        <string name="h30" value="消耗MP 30，伤害 380%"/>
-        <string name="h4" value="消耗MP 20，伤害 172%"/>
-        <string name="h5" value="消耗MP 20，伤害 180%"/>
-        <string name="h6" value="消耗MP 20，伤害 188%"/>
-        <string name="h7" value="消耗MP 20，伤害 196%"/>
-        <string name="h8" value="消耗MP 20，伤害 204%"/>
-        <string name="h9" value="消耗MP 20，伤害 212%"/>
-        <string name="desc" value="[最高等级 : 30]\n向敌人派遣瞄准用鹦鹉。\n以后所有的攻击都指向鹦鹉跟随的敌人"/>
+        <string name="desc" value="[最高等级：30]\n标记1个敌人，之后攻击会集中到被标记目标。"/>
+        <string name="h1" value="消耗MP 20，标记1个敌人，伤害 148%，射程 350"/>
+        <string name="h2" value="消耗MP 20，标记1个敌人，伤害 156%，射程 350"/>
+        <string name="h3" value="消耗MP 20，标记1个敌人，伤害 164%，射程 350"/>
+        <string name="h4" value="消耗MP 20，标记1个敌人，伤害 172%，射程 350"/>
+        <string name="h5" value="消耗MP 20，标记1个敌人，伤害 180%，射程 350"/>
+        <string name="h6" value="消耗MP 20，标记1个敌人，伤害 188%，射程 350"/>
+        <string name="h7" value="消耗MP 20，标记1个敌人，伤害 196%，射程 350"/>
+        <string name="h8" value="消耗MP 20，标记1个敌人，伤害 204%，射程 350"/>
+        <string name="h9" value="消耗MP 20，标记1个敌人，伤害 212%，射程 350"/>
+        <string name="h10" value="消耗MP 20，标记1个敌人，伤害 220%，射程 350"/>
+        <string name="h11" value="消耗MP 25，标记1个敌人，伤害 228%，射程 350"/>
+        <string name="h12" value="消耗MP 25，标记1个敌人，伤害 236%，射程 350"/>
+        <string name="h13" value="消耗MP 25，标记1个敌人，伤害 244%，射程 350"/>
+        <string name="h14" value="消耗MP 25，标记1个敌人，伤害 252%，射程 350"/>
+        <string name="h15" value="消耗MP 25，标记1个敌人，伤害 260%，射程 350"/>
+        <string name="h16" value="消耗MP 25，标记1个敌人，伤害 268%，射程 350"/>
+        <string name="h17" value="消耗MP 25，标记1个敌人，伤害 276%，射程 350"/>
+        <string name="h18" value="消耗MP 25，标记1个敌人，伤害 284%，射程 350"/>
+        <string name="h19" value="消耗MP 25，标记1个敌人，伤害 292%，射程 350"/>
+        <string name="h20" value="消耗MP 25，标记1个敌人，伤害 300%，射程 350"/>
+        <string name="h21" value="消耗MP 30，标记1个敌人，伤害 308%，射程 350"/>
+        <string name="h22" value="消耗MP 30，标记1个敌人，伤害 316%，射程 350"/>
+        <string name="h23" value="消耗MP 30，标记1个敌人，伤害 324%，射程 350"/>
+        <string name="h24" value="消耗MP 30，标记1个敌人，伤害 332%，射程 350"/>
+        <string name="h25" value="消耗MP 30，标记1个敌人，伤害 340%，射程 350"/>
+        <string name="h26" value="消耗MP 30，标记1个敌人，伤害 348%，射程 350"/>
+        <string name="h27" value="消耗MP 30，标记1个敌人，伤害 356%，射程 350"/>
+        <string name="h28" value="消耗MP 30，标记1个敌人，伤害 364%，射程 350"/>
+        <string name="h29" value="消耗MP 30，标记1个敌人，伤害 372%，射程 350"/>
+        <string name="h30" value="消耗MP 30，标记1个敌人，伤害 380%，射程 350"/>
     </imgdir>
     <imgdir name="522">
         <string name="bookName" value="船长的完成"/>
     </imgdir>
     <imgdir name="5220001">
         <string name="name" value="属性强化"/>
-        <string name="h1" value="伤害 6%，持续伤害力 1%，结冰持续时间 1秒"/>
-        <string name="h10" value="伤害 60%，持续伤害力 2%，结冰持续时间 1秒"/>
-        <string name="h11" value="伤害 76%，持续伤害力 2%，结冰持续时间 1秒"/>
-        <string name="h12" value="伤害 82%，持续伤害力 2%，结冰持续时间 1秒"/>
-        <string name="h13" value="伤害 88%，持续伤害力 3%，结冰持续时间 1秒"/>
-        <string name="h14" value="伤害 94%，持续伤害力 3%，结冰持续时间 1秒"/>
-        <string name="h15" value="伤害 100%，持续伤害力 3%，结冰持续时间 1秒"/>
-        <string name="h16" value="伤害 106%，持续伤害力 3%，结冰持续时间 2秒"/>
-        <string name="h17" value="伤害 112%，持续伤害力 3%，结冰持续时间 2秒"/>
-        <string name="h18" value="伤害 118%，持续伤害力 3%，结冰持续时间 2秒"/>
-        <string name="h19" value="伤害 124%，持续伤害力 4%，结冰持续时间 2秒"/>
-        <string name="h2" value="伤害 12%，持续伤害力 1%，结冰持续时间 1秒"/>
-        <string name="h20" value="伤害 130%，持续伤害力 4%，结冰持续时间 2秒"/>
-        <string name="h21" value="伤害 146%，持续伤害力 4%，结冰持续时间 2秒"/>
-        <string name="h22" value="伤害 152%，持续伤害力 4%，结冰持续时间 2秒"/>
-        <string name="h23" value="伤害 158%，持续伤害力 4%，结冰持续时间 2秒"/>
-        <string name="h24" value="伤害 164%，持续伤害力 4%，结冰持续时间 2秒"/>
-        <string name="h25" value="伤害 170%，持续伤害力 5%，结冰持续时间 2秒"/>
-        <string name="h26" value="伤害 176%，持续伤害力 5%，结冰持续时间 2秒"/>
-        <string name="h27" value="伤害 182%，持续伤害力 5%，结冰持续时间 2秒"/>
-        <string name="h28" value="伤害 188%，持续伤害力 5%，结冰持续时间 2秒"/>
-        <string name="h29" value="伤害 194%，持续伤害力 5%，结冰持续时间 2秒"/>
-        <string name="h3" value="伤害 18%，持续伤害力 1%，结冰持续时间 1秒"/>
-        <string name="h30" value="伤害 200%，持续伤害力 5%，结冰持续时间 2秒"/>
-        <string name="h4" value="伤害 24%，持续伤害力 1%，结冰持续时间 1秒"/>
-        <string name="h5" value="伤害 30%，持续伤害力 1%，结冰持续时间 1秒"/>
-        <string name="h6" value="伤害 36%，持续伤害力 1%，结冰持续时间 1秒"/>
-        <string name="h7" value="伤害 42%，持续伤害力 2%，结冰持续时间 1秒"/>
-        <string name="h8" value="伤害 48%，持续伤害力 2%，结冰持续时间 1秒"/>
-        <string name="h9" value="伤害 54%，持续伤害力 2%，结冰持续时间 1秒"/>
-        <string name="desc" value="提升烈焰喷射和寒冰喷射技能的伤害值"/>
+        <string name="desc" value="[最高等级：30]\n提高烈焰喷射和寒冰喷射的伤害、火焰持续伤害和冻结时间。"/>
+        <string name="h1" value="伤害 +6%，火焰持续伤害 +1%，冻结时间 +1 秒"/>
+        <string name="h2" value="伤害 +12%，火焰持续伤害 +1%，冻结时间 +1 秒"/>
+        <string name="h3" value="伤害 +18%，火焰持续伤害 +1%，冻结时间 +1 秒"/>
+        <string name="h4" value="伤害 +24%，火焰持续伤害 +1%，冻结时间 +1 秒"/>
+        <string name="h5" value="伤害 +30%，火焰持续伤害 +1%，冻结时间 +1 秒"/>
+        <string name="h6" value="伤害 +36%，火焰持续伤害 +1%，冻结时间 +1 秒"/>
+        <string name="h7" value="伤害 +42%，火焰持续伤害 +2%，冻结时间 +1 秒"/>
+        <string name="h8" value="伤害 +48%，火焰持续伤害 +2%，冻结时间 +1 秒"/>
+        <string name="h9" value="伤害 +54%，火焰持续伤害 +2%，冻结时间 +1 秒"/>
+        <string name="h10" value="伤害 +60%，火焰持续伤害 +2%，冻结时间 +1 秒"/>
+        <string name="h11" value="伤害 +76%，火焰持续伤害 +2%，冻结时间 +1 秒"/>
+        <string name="h12" value="伤害 +82%，火焰持续伤害 +2%，冻结时间 +1 秒"/>
+        <string name="h13" value="伤害 +88%，火焰持续伤害 +3%，冻结时间 +1 秒"/>
+        <string name="h14" value="伤害 +94%，火焰持续伤害 +3%，冻结时间 +1 秒"/>
+        <string name="h15" value="伤害 +100%，火焰持续伤害 +3%，冻结时间 +1 秒"/>
+        <string name="h16" value="伤害 +106%，火焰持续伤害 +3%，冻结时间 +2 秒"/>
+        <string name="h17" value="伤害 +112%，火焰持续伤害 +3%，冻结时间 +2 秒"/>
+        <string name="h18" value="伤害 +118%，火焰持续伤害 +3%，冻结时间 +2 秒"/>
+        <string name="h19" value="伤害 +124%，火焰持续伤害 +4%，冻结时间 +2 秒"/>
+        <string name="h20" value="伤害 +130%，火焰持续伤害 +4%，冻结时间 +2 秒"/>
+        <string name="h21" value="伤害 +146%，火焰持续伤害 +4%，冻结时间 +2 秒"/>
+        <string name="h22" value="伤害 +152%，火焰持续伤害 +4%，冻结时间 +2 秒"/>
+        <string name="h23" value="伤害 +158%，火焰持续伤害 +4%，冻结时间 +2 秒"/>
+        <string name="h24" value="伤害 +164%，火焰持续伤害 +4%，冻结时间 +2 秒"/>
+        <string name="h25" value="伤害 +170%，火焰持续伤害 +5%，冻结时间 +2 秒"/>
+        <string name="h26" value="伤害 +176%，火焰持续伤害 +5%，冻结时间 +2 秒"/>
+        <string name="h27" value="伤害 +182%，火焰持续伤害 +5%，冻结时间 +2 秒"/>
+        <string name="h28" value="伤害 +188%，火焰持续伤害 +5%，冻结时间 +2 秒"/>
+        <string name="h29" value="伤害 +194%，火焰持续伤害 +5%，冻结时间 +2 秒"/>
+        <string name="h30" value="伤害 +200%，火焰持续伤害 +5%，冻结时间 +2 秒"/>
     </imgdir>
     <imgdir name="5220002">
         <string name="name" value="超级章鱼炮台"/>
-        <string name="h1" value="消耗MP 26，攻击力 210，持续时间 35秒，冷却时间 10秒"/>
-        <string name="h10" value="消耗MP 30，攻击力 300，持续时间 35秒，冷却时间 10秒"/>
-        <string name="h11" value="消耗MP 31，攻击力 320，持续时间 40秒，冷却时间 10秒"/>
-        <string name="h12" value="消耗MP 31，攻击力 340，持续时间 40秒，冷却时间 10秒"/>
-        <string name="h13" value="消耗MP 32，攻击力 360，持续时间 40秒，冷却时间 10秒"/>
-        <string name="h14" value="消耗MP 32，攻击力 380，持续时间 40秒，冷却时间 10秒"/>
-        <string name="h15" value="消耗MP 33，攻击力 400，持续时间 40秒，冷却时间 10秒"/>
-        <string name="h16" value="消耗MP 33，攻击力 420，持续时间 40秒，冷却时间 10秒"/>
-        <string name="h17" value="消耗MP 34，攻击力 440，持续时间 40秒，冷却时间 10秒"/>
-        <string name="h18" value="消耗MP 34，攻击力 460，持续时间 40秒，冷却时间 10秒"/>
-        <string name="h19" value="消耗MP 35，攻击力 480，持续时间 40秒，冷却时间 10秒"/>
-        <string name="h2" value="消耗MP 26，攻击力 220，持续时间 35秒，冷却时间 10秒"/>
-        <string name="h20" value="消耗MP 35，攻击力 500，持续时间 40秒，冷却时间 10秒"/>
-        <string name="h3" value="消耗MP 27，攻击力 230，持续时间 35秒，冷却时间 10秒"/>
-        <string name="h4" value="消耗MP 27，攻击力 240，持续时间 35秒，冷却时间 10秒"/>
-        <string name="h5" value="消耗MP 28，攻击力 250，持续时间 35秒，冷却时间 10秒"/>
-        <string name="h6" value="消耗MP 28，攻击力 260，持续时间 35秒，冷却时间 10秒"/>
-        <string name="h7" value="消耗MP 29，攻击力 270，持续时间 35秒，冷却时间 10秒"/>
-        <string name="h8" value="消耗MP 29，攻击力 280，持续时间 35秒，冷却时间 10秒"/>
-        <string name="h9" value="消耗MP 30，攻击力 290，持续时间 35秒，冷却时间 10秒"/>
-        <string name="desc" value="召唤一只章鱼提升连射速度和伤害值。\n必要技能 : #c章鱼炮台30等级#"/>
+        <string name="desc" value="[最高等级：30]\n额外召唤1个固定位置的强化章鱼炮台。需要章鱼炮台30级。"/>
+        <string name="h1" value="消耗MP 26，召唤攻击力 210，持续 35 秒，冷却 10 秒"/>
+        <string name="h2" value="消耗MP 26，召唤攻击力 220，持续 35 秒，冷却 10 秒"/>
+        <string name="h3" value="消耗MP 27，召唤攻击力 230，持续 35 秒，冷却 10 秒"/>
+        <string name="h4" value="消耗MP 27，召唤攻击力 240，持续 35 秒，冷却 10 秒"/>
+        <string name="h5" value="消耗MP 28，召唤攻击力 250，持续 35 秒，冷却 10 秒"/>
+        <string name="h6" value="消耗MP 28，召唤攻击力 260，持续 35 秒，冷却 10 秒"/>
+        <string name="h7" value="消耗MP 29，召唤攻击力 270，持续 35 秒，冷却 10 秒"/>
+        <string name="h8" value="消耗MP 29，召唤攻击力 280，持续 35 秒，冷却 10 秒"/>
+        <string name="h9" value="消耗MP 30，召唤攻击力 290，持续 35 秒，冷却 10 秒"/>
+        <string name="h10" value="消耗MP 30，召唤攻击力 300，持续 35 秒，冷却 10 秒"/>
+        <string name="h11" value="消耗MP 31，召唤攻击力 320，持续 40 秒，冷却 10 秒"/>
+        <string name="h12" value="消耗MP 31，召唤攻击力 340，持续 40 秒，冷却 10 秒"/>
+        <string name="h13" value="消耗MP 32，召唤攻击力 360，持续 40 秒，冷却 10 秒"/>
+        <string name="h14" value="消耗MP 32，召唤攻击力 380，持续 40 秒，冷却 10 秒"/>
+        <string name="h15" value="消耗MP 33，召唤攻击力 400，持续 40 秒，冷却 10 秒"/>
+        <string name="h16" value="消耗MP 33，召唤攻击力 420，持续 40 秒，冷却 10 秒"/>
+        <string name="h17" value="消耗MP 34，召唤攻击力 440，持续 40 秒，冷却 10 秒"/>
+        <string name="h18" value="消耗MP 34，召唤攻击力 460，持续 40 秒，冷却 10 秒"/>
+        <string name="h19" value="消耗MP 35，召唤攻击力 480，持续 40 秒，冷却 10 秒"/>
+        <string name="h20" value="消耗MP 35，召唤攻击力 500，持续 40 秒，冷却 10 秒"/>
     </imgdir>
     <imgdir name="5220011">
         <string name="name" value="导航辅助"/>
-        <string name="h1" value="消耗MP 35，伤害 390%，伤害 1% 增加"/>
-        <string name="h10" value="消耗MP 35，伤害 480%，伤害 10% 增加"/>
-        <string name="h11" value="消耗MP 40，伤害 490%，伤害 11% 增加"/>
-        <string name="h12" value="消耗MP 40，伤害 500%，伤害 12% 增加"/>
-        <string name="h13" value="消耗MP 40，伤害 510%，伤害 13% 增加"/>
-        <string name="h14" value="消耗MP 40，伤害 520%，伤害 14% 增加"/>
-        <string name="h15" value="消耗MP 40，伤害 530%，伤害 15% 增加"/>
-        <string name="h16" value="消耗MP 40，伤害 540%，伤害 16% 增加"/>
-        <string name="h17" value="消耗MP 40，伤害 550%，伤害 17% 增加"/>
-        <string name="h18" value="消耗MP 40，伤害 560%，伤害 18% 增加"/>
-        <string name="h19" value="消耗MP 40，伤害 570%，伤害 19% 增加"/>
-        <string name="h2" value="消耗MP 35，伤害 400%，伤害 2% 增加"/>
-        <string name="h20" value="消耗MP 40，伤害 580%，伤害 20% 增加"/>
-        <string name="h3" value="消耗MP 35，伤害 410%，伤害 3% 增加"/>
-        <string name="h4" value="消耗MP 35，伤害 420%，伤害 4% 增加"/>
-        <string name="h5" value="消耗MP 35，伤害 430%，伤害 5% 增加"/>
-        <string name="h6" value="消耗MP 35，伤害 440%，伤害 6% 增加"/>
-        <string name="h7" value="消耗MP 35，伤害 450%，伤害 7% 增加"/>
-        <string name="h8" value="消耗MP 35，伤害 460%，伤害 8% 增加"/>
-        <string name="h9" value="消耗MP 35，伤害 470%，伤害 9% 增加"/>
-        <string name="desc" value="给与中招的怪物更多的伤害。\n必要技能 : #c导航 30等级#"/>
+        <string name="desc" value="[最高等级：20]\n标记1个敌人，并提高对被标记目标造成的伤害。需要导航30级。"/>
+        <string name="h1" value="消耗MP 35，标记1个敌人，伤害 390%，额外伤害 +1%，射程 350"/>
+        <string name="h2" value="消耗MP 35，标记1个敌人，伤害 400%，额外伤害 +2%，射程 350"/>
+        <string name="h3" value="消耗MP 35，标记1个敌人，伤害 410%，额外伤害 +3%，射程 350"/>
+        <string name="h4" value="消耗MP 35，标记1个敌人，伤害 420%，额外伤害 +4%，射程 350"/>
+        <string name="h5" value="消耗MP 35，标记1个敌人，伤害 430%，额外伤害 +5%，射程 350"/>
+        <string name="h6" value="消耗MP 35，标记1个敌人，伤害 440%，额外伤害 +6%，射程 350"/>
+        <string name="h7" value="消耗MP 35，标记1个敌人，伤害 450%，额外伤害 +7%，射程 350"/>
+        <string name="h8" value="消耗MP 35，标记1个敌人，伤害 460%，额外伤害 +8%，射程 350"/>
+        <string name="h9" value="消耗MP 35，标记1个敌人，伤害 470%，额外伤害 +9%，射程 350"/>
+        <string name="h10" value="消耗MP 35，标记1个敌人，伤害 480%，额外伤害 +10%，射程 350"/>
+        <string name="h11" value="消耗MP 40，标记1个敌人，伤害 490%，额外伤害 +11%，射程 350"/>
+        <string name="h12" value="消耗MP 40，标记1个敌人，伤害 500%，额外伤害 +12%，射程 350"/>
+        <string name="h13" value="消耗MP 40，标记1个敌人，伤害 510%，额外伤害 +13%，射程 350"/>
+        <string name="h14" value="消耗MP 40，标记1个敌人，伤害 520%，额外伤害 +14%，射程 350"/>
+        <string name="h15" value="消耗MP 40，标记1个敌人，伤害 530%，额外伤害 +15%，射程 350"/>
+        <string name="h16" value="消耗MP 40，标记1个敌人，伤害 540%，额外伤害 +16%，射程 350"/>
+        <string name="h17" value="消耗MP 40，标记1个敌人，伤害 550%，额外伤害 +17%，射程 350"/>
+        <string name="h18" value="消耗MP 40，标记1个敌人，伤害 560%，额外伤害 +18%，射程 350"/>
+        <string name="h19" value="消耗MP 40，标记1个敌人，伤害 570%，额外伤害 +19%，射程 350"/>
+        <string name="h20" value="消耗MP 40，标记1个敌人，伤害 580%，额外伤害 +20%，射程 350"/>
     </imgdir>
     <imgdir name="5221000">
         <string name="name" value="冒险岛勇士"/>
-        <string name="h1" value="消耗MP 10  30秒内所有的属性提升 1%"/>
-        <string name="h10" value="消耗MP 20  300秒内所有的属性提升 5%"/>
-        <string name="h11" value="消耗MP 30  330秒内所有的属性提升 6%"/>
-        <string name="h12" value="消耗MP 30  360秒内所有的属性提升 6%"/>
-        <string name="h13" value="消耗MP 30  390秒内所有的属性提升 7%"/>
-        <string name="h14" value="消耗MP 30  420秒内所有的属性提升 7%"/>
-        <string name="h15" value="消耗MP 30  450秒内所有的属性提升 8%"/>
-        <string name="h16" value="消耗MP 40  480秒内所有的属性提升 8%"/>
-        <string name="h17" value="消耗MP 40  510秒内所有的属性提升 9%"/>
-        <string name="h18" value="消耗MP 40  540秒内所有的属性提升 9%"/>
-        <string name="h19" value="消耗MP 40  570秒内所有的属性提升 10%"/>
-        <string name="h2" value="消耗MP 10  60秒内所有的属性提升 1%"/>
-        <string name="h20" value="消耗MP 40  600秒内所有的属性提升 10%"/>
-        <string name="h21" value="消耗MP 50，630秒内所有的属性点提高 11%"/>
-        <string name="h22" value="消耗MP 50，660秒内所有的属性点提高 11%"/>
-        <string name="h23" value="消耗MP 50，690秒内所有的属性点提高 12%"/>
-        <string name="h24" value="消耗MP 50，720秒内所有的属性点提高 12%"/>
-        <string name="h25" value="消耗MP 50，750秒内所有的属性点提高 13%"/>
-        <string name="h26" value="消耗MP 60，780秒内所有的属性点提高 13%"/>
-        <string name="h27" value="消耗MP 60，810秒内所有的属性点提高 14%"/>
-        <string name="h28" value="消耗MP 60，840秒内所有的属性点提高 14%"/>
-        <string name="h29" value="消耗MP 60，870秒内所有的属性点提高 15%"/>
-        <string name="h3" value="消耗MP 10  90秒内所有的属性提升 2%"/>
-        <string name="h30" value="消耗MP 60，900秒内所有的属性点提高 15%"/>
-        <string name="h4" value="消耗MP 10  120秒内所有的属性提升 2%"/>
-        <string name="h5" value="消耗MP 10  150秒内所有的属性提升 3%"/>
-        <string name="h6" value="消耗MP 20  180秒内所有的属性提升 3%"/>
-        <string name="h7" value="消耗MP 20  210秒内所有的属性提升 4%"/>
-        <string name="h8" value="消耗MP 20  240秒内所有的属性提升 4%"/>
-        <string name="h9" value="消耗MP 20  270秒内所有的属性提升 5%"/>
-        <string name="desc" value="一定时间内把组队成员的所有属性点提高\n一定的百分比"/>
+        <string name="desc" value="[最高等级：30]\n一定时间内按百分比提高自身及周围队员的所有属性。"/>
+        <string name="h1" value="消耗MP 10，所有属性 +1%，持续30秒"/>
+        <string name="h2" value="消耗MP 10，所有属性 +1%，持续60秒"/>
+        <string name="h3" value="消耗MP 10，所有属性 +2%，持续90秒"/>
+        <string name="h4" value="消耗MP 10，所有属性 +2%，持续120秒"/>
+        <string name="h5" value="消耗MP 10，所有属性 +3%，持续150秒"/>
+        <string name="h6" value="消耗MP 20，所有属性 +3%，持续180秒"/>
+        <string name="h7" value="消耗MP 20，所有属性 +4%，持续210秒"/>
+        <string name="h8" value="消耗MP 20，所有属性 +4%，持续240秒"/>
+        <string name="h9" value="消耗MP 20，所有属性 +5%，持续270秒"/>
+        <string name="h10" value="消耗MP 20，所有属性 +5%，持续300秒"/>
+        <string name="h11" value="消耗MP 30，所有属性 +6%，持续330秒"/>
+        <string name="h12" value="消耗MP 30，所有属性 +6%，持续360秒"/>
+        <string name="h13" value="消耗MP 30，所有属性 +7%，持续390秒"/>
+        <string name="h14" value="消耗MP 30，所有属性 +7%，持续420秒"/>
+        <string name="h15" value="消耗MP 30，所有属性 +8%，持续450秒"/>
+        <string name="h16" value="消耗MP 40，所有属性 +8%，持续480秒"/>
+        <string name="h17" value="消耗MP 40，所有属性 +9%，持续510秒"/>
+        <string name="h18" value="消耗MP 40，所有属性 +9%，持续540秒"/>
+        <string name="h19" value="消耗MP 40，所有属性 +10%，持续570秒"/>
+        <string name="h20" value="消耗MP 40，所有属性 +10%，持续600秒"/>
+        <string name="h21" value="消耗MP 50，所有属性 +11%，持续630秒"/>
+        <string name="h22" value="消耗MP 50，所有属性 +11%，持续660秒"/>
+        <string name="h23" value="消耗MP 50，所有属性 +12%，持续690秒"/>
+        <string name="h24" value="消耗MP 50，所有属性 +12%，持续720秒"/>
+        <string name="h25" value="消耗MP 50，所有属性 +13%，持续750秒"/>
+        <string name="h26" value="消耗MP 60，所有属性 +13%，持续780秒"/>
+        <string name="h27" value="消耗MP 60，所有属性 +14%，持续810秒"/>
+        <string name="h28" value="消耗MP 60，所有属性 +14%，持续840秒"/>
+        <string name="h29" value="消耗MP 60，所有属性 +15%，持续870秒"/>
+        <string name="h30" value="消耗MP 60，所有属性 +15%，持续900秒"/>
     </imgdir>
     <imgdir name="5221003">
         <string name="name" value="地毯式空袭"/>
-        <string name="h1" value="消耗MP 31，伤害 520%，冷却时间 5秒"/>
-        <string name="h10" value="消耗MP 40，伤害 700%，冷却时间 5秒"/>
-        <string name="h11" value="消耗MP 41，伤害 770%，冷却时间 5秒"/>
-        <string name="h12" value="消耗MP 42，伤害 790%，冷却时间 5秒"/>
-        <string name="h13" value="消耗MP 43，伤害 810%，冷却时间 5秒"/>
-        <string name="h14" value="消耗MP 44，伤害 830%，冷却时间 5秒"/>
-        <string name="h15" value="消耗MP 45，伤害 850%，冷却时间 5秒"/>
-        <string name="h16" value="消耗MP 46，伤害 870%，冷却时间 5秒"/>
-        <string name="h17" value="消耗MP 47，伤害 890%，冷却时间 5秒"/>
-        <string name="h18" value="消耗MP 48，伤害 910%，冷却时间 5秒"/>
-        <string name="h19" value="消耗MP 49，伤害 930%，冷却时间 5秒"/>
-        <string name="h2" value="消耗MP 32，伤害 540%，冷却时间 5秒"/>
-        <string name="h20" value="消耗MP 50，伤害 950%，冷却时间 5秒"/>
-        <string name="h21" value="消耗MP 51，伤害 1020%，冷却时间 5秒"/>
-        <string name="h22" value="消耗MP 52，伤害 1040%，冷却时间 5秒"/>
-        <string name="h23" value="消耗MP 53，伤害 1060%，冷却时间 5秒"/>
-        <string name="h24" value="消耗MP 54，伤害 1080%，冷却时间 5秒"/>
-        <string name="h25" value="消耗MP 55，伤害 1100%，冷却时间 5秒"/>
-        <string name="h26" value="消耗MP 56，伤害 1120%，冷却时间 5秒"/>
-        <string name="h27" value="消耗MP 57，伤害 1140%，冷却时间 5秒"/>
-        <string name="h28" value="消耗MP 58，伤害 1160%，冷却时间 5秒"/>
-        <string name="h29" value="消耗MP 59，伤害 1180%，冷却时间 5秒"/>
-        <string name="h3" value="消耗MP 33，伤害 560%，冷却时间 5秒"/>
-        <string name="h30" value="消耗MP 60，伤害 1200%，冷却时间 5秒"/>
-        <string name="h4" value="消耗MP 34，伤害 580%，冷却时间 5秒"/>
-        <string name="h5" value="消耗MP 35，伤害 600%，冷却时间 5秒"/>
-        <string name="h6" value="消耗MP 36，伤害 620%，冷却时间 5秒"/>
-        <string name="h7" value="消耗MP 37，伤害 640%，冷却时间 5秒"/>
-        <string name="h8" value="消耗MP 38，伤害 660%，冷却时间 5秒"/>
-        <string name="h9" value="消耗MP 39，伤害 680%，冷却时间 5秒"/>
-        <string name="desc" value="召唤海鸥群的炸弹攻击，攻击6个以下的敌人。 \n必要技能 : #c海鸥空袭15级以上#"/>
+        <string name="desc" value="[最高等级：30]\n呼叫空袭轰炸，攻击最多6个敌人。需要海鸥空袭15级以上。"/>
+        <string name="h1" value="消耗MP 31，伤害 520%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h2" value="消耗MP 32，伤害 540%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h3" value="消耗MP 33，伤害 560%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h4" value="消耗MP 34，伤害 580%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h5" value="消耗MP 35，伤害 600%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h6" value="消耗MP 36，伤害 620%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h7" value="消耗MP 37，伤害 640%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h8" value="消耗MP 38，伤害 660%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h9" value="消耗MP 39，伤害 680%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h10" value="消耗MP 40，伤害 700%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h11" value="消耗MP 41，伤害 770%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h12" value="消耗MP 42，伤害 790%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h13" value="消耗MP 43，伤害 810%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h14" value="消耗MP 44，伤害 830%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h15" value="消耗MP 45，伤害 850%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h16" value="消耗MP 46，伤害 870%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h17" value="消耗MP 47，伤害 890%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h18" value="消耗MP 48，伤害 910%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h19" value="消耗MP 49，伤害 930%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h20" value="消耗MP 50，伤害 950%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h21" value="消耗MP 51，伤害 1020%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h22" value="消耗MP 52，伤害 1040%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h23" value="消耗MP 53，伤害 1060%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h24" value="消耗MP 54，伤害 1080%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h25" value="消耗MP 55，伤害 1100%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h26" value="消耗MP 56，伤害 1120%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h27" value="消耗MP 57，伤害 1140%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h28" value="消耗MP 58，伤害 1160%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h29" value="消耗MP 59，伤害 1180%，最多攻击 6 个敌人，冷却 5 秒"/>
+        <string name="h30" value="消耗MP 60，伤害 1200%，最多攻击 6 个敌人，冷却 5 秒"/>
     </imgdir>
     <imgdir name="5221004">
         <string name="name" value="金属风暴"/>
-        <string name="h1" value="消耗MP 6，伤害 142%"/>
-        <string name="h10" value="消耗MP 6，伤害 160%"/>
-        <string name="h11" value="消耗MP 8，伤害 162%"/>
-        <string name="h12" value="消耗MP 8，伤害 164%"/>
-        <string name="h13" value="消耗MP 8，伤害 166%"/>
-        <string name="h14" value="消耗MP 8，伤害 168%"/>
-        <string name="h15" value="消耗MP 8，伤害 170%"/>
-        <string name="h16" value="消耗MP 8，伤害 172%"/>
-        <string name="h17" value="消耗MP 8，伤害 174%"/>
-        <string name="h18" value="消耗MP 8，伤害 176%"/>
-        <string name="h19" value="消耗MP 8，伤害 178%"/>
-        <string name="h2" value="消耗MP 6，伤害 144%"/>
-        <string name="h20" value="消耗MP 8，伤害 180%"/>
-        <string name="h21" value="消耗MP 10，伤害 182%"/>
-        <string name="h22" value="消耗MP 10，伤害 184%"/>
-        <string name="h23" value="消耗MP 10，伤害 186%"/>
-        <string name="h24" value="消耗MP 10，伤害 188%"/>
-        <string name="h25" value="消耗MP 10，伤害 190%"/>
-        <string name="h26" value="消耗MP 9，伤害 192%"/>
-        <string name="h27" value="消耗MP 9，伤害 194%"/>
-        <string name="h28" value="消耗MP 9，伤害 196%"/>
-        <string name="h29" value="消耗MP 9，伤害 198%"/>
-        <string name="h3" value="消耗MP 6，伤害 146%"/>
-        <string name="h30" value="消耗MP 9，伤害 200%"/>
-        <string name="h4" value="消耗MP 6，伤害 148%"/>
-        <string name="h5" value="消耗MP 6，伤害 150%"/>
-        <string name="h6" value="消耗MP 6，伤害 152%"/>
-        <string name="h7" value="消耗MP 6，伤害 154%"/>
-        <string name="h8" value="消耗MP 6，伤害 156%"/>
-        <string name="h9" value="消耗MP 6，伤害 158%"/>
-        <string name="desc" value="发射非常快的子弹。\n摁住此技能键的状态可持续。\n必要技能 : #c三连射杀 20等级#"/>
+        <string name="desc" value="[最高等级：30]\n按住技能键时连续高速射击。需要三连射杀20级。"/>
+        <string name="h1" value="消耗MP 6，按住技能键时每发伤害 102%"/>
+        <string name="h2" value="消耗MP 6，按住技能键时每发伤害 104%"/>
+        <string name="h3" value="消耗MP 6，按住技能键时每发伤害 106%"/>
+        <string name="h4" value="消耗MP 6，按住技能键时每发伤害 108%"/>
+        <string name="h5" value="消耗MP 6，按住技能键时每发伤害 110%"/>
+        <string name="h6" value="消耗MP 6，按住技能键时每发伤害 112%"/>
+        <string name="h7" value="消耗MP 6，按住技能键时每发伤害 114%"/>
+        <string name="h8" value="消耗MP 6，按住技能键时每发伤害 116%"/>
+        <string name="h9" value="消耗MP 6，按住技能键时每发伤害 118%"/>
+        <string name="h10" value="消耗MP 6，按住技能键时每发伤害 120%"/>
+        <string name="h11" value="消耗MP 8，按住技能键时每发伤害 122%"/>
+        <string name="h12" value="消耗MP 8，按住技能键时每发伤害 124%"/>
+        <string name="h13" value="消耗MP 8，按住技能键时每发伤害 126%"/>
+        <string name="h14" value="消耗MP 8，按住技能键时每发伤害 128%"/>
+        <string name="h15" value="消耗MP 8，按住技能键时每发伤害 130%"/>
+        <string name="h16" value="消耗MP 8，按住技能键时每发伤害 132%"/>
+        <string name="h17" value="消耗MP 8，按住技能键时每发伤害 134%"/>
+        <string name="h18" value="消耗MP 8，按住技能键时每发伤害 136%"/>
+        <string name="h19" value="消耗MP 8，按住技能键时每发伤害 138%"/>
+        <string name="h20" value="消耗MP 8，按住技能键时每发伤害 140%"/>
+        <string name="h21" value="消耗MP 10，按住技能键时每发伤害 152%"/>
+        <string name="h22" value="消耗MP 10，按住技能键时每发伤害 154%"/>
+        <string name="h23" value="消耗MP 10，按住技能键时每发伤害 156%"/>
+        <string name="h24" value="消耗MP 10，按住技能键时每发伤害 158%"/>
+        <string name="h25" value="消耗MP 10，按住技能键时每发伤害 160%"/>
+        <string name="h26" value="消耗MP 9，按住技能键时每发伤害 162%"/>
+        <string name="h27" value="消耗MP 9，按住技能键时每发伤害 164%"/>
+        <string name="h28" value="消耗MP 9，按住技能键时每发伤害 166%"/>
+        <string name="h29" value="消耗MP 9，按住技能键时每发伤害 168%"/>
+        <string name="h30" value="消耗MP 9，按住技能键时每发伤害 170%"/>
     </imgdir>
     <imgdir name="5221006">
         <string name="name" value="武装"/>
-        <string name="h1" value="消耗MP 22，物理，魔力防御力 10 增加"/>
-        <string name="h10" value="消耗MP 40，物理，魔力防御力 100 增加"/>
-        <string name="h2" value="消耗MP 24，物理，魔力防御力 20 增加"/>
-        <string name="h3" value="消耗MP 26，物理，魔力防御力 30 增加"/>
-        <string name="h4" value="消耗MP 28，物理，魔力防御力 40 增加"/>
-        <string name="h5" value="消耗MP 30，物理，魔力防御力 50 增加"/>
-        <string name="h6" value="消耗MP 32，物理，魔力防御力 60 增加"/>
-        <string name="h7" value="消耗MP 34，物理，魔力防御力 70 增加"/>
-        <string name="h8" value="消耗MP 36，物理，魔力防御力 80 增加"/>
-        <string name="h9" value="消耗MP 38，物理，魔力防御力 90 增加"/>
-        <string name="desc" value="登上海盗船。受到伤害时耐久度减少，耐久\n度为0时，一定时间内将不能乘坐海盗船。\n可使用技能 : 武装，投弹攻击，速射，烈焰喷射，\n寒冰喷射，海鸥空袭，章鱼炮台，冒险岛勇士，\n勇士的意志 #c耐久度耗尽后冷却时间 : 90秒#"/>
+        <string name="desc" value="[最高等级：10]\n登上战舰。受到伤害会减少战舰耐久，耐久为0时进入冷却。耐久为 400 x 技能等级 + 200 x max(角色等级 - 120, 0)。"/>
+        <string name="h1" value="消耗MP 22，物理防御 +10，魔法防御 +10，战舰冷却 90 秒"/>
+        <string name="h2" value="消耗MP 24，物理防御 +20，魔法防御 +20，战舰冷却 90 秒"/>
+        <string name="h3" value="消耗MP 26，物理防御 +30，魔法防御 +30，战舰冷却 90 秒"/>
+        <string name="h4" value="消耗MP 28，物理防御 +40，魔法防御 +40，战舰冷却 90 秒"/>
+        <string name="h5" value="消耗MP 30，物理防御 +50，魔法防御 +50，战舰冷却 90 秒"/>
+        <string name="h6" value="消耗MP 32，物理防御 +60，魔法防御 +60，战舰冷却 90 秒"/>
+        <string name="h7" value="消耗MP 34，物理防御 +70，魔法防御 +70，战舰冷却 90 秒"/>
+        <string name="h8" value="消耗MP 36，物理防御 +80，魔法防御 +80，战舰冷却 90 秒"/>
+        <string name="h9" value="消耗MP 38，物理防御 +90，魔法防御 +90，战舰冷却 90 秒"/>
+        <string name="h10" value="消耗MP 40，物理防御 +100，魔法防御 +100，战舰冷却 90 秒"/>
     </imgdir>
     <imgdir name="5221007">
         <string name="name" value="急速射"/>
-        <string name="h1" value="消耗MP 22，205%的伤害攻击敌人 3次"/>
-        <string name="h10" value="消耗MP 28，250%的伤害攻击敌人 3次"/>
-        <string name="h11" value="消耗MP 28，265%的伤害攻击敌人 4次"/>
-        <string name="h12" value="消耗MP 28，270%的伤害攻击敌人 4次"/>
-        <string name="h13" value="消耗MP 30，275%的伤害攻击敌人 4次"/>
-        <string name="h14" value="消耗MP 30，280%的伤害攻击敌人 4次"/>
-        <string name="h15" value="消耗MP 30，285%的伤害攻击敌人 4次"/>
-        <string name="h16" value="消耗MP 32，290%的伤害攻击敌人 4次"/>
-        <string name="h17" value="消耗MP 32，295%的伤害攻击敌人 4次"/>
-        <string name="h18" value="消耗MP 32，300%的伤害攻击敌人 4次"/>
-        <string name="h19" value="消耗MP 34，305%的伤害攻击敌人 4次"/>
-        <string name="h2" value="消耗MP 22，210%的伤害攻击敌人 3次"/>
-        <string name="h20" value="消耗MP 34，310%的伤害攻击敌人 4次"/>
-        <string name="h21" value="消耗MP 34，335%的伤害攻击敌人 4次"/>
-        <string name="h22" value="消耗MP 36，340%的伤害攻击敌人 4次"/>
-        <string name="h23" value="消耗MP 36，345%的伤害攻击敌人 4次"/>
-        <string name="h24" value="消耗MP 36，350%的伤害攻击敌人 4次"/>
-        <string name="h25" value="消耗MP 38，355%的伤害攻击敌人 4次"/>
-        <string name="h26" value="消耗MP 38，360%的伤害攻击敌人 4次"/>
-        <string name="h27" value="消耗MP 38，365%的伤害攻击敌人 4次"/>
-        <string name="h28" value="消耗MP 40，370%的伤害攻击敌人 4次"/>
-        <string name="h29" value="消耗MP 40，375%的伤害攻击敌人 4次"/>
-        <string name="h3" value="消耗MP 22，215%的伤害攻击敌人 3次"/>
-        <string name="h30" value="消耗MP 40，380%的伤害攻击敌人 4次"/>
-        <string name="h4" value="消耗MP 24，220%的伤害攻击敌人 3次"/>
-        <string name="h5" value="消耗MP 24，225%的伤害攻击敌人 3次"/>
-        <string name="h6" value="消耗MP 24，230%的伤害攻击敌人 3次"/>
-        <string name="h7" value="消耗MP 26，235%的伤害攻击敌人 3次"/>
-        <string name="h8" value="消耗MP 26，240%的伤害攻击敌人 3次"/>
-        <string name="h9" value="消耗MP 26，245%的伤害攻击敌人 3次"/>
-        <string name="desc" value="连续发射数发炮弹。\n只能是“武装”技能使用状态下才可使用。\n必要技能 : #c武装 1级以上#"/>
+        <string name="desc" value="[最高等级：30]\n在战舰上连续发射炮弹。只能在武装状态下使用。"/>
+        <string name="h1" value="消耗MP 22，每发炮弹伤害 205%，发射 3 发"/>
+        <string name="h2" value="消耗MP 22，每发炮弹伤害 210%，发射 3 发"/>
+        <string name="h3" value="消耗MP 22，每发炮弹伤害 215%，发射 3 发"/>
+        <string name="h4" value="消耗MP 24，每发炮弹伤害 220%，发射 3 发"/>
+        <string name="h5" value="消耗MP 24，每发炮弹伤害 225%，发射 3 发"/>
+        <string name="h6" value="消耗MP 24，每发炮弹伤害 230%，发射 3 发"/>
+        <string name="h7" value="消耗MP 26，每发炮弹伤害 235%，发射 3 发"/>
+        <string name="h8" value="消耗MP 26，每发炮弹伤害 240%，发射 3 发"/>
+        <string name="h9" value="消耗MP 26，每发炮弹伤害 245%，发射 3 发"/>
+        <string name="h10" value="消耗MP 28，每发炮弹伤害 250%，发射 3 发"/>
+        <string name="h11" value="消耗MP 28，每发炮弹伤害 265%，发射 4 发"/>
+        <string name="h12" value="消耗MP 28，每发炮弹伤害 270%，发射 4 发"/>
+        <string name="h13" value="消耗MP 30，每发炮弹伤害 275%，发射 4 发"/>
+        <string name="h14" value="消耗MP 30，每发炮弹伤害 280%，发射 4 发"/>
+        <string name="h15" value="消耗MP 30，每发炮弹伤害 285%，发射 4 发"/>
+        <string name="h16" value="消耗MP 32，每发炮弹伤害 290%，发射 4 发"/>
+        <string name="h17" value="消耗MP 32，每发炮弹伤害 295%，发射 4 发"/>
+        <string name="h18" value="消耗MP 32，每发炮弹伤害 300%，发射 4 发"/>
+        <string name="h19" value="消耗MP 34，每发炮弹伤害 305%，发射 4 发"/>
+        <string name="h20" value="消耗MP 34，每发炮弹伤害 310%，发射 4 发"/>
+        <string name="h21" value="消耗MP 34，每发炮弹伤害 335%，发射 4 发"/>
+        <string name="h22" value="消耗MP 36，每发炮弹伤害 340%，发射 4 发"/>
+        <string name="h23" value="消耗MP 36，每发炮弹伤害 345%，发射 4 发"/>
+        <string name="h24" value="消耗MP 36，每发炮弹伤害 350%，发射 4 发"/>
+        <string name="h25" value="消耗MP 38，每发炮弹伤害 355%，发射 4 发"/>
+        <string name="h26" value="消耗MP 38，每发炮弹伤害 360%，发射 4 发"/>
+        <string name="h27" value="消耗MP 38，每发炮弹伤害 365%，发射 4 发"/>
+        <string name="h28" value="消耗MP 40，每发炮弹伤害 370%，发射 4 发"/>
+        <string name="h29" value="消耗MP 40，每发炮弹伤害 375%，发射 4 发"/>
+        <string name="h30" value="消耗MP 40，每发炮弹伤害 380%，发射 4 发"/>
     </imgdir>
     <imgdir name="5221008">
         <string name="name" value="重量炮击"/>
-        <string name="h1" value="消耗MP 22，伤害 390%，4只 攻击"/>
-        <string name="h10" value="消耗MP 28，伤害 480%，4只 攻击"/>
-        <string name="h11" value="消耗MP 28，伤害 540%，5只 攻击"/>
-        <string name="h12" value="消耗MP 28，伤害 550%，5只 攻击"/>
-        <string name="h13" value="消耗MP 30，伤害 560%，5只 攻击"/>
-        <string name="h14" value="消耗MP 30，伤害 570%，5只 攻击"/>
-        <string name="h15" value="消耗MP 30，伤害 580%，5只 攻击"/>
-        <string name="h16" value="消耗MP 32，伤害 590%，5只 攻击"/>
-        <string name="h17" value="消耗MP 32，伤害 600%，5只 攻击"/>
-        <string name="h18" value="消耗MP 32，伤害 610%，5只 攻击"/>
-        <string name="h19" value="消耗MP 34，伤害 620%，5只 攻击"/>
-        <string name="h2" value="消耗MP 22，伤害 400%，4只 攻击"/>
-        <string name="h20" value="消耗MP 34，伤害 630%，5只 攻击"/>
-        <string name="h21" value="消耗MP 34，伤害 690%，6只 攻击"/>
-        <string name="h22" value="消耗MP 36，伤害 700%，6只 攻击"/>
-        <string name="h23" value="消耗MP 36，伤害 710%，6只 攻击"/>
-        <string name="h24" value="消耗MP 36，伤害 720%，6只 攻击"/>
-        <string name="h25" value="消耗MP 38，伤害 730%，6只 攻击"/>
-        <string name="h26" value="消耗MP 38，伤害 740%，6只 攻击"/>
-        <string name="h27" value="消耗MP 38，伤害 750%，6只 攻击"/>
-        <string name="h28" value="消耗MP 40，伤害 760%，6只 攻击"/>
-        <string name="h29" value="消耗MP 40，伤害 770%，6只 攻击"/>
-        <string name="h3" value="消耗MP 22，伤害 410%，4只 攻击"/>
-        <string name="h30" value="消耗MP 40，伤害 780%，6只 攻击"/>
-        <string name="h4" value="消耗MP 24，伤害 420%，4只 攻击"/>
-        <string name="h5" value="消耗MP 24，伤害 430%，4只 攻击"/>
-        <string name="h6" value="消耗MP 24，伤害 440%，4只 攻击"/>
-        <string name="h7" value="消耗MP 26，伤害 450%，4只 攻击"/>
-        <string name="h8" value="消耗MP 26，伤害 460%，4只 攻击"/>
-        <string name="h9" value="消耗MP 26，伤害 470%，4只 攻击"/>
-        <string name="desc" value="向敌人发射结实的炮弹。\n只能是“武装”技能使用状态下才可使用。\n必要技能 : #c武装 1级以上#"/>
+        <string name="desc" value="[最高等级：30]\n在战舰上发射贯穿敌人的炮弹。只能在武装状态下使用。"/>
+        <string name="h1" value="消耗MP 22，伤害 390%，最多攻击 4 个敌人"/>
+        <string name="h2" value="消耗MP 22，伤害 400%，最多攻击 4 个敌人"/>
+        <string name="h3" value="消耗MP 22，伤害 410%，最多攻击 4 个敌人"/>
+        <string name="h4" value="消耗MP 24，伤害 420%，最多攻击 4 个敌人"/>
+        <string name="h5" value="消耗MP 24，伤害 430%，最多攻击 4 个敌人"/>
+        <string name="h6" value="消耗MP 24，伤害 440%，最多攻击 4 个敌人"/>
+        <string name="h7" value="消耗MP 26，伤害 450%，最多攻击 4 个敌人"/>
+        <string name="h8" value="消耗MP 26，伤害 460%，最多攻击 4 个敌人"/>
+        <string name="h9" value="消耗MP 26，伤害 470%，最多攻击 4 个敌人"/>
+        <string name="h10" value="消耗MP 28，伤害 480%，最多攻击 4 个敌人"/>
+        <string name="h11" value="消耗MP 28，伤害 540%，最多攻击 5 个敌人"/>
+        <string name="h12" value="消耗MP 28，伤害 550%，最多攻击 5 个敌人"/>
+        <string name="h13" value="消耗MP 30，伤害 560%，最多攻击 5 个敌人"/>
+        <string name="h14" value="消耗MP 30，伤害 570%，最多攻击 5 个敌人"/>
+        <string name="h15" value="消耗MP 30，伤害 580%，最多攻击 5 个敌人"/>
+        <string name="h16" value="消耗MP 32，伤害 590%，最多攻击 5 个敌人"/>
+        <string name="h17" value="消耗MP 32，伤害 600%，最多攻击 5 个敌人"/>
+        <string name="h18" value="消耗MP 32，伤害 610%，最多攻击 5 个敌人"/>
+        <string name="h19" value="消耗MP 34，伤害 620%，最多攻击 5 个敌人"/>
+        <string name="h20" value="消耗MP 34，伤害 630%，最多攻击 5 个敌人"/>
+        <string name="h21" value="消耗MP 34，伤害 690%，最多攻击 6 个敌人"/>
+        <string name="h22" value="消耗MP 36，伤害 700%，最多攻击 6 个敌人"/>
+        <string name="h23" value="消耗MP 36，伤害 710%，最多攻击 6 个敌人"/>
+        <string name="h24" value="消耗MP 36，伤害 720%，最多攻击 6 个敌人"/>
+        <string name="h25" value="消耗MP 38，伤害 730%，最多攻击 6 个敌人"/>
+        <string name="h26" value="消耗MP 38，伤害 740%，最多攻击 6 个敌人"/>
+        <string name="h27" value="消耗MP 38，伤害 750%，最多攻击 6 个敌人"/>
+        <string name="h28" value="消耗MP 40，伤害 760%，最多攻击 6 个敌人"/>
+        <string name="h29" value="消耗MP 40，伤害 770%，最多攻击 6 个敌人"/>
+        <string name="h30" value="消耗MP 40，伤害 780%，最多攻击 6 个敌人"/>
     </imgdir>
     <imgdir name="5221009">
         <string name="name" value="心灵控制"/>
-        <string name="h1" value="消耗MP 31，持续时间 21秒，成功率 43 %"/>
-        <string name="h10" value="消耗MP 40，持续时间 30秒，成功率 70 %"/>
-        <string name="h11" value="消耗MP 41，持续时间 31秒，成功率 73 %"/>
-        <string name="h12" value="消耗MP 42，持续时间 32秒，成功率 76 %"/>
-        <string name="h13" value="消耗MP 43，持续时间 33秒，成功率 79 %"/>
-        <string name="h14" value="消耗MP 44，持续时间 34秒，成功率 82 %"/>
-        <string name="h15" value="消耗MP 45，持续时间 35秒，成功率 85 %"/>
-        <string name="h16" value="消耗MP 46，持续时间 36秒，成功率 88 %"/>
-        <string name="h17" value="消耗MP 47，持续时间 37秒，成功率 91 %"/>
-        <string name="h18" value="消耗MP 48，持续时间 38秒，成功率 94 %"/>
-        <string name="h19" value="消耗MP 49，持续时间 39秒，成功率 97 %"/>
-        <string name="h2" value="消耗MP 32，持续时间 22秒，成功率 46 %"/>
-        <string name="h20" value="消耗MP 30，持续时间 30秒，成功率 100 %"/>
-        <string name="h3" value="消耗MP 33，持续时间 23秒，成功率 49 %"/>
-        <string name="h4" value="消耗MP 34，持续时间 24秒，成功率 52 %"/>
-        <string name="h5" value="消耗MP 35，持续时间 25秒，成功率 55 %"/>
-        <string name="h6" value="消耗MP 36，持续时间 26秒，成功率 58 %"/>
-        <string name="h7" value="消耗MP 37，持续时间 27秒，成功率 61 %"/>
-        <string name="h8" value="消耗MP 38，持续时间 28秒，成功率 64 %"/>
-        <string name="h9" value="消耗MP 39，持续时间 29秒，成功率 67 %"/>
-        <string name="desc" value="诱惑怪物，使其在一定时间内攻击其他怪物。 "/>
+        <string name="desc" value="[最高等级：20]\n催眠1个怪物，使其在一定时间内攻击其他怪物。"/>
+        <string name="h1" value="消耗MP 31，43% 概率催眠 21 秒，射程 350"/>
+        <string name="h2" value="消耗MP 32，46% 概率催眠 22 秒，射程 350"/>
+        <string name="h3" value="消耗MP 33，49% 概率催眠 23 秒，射程 350"/>
+        <string name="h4" value="消耗MP 34，52% 概率催眠 24 秒，射程 350"/>
+        <string name="h5" value="消耗MP 35，55% 概率催眠 25 秒，射程 350"/>
+        <string name="h6" value="消耗MP 36，58% 概率催眠 26 秒，射程 350"/>
+        <string name="h7" value="消耗MP 37，61% 概率催眠 27 秒，射程 350"/>
+        <string name="h8" value="消耗MP 38，64% 概率催眠 28 秒，射程 350"/>
+        <string name="h9" value="消耗MP 39，67% 概率催眠 29 秒，射程 350"/>
+        <string name="h10" value="消耗MP 40，70% 概率催眠 30 秒，射程 350"/>
+        <string name="h11" value="消耗MP 41，73% 概率催眠 31 秒，射程 350"/>
+        <string name="h12" value="消耗MP 42，76% 概率催眠 32 秒，射程 350"/>
+        <string name="h13" value="消耗MP 43，79% 概率催眠 33 秒，射程 350"/>
+        <string name="h14" value="消耗MP 44，82% 概率催眠 34 秒，射程 350"/>
+        <string name="h15" value="消耗MP 45，85% 概率催眠 35 秒，射程 350"/>
+        <string name="h16" value="消耗MP 46，88% 概率催眠 36 秒，射程 350"/>
+        <string name="h17" value="消耗MP 47，91% 概率催眠 37 秒，射程 350"/>
+        <string name="h18" value="消耗MP 48，94% 概率催眠 38 秒，射程 350"/>
+        <string name="h19" value="消耗MP 49，97% 概率催眠 39 秒，射程 350"/>
+        <string name="h20" value="消耗MP 50，100% 概率催眠 40 秒，射程 350"/>
     </imgdir>
     <imgdir name="5221010">
-        <string name="name" value="勇士的意志"/>
-        <string name="h1" value="消耗MP 30，解除诱惑异常状态，冷却时间10分钟"/>
-        <string name="h25" value="MP -75，waiting time until next use: 25 min"/>
-        <string name="desc" value="从异常状态中恢复。\n随着等级的上升，冷却时间逐渐缩短"/>
+        <string name="name" value="极速领域"/>
+        <string name="desc" value="[最高等级：5]\n消耗MP启用服务端船长极速领域增益槽。当前WZ数值只提供冷却时间。"/>
+        <string name="h1" value="消耗MP 30，冷却 600 秒"/>
+        <string name="h2" value="消耗MP 30，冷却 540 秒"/>
+        <string name="h3" value="消耗MP 30，冷却 480 秒"/>
+        <string name="h4" value="消耗MP 30，冷却 420 秒"/>
+        <string name="h5" value="消耗MP 30，冷却 360 秒"/>
     </imgdir>
     <imgdir name="800">
         <string name="bookName" value="管理员技能书"/>

--- a/gms-server/wz/String.wz/Skill.img.xml
+++ b/gms-server/wz/String.wz/Skill.img.xml
@@ -7777,1414 +7777,1423 @@
   </imgdir>
   <imgdir name="5000000">
     <string name="name" value="Bullet Time"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases accuracy and avoidability."/>
-    <string name="h1" value="Accuracy +1, Avoidability +1"/>
-    <string name="h2" value="Accuracy +2, Avoidability +2"/>
-    <string name="h3" value="Accuracy +3, Avoidability +3"/>
-    <string name="h4" value="Accuracy +4, Avoidability +4"/>
-    <string name="h5" value="Accuracy +5, Avoidability +5"/>
-    <string name="h6" value="Accuracy +6, Avoidability +6"/>
-    <string name="h7" value="Accuracy +7, Avoidability +7"/>
-    <string name="h8" value="Accuracy +8, Avoidability +8"/>
-    <string name="h9" value="Accuracy +9, Avoidability +9"/>
-    <string name="h10" value="Accuracy +10, Avoidability +10"/>
-    <string name="h11" value="Accuracy +11, Avoidability +11"/>
-    <string name="h12" value="Accuracy +12, Avoidability +12"/>
-    <string name="h13" value="Accuracy +13, Avoidability +13"/>
-    <string name="h14" value="Accuracy +14, Avoidability +14"/>
-    <string name="h15" value="Accuracy +15, Avoidability +15"/>
-    <string name="h16" value="Accuracy +16, Avoidability +16"/>
-    <string name="h17" value="Accuracy +17, Avoidability +17"/>
-    <string name="h18" value="Accuracy +18, Avoidability +18"/>
-    <string name="h19" value="Accuracy +19, Avoidability +19"/>
-    <string name="h20" value="Accuracy +20, Avoidability +20"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases accuracy and avoidability."/>
+    <string name="h1" value="Accuracy +1, avoidability +1"/>
+    <string name="h2" value="Accuracy +2, avoidability +2"/>
+    <string name="h3" value="Accuracy +3, avoidability +3"/>
+    <string name="h4" value="Accuracy +4, avoidability +4"/>
+    <string name="h5" value="Accuracy +5, avoidability +5"/>
+    <string name="h6" value="Accuracy +6, avoidability +6"/>
+    <string name="h7" value="Accuracy +7, avoidability +7"/>
+    <string name="h8" value="Accuracy +8, avoidability +8"/>
+    <string name="h9" value="Accuracy +9, avoidability +9"/>
+    <string name="h10" value="Accuracy +10, avoidability +10"/>
+    <string name="h11" value="Accuracy +11, avoidability +11"/>
+    <string name="h12" value="Accuracy +12, avoidability +12"/>
+    <string name="h13" value="Accuracy +13, avoidability +13"/>
+    <string name="h14" value="Accuracy +14, avoidability +14"/>
+    <string name="h15" value="Accuracy +15, avoidability +15"/>
+    <string name="h16" value="Accuracy +16, avoidability +16"/>
+    <string name="h17" value="Accuracy +17, avoidability +17"/>
+    <string name="h18" value="Accuracy +18, avoidability +18"/>
+    <string name="h19" value="Accuracy +19, avoidability +19"/>
+    <string name="h20" value="Accuracy +20, avoidability +20"/>
   </imgdir>
   <imgdir name="5001001">
     <string name="name" value="Flash Fist"/>
-    <string name="desc" value="[Master Level : 20]\nUses MP to speed up the punch to rapidly attack enemies."/>
-    <string name="h1" value="MP -6, damage 156%"/>
-    <string name="h2" value="MP -6, damage 162%"/>
-    <string name="h3" value="MP -6, damage 168%"/>
-    <string name="h4" value="MP -6, damage 174%"/>
-    <string name="h5" value="MP -7, damage 180%"/>
-    <string name="h6" value="MP -7, damage 186%"/>
-    <string name="h7" value="MP -7, damage 192%"/>
-    <string name="h8" value="MP -8, damage 198%"/>
-    <string name="h9" value="MP -8, damage 204%"/>
-    <string name="h10" value="MP -9, damage 210%"/>
-    <string name="h11" value="MP -9, damage 216%"/>
-    <string name="h12" value="MP -10, damage 222%"/>
-    <string name="h13" value="MP -10, damage 228%"/>
-    <string name="h14" value="MP -11, damage 234%"/>
-    <string name="h15" value="MP -11, damage 240%"/>
-    <string name="h16" value="MP -12, damage 246%"/>
-    <string name="h17" value="MP -12, damage 252%"/>
-    <string name="h18" value="MP -13, damage 258%"/>
-    <string name="h19" value="MP -13, damage 264%"/>
-    <string name="h20" value="MP -14, damage 270%"/>
+    <string name="desc" value="[Master Level: 20]\nUses MP to punch one enemy at high speed."/>
+    <string name="h1" value="MP -6; damage 156%"/>
+    <string name="h2" value="MP -6; damage 162%"/>
+    <string name="h3" value="MP -6; damage 168%"/>
+    <string name="h4" value="MP -6; damage 174%"/>
+    <string name="h5" value="MP -7; damage 180%"/>
+    <string name="h6" value="MP -7; damage 186%"/>
+    <string name="h7" value="MP -7; damage 192%"/>
+    <string name="h8" value="MP -8; damage 198%"/>
+    <string name="h9" value="MP -8; damage 204%"/>
+    <string name="h10" value="MP -9; damage 210%"/>
+    <string name="h11" value="MP -9; damage 216%"/>
+    <string name="h12" value="MP -10; damage 222%"/>
+    <string name="h13" value="MP -10; damage 228%"/>
+    <string name="h14" value="MP -11; damage 234%"/>
+    <string name="h15" value="MP -11; damage 240%"/>
+    <string name="h16" value="MP -12; damage 246%"/>
+    <string name="h17" value="MP -12; damage 252%"/>
+    <string name="h18" value="MP -13; damage 258%"/>
+    <string name="h19" value="MP -13; damage 264%"/>
+    <string name="h20" value="MP -14; damage 270%"/>
   </imgdir>
   <imgdir name="5001002">
-    <string name="name" value="Sommersault Kick"/>
-    <string name="desc" value="[Master Level : 20]\nA devastating kick that accompanies a backward sommersault. Attacks all enemies in the vicinity."/>
-    <string name="h1" value="MP -8, damage 114%, attacks up to 3 monsters"/>
-    <string name="h2" value="MP -8, damage 118%, attacks up to 3 monsters"/>
-    <string name="h3" value="MP -8, damage 122%, attacks up to 3 monsters"/>
-    <string name="h4" value="MP -8, damage 126%, attacks up to 3 monsters"/>
-    <string name="h5" value="MP -9, damage 130%, attacks up to 3 monsters"/>
-    <string name="h6" value="MP -9, damage 134%, attacks up to 4 monsters"/>
-    <string name="h7" value="MP -9, damage 138%, attacks up to 4 monsters"/>
-    <string name="h8" value="MP -10, damage 142%, attacks up to 4 monsters"/>
-    <string name="h9" value="MP -10, damage 146%, attacks up to 4 monsters"/>
-    <string name="h10" value="MP -11, damage 150%, attacks up to 4 monsters"/>
-    <string name="h11" value="MP -11, damage 154%, attacks up to 5 monsters"/>
-    <string name="h12" value="MP -12, damage 158%, attacks up to 5 monsters"/>
-    <string name="h13" value="MP -12, damage 162%, attacks up to 5 monsters"/>
-    <string name="h14" value="MP -13, damage 166%, attacks up to 5 monsters"/>
-    <string name="h15" value="MP -13, damage 170%, attacks up to 5 monsters"/>
-    <string name="h16" value="MP -14, damage 174%, attacks up to 6 monsters"/>
-    <string name="h17" value="MP -14, damage 178%, attacks up to 6 monsters"/>
-    <string name="h18" value="MP -15, damage 182%, attacks up to 6 monsters"/>
-    <string name="h19" value="MP -15, damage 186%, attacks up to 6 monsters"/>
-    <string name="h20" value="MP -16, damage 190%, attacks up to 6 monsters"/>
+    <string name="name" value="Somersault Kick"/>
+    <string name="desc" value="[Master Level: 20]\nPerforms a backward somersault kick to attack nearby enemies."/>
+    <string name="h1" value="MP -8; damage 114%, attacks up to 3 enemies"/>
+    <string name="h2" value="MP -8; damage 118%, attacks up to 3 enemies"/>
+    <string name="h3" value="MP -8; damage 122%, attacks up to 3 enemies"/>
+    <string name="h4" value="MP -8; damage 126%, attacks up to 3 enemies"/>
+    <string name="h5" value="MP -9; damage 130%, attacks up to 3 enemies"/>
+    <string name="h6" value="MP -9; damage 134%, attacks up to 4 enemies"/>
+    <string name="h7" value="MP -9; damage 138%, attacks up to 4 enemies"/>
+    <string name="h8" value="MP -10; damage 142%, attacks up to 4 enemies"/>
+    <string name="h9" value="MP -10; damage 146%, attacks up to 4 enemies"/>
+    <string name="h10" value="MP -11; damage 150%, attacks up to 4 enemies"/>
+    <string name="h11" value="MP -11; damage 154%, attacks up to 5 enemies"/>
+    <string name="h12" value="MP -12; damage 158%, attacks up to 5 enemies"/>
+    <string name="h13" value="MP -12; damage 162%, attacks up to 5 enemies"/>
+    <string name="h14" value="MP -13; damage 166%, attacks up to 5 enemies"/>
+    <string name="h15" value="MP -13; damage 170%, attacks up to 5 enemies"/>
+    <string name="h16" value="MP -14; damage 174%, attacks up to 6 enemies"/>
+    <string name="h17" value="MP -14; damage 178%, attacks up to 6 enemies"/>
+    <string name="h18" value="MP -15; damage 182%, attacks up to 6 enemies"/>
+    <string name="h19" value="MP -15; damage 186%, attacks up to 6 enemies"/>
+    <string name="h20" value="MP -16; damage 190%, attacks up to 6 enemies"/>
   </imgdir>
   <imgdir name="5001003">
     <string name="name" value="Double Shot"/>
-    <string name="desc" value="[Master Level : 20]\nFires two bullets at once to apply double damage to monsters."/>
-    <string name="h1" value="MP -4, damage 61%"/>
-    <string name="h2" value="MP -4, damage 62%"/>
-    <string name="h3" value="MP -4, damage 63%"/>
-    <string name="h4" value="MP -4, damage 64%"/>
-    <string name="h5" value="MP -4, damage 65%"/>
-    <string name="h6" value="MP -5, damage 66%"/>
-    <string name="h7" value="MP -5, damage 67%"/>
-    <string name="h8" value="MP -5, damage 68%"/>
-    <string name="h9" value="MP -5, damage 69%"/>
-    <string name="h10" value="MP -5, damage 70%"/>
-    <string name="h11" value="MP -6, damage 71%"/>
-    <string name="h12" value="MP -6, damage 72%"/>
-    <string name="h13" value="MP -6, damage 73%"/>
-    <string name="h14" value="MP -6, damage 74%"/>
-    <string name="h15" value="MP -6, damage 75%"/>
-    <string name="h16" value="MP -7, damage 76%"/>
-    <string name="h17" value="MP -7, damage 77%"/>
-    <string name="h18" value="MP -7, damage 78%"/>
-    <string name="h19" value="MP -7, damage 79%"/>
-    <string name="h20" value="MP -7, damage 80%"/>
+    <string name="desc" value="[Master Level: 20]\nFires two bullets at one enemy. Requires a gun and bullets."/>
+    <string name="h1" value="MP -4; damage 61% per shot, fires 2 shots"/>
+    <string name="h2" value="MP -4; damage 62% per shot, fires 2 shots"/>
+    <string name="h3" value="MP -4; damage 63% per shot, fires 2 shots"/>
+    <string name="h4" value="MP -4; damage 64% per shot, fires 2 shots"/>
+    <string name="h5" value="MP -4; damage 65% per shot, fires 2 shots"/>
+    <string name="h6" value="MP -5; damage 66% per shot, fires 2 shots"/>
+    <string name="h7" value="MP -5; damage 67% per shot, fires 2 shots"/>
+    <string name="h8" value="MP -5; damage 68% per shot, fires 2 shots"/>
+    <string name="h9" value="MP -5; damage 69% per shot, fires 2 shots"/>
+    <string name="h10" value="MP -5; damage 70% per shot, fires 2 shots"/>
+    <string name="h11" value="MP -6; damage 71% per shot, fires 2 shots"/>
+    <string name="h12" value="MP -6; damage 72% per shot, fires 2 shots"/>
+    <string name="h13" value="MP -6; damage 73% per shot, fires 2 shots"/>
+    <string name="h14" value="MP -6; damage 74% per shot, fires 2 shots"/>
+    <string name="h15" value="MP -6; damage 75% per shot, fires 2 shots"/>
+    <string name="h16" value="MP -7; damage 76% per shot, fires 2 shots"/>
+    <string name="h17" value="MP -7; damage 77% per shot, fires 2 shots"/>
+    <string name="h18" value="MP -7; damage 78% per shot, fires 2 shots"/>
+    <string name="h19" value="MP -7; damage 79% per shot, fires 2 shots"/>
+    <string name="h20" value="MP -7; damage 80% per shot, fires 2 shots"/>
   </imgdir>
   <imgdir name="5001005">
     <string name="name" value="Dash"/>
-    <string name="desc" value="[Master Level : 10]\nPress left or right arrow twice to temporarily boost your speed and jump."/>
-    <string name="h1" value="MP -14, effect sustained for 4 sec."/>
-    <string name="h2" value="MP -13, effect sustained for 4 sec."/>
-    <string name="h3" value="MP -12, effect sustained for 8 sec."/>
-    <string name="h4" value="MP -11, effect sustained for 8 sec."/>
-    <string name="h5" value="MP -10, effect sustained for 12 sec."/>
-    <string name="h6" value="MP -9, effect sustained for 12 sec."/>
-    <string name="h7" value="MP -8, effect sustained for 16 sec."/>
-    <string name="h8" value="MP -7, effect sustained for 16 sec."/>
-    <string name="h9" value="MP -6, effect sustained for 20 sec."/>
-    <string name="h10" value="MP -5, effect sustained for 20 sec."/>
+    <string name="desc" value="[Master Level: 10]\nDouble-tap a direction key to increase movement speed and jump temporarily."/>
+    <string name="h1" value="MP -14; Speed +12, Jump +1 for 4 sec"/>
+    <string name="h2" value="MP -13; Speed +14, Jump +2 for 4 sec"/>
+    <string name="h3" value="MP -12; Speed +16, Jump +3 for 8 sec"/>
+    <string name="h4" value="MP -11; Speed +18, Jump +4 for 8 sec"/>
+    <string name="h5" value="MP -10; Speed +20, Jump +5 for 12 sec"/>
+    <string name="h6" value="MP -9; Speed +22, Jump +6 for 12 sec"/>
+    <string name="h7" value="MP -8; Speed +24, Jump +7 for 16 sec"/>
+    <string name="h8" value="MP -7; Speed +26, Jump +8 for 16 sec"/>
+    <string name="h9" value="MP -6; Speed +28, Jump +9 for 20 sec"/>
+    <string name="h10" value="MP -5; Speed +30, Jump +10 for 20 sec"/>
   </imgdir>
   <imgdir name="510">
     <string name="bookName" value="Brawler Guide"/>
   </imgdir>
   <imgdir name="5100000">
     <string name="name" value="Improve MaxHP"/>
-    <string name="desc" value="[Master Level : 10]\nApply AP to MaxHP to improve the rate of increase for MaxHP."/>
-    <string name="h1" value="If Level UP, +3 more; if AP applied, +2 more on top of MaxHP"/>
-    <string name="h2" value="If Level UP, +6 more; if AP applied, +4 more on top of MaxHP"/>
-    <string name="h3" value="If Level UP, +9 more; if AP applied, +6 more on top of MaxHP"/>
-    <string name="h4" value="If Level UP, +12 more; if AP applied, +8 more on top of MaxHP"/>
-    <string name="h5" value="If Level UP, +15 more; if AP applied, +10 more on top of MaxHP"/>
-    <string name="h6" value="If Level UP, +18 more; if AP applied, +12 more on top of MaxHP"/>
-    <string name="h7" value="If Level UP, +21 more; if AP applied, +14 more on top of MaxHP"/>
-    <string name="h8" value="If Level UP, +24 more; if AP applied, +16 more on top of MaxHP"/>
-    <string name="h9" value="If Level UP, +27 more; if AP applied, +18 more on top of MaxHP"/>
-    <string name="h10" value="If Level UP, +30 more; if AP applied, +20 more on top of MaxHP"/>
+    <string name="desc" value="[Master Level: 10]\nIncreases MaxHP gained when leveling up or assigning AP to MaxHP."/>
+    <string name="h1" value="MaxHP on level up +3; MaxHP when AP is assigned +2"/>
+    <string name="h2" value="MaxHP on level up +6; MaxHP when AP is assigned +4"/>
+    <string name="h3" value="MaxHP on level up +9; MaxHP when AP is assigned +6"/>
+    <string name="h4" value="MaxHP on level up +12; MaxHP when AP is assigned +8"/>
+    <string name="h5" value="MaxHP on level up +15; MaxHP when AP is assigned +10"/>
+    <string name="h6" value="MaxHP on level up +18; MaxHP when AP is assigned +12"/>
+    <string name="h7" value="MaxHP on level up +21; MaxHP when AP is assigned +14"/>
+    <string name="h8" value="MaxHP on level up +24; MaxHP when AP is assigned +16"/>
+    <string name="h9" value="MaxHP on level up +27; MaxHP when AP is assigned +18"/>
+    <string name="h10" value="MaxHP on level up +30; MaxHP when AP is assigned +20"/>
   </imgdir>
   <imgdir name="5100001">
     <string name="name" value="Knuckler Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nBoosts the accuracy and the mastery of Knucklers. This skill only applies when you equip a Knuckler."/>
-    <string name="h1" value="Knuckler Mastery 15%, Accuracy +1."/>
-    <string name="h2" value="Knuckler Mastery 15%, Accuracy +2."/>
-    <string name="h3" value="Knuckler Mastery 20%, Accuracy +3."/>
-    <string name="h4" value="Knuckler Mastery 20%, Accuracy +4."/>
-    <string name="h5" value="Knuckler Mastery 25%, Accuracy +5."/>
-    <string name="h6" value="Knuckler Mastery 25%, Accuracy +6."/>
-    <string name="h7" value="Knuckler Mastery 30%, Accuracy +7."/>
-    <string name="h8" value="Knuckler Mastery 30%, Accuracy +8."/>
-    <string name="h9" value="Knuckler Mastery 35%, Accuracy +9."/>
-    <string name="h10" value="Knuckler Mastery 35%, Accuracy +10."/>
-    <string name="h11" value="Knuckler Mastery 40%, Accuracy +11."/>
-    <string name="h12" value="Knuckler Mastery 40%, Accuracy +12."/>
-    <string name="h13" value="Knuckler Mastery 45%, Accuracy +13."/>
-    <string name="h14" value="Knuckler Mastery 45%, Accuracy +14."/>
-    <string name="h15" value="Knuckler Mastery 50%, Accuracy +15."/>
-    <string name="h16" value="Knuckler Mastery 50%, Accuracy +16."/>
-    <string name="h17" value="Knuckler Mastery 55%, Accuracy +17."/>
-    <string name="h18" value="Knuckler Mastery 55%, Accuracy +18."/>
-    <string name="h19" value="Knuckler Mastery 60%, Accuracy +19."/>
-    <string name="h20" value="Knuckler Mastery 60%, Accuracy +20."/>
+    <string name="desc" value="[Master Level: 20]\nIncreases knuckler mastery and accuracy while a knuckler is equipped."/>
+    <string name="h1" value="Knuckler mastery +15%, accuracy +1"/>
+    <string name="h2" value="Knuckler mastery +15%, accuracy +2"/>
+    <string name="h3" value="Knuckler mastery +20%, accuracy +3"/>
+    <string name="h4" value="Knuckler mastery +20%, accuracy +4"/>
+    <string name="h5" value="Knuckler mastery +25%, accuracy +5"/>
+    <string name="h6" value="Knuckler mastery +25%, accuracy +6"/>
+    <string name="h7" value="Knuckler mastery +30%, accuracy +7"/>
+    <string name="h8" value="Knuckler mastery +30%, accuracy +8"/>
+    <string name="h9" value="Knuckler mastery +35%, accuracy +9"/>
+    <string name="h10" value="Knuckler mastery +35%, accuracy +10"/>
+    <string name="h11" value="Knuckler mastery +40%, accuracy +11"/>
+    <string name="h12" value="Knuckler mastery +40%, accuracy +12"/>
+    <string name="h13" value="Knuckler mastery +45%, accuracy +13"/>
+    <string name="h14" value="Knuckler mastery +45%, accuracy +14"/>
+    <string name="h15" value="Knuckler mastery +50%, accuracy +15"/>
+    <string name="h16" value="Knuckler mastery +50%, accuracy +16"/>
+    <string name="h17" value="Knuckler mastery +55%, accuracy +17"/>
+    <string name="h18" value="Knuckler mastery +55%, accuracy +18"/>
+    <string name="h19" value="Knuckler mastery +60%, accuracy +19"/>
+    <string name="h20" value="Knuckler mastery +60%, accuracy +20"/>
   </imgdir>
   <imgdir name="5101002">
     <string name="name" value="Backspin Blow"/>
-    <string name="desc" value="[Master Level : 20]\nThis skill allows you to quickly slide back and elbow multiple monsters at once to apply damage and temporarily stun them."/>
-    <string name="h1" value="MP -12, damage 88%, attacks up to 3 monsters"/>
-    <string name="h2" value="MP -12, damage 96%, attacks up to 3 monsters"/>
-    <string name="h3" value="MP -14, damage 104%, attacks up to 3 monsters"/>
-    <string name="h4" value="MP -14, damage 112%, attacks up to 3 monsters"/>
-    <string name="h5" value="MP -16, damage 120%, attacks up to 3 monsters"/>
-    <string name="h6" value="MP -16, damage 128%, attacks up to 3 monsters"/>
-    <string name="h7" value="MP -18, damage 136%, attacks up to 3 monsters"/>
-    <string name="h8" value="MP -18, damage 144%, attacks up to 3 monsters"/>
-    <string name="h9" value="MP -20, damage 152%, attacks up to 3 monsters"/>
-    <string name="h10" value="MP -20, damage 160%, attacks up to 3 monsters"/>
-    <string name="h11" value="MP -22, damage 168%, attacks up to 3 monsters"/>
-    <string name="h12" value="MP -22, damage 176%, attacks up to 3 monsters"/>
-    <string name="h13" value="MP -24, damage 184%, attacks up to 3 monsters"/>
-    <string name="h14" value="MP -24, damage 192%, attacks up to 3 monsters"/>
-    <string name="h15" value="MP -26, damage 200%, attacks up to 3 monsters"/>
-    <string name="h16" value="MP -26, damage 208%, attacks up to 3 monsters"/>
-    <string name="h17" value="MP -28, damage 216%, attacks up to 3 monsters"/>
-    <string name="h18" value="MP -28, damage 224%, attacks up to 3 monsters"/>
-    <string name="h19" value="MP -30, damage 232%, attacks up to 3 monsters"/>
-    <string name="h20" value="MP -30, damage 240%, attacks up to 3 monsters"/>
+    <string name="desc" value="[Master Level: 20]\nSlides backward to attack and stun multiple enemies."/>
+    <string name="h1" value="MP -12; damage 88%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h2" value="MP -12; damage 96%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h3" value="MP -14; damage 104%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h4" value="MP -14; damage 112%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h5" value="MP -16; damage 120%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h6" value="MP -16; damage 128%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h7" value="MP -18; damage 136%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h8" value="MP -18; damage 144%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h9" value="MP -20; damage 152%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h10" value="MP -20; damage 160%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h11" value="MP -22; damage 168%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h12" value="MP -22; damage 176%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h13" value="MP -24; damage 184%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h14" value="MP -24; damage 192%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h15" value="MP -26; damage 200%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h16" value="MP -26; damage 208%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h17" value="MP -28; damage 216%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h18" value="MP -28; damage 224%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h19" value="MP -30; damage 232%, attacks 1 time(s), stuns for 1 sec"/>
+    <string name="h20" value="MP -30; damage 240%, attacks 1 time(s), stuns for 1 sec"/>
   </imgdir>
   <imgdir name="5101003">
     <string name="name" value="Double Uppercut"/>
-    <string name="desc" value="[Master Level : 20]\nA quick round of two punches to apply damage and temporarily stun a monster."/>
-    <string name="h1" value="MP -15, damage 100%"/>
-    <string name="h2" value="MP -15, damage 110%"/>
-    <string name="h3" value="MP -15, damage 120%"/>
-    <string name="h4" value="MP -15, damage 130%"/>
-    <string name="h5" value="MP -15, damage 140%"/>
-    <string name="h6" value="MP -20, damage 150%"/>
-    <string name="h7" value="MP -20, damage 160%"/>
-    <string name="h8" value="MP -20, damage 170%"/>
-    <string name="h9" value="MP -20, damage 180%"/>
-    <string name="h10" value="MP -20, damage 190%"/>
-    <string name="h11" value="MP -25, damage 200%"/>
-    <string name="h12" value="MP -25, damage 210%"/>
-    <string name="h13" value="MP -25, damage 220%"/>
-    <string name="h14" value="MP -25, damage 230%"/>
-    <string name="h15" value="MP -25, damage 240%"/>
-    <string name="h16" value="MP -30, damage 250%"/>
-    <string name="h17" value="MP -30, damage 260%"/>
-    <string name="h18" value="MP -30, damage 270%"/>
-    <string name="h19" value="MP -30, damage 280%"/>
-    <string name="h20" value="MP -30, damage 290%"/>
+    <string name="desc" value="[Master Level: 20]\nAttacks one enemy twice and stuns it."/>
+    <string name="h1" value="MP -15; damage 100%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h2" value="MP -15; damage 110%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h3" value="MP -15; damage 120%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h4" value="MP -15; damage 130%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h5" value="MP -15; damage 140%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h6" value="MP -20; damage 150%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h7" value="MP -20; damage 160%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h8" value="MP -20; damage 170%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h9" value="MP -20; damage 180%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h10" value="MP -20; damage 190%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h11" value="MP -25; damage 200%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h12" value="MP -25; damage 210%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h13" value="MP -25; damage 220%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h14" value="MP -25; damage 230%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h15" value="MP -25; damage 240%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h16" value="MP -30; damage 250%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h17" value="MP -30; damage 260%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h18" value="MP -30; damage 270%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h19" value="MP -30; damage 280%, attacks 2 time(s), stuns for 1 sec"/>
+    <string name="h20" value="MP -30; damage 290%, attacks 2 time(s), stuns for 1 sec"/>
   </imgdir>
   <imgdir name="5101004">
     <string name="name" value="Corkscrew Blow"/>
-    <string name="desc" value="[Master Level : 20]\nThis skill allows you to run forward and punch multiple monsters in front at once."/>
-    <string name="h1" value="MP -20, damage 135%, attacks up to 3 monsters"/>
-    <string name="h2" value="MP -20, damage 150%, attacks up to 3 monsters"/>
-    <string name="h3" value="MP -20, damage 165%, attacks up to 3 monsters"/>
-    <string name="h4" value="MP -20, damage 180%, attacks up to 3 monsters"/>
-    <string name="h5" value="MP -24, damage 195%, attacks up to 3 monsters"/>
-    <string name="h6" value="MP -24, damage 210%, attacks up to 3 monsters"/>
-    <string name="h7" value="MP -24, damage 225%, attacks up to 3 monsters"/>
-    <string name="h8" value="MP -24, damage 240%, attacks up to 3 monsters"/>
-    <string name="h9" value="MP -28, damage 255%, attacks up to 3 monsters"/>
-    <string name="h10" value="MP -28, damage 270%, attacks up to 3 monsters"/>
-    <string name="h11" value="MP -28, damage 285%, attacks up to 3 monsters"/>
-    <string name="h12" value="MP -28, damage 300%, attacks up to 3 monsters"/>
-    <string name="h13" value="MP -32, damage 315%, attacks up to 3 monsters"/>
-    <string name="h14" value="MP -32, damage 330%, attacks up to 3 monsters"/>
-    <string name="h15" value="MP -32, damage 345%, attacks up to 3 monsters"/>
-    <string name="h16" value="MP -32, damage 360%, attacks up to 3 monsters"/>
-    <string name="h17" value="MP -36, damage 375%, attacks up to 3 monsters"/>
-    <string name="h18" value="MP -36, damage 390%, attacks up to 3 monsters"/>
-    <string name="h19" value="MP -36, damage 405%, attacks up to 3 monsters"/>
-    <string name="h20" value="MP -36, damage 420%, attacks up to 3 monsters"/>
+    <string name="desc" value="[Master Level: 20]\nCharges forward and punches multiple enemies."/>
+    <string name="h1" value="MP -20; damage 135%, attacks up to 3 enemies"/>
+    <string name="h2" value="MP -20; damage 150%, attacks up to 3 enemies"/>
+    <string name="h3" value="MP -20; damage 165%, attacks up to 3 enemies"/>
+    <string name="h4" value="MP -20; damage 180%, attacks up to 3 enemies"/>
+    <string name="h5" value="MP -24; damage 195%, attacks up to 3 enemies"/>
+    <string name="h6" value="MP -24; damage 210%, attacks up to 3 enemies"/>
+    <string name="h7" value="MP -24; damage 225%, attacks up to 3 enemies"/>
+    <string name="h8" value="MP -24; damage 240%, attacks up to 3 enemies"/>
+    <string name="h9" value="MP -28; damage 255%, attacks up to 3 enemies"/>
+    <string name="h10" value="MP -28; damage 270%, attacks up to 3 enemies"/>
+    <string name="h11" value="MP -28; damage 285%, attacks up to 3 enemies"/>
+    <string name="h12" value="MP -28; damage 300%, attacks up to 3 enemies"/>
+    <string name="h13" value="MP -32; damage 315%, attacks up to 3 enemies"/>
+    <string name="h14" value="MP -32; damage 330%, attacks up to 3 enemies"/>
+    <string name="h15" value="MP -32; damage 345%, attacks up to 3 enemies"/>
+    <string name="h16" value="MP -32; damage 360%, attacks up to 3 enemies"/>
+    <string name="h17" value="MP -36; damage 375%, attacks up to 3 enemies"/>
+    <string name="h18" value="MP -36; damage 390%, attacks up to 3 enemies"/>
+    <string name="h19" value="MP -36; damage 405%, attacks up to 3 enemies"/>
+    <string name="h20" value="MP -36; damage 420%, attacks up to 3 enemies"/>
   </imgdir>
   <imgdir name="5101005">
     <string name="name" value="MP Recovery"/>
-    <string name="desc" value="[Master Level : 10]\nRecovers MP by using up a bit of HP."/>
-    <string name="h1" value="Uses 10% of MaxHP, Uses 55% of the used HP on MP, 70 seconds until next use"/>
-    <string name="h2" value="Uses 10% of MaxHP, Uses 60% of the used HP on MP, 65 seconds until next use"/>
-    <string name="h3" value="Uses 10% of MaxHP, Uses 65% of the used HP on MP, 60 seconds until next use"/>
-    <string name="h4" value="Uses 10% of MaxHP, Uses 70% of the used HP on MP, 55 seconds until next use"/>
-    <string name="h5" value="Uses 10% of MaxHP, Uses 75% of the used HP on MP, 50 seconds until next use"/>
-    <string name="h6" value="Uses 10% of MaxHP, Uses 80% of the used HP on MP, 45 seconds until next use"/>
-    <string name="h7" value="Uses 10% of MaxHP, Uses 85% of the used HP on MP, 40 seconds until next use"/>
-    <string name="h8" value="Uses 10% of MaxHP, Uses 90% of the used HP on MP, 35 seconds until next use"/>
-    <string name="h9" value="Uses 10% of MaxHP, Uses 95% of the used HP on MP, 30 seconds until next use"/>
-    <string name="h10" value="Uses 10% of MaxHP, Uses 100% of the used HP on MP, 25 seconds until next use"/>
+    <string name="desc" value="[Master Level: 10]\nConsumes HP to recover MP. Cooldown applies."/>
+    <string name="h1" value="Consumes 10% HP to recover 55% MP; cooldown 70 sec"/>
+    <string name="h2" value="Consumes 10% HP to recover 60% MP; cooldown 65 sec"/>
+    <string name="h3" value="Consumes 10% HP to recover 65% MP; cooldown 60 sec"/>
+    <string name="h4" value="Consumes 10% HP to recover 70% MP; cooldown 55 sec"/>
+    <string name="h5" value="Consumes 10% HP to recover 75% MP; cooldown 50 sec"/>
+    <string name="h6" value="Consumes 10% HP to recover 80% MP; cooldown 45 sec"/>
+    <string name="h7" value="Consumes 10% HP to recover 85% MP; cooldown 40 sec"/>
+    <string name="h8" value="Consumes 10% HP to recover 90% MP; cooldown 35 sec"/>
+    <string name="h9" value="Consumes 10% HP to recover 95% MP; cooldown 30 sec"/>
+    <string name="h10" value="Consumes 10% HP to recover 100% MP; cooldown 25 sec"/>
   </imgdir>
   <imgdir name="5101006">
     <string name="name" value="Knuckler Booster"/>
-    <string name="desc" value="[Master Level : 20]\nUses parts of HP and MP to temporarily boost the speed of a Knuckler. This skill can only be triggered when a Knuckler is equipped. \nRequired Skill : #cLevel 5 or above on Knuckler Mastery"/>
-    <string name="h1" value="HP -29, MP -29; Improves speed of Knuckler for 10 sec."/>
-    <string name="h2" value="HP -28, MP -28; Improves speed of Knuckler for 20 sec."/>
-    <string name="h3" value="HP -27, MP -27; Improves speed of Knuckler for 30 sec."/>
-    <string name="h4" value="HP -26, MP -26; Improves speed of Knuckler for 40 sec."/>
-    <string name="h5" value="HP -25, MP -25; Improves speed of Knuckler for 50 sec."/>
-    <string name="h6" value="HP -24, MP -24; Improves speed of Knuckler for 60 sec."/>
-    <string name="h7" value="HP -23, MP -23; Improves speed of Knuckler for 70 sec."/>
-    <string name="h8" value="HP -22, MP -22; Improves speed of Knuckler for 80 sec."/>
-    <string name="h9" value="HP -21, MP -21; Improves speed of Knuckler for 90 sec."/>
-    <string name="h10" value="HP -20, MP -20; Improves speed of Knuckler for 100 sec."/>
-    <string name="h11" value="HP -19, MP -19; Improves speed of Knuckler for 110 sec."/>
-    <string name="h12" value="HP -18, MP -18; Improves speed of Knuckler for 120 sec."/>
-    <string name="h13" value="HP -17, MP -17; Improves speed of Knuckler for 130 sec."/>
-    <string name="h14" value="HP -16, MP -16; Improves speed of Knuckler for 140 sec."/>
-    <string name="h15" value="HP -15, MP -15; Improves speed of Knuckler for 150 sec."/>
-    <string name="h16" value="HP -14, MP -14; Improves speed of Knuckler for 160 sec."/>
-    <string name="h17" value="HP -13, MP -13; Improves speed of Knuckler for 170 sec."/>
-    <string name="h18" value="HP -12, MP -12; Improves speed of Knuckler for 180 sec."/>
-    <string name="h19" value="HP -11, MP -11; Improves speed of Knuckler for 190 sec."/>
-    <string name="h20" value="HP -10, MP -10; Improves speed of Knuckler for 200 sec."/>
+    <string name="desc" value="[Master Level: 20]\nConsumes HP and MP to increase knuckler attack speed by 2 stages. Requires Knuckler Mastery Lv.5 or higher."/>
+    <string name="h1" value="HP -29, MP -29; attack speed +2 stages for 10 sec"/>
+    <string name="h2" value="HP -28, MP -28; attack speed +2 stages for 20 sec"/>
+    <string name="h3" value="HP -27, MP -27; attack speed +2 stages for 30 sec"/>
+    <string name="h4" value="HP -26, MP -26; attack speed +2 stages for 40 sec"/>
+    <string name="h5" value="HP -25, MP -25; attack speed +2 stages for 50 sec"/>
+    <string name="h6" value="HP -24, MP -24; attack speed +2 stages for 60 sec"/>
+    <string name="h7" value="HP -23, MP -23; attack speed +2 stages for 70 sec"/>
+    <string name="h8" value="HP -22, MP -22; attack speed +2 stages for 80 sec"/>
+    <string name="h9" value="HP -21, MP -21; attack speed +2 stages for 90 sec"/>
+    <string name="h10" value="HP -20, MP -20; attack speed +2 stages for 100 sec"/>
+    <string name="h11" value="HP -19, MP -19; attack speed +2 stages for 110 sec"/>
+    <string name="h12" value="HP -18, MP -18; attack speed +2 stages for 120 sec"/>
+    <string name="h13" value="HP -17, MP -17; attack speed +2 stages for 130 sec"/>
+    <string name="h14" value="HP -16, MP -16; attack speed +2 stages for 140 sec"/>
+    <string name="h15" value="HP -15, MP -15; attack speed +2 stages for 150 sec"/>
+    <string name="h16" value="HP -14, MP -14; attack speed +2 stages for 160 sec"/>
+    <string name="h17" value="HP -13, MP -13; attack speed +2 stages for 170 sec"/>
+    <string name="h18" value="HP -12, MP -12; attack speed +2 stages for 180 sec"/>
+    <string name="h19" value="HP -11, MP -11; attack speed +2 stages for 190 sec"/>
+    <string name="h20" value="HP -10, MP -10; attack speed +2 stages for 200 sec"/>
   </imgdir>
   <imgdir name="5101007">
     <string name="name" value="Oak Barrel"/>
-    <string name="desc" value="[Master Level : 10]\nThis skill will allow you to safely navigate your way through monsters without being recognized by them...by donning an Oak Barrel. Some clever monsters may be able to tell, though, so be careful. If you are lying down, it&apos;s literally impossible to tell the difference!"/>
-    <string name="h1" value="MP -12; sustained for 12 sec., 35 sec. until next use; 37% failure rate"/>
-    <string name="h2" value="MP -12; sustained for 14 sec., 35 sec. until next use; 34% failure rate"/>
-    <string name="h3" value="MP -14; sustained for 16 sec., 30 sec. until next use; 31% failure rate"/>
-    <string name="h4" value="MP -14; sustained for 18 sec., 30 sec. until next use; 28% failure rate"/>
-    <string name="h5" value="MP -16; sustained for 20 sec., 25 sec. until next use; 25% failure rate"/>
-    <string name="h6" value="MP -16; sustained for 22 sec., 25 sec. until next use; 22% failure rate"/>
-    <string name="h7" value="MP -18; sustained for 24 sec., 20 sec. until next use; 19% failure rate"/>
-    <string name="h8" value="MP -18; sustained for 26 sec., 20 sec. until next use; 16% failure rate"/>
-    <string name="h9" value="MP -20; sustained for 28 sec., 15 sec. until next use; 13% failure rate"/>
-    <string name="h10" value="MP -20; sustained for 30 sec., 15 sec. until next use; 10% failure rate"/>
+    <string name="desc" value="[Master Level: 10]\nDisguises you in an oak barrel to avoid monster attention. Cooldown applies."/>
+    <string name="h1" value="MP -11; disguised for 12 sec, detection chance 37%, cooldown 35 sec"/>
+    <string name="h2" value="MP -12; disguised for 14 sec, detection chance 34%, cooldown 35 sec"/>
+    <string name="h3" value="MP -13; disguised for 16 sec, detection chance 31%, cooldown 30 sec"/>
+    <string name="h4" value="MP -14; disguised for 18 sec, detection chance 28%, cooldown 30 sec"/>
+    <string name="h5" value="MP -15; disguised for 20 sec, detection chance 25%, cooldown 25 sec"/>
+    <string name="h6" value="MP -16; disguised for 22 sec, detection chance 22%, cooldown 25 sec"/>
+    <string name="h7" value="MP -17; disguised for 24 sec, detection chance 19%, cooldown 20 sec"/>
+    <string name="h8" value="MP -18; disguised for 26 sec, detection chance 16%, cooldown 20 sec"/>
+    <string name="h9" value="MP -19; disguised for 28 sec, detection chance 13%, cooldown 15 sec"/>
+    <string name="h10" value="MP -20; disguised for 30 sec, detection chance 10%, cooldown 15 sec"/>
   </imgdir>
   <imgdir name="520">
     <string name="bookName" value="Gunslinger Guide"/>
   </imgdir>
   <imgdir name="5200000">
     <string name="name" value="Gun Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nBoosts the accuracy and the mastery of your Guns. This skill only applies when you equip a Gun."/>
-    <string name="h1" value="Gun mastery +15%, Accuracy +1, Bullet Count +10"/>
-    <string name="h2" value="Gun mastery +15%, Accuracy +2, Bullet Count +20"/>
-    <string name="h3" value="Gun mastery +20%, Accuracy +3, Bullet Count +30"/>
-    <string name="h4" value="Gun mastery +20%, Accuracy +4, Bullet Count +40"/>
-    <string name="h5" value="Gun mastery +25%, Accuracy +5, Bullet Count +50"/>
-    <string name="h6" value="Gun mastery +25%, Accuracy +6, Bullet Count +60"/>
-    <string name="h7" value="Gun mastery +30%, Accuracy +7, Bullet Count +70"/>
-    <string name="h8" value="Gun mastery +30%, Accuracy +8, Bullet Count +80"/>
-    <string name="h9" value="Gun mastery +35%, Accuracy +9, Bullet Count +90"/>
-    <string name="h10" value="Gun mastery +35%, Accuracy +10, Bullet Count +100"/>
-    <string name="h11" value="Gun mastery +40%, Accuracy +11, Bullet Count +110"/>
-    <string name="h12" value="Gun mastery +40%, Accuracy +12, Bullet Count +120"/>
-    <string name="h13" value="Gun mastery +45%, Accuracy +13, Bullet Count +130"/>
-    <string name="h14" value="Gun mastery +45%, Accuracy +14, Bullet Count +140"/>
-    <string name="h15" value="Gun mastery +50%, Accuracy +15, Bullet Count +150"/>
-    <string name="h16" value="Gun mastery +50%, Accuracy +16, Bullet Count +160"/>
-    <string name="h17" value="Gun mastery +55%, Accuracy +17, Bullet Count +170"/>
-    <string name="h18" value="Gun mastery +55%, Accuracy +18, Bullet Count +180"/>
-    <string name="h19" value="Gun mastery +60%, Accuracy +19, Bullet Count +190"/>
-    <string name="h20" value="Gun mastery +60%, Accuracy +20, Bullet Count +200"/>
+    <string name="desc" value="[Master Level: 20]\nIncreases gun mastery, accuracy, and bullet capacity while a gun is equipped."/>
+    <string name="h1" value="Gun mastery +15%, accuracy +1, bullet capacity +10"/>
+    <string name="h2" value="Gun mastery +15%, accuracy +2, bullet capacity +20"/>
+    <string name="h3" value="Gun mastery +20%, accuracy +3, bullet capacity +30"/>
+    <string name="h4" value="Gun mastery +20%, accuracy +4, bullet capacity +40"/>
+    <string name="h5" value="Gun mastery +25%, accuracy +5, bullet capacity +50"/>
+    <string name="h6" value="Gun mastery +25%, accuracy +6, bullet capacity +60"/>
+    <string name="h7" value="Gun mastery +30%, accuracy +7, bullet capacity +70"/>
+    <string name="h8" value="Gun mastery +30%, accuracy +8, bullet capacity +80"/>
+    <string name="h9" value="Gun mastery +35%, accuracy +9, bullet capacity +90"/>
+    <string name="h10" value="Gun mastery +35%, accuracy +10, bullet capacity +100"/>
+    <string name="h11" value="Gun mastery +40%, accuracy +11, bullet capacity +110"/>
+    <string name="h12" value="Gun mastery +40%, accuracy +12, bullet capacity +120"/>
+    <string name="h13" value="Gun mastery +45%, accuracy +13, bullet capacity +130"/>
+    <string name="h14" value="Gun mastery +45%, accuracy +14, bullet capacity +140"/>
+    <string name="h15" value="Gun mastery +50%, accuracy +15, bullet capacity +150"/>
+    <string name="h16" value="Gun mastery +50%, accuracy +16, bullet capacity +160"/>
+    <string name="h17" value="Gun mastery +55%, accuracy +17, bullet capacity +170"/>
+    <string name="h18" value="Gun mastery +55%, accuracy +18, bullet capacity +180"/>
+    <string name="h19" value="Gun mastery +60%, accuracy +19, bullet capacity +190"/>
+    <string name="h20" value="Gun mastery +60%, accuracy +20, bullet capacity +200"/>
   </imgdir>
   <imgdir name="5201001">
     <string name="name" value="Invisible Shot"/>
-    <string name="desc" value="[Master Level : 20]\nAttacks multiple monsters by quickly firing a few bullets, so fast that the naked eye can&apos;t see the shooting."/>
-    <string name="h1" value="MP -11, damage 75%, attacks up to 3 monsters"/>
-    <string name="h2" value="MP -12, damage 80%, attacks up to 3 monsters"/>
-    <string name="h3" value="MP -13, damage 85%, attacks up to 3 monsters"/>
-    <string name="h4" value="MP -14, damage 90%, attacks up to 3 monsters"/>
-    <string name="h5" value="MP -15, damage 95%, attacks up to 3 monsters"/>
-    <string name="h6" value="MP -16, damage 100%, attacks up to 3 monsters"/>
-    <string name="h7" value="MP -17, damage 105%, attacks up to 3 monsters"/>
-    <string name="h8" value="MP -18, damage 110%, attacks up to 3 monsters"/>
-    <string name="h9" value="MP -19, damage 115%, attacks up to 3 monsters"/>
-    <string name="h10" value="MP -20, damage 120%, attacks up to 3 monsters"/>
-    <string name="h11" value="MP -21, damage 125%, attacks up to 3 monsters"/>
-    <string name="h12" value="MP -22, damage 130%, attacks up to 3 monsters"/>
-    <string name="h13" value="MP -23, damage 135%, attacks up to 3 monsters"/>
-    <string name="h14" value="MP -24, damage 140%, attacks up to 3 monsters"/>
-    <string name="h15" value="MP -25, damage 145%, attacks up to 3 monsters"/>
-    <string name="h16" value="MP -26, damage 150%, attacks up to 3 monsters"/>
-    <string name="h17" value="MP -27, damage 155%, attacks up to 3 monsters"/>
-    <string name="h18" value="MP -28, damage 160%, attacks up to 3 monsters"/>
-    <string name="h19" value="MP -29, damage 165%, attacks up to 3 monsters"/>
-    <string name="h20" value="MP -30, damage 170%, attacks up to 3 monsters"/>
+    <string name="desc" value="[Master Level: 20]\nFires rapidly to attack multiple enemies."/>
+    <string name="h1" value="MP -10; damage 75%, attacks up to 3 enemies"/>
+    <string name="h2" value="MP -10; damage 80%, attacks up to 3 enemies"/>
+    <string name="h3" value="MP -10; damage 85%, attacks up to 3 enemies"/>
+    <string name="h4" value="MP -10; damage 90%, attacks up to 3 enemies"/>
+    <string name="h5" value="MP -10; damage 95%, attacks up to 3 enemies"/>
+    <string name="h6" value="MP -15; damage 100%, attacks up to 3 enemies"/>
+    <string name="h7" value="MP -15; damage 105%, attacks up to 3 enemies"/>
+    <string name="h8" value="MP -15; damage 110%, attacks up to 3 enemies"/>
+    <string name="h9" value="MP -15; damage 115%, attacks up to 3 enemies"/>
+    <string name="h10" value="MP -15; damage 120%, attacks up to 3 enemies"/>
+    <string name="h11" value="MP -20; damage 125%, attacks up to 3 enemies"/>
+    <string name="h12" value="MP -20; damage 130%, attacks up to 3 enemies"/>
+    <string name="h13" value="MP -20; damage 135%, attacks up to 3 enemies"/>
+    <string name="h14" value="MP -20; damage 140%, attacks up to 3 enemies"/>
+    <string name="h15" value="MP -20; damage 145%, attacks up to 3 enemies"/>
+    <string name="h16" value="MP -25; damage 150%, attacks up to 3 enemies"/>
+    <string name="h17" value="MP -25; damage 155%, attacks up to 3 enemies"/>
+    <string name="h18" value="MP -25; damage 160%, attacks up to 3 enemies"/>
+    <string name="h19" value="MP -25; damage 165%, attacks up to 3 enemies"/>
+    <string name="h20" value="MP -25; damage 170%, attacks up to 3 enemies"/>
   </imgdir>
   <imgdir name="5201002">
     <string name="name" value="Grenade"/>
-    <string name="desc" value="[Master Level : 20]\nAttacks a monster by throwing a grenade. The distance the grenade travels depends on how long you press the skill key."/>
-    <string name="h1" value="MP -18, damage 45%, attacks 3 monsters"/>
-    <string name="h2" value="MP -18, damage 50%, attacks 3 monsters"/>
-    <string name="h3" value="MP -18, damage 55%, attacks 3 monsters"/>
-    <string name="h4" value="MP -18, damage 60%, attacks 3 monsters"/>
-    <string name="h5" value="MP -18, damage 65%, attacks 3 monsters"/>
-    <string name="h6" value="MP -24, damage 70%, attacks 4 monsters"/>
-    <string name="h7" value="MP -24, damage 75%, attacks 4 monsters"/>
-    <string name="h8" value="MP -24, damage 80%, attacks 4 monsters"/>
-    <string name="h9" value="MP -24, damage 85%, attacks 4 monsters"/>
-    <string name="h10" value="MP -24, damage 90%, attacks 4 monsters"/>
-    <string name="h11" value="MP -30, damage 95%, attacks 5 monsters"/>
-    <string name="h12" value="MP -30, damage 100%, attacks 5 monsters"/>
-    <string name="h13" value="MP -30, damage 105%, attacks 5 monsters"/>
-    <string name="h14" value="MP -30, damage 110%, attacks 5 monsters"/>
-    <string name="h15" value="MP -30, damage 115%, attacks 5 monsters"/>
-    <string name="h16" value="MP -36, damage 120%, attacks 6 monsters"/>
-    <string name="h17" value="MP -36, damage 125%, attacks 6 monsters"/>
-    <string name="h18" value="MP -36, damage 130%, attacks 6 monsters"/>
-    <string name="h19" value="MP -36, damage 135%, attacks 6 monsters"/>
-    <string name="h20" value="MP -36, damage 140%, attacks 6 monsters"/>
+    <string name="desc" value="[Master Level: 20]\nThrows a grenade. Holding the skill key changes the throwing distance."/>
+    <string name="h1" value="MP -15; damage 45%, attacks up to 3 enemies"/>
+    <string name="h2" value="MP -15; damage 50%, attacks up to 3 enemies"/>
+    <string name="h3" value="MP -15; damage 55%, attacks up to 3 enemies"/>
+    <string name="h4" value="MP -15; damage 60%, attacks up to 3 enemies"/>
+    <string name="h5" value="MP -15; damage 65%, attacks up to 3 enemies"/>
+    <string name="h6" value="MP -19; damage 70%, attacks up to 4 enemies"/>
+    <string name="h7" value="MP -19; damage 75%, attacks up to 4 enemies"/>
+    <string name="h8" value="MP -19; damage 80%, attacks up to 4 enemies"/>
+    <string name="h9" value="MP -19; damage 85%, attacks up to 4 enemies"/>
+    <string name="h10" value="MP -19; damage 90%, attacks up to 4 enemies"/>
+    <string name="h11" value="MP -23; damage 95%, attacks up to 5 enemies"/>
+    <string name="h12" value="MP -23; damage 100%, attacks up to 5 enemies"/>
+    <string name="h13" value="MP -23; damage 105%, attacks up to 5 enemies"/>
+    <string name="h14" value="MP -23; damage 110%, attacks up to 5 enemies"/>
+    <string name="h15" value="MP -23; damage 115%, attacks up to 5 enemies"/>
+    <string name="h16" value="MP -27; damage 120%, attacks up to 6 enemies"/>
+    <string name="h17" value="MP -27; damage 125%, attacks up to 6 enemies"/>
+    <string name="h18" value="MP -27; damage 130%, attacks up to 6 enemies"/>
+    <string name="h19" value="MP -27; damage 135%, attacks up to 6 enemies"/>
+    <string name="h20" value="MP -27; damage 140%, attacks up to 6 enemies"/>
   </imgdir>
   <imgdir name="5201003">
     <string name="name" value="Gun Booster"/>
-    <string name="desc" value="[Master Level : 20]\nUses parts of HP and MP to temporarily boost the firing speed of the Gun.This skill can only be triggered when the Gun is equipped. \nRequired Skill : #cLevel 5 or above on Gun Mastery"/>
-    <string name="h1" value="HP -29, MP -29; Improves gun speed for 10 sec."/>
-    <string name="h2" value="HP -28, MP -28; Improves gun speed for 20 sec."/>
-    <string name="h3" value="HP -27, MP -27; Improves gun speed for 30 sec."/>
-    <string name="h4" value="HP -26, MP -26; Improves gun speed for 40 sec."/>
-    <string name="h5" value="HP -25, MP -25; Improves gun speed for 50 sec."/>
-    <string name="h6" value="HP -24, MP -24; Improves gun speed for 60 sec."/>
-    <string name="h7" value="HP -23, MP -23; Improves gun speed for 70 sec."/>
-    <string name="h8" value="HP -22, MP -22; Improves gun speed for 80 sec."/>
-    <string name="h9" value="HP -21, MP -21; Improves gun speed for 90 sec."/>
-    <string name="h10" value="HP -20, MP -20; Improves gun speed for 100 sec."/>
-    <string name="h11" value="HP -19, MP -19; Improves gun speed for 110 sec."/>
-    <string name="h12" value="HP -18, MP -18; Improves gun speed for 120 sec."/>
-    <string name="h13" value="HP -17, MP -17; Improves gun speed for 130 sec."/>
-    <string name="h14" value="HP -16, MP -16; Improves gun speed for 140 sec."/>
-    <string name="h15" value="HP -15, MP -15; Improves gun speed for 150 sec."/>
-    <string name="h16" value="HP -14, MP -14; Improves gun speed for 160 sec."/>
-    <string name="h17" value="HP -13, MP -13; Improves gun speed for 170 sec."/>
-    <string name="h18" value="HP -12, MP -12; Improves gun speed for 180 sec."/>
-    <string name="h19" value="HP -11, MP -11; Improves gun speed for 190 sec."/>
-    <string name="h20" value="HP -10, MP -10; Improves gun speed for 200 sec."/>
+    <string name="desc" value="[Master Level: 20]\nConsumes HP and MP to increase gun attack speed by 2 stages. Requires Gun Mastery Lv.5 or higher."/>
+    <string name="h1" value="HP -29, MP -29; attack speed +2 stages for 10 sec"/>
+    <string name="h2" value="HP -28, MP -28; attack speed +2 stages for 20 sec"/>
+    <string name="h3" value="HP -27, MP -27; attack speed +2 stages for 30 sec"/>
+    <string name="h4" value="HP -26, MP -26; attack speed +2 stages for 40 sec"/>
+    <string name="h5" value="HP -25, MP -25; attack speed +2 stages for 50 sec"/>
+    <string name="h6" value="HP -24, MP -24; attack speed +2 stages for 60 sec"/>
+    <string name="h7" value="HP -23, MP -23; attack speed +2 stages for 70 sec"/>
+    <string name="h8" value="HP -22, MP -22; attack speed +2 stages for 80 sec"/>
+    <string name="h9" value="HP -21, MP -21; attack speed +2 stages for 90 sec"/>
+    <string name="h10" value="HP -20, MP -20; attack speed +2 stages for 100 sec"/>
+    <string name="h11" value="HP -19, MP -19; attack speed +2 stages for 110 sec"/>
+    <string name="h12" value="HP -18, MP -18; attack speed +2 stages for 120 sec"/>
+    <string name="h13" value="HP -17, MP -17; attack speed +2 stages for 130 sec"/>
+    <string name="h14" value="HP -16, MP -16; attack speed +2 stages for 140 sec"/>
+    <string name="h15" value="HP -15, MP -15; attack speed +2 stages for 150 sec"/>
+    <string name="h16" value="HP -14, MP -14; attack speed +2 stages for 160 sec"/>
+    <string name="h17" value="HP -13, MP -13; attack speed +2 stages for 170 sec"/>
+    <string name="h18" value="HP -12, MP -12; attack speed +2 stages for 180 sec"/>
+    <string name="h19" value="HP -11, MP -11; attack speed +2 stages for 190 sec"/>
+    <string name="h20" value="HP -10, MP -10; attack speed +2 stages for 200 sec"/>
   </imgdir>
   <imgdir name="5201004">
     <string name="name" value="Blank Shot"/>
-    <string name="desc" value="[Master Level : 20]\nThis skill allows you to pretend shooting a gun, faking out the monsters, and instead of firing bullets, it&apos;ll fire a flag. This will temporarily stun up to 3 monsters."/>
-    <string name="h1" value="MP -10, damage 63%; 43% possibility of the monsters being stunned for 1 sec."/>
-    <string name="h2" value="MP -10, damage 66%; 46% possibility of the monsters being stunned for 1 sec."/>
-    <string name="h3" value="MP -10, damage 69%; 49% possibility of the monsters being stunned for 1 sec."/>
-    <string name="h4" value="MP -10, damage 72%; 52% possibility of the monsters being stunned for 1 sec."/>
-    <string name="h5" value="MP -10, damage 75%; 55% possibility of the monsters being stunned for 1 sec."/>
-    <string name="h6" value="MP -15, damage 78%; 58% possibility of the monsters being stunned for 2 sec."/>
-    <string name="h7" value="MP -15, damage 81%; 61% possibility of the monsters being stunned for 2 sec."/>
-    <string name="h8" value="MP -15, damage 84%; 64% possibility of the monsters being stunned for 2 sec."/>
-    <string name="h9" value="MP -15, damage 87%; 67% possibility of the monsters being stunned for 2 sec."/>
-    <string name="h10" value="MP -15, damage 90%; 70% possibility of the monsters being stunned for 2 sec."/>
-    <string name="h11" value="MP -20, damage 93%; 73% possibility of the monsters being stunned for 3 sec."/>
-    <string name="h12" value="MP -20, damage 96%; 76% possibility of the monsters being stunned for 3 sec."/>
-    <string name="h13" value="MP -20, damage 99%; 79% possibility of the monsters being stunned for 3 sec."/>
-    <string name="h14" value="MP -20, damage 102%; 82% possibility of the monsters being stunned for 3 sec."/>
-    <string name="h15" value="MP -20, damage 105%; 85% possibility of the monsters being stunned for 3 sec."/>
-    <string name="h16" value="MP -25, damage 108%; 88% possibility of the monsters being stunned for 4 sec."/>
-    <string name="h17" value="MP -25, damage 111%; 91% possibility of the monsters being stunned for 4 sec."/>
-    <string name="h18" value="MP -25, damage 114%; 94% possibility of the monsters being stunned for 4 sec."/>
-    <string name="h19" value="MP -25, damage 117%; 97% possibility of the monsters being stunned for 4 sec."/>
-    <string name="h20" value="MP -25, damage 120%; 100% possibility of the monsters being stunned for 4 sec."/>
+    <string name="desc" value="[Master Level: 20]\nFires a fake shot that attacks and stuns up to 3 enemies."/>
+    <string name="h1" value="MP -10; damage 63%, attacks up to 3 enemies, 43% chance to stun for 1 sec"/>
+    <string name="h2" value="MP -10; damage 66%, attacks up to 3 enemies, 46% chance to stun for 1 sec"/>
+    <string name="h3" value="MP -10; damage 69%, attacks up to 3 enemies, 49% chance to stun for 1 sec"/>
+    <string name="h4" value="MP -10; damage 72%, attacks up to 3 enemies, 52% chance to stun for 1 sec"/>
+    <string name="h5" value="MP -10; damage 75%, attacks up to 3 enemies, 55% chance to stun for 1 sec"/>
+    <string name="h6" value="MP -15; damage 78%, attacks up to 3 enemies, 58% chance to stun for 2 sec"/>
+    <string name="h7" value="MP -15; damage 81%, attacks up to 3 enemies, 61% chance to stun for 2 sec"/>
+    <string name="h8" value="MP -15; damage 84%, attacks up to 3 enemies, 64% chance to stun for 2 sec"/>
+    <string name="h9" value="MP -15; damage 87%, attacks up to 3 enemies, 67% chance to stun for 2 sec"/>
+    <string name="h10" value="MP -15; damage 90%, attacks up to 3 enemies, 70% chance to stun for 2 sec"/>
+    <string name="h11" value="MP -20; damage 93%, attacks up to 3 enemies, 73% chance to stun for 3 sec"/>
+    <string name="h12" value="MP -20; damage 96%, attacks up to 3 enemies, 76% chance to stun for 3 sec"/>
+    <string name="h13" value="MP -20; damage 99%, attacks up to 3 enemies, 79% chance to stun for 3 sec"/>
+    <string name="h14" value="MP -20; damage 102%, attacks up to 3 enemies, 82% chance to stun for 3 sec"/>
+    <string name="h15" value="MP -20; damage 105%, attacks up to 3 enemies, 85% chance to stun for 3 sec"/>
+    <string name="h16" value="MP -25; damage 108%, attacks up to 3 enemies, 88% chance to stun for 4 sec"/>
+    <string name="h17" value="MP -25; damage 111%, attacks up to 3 enemies, 91% chance to stun for 4 sec"/>
+    <string name="h18" value="MP -25; damage 114%, attacks up to 3 enemies, 94% chance to stun for 4 sec"/>
+    <string name="h19" value="MP -25; damage 117%, attacks up to 3 enemies, 97% chance to stun for 4 sec"/>
+    <string name="h20" value="MP -25; damage 120%, attacks up to 3 enemies, 100% chance to stun for 4 sec"/>
   </imgdir>
   <imgdir name="5201005">
     <string name="name" value="Wings"/>
-    <string name="desc" value="[Master Level : 10]\nAllows for a longer, more sustained jump than a regular jump."/>
-    <string name="h1" value="MP -50, descending speed: 280"/>
-    <string name="h2" value="MP -46, descending speed: 260"/>
-    <string name="h3" value="MP -42, descending speed: 240"/>
-    <string name="h4" value="MP -38, descending speed: 220"/>
-    <string name="h5" value="MP -34, descending speed: 200"/>
-    <string name="h6" value="MP -30, descending speed: 180"/>
-    <string name="h7" value="MP -26, descending speed: 160"/>
-    <string name="h8" value="MP -22, descending speed: 140"/>
-    <string name="h9" value="MP -18, descending speed: 120"/>
-    <string name="h10" value="MP -14, descending speed: 100"/>
+    <string name="desc" value="[Master Level: 10]\nUses MP to stay airborne longer during a jump."/>
+    <string name="h1" value="MP -50; airborne control for 5 sec, falling speed 280"/>
+    <string name="h2" value="MP -46; airborne control for 5 sec, falling speed 260"/>
+    <string name="h3" value="MP -42; airborne control for 5 sec, falling speed 240"/>
+    <string name="h4" value="MP -38; airborne control for 5 sec, falling speed 220"/>
+    <string name="h5" value="MP -34; airborne control for 5 sec, falling speed 200"/>
+    <string name="h6" value="MP -30; airborne control for 5 sec, falling speed 180"/>
+    <string name="h7" value="MP -26; airborne control for 5 sec, falling speed 160"/>
+    <string name="h8" value="MP -22; airborne control for 5 sec, falling speed 140"/>
+    <string name="h9" value="MP -18; airborne control for 5 sec, falling speed 120"/>
+    <string name="h10" value="MP -14; airborne control for 5 sec, falling speed 100"/>
   </imgdir>
   <imgdir name="5201006">
     <string name="name" value="Recoil Shot"/>
-    <string name="desc" value="[Master Level : 20]\nUses the recoil of the gun to run back after a gunshot. \nRequired Skill : #cLevel 5 or above on Wings#"/>
-    <string name="h1" value="MP -14, damage 70%"/>
-    <string name="h2" value="MP -14, damage 80%"/>
-    <string name="h3" value="MP -14, damage 90%"/>
-    <string name="h4" value="MP -14, damage 100%"/>
-    <string name="h5" value="MP -14, damage 110%"/>
-    <string name="h6" value="MP -18, damage 120%"/>
-    <string name="h7" value="MP -18, damage 130%"/>
-    <string name="h8" value="MP -18, damage 140%"/>
-    <string name="h9" value="MP -18, damage 150%"/>
-    <string name="h10" value="MP -18, damage 160%"/>
-    <string name="h11" value="MP -22, damage 170%"/>
-    <string name="h12" value="MP -22, damage 180%"/>
-    <string name="h13" value="MP -22, damage 190%"/>
-    <string name="h14" value="MP -22, damage 200%"/>
-    <string name="h15" value="MP -22, damage 210%"/>
-    <string name="h16" value="MP -26, damage 220%"/>
-    <string name="h17" value="MP -26, damage 230%"/>
-    <string name="h18" value="MP -26, damage 240%"/>
-    <string name="h19" value="MP -26, damage 250%"/>
-    <string name="h20" value="MP -26, damage 260%"/>
+    <string name="desc" value="[Master Level: 20]\nUses gun recoil to shoot while moving backward. Requires Wings Lv.5 or higher."/>
+    <string name="h1" value="MP -14; damage 70%, recoil range 115"/>
+    <string name="h2" value="MP -14; damage 80%, recoil range 115"/>
+    <string name="h3" value="MP -14; damage 90%, recoil range 130"/>
+    <string name="h4" value="MP -14; damage 100%, recoil range 130"/>
+    <string name="h5" value="MP -14; damage 110%, recoil range 145"/>
+    <string name="h6" value="MP -18; damage 120%, recoil range 145"/>
+    <string name="h7" value="MP -18; damage 130%, recoil range 160"/>
+    <string name="h8" value="MP -18; damage 140%, recoil range 160"/>
+    <string name="h9" value="MP -18; damage 150%, recoil range 175"/>
+    <string name="h10" value="MP -18; damage 160%, recoil range 175"/>
+    <string name="h11" value="MP -22; damage 170%, recoil range 190"/>
+    <string name="h12" value="MP -22; damage 180%, recoil range 190"/>
+    <string name="h13" value="MP -22; damage 190%, recoil range 205"/>
+    <string name="h14" value="MP -22; damage 200%, recoil range 205"/>
+    <string name="h15" value="MP -22; damage 210%, recoil range 220"/>
+    <string name="h16" value="MP -26; damage 220%, recoil range 220"/>
+    <string name="h17" value="MP -26; damage 230%, recoil range 235"/>
+    <string name="h18" value="MP -26; damage 240%, recoil range 235"/>
+    <string name="h19" value="MP -26; damage 250%, recoil range 250"/>
+    <string name="h20" value="MP -26; damage 260%, recoil range 250"/>
   </imgdir>
   <imgdir name="511">
     <string name="bookName" value="The Path of the Marauder"/>
   </imgdir>
   <imgdir name="5110000">
     <string name="name" value="Stun Mastery"/>
-    <string name="desc" value="[Master Level : 20]\nWhen attacking a monster that&apos;s stunned, the critical attack will be triggered at a set rate."/>
-    <string name="h1" value="22% success rate, 3% additional damage"/>
-    <string name="h2" value="24% success rate, 6% additional damage"/>
-    <string name="h3" value="26% success rate, 9% additional damage"/>
-    <string name="h4" value="28% success rate, 12% additional damage"/>
-    <string name="h5" value="30% success rate, 15% additional damage"/>
-    <string name="h6" value="32% success rate, 18% additional damage"/>
-    <string name="h7" value="34% success rate, 21% additional damage"/>
-    <string name="h8" value="36% success rate, 24% additional damage"/>
-    <string name="h9" value="38% success rate, 27% additional damage"/>
-    <string name="h10" value="40% success rate, 30% additional damage"/>
-    <string name="h11" value="42% success rate, 33% additional damage"/>
-    <string name="h12" value="44% success rate, 36% additional damage"/>
-    <string name="h13" value="46% success rate, 39% additional damage"/>
-    <string name="h14" value="48% success rate, 42% additional damage"/>
-    <string name="h15" value="50% success rate, 45% additional damage"/>
-    <string name="h16" value="52% success rate, 48% additional damage"/>
-    <string name="h17" value="54% success rate, 51% additional damage"/>
-    <string name="h18" value="56% success rate, 54% additional damage"/>
-    <string name="h19" value="58% success rate, 57% additional damage"/>
-    <string name="h20" value="60% success rate, 60% additional damage"/>
+    <string name="desc" value="[Master Level: 20]\nWhen attacking stunned enemies, grants a chance to deal extra critical damage."/>
+    <string name="h1" value="22% chance to deal +103% critical damage to stunned enemies"/>
+    <string name="h2" value="24% chance to deal +106% critical damage to stunned enemies"/>
+    <string name="h3" value="26% chance to deal +109% critical damage to stunned enemies"/>
+    <string name="h4" value="28% chance to deal +112% critical damage to stunned enemies"/>
+    <string name="h5" value="30% chance to deal +115% critical damage to stunned enemies"/>
+    <string name="h6" value="32% chance to deal +118% critical damage to stunned enemies"/>
+    <string name="h7" value="34% chance to deal +121% critical damage to stunned enemies"/>
+    <string name="h8" value="36% chance to deal +124% critical damage to stunned enemies"/>
+    <string name="h9" value="38% chance to deal +127% critical damage to stunned enemies"/>
+    <string name="h10" value="40% chance to deal +130% critical damage to stunned enemies"/>
+    <string name="h11" value="42% chance to deal +133% critical damage to stunned enemies"/>
+    <string name="h12" value="44% chance to deal +136% critical damage to stunned enemies"/>
+    <string name="h13" value="46% chance to deal +139% critical damage to stunned enemies"/>
+    <string name="h14" value="48% chance to deal +142% critical damage to stunned enemies"/>
+    <string name="h15" value="50% chance to deal +145% critical damage to stunned enemies"/>
+    <string name="h16" value="52% chance to deal +148% critical damage to stunned enemies"/>
+    <string name="h17" value="54% chance to deal +151% critical damage to stunned enemies"/>
+    <string name="h18" value="56% chance to deal +154% critical damage to stunned enemies"/>
+    <string name="h19" value="58% chance to deal +157% critical damage to stunned enemies"/>
+    <string name="h20" value="60% chance to deal +160% critical damage to stunned enemies"/>
   </imgdir>
   <imgdir name="5110001">
     <string name="name" value="Energy Charge"/>
-    <string name="desc" value="[Master Level : 40]\nA set amount of energy is charged after every attack. When the energy is fully charged, this will automatically trigger the effects of the Body Attack and Stance will be triggered at a specific rate. This will allow you to use energy-related skills."/>
-    <string name="h1" value="Once triggered, sustained for 31 sec., Accuracy +1, Avoidability +1"/>
-    <string name="h2" value="Once triggered, sustained for 31 sec., Accuracy +1, Avoidability +1"/>
-    <string name="h3" value="Once triggered, sustained for 32 sec., Accuracy +2, Avoidability +2"/>
-    <string name="h4" value="Once triggered, sustained for 32 sec., Accuracy +2, Avoidability +2, Weapon att. +11"/>
-    <string name="h5" value="Once triggered, sustained for 33 sec., Accuracy +3, Avoidability +3, Weapon att. +11"/>
-    <string name="h6" value="Once triggered, sustained for 33 sec., Accuracy +3, Avoidability +3, Weapon att. +11"/>
-    <string name="h7" value="Once triggered, sustained for 34 sec., Accuracy +4, Avoidability +4, Weapon att. +11"/>
-    <string name="h8" value="Once triggered, sustained for 34 sec., Accuracy +4, Avoidability +4, Weapon att. +12"/>
-    <string name="h9" value="Once triggered, sustained for 35 sec., Accuracy +5, Avoidability +5, Weapon att. +12"/>
-    <string name="h10" value="Once triggered, sustained for 35 sec., Accuracy +5, Avoidability +5, Weapon att. +12"/>
-    <string name="h11" value="Once triggered, sustained for 36 sec., Accuracy +6, Avoidability +6, Weapon att. +12"/>
-    <string name="h12" value="Once triggered, sustained for 36 sec., Accuracy +6, Avoidability +6, Weapon att. +13"/>
-    <string name="h13" value="Once triggered, sustained for 37 sec., Accuracy +7, Avoidability +7, Weapon att. +13"/>
-    <string name="h14" value="Once triggered, sustained for 37 sec., Accuracy +7, Avoidability +7, Weapon att. +13"/>
-    <string name="h15" value="Once triggered, sustained for 38 sec., Accuracy +8, Avoidability +8, Weapon att. +13"/>
-    <string name="h16" value="Once triggered, sustained for 38 sec., Accuracy +8, Avoidability +8, Weapon att. +14"/>
-    <string name="h17" value="Once triggered, sustained for 39 sec., Accuracy +9, Avoidability +9, Weapon att. +14"/>
-    <string name="h18" value="Once triggered, sustained for 39 sec., Accuracy +9, Avoidability +9, Weapon att. +14"/>
-    <string name="h19" value="Once triggered, sustained for 40 sec., Accuracy +10, Avoidability +10, Weapon att. +14"/>
-    <string name="h20" value="Once triggered, sustained for 40 sec., Accuracy +10, Avoidability +10, Weapon att. +15"/>
-    <string name="h21" value="Once triggered, sustained for 41 sec., Accuracy +11, Avoidability +11, Weapon att. +15"/>
-    <string name="h22" value="Once triggered, sustained for 41 sec., Accuracy +11, Avoidability +11, Weapon att. +15"/>
-    <string name="h23" value="Once triggered, sustained for 42 sec., Accuracy +12, Avoidability +12, Weapon att. +15"/>
-    <string name="h24" value="Once triggered, sustained for 42 sec., Accuracy +12, Avoidability +12, Weapon att. +16"/>
-    <string name="h25" value="Once triggered, sustained for 43 sec., Accuracy +13, Avoidability +13, Weapon att. +16"/>
-    <string name="h26" value="Once triggered, sustained for 43 sec., Accuracy +13, Avoidability +13, Weapon att. +16"/>
-    <string name="h27" value="Once triggered, sustained for 44 sec., Accuracy +14, Avoidability +14, Weapon att. +16"/>
-    <string name="h28" value="Once triggered, sustained for 44 sec., Accuracy +14, Avoidability +14, Weapon att. +17"/>
-    <string name="h29" value="Once triggered, sustained for 45 sec., Accuracy +15, Avoidability +15, Weapon att. +17"/>
-    <string name="h30" value="Once triggered, sustained for 45 sec., Accuracy +15, Avoidability +15, Weapon att. +17"/>
-    <string name="h31" value="Once triggered, sustained for 46 sec., Accuracy +16, Avoidability +16, Weapon att. +17"/>
-    <string name="h32" value="Once triggered, sustained for 46 sec., Accuracy +16, Avoidability +16, Weapon att. +18"/>
-    <string name="h33" value="Once triggered, sustained for 47 sec., Accuracy +17, Avoidability +17, Weapon att. +18"/>
-    <string name="h35" value="Once triggered, sustained for 48 sec., Accuracy +18, Avoidability +18, Weapon att. +18"/>
-    <string name="h36" value="Once triggered, sustained for 48 sec., Accuracy +18, Avoidability +18, Weapon att. +19"/>
-    <string name="h37" value="Once triggered, sustained for 49 sec., Accuracy +19, Avoidability +19, Weapon att. +19"/>
-    <string name="h38" value="Once triggered, sustained for 49 sec., Accuracy +19, Avoidability +19, Weapon att. +19"/>
-    <string name="h39" value="Once triggered, sustained for 50 sec., Accuracy +20, Avoidability +20, Weapon att. +19"/>
-    <string name="h40" value="Once triggered, sustained for 50 sec., Accuracy +20, Avoidability +20, Weapon att. +20"/>
+    <string name="desc" value="[Master Level: 40]\nSuccessful attacks charge the energy bar. Each hit adds 102 energy. At 10000 energy, the charged state begins and lasts for the listed duration."/>
+    <string name="h1" value="Charged state lasts 31 sec; damage +5%, weapon attack +0, accuracy +1, avoidability +1, stance/body attack chance 11%"/>
+    <string name="h2" value="Charged state lasts 31 sec; damage +10%, weapon attack +0, accuracy +1, avoidability +1, stance/body attack chance 12%"/>
+    <string name="h3" value="Charged state lasts 32 sec; damage +15%, weapon attack +0, accuracy +2, avoidability +2, stance/body attack chance 13%"/>
+    <string name="h4" value="Charged state lasts 32 sec; damage +20%, weapon attack +11, accuracy +2, avoidability +2, stance/body attack chance 14%"/>
+    <string name="h5" value="Charged state lasts 33 sec; damage +25%, weapon attack +11, accuracy +3, avoidability +3, stance/body attack chance 15%"/>
+    <string name="h6" value="Charged state lasts 33 sec; damage +30%, weapon attack +11, accuracy +3, avoidability +3, stance/body attack chance 16%"/>
+    <string name="h7" value="Charged state lasts 34 sec; damage +35%, weapon attack +11, accuracy +4, avoidability +4, stance/body attack chance 17%"/>
+    <string name="h8" value="Charged state lasts 34 sec; damage +40%, weapon attack +12, accuracy +4, avoidability +4, stance/body attack chance 18%"/>
+    <string name="h9" value="Charged state lasts 35 sec; damage +45%, weapon attack +12, accuracy +5, avoidability +5, stance/body attack chance 19%"/>
+    <string name="h10" value="Charged state lasts 35 sec; damage +50%, weapon attack +12, accuracy +5, avoidability +5, stance/body attack chance 20%"/>
+    <string name="h11" value="Charged state lasts 36 sec; damage +55%, weapon attack +12, accuracy +6, avoidability +6, stance/body attack chance 21%"/>
+    <string name="h12" value="Charged state lasts 36 sec; damage +60%, weapon attack +13, accuracy +6, avoidability +6, stance/body attack chance 22%"/>
+    <string name="h13" value="Charged state lasts 37 sec; damage +65%, weapon attack +13, accuracy +7, avoidability +7, stance/body attack chance 23%"/>
+    <string name="h14" value="Charged state lasts 37 sec; damage +70%, weapon attack +13, accuracy +7, avoidability +7, stance/body attack chance 24%"/>
+    <string name="h15" value="Charged state lasts 38 sec; damage +75%, weapon attack +13, accuracy +8, avoidability +8, stance/body attack chance 25%"/>
+    <string name="h16" value="Charged state lasts 38 sec; damage +80%, weapon attack +14, accuracy +8, avoidability +8, stance/body attack chance 26%"/>
+    <string name="h17" value="Charged state lasts 39 sec; damage +85%, weapon attack +14, accuracy +9, avoidability +9, stance/body attack chance 27%"/>
+    <string name="h18" value="Charged state lasts 39 sec; damage +90%, weapon attack +14, accuracy +9, avoidability +9, stance/body attack chance 28%"/>
+    <string name="h19" value="Charged state lasts 40 sec; damage +95%, weapon attack +14, accuracy +10, avoidability +10, stance/body attack chance 29%"/>
+    <string name="h20" value="Charged state lasts 40 sec; damage +100%, weapon attack +15, accuracy +10, avoidability +10, stance/body attack chance 30%"/>
+    <string name="h21" value="Charged state lasts 41 sec; damage +105%, weapon attack +15, accuracy +11, avoidability +11, stance/body attack chance 31%"/>
+    <string name="h22" value="Charged state lasts 41 sec; damage +110%, weapon attack +15, accuracy +11, avoidability +11, stance/body attack chance 32%"/>
+    <string name="h23" value="Charged state lasts 42 sec; damage +115%, weapon attack +15, accuracy +12, avoidability +12, stance/body attack chance 33%"/>
+    <string name="h24" value="Charged state lasts 42 sec; damage +120%, weapon attack +16, accuracy +12, avoidability +12, stance/body attack chance 34%"/>
+    <string name="h25" value="Charged state lasts 43 sec; damage +125%, weapon attack +16, accuracy +13, avoidability +13, stance/body attack chance 35%"/>
+    <string name="h26" value="Charged state lasts 43 sec; damage +130%, weapon attack +16, accuracy +13, avoidability +13, stance/body attack chance 36%"/>
+    <string name="h27" value="Charged state lasts 44 sec; damage +135%, weapon attack +16, accuracy +14, avoidability +14, stance/body attack chance 37%"/>
+    <string name="h28" value="Charged state lasts 44 sec; damage +140%, weapon attack +17, accuracy +14, avoidability +14, stance/body attack chance 38%"/>
+    <string name="h29" value="Charged state lasts 45 sec; damage +145%, weapon attack +17, accuracy +15, avoidability +15, stance/body attack chance 39%"/>
+    <string name="h30" value="Charged state lasts 45 sec; damage +150%, weapon attack +17, accuracy +15, avoidability +15, stance/body attack chance 40%"/>
+    <string name="h31" value="Charged state lasts 46 sec; damage +155%, weapon attack +17, accuracy +16, avoidability +16, stance/body attack chance 41%"/>
+    <string name="h32" value="Charged state lasts 46 sec; damage +160%, weapon attack +18, accuracy +16, avoidability +16, stance/body attack chance 42%"/>
+    <string name="h33" value="Charged state lasts 47 sec; damage +165%, weapon attack +18, accuracy +17, avoidability +17, stance/body attack chance 43%"/>
+    <string name="h34" value="Charged state lasts 47 sec; damage +170%, weapon attack +18, accuracy +17, avoidability +17, stance/body attack chance 44%"/>
+    <string name="h35" value="Charged state lasts 48 sec; damage +175%, weapon attack +18, accuracy +18, avoidability +18, stance/body attack chance 45%"/>
+    <string name="h36" value="Charged state lasts 48 sec; damage +180%, weapon attack +19, accuracy +18, avoidability +18, stance/body attack chance 46%"/>
+    <string name="h37" value="Charged state lasts 49 sec; damage +185%, weapon attack +19, accuracy +19, avoidability +19, stance/body attack chance 47%"/>
+    <string name="h38" value="Charged state lasts 49 sec; damage +190%, weapon attack +19, accuracy +19, avoidability +19, stance/body attack chance 48%"/>
+    <string name="h39" value="Charged state lasts 50 sec; damage +195%, weapon attack +19, accuracy +20, avoidability +20, stance/body attack chance 49%"/>
+    <string name="h40" value="Charged state lasts 50 sec; damage +200%, weapon attack +20, accuracy +20, avoidability +20, stance/body attack chance 50%"/>
   </imgdir>
   <imgdir name="5111002">
     <string name="name" value="Energy Blast"/>
-    <string name="desc" value="[Master Level : 30]\nBlasts a ball of energy to attack multiple monsters at once. This skill can only be used when #cthe energy is fully charged#.\nRequired Skill : #cLevel 1 of Energy Charge#"/>
-    <string name="h1" value="Damage 246%, attacks up to 2 monsters"/>
-    <string name="h2" value="Damage 252%, attacks up to 2 monsters"/>
-    <string name="h3" value="Damage 258%, attacks up to 2 monsters"/>
-    <string name="h4" value="Damage 264%, attacks up to 2 monsters"/>
-    <string name="h5" value="Damage 270%, attacks up to 2 monsters"/>
-    <string name="h6" value="Damage 276%, attacks up to 2 monsters"/>
-    <string name="h7" value="Damage 282%, attacks up to 2 monsters"/>
-    <string name="h8" value="Damage 288%, attacks up to 2 monsters"/>
-    <string name="h9" value="Damage 294%, attacks up to 2 monsters"/>
-    <string name="h10" value="Damage 300%, attacks up to 2 monsters"/>
-    <string name="h11" value="Damage 306%, attacks up to 3 monsters"/>
-    <string name="h12" value="Damage 312%, attacks up to 3 monsters"/>
-    <string name="h13" value="Damage 318%, attacks up to 3 monsters"/>
-    <string name="h14" value="Damage 324%, attacks up to 3 monsters"/>
-    <string name="h15" value="Damage 330%, attacks up to 3 monsters"/>
-    <string name="h16" value="Damage 336%, attacks up to 3 monsters"/>
-    <string name="h17" value="Damage 342%, attacks up to 3 monsters"/>
-    <string name="h18" value="Damage 348%, attacks up to 3 monsters"/>
-    <string name="h19" value="Damage 354%, attacks up to 3 monsters"/>
-    <string name="h20" value="Damage 360%, attacks up to 3 monsters"/>
-    <string name="h21" value="Damage 366%, attacks up to 4 monsters"/>
-    <string name="h22" value="Damage 372%, attacks up to 4 monsters"/>
-    <string name="h23" value="Damage 378%, attacks up to 4 monsters"/>
-    <string name="h24" value="Damage 384%, attacks up to 4 monsters"/>
-    <string name="h25" value="Damage 390%, attacks up to 4 monsters"/>
-    <string name="h26" value="Damage 396%, attacks up to 4 monsters"/>
-    <string name="h27" value="Damage 402%, attacks up to 4 monsters"/>
-    <string name="h28" value="Damage 408%, attacks up to 4 monsters"/>
-    <string name="h29" value="Damage 414%, attacks up to 4 monsters"/>
-    <string name="h30" value="Damage 420%, attacks up to 4 monsters"/>
+    <string name="desc" value="[Master Level: 30]\nReleases charged energy to attack multiple enemies. Can only be used while Energy Charge is full."/>
+    <string name="h1" value="damage 246%, attacks up to 2 enemies while energy is full"/>
+    <string name="h2" value="damage 252%, attacks up to 2 enemies while energy is full"/>
+    <string name="h3" value="damage 258%, attacks up to 2 enemies while energy is full"/>
+    <string name="h4" value="damage 264%, attacks up to 2 enemies while energy is full"/>
+    <string name="h5" value="damage 270%, attacks up to 2 enemies while energy is full"/>
+    <string name="h6" value="damage 276%, attacks up to 2 enemies while energy is full"/>
+    <string name="h7" value="damage 282%, attacks up to 2 enemies while energy is full"/>
+    <string name="h8" value="damage 288%, attacks up to 2 enemies while energy is full"/>
+    <string name="h9" value="damage 294%, attacks up to 2 enemies while energy is full"/>
+    <string name="h10" value="damage 300%, attacks up to 2 enemies while energy is full"/>
+    <string name="h11" value="damage 306%, attacks up to 3 enemies while energy is full"/>
+    <string name="h12" value="damage 312%, attacks up to 3 enemies while energy is full"/>
+    <string name="h13" value="damage 318%, attacks up to 3 enemies while energy is full"/>
+    <string name="h14" value="damage 324%, attacks up to 3 enemies while energy is full"/>
+    <string name="h15" value="damage 330%, attacks up to 3 enemies while energy is full"/>
+    <string name="h16" value="damage 336%, attacks up to 3 enemies while energy is full"/>
+    <string name="h17" value="damage 342%, attacks up to 3 enemies while energy is full"/>
+    <string name="h18" value="damage 348%, attacks up to 3 enemies while energy is full"/>
+    <string name="h19" value="damage 354%, attacks up to 3 enemies while energy is full"/>
+    <string name="h20" value="damage 360%, attacks up to 3 enemies while energy is full"/>
+    <string name="h21" value="damage 366%, attacks up to 4 enemies while energy is full"/>
+    <string name="h22" value="damage 372%, attacks up to 4 enemies while energy is full"/>
+    <string name="h23" value="damage 378%, attacks up to 4 enemies while energy is full"/>
+    <string name="h24" value="damage 384%, attacks up to 4 enemies while energy is full"/>
+    <string name="h25" value="damage 390%, attacks up to 4 enemies while energy is full"/>
+    <string name="h26" value="damage 396%, attacks up to 4 enemies while energy is full"/>
+    <string name="h27" value="damage 402%, attacks up to 4 enemies while energy is full"/>
+    <string name="h28" value="damage 408%, attacks up to 4 enemies while energy is full"/>
+    <string name="h29" value="damage 414%, attacks up to 4 enemies while energy is full"/>
+    <string name="h30" value="damage 420%, attacks up to 4 enemies while energy is full"/>
   </imgdir>
   <imgdir name="5111004">
     <string name="name" value="Energy Drain"/>
-    <string name="desc" value="[Master Level : 20]\nUses energy to convert the lost HP of a monster into your own HP. This skill can only be used when #cthe energy is full charged#.\nRequired Skill : #cLevel 1 of Energy Charge#"/>
-    <string name="h1" value="Damage 265%, 11% of the damage used to recover HP"/>
-    <string name="h2" value="Damage 270%, 11% of the damage used to recover HP"/>
-    <string name="h3" value="Damage 275%, 12% of the damage used to recover HP"/>
-    <string name="h4" value="Damage 280%, 12% of the damage used to recover HP"/>
-    <string name="h5" value="Damage 285%, 13% of the damage used to recover HP"/>
-    <string name="h6" value="Damage 290%, 13% of the damage used to recover HP"/>
-    <string name="h7" value="Damage 295%, 14% of the damage used to recover HP"/>
-    <string name="h8" value="Damage 300%, 14% of the damage used to recover HP"/>
-    <string name="h9" value="Damage 305%, 15% of the damage used to recover HP"/>
-    <string name="h10" value="Damage 310%, 15% of the damage used to recover HP"/>
-    <string name="h11" value="Damage 315%, 16% of the damage used to recover HP"/>
-    <string name="h12" value="Damage 320%, 16% of the damage used to recover HP"/>
-    <string name="h13" value="Damage 325%, 17% of the damage used to recover HP"/>
-    <string name="h14" value="Damage 330%, 17% of the damage used to recover HP"/>
-    <string name="h15" value="Damage 335%, 18% of the damage used to recover HP"/>
-    <string name="h16" value="Damage 340%, 18% of the damage used to recover HP"/>
-    <string name="h17" value="Damage 345%, 19% of the damage used to recover HP"/>
-    <string name="h18" value="Damage 350%, 19% of the damage used to recover HP"/>
-    <string name="h19" value="Damage 355%, 20% of the damage used to recover HP"/>
-    <string name="h20" value="Damage 360%, 20% of the damage used to recover HP"/>
+    <string name="desc" value="[Master Level: 20]\nUses charged energy to damage one enemy and recover HP equal to part of the damage dealt. Can only be used while Energy Charge is full."/>
+    <string name="h1" value="damage 265%, recovers HP equal to 11% of damage dealt"/>
+    <string name="h2" value="damage 270%, recovers HP equal to 11% of damage dealt"/>
+    <string name="h3" value="damage 275%, recovers HP equal to 12% of damage dealt"/>
+    <string name="h4" value="damage 280%, recovers HP equal to 12% of damage dealt"/>
+    <string name="h5" value="damage 285%, recovers HP equal to 13% of damage dealt"/>
+    <string name="h6" value="damage 290%, recovers HP equal to 13% of damage dealt"/>
+    <string name="h7" value="damage 295%, recovers HP equal to 14% of damage dealt"/>
+    <string name="h8" value="damage 300%, recovers HP equal to 14% of damage dealt"/>
+    <string name="h9" value="damage 305%, recovers HP equal to 15% of damage dealt"/>
+    <string name="h10" value="damage 310%, recovers HP equal to 15% of damage dealt"/>
+    <string name="h11" value="damage 315%, recovers HP equal to 16% of damage dealt"/>
+    <string name="h12" value="damage 320%, recovers HP equal to 16% of damage dealt"/>
+    <string name="h13" value="damage 325%, recovers HP equal to 17% of damage dealt"/>
+    <string name="h14" value="damage 330%, recovers HP equal to 17% of damage dealt"/>
+    <string name="h15" value="damage 335%, recovers HP equal to 18% of damage dealt"/>
+    <string name="h16" value="damage 340%, recovers HP equal to 18% of damage dealt"/>
+    <string name="h17" value="damage 345%, recovers HP equal to 19% of damage dealt"/>
+    <string name="h18" value="damage 350%, recovers HP equal to 19% of damage dealt"/>
+    <string name="h19" value="damage 355%, recovers HP equal to 20% of damage dealt"/>
+    <string name="h20" value="damage 360%, recovers HP equal to 20% of damage dealt"/>
   </imgdir>
   <imgdir name="5111005">
     <string name="name" value="Transformation"/>
-    <string name="desc" value="[Master Level : 20]\nTransforms you into a more powerful state for 120 seconds. \nSkills available : Changes have been made so that while using the Buccaneer skill, Transform, you can now use all skills besides the Oak Barrel, Double Fire, Demolition and Snatch."/>
-    <string name="h1" value="MP -22; weapon &amp; magic def. +2, waiting time until next use : 860 sec."/>
-    <string name="h2" value="MP -24; weapon &amp; magic def. +4, waiting time until next use : 840 sec."/>
-    <string name="h3" value="MP -26; weapon &amp; magic def. +6, waiting time until next use : 820 sec."/>
-    <string name="h4" value="MP -28; weapon &amp; magic def. +8, waiting time until next use : 800 sec."/>
-    <string name="h5" value="MP -30; weapon &amp; magic def. +10, waiting time until next use : 780 sec."/>
-    <string name="h6" value="MP -32; weapon &amp; magic def. +12, waiting time until next use : 760 sec."/>
-    <string name="h7" value="MP -34; weapon &amp; magic def. +14, waiting time until next use : 740 sec."/>
-    <string name="h8" value="MP -36; weapon &amp; magic def. +16, waiting time until next use : 720 sec."/>
-    <string name="h9" value="MP -38; weapon &amp; magic def. +18, waiting time until next use : 700 sec."/>
-    <string name="h10" value="MP -40; weapon &amp; magic def. +20, waiting time until next use : 680 sec."/>
-    <string name="h11" value="MP -42, weapon &amp; magic def. +22, waiting time until next use : 660 sec."/>
-    <string name="h12" value="MP -44; weapon &amp; magic def. +24, waiting time until next use : 640 sec."/>
-    <string name="h13" value="MP -46; weapon &amp; magic def. +26, waiting time until next use : 620 sec."/>
-    <string name="h14" value="MP -48; weapon &amp; magic def. +28, waiting time until next use : 600 sec."/>
-    <string name="h15" value="MP -50; weapon &amp; magic def. +30, waiting time until next use : 580 sec. "/>
-    <string name="h16" value="MP -52; weapon &amp; magic def. +32, waiting time until next use : 560 sec."/>
-    <string name="h17" value="MP -54; weapon &amp; magic def. +34, waiting time until next use : 540 sec."/>
-    <string name="h18" value="MP -56; weapon &amp; magic def. +36, waiting time until next use : 520 sec."/>
-    <string name="h19" value="MP -58; weapon &amp; magic def. +38, waiting time until next use : 500 sec."/>
-    <string name="h20" value="MP -60; weapon &amp; magic def. +40, waiting time until next use : 480 sec."/>
+    <string name="desc" value="[Master Level: 20]\nTransforms for 120 seconds, increasing STR, weapon defense, magic defense, speed, and jump. Cooldown applies."/>
+    <string name="h1" value="MP -22; STR +1, weapon def. +2, magic def. +2, Speed +40, Jump +20 for 120 sec; cooldown 550 sec"/>
+    <string name="h2" value="MP -24; STR +2, weapon def. +4, magic def. +4, Speed +40, Jump +20 for 120 sec; cooldown 540 sec"/>
+    <string name="h3" value="MP -26; STR +3, weapon def. +6, magic def. +6, Speed +40, Jump +20 for 120 sec; cooldown 530 sec"/>
+    <string name="h4" value="MP -28; STR +4, weapon def. +8, magic def. +8, Speed +40, Jump +20 for 120 sec; cooldown 520 sec"/>
+    <string name="h5" value="MP -30; STR +5, weapon def. +10, magic def. +10, Speed +40, Jump +20 for 120 sec; cooldown 510 sec"/>
+    <string name="h6" value="MP -32; STR +6, weapon def. +12, magic def. +12, Speed +40, Jump +20 for 120 sec; cooldown 500 sec"/>
+    <string name="h7" value="MP -34; STR +7, weapon def. +14, magic def. +14, Speed +40, Jump +20 for 120 sec; cooldown 490 sec"/>
+    <string name="h8" value="MP -36; STR +8, weapon def. +16, magic def. +16, Speed +40, Jump +20 for 120 sec; cooldown 480 sec"/>
+    <string name="h9" value="MP -38; STR +9, weapon def. +18, magic def. +18, Speed +40, Jump +20 for 120 sec; cooldown 470 sec"/>
+    <string name="h10" value="MP -40; STR +10, weapon def. +20, magic def. +20, Speed +40, Jump +20 for 120 sec; cooldown 460 sec"/>
+    <string name="h11" value="MP -42; STR +11, weapon def. +22, magic def. +22, Speed +40, Jump +20 for 120 sec; cooldown 450 sec"/>
+    <string name="h12" value="MP -44; STR +12, weapon def. +24, magic def. +24, Speed +40, Jump +20 for 120 sec; cooldown 440 sec"/>
+    <string name="h13" value="MP -46; STR +13, weapon def. +26, magic def. +26, Speed +40, Jump +20 for 120 sec; cooldown 430 sec"/>
+    <string name="h14" value="MP -48; STR +14, weapon def. +28, magic def. +28, Speed +40, Jump +20 for 120 sec; cooldown 420 sec"/>
+    <string name="h15" value="MP -50; STR +15, weapon def. +30, magic def. +30, Speed +40, Jump +20 for 120 sec; cooldown 410 sec"/>
+    <string name="h16" value="MP -52; STR +16, weapon def. +32, magic def. +32, Speed +40, Jump +20 for 120 sec; cooldown 400 sec"/>
+    <string name="h17" value="MP -54; STR +17, weapon def. +34, magic def. +34, Speed +40, Jump +20 for 120 sec; cooldown 390 sec"/>
+    <string name="h18" value="MP -56; STR +18, weapon def. +36, magic def. +36, Speed +40, Jump +20 for 120 sec; cooldown 380 sec"/>
+    <string name="h19" value="MP -58; STR +19, weapon def. +38, magic def. +38, Speed +40, Jump +20 for 120 sec; cooldown 370 sec"/>
+    <string name="h20" value="MP -60; STR +20, weapon def. +40, magic def. +40, Speed +40, Jump +20 for 120 sec; cooldown 360 sec"/>
   </imgdir>
   <imgdir name="5111006">
     <string name="name" value="Shockwave"/>
-    <string name="desc" value="[Master Level : 30]\nStrikes the ground with tremendous force, affecting multiple monsters. This skill can only be used during #cTransformation or Super Transformation#.\nRequired Skill : #cLevel 1 of Transformation#"/>
-    <string name="h1" value="MP -18, damage 265%, attacks up to 4 monsters"/>
-    <string name="h2" value="MP -18, damage 280%, attacks up to 4 monsters"/>
-    <string name="h3" value="MP -18, damage 295%, attacks up to 4 monsters"/>
-    <string name="h4" value="MP -18, damage 310%, attacks up to 4 monsters"/>
-    <string name="h5" value="MP -18, damage 325%, attacks up to 4 monsters"/>
-    <string name="h6" value="MP -22, damage 340%, attacks up to 4 monsters"/>
-    <string name="h7" value="MP -22, damage 355%, attacks up to 4 monsters"/>
-    <string name="h8" value="MP -22, damage 370%, attacks up to 4 monsters"/>
-    <string name="h9" value="MP -22, damage 385%, attacks up to 4 monsters"/>
-    <string name="h10" value="MP -22, damage 400%, attacks up to 4 monsters"/>
-    <string name="h11" value="MP -26, damage 415%, attacks up to 5 monsters"/>
-    <string name="h12" value="MP -26, damage 430%, attacks up to 5 monsters"/>
-    <string name="h13" value="MP -26, damage 445%, attacks up to 5 monsters"/>
-    <string name="h14" value="MP -26, damage 460%, attacks up to 5 monsters"/>
-    <string name="h15" value="MP -26, damage 475%, attacks up to 5 monsters"/>
-    <string name="h16" value="MP -30, damage 490%, attacks up to 5 monsters"/>
-    <string name="h17" value="MP -30, damage 505%, attacks up to 5 monsters"/>
-    <string name="h18" value="MP -30, damage 520%, attacks up to 5 monsters"/>
-    <string name="h19" value="MP -30, damage 535%, attacks up to 5 monsters"/>
-    <string name="h20" value="MP -30, damage 550%, attacks up to 5 monsters"/>
-    <string name="h21" value="MP -34, damage 565%, attacks up to 6 monsters"/>
-    <string name="h22" value="MP -34, damage 580%, attacks up to 6 monsters"/>
-    <string name="h23" value="MP -34, damage 595%, attacks up to 6 monsters"/>
-    <string name="h24" value="MP -34, damage 610%, attacks up to 6 monsters"/>
-    <string name="h25" value="MP -34, damage 625%, attacks up to 6 monsters"/>
-    <string name="h26" value="MP -38, damage 640%, attacks up to 6 monsters"/>
-    <string name="h27" value="MP -38, damage 655%, attacks up to 6 monsters"/>
-    <string name="h28" value="MP -38, damage 670%, attacks up to 6 monsters"/>
-    <string name="h29" value="MP -38, damage 685%, attacks up to 6 monsters"/>
-    <string name="h30" value="MP -38, damage 700%, attacks up to 6 monsters"/>
+    <string name="desc" value="[Master Level: 30]\nStrikes the ground to attack multiple enemies. Requires Transformation or Super Transformation."/>
+    <string name="h1" value="MP -18; damage 265%, attacks up to 4 enemies"/>
+    <string name="h2" value="MP -18; damage 280%, attacks up to 4 enemies"/>
+    <string name="h3" value="MP -18; damage 295%, attacks up to 4 enemies"/>
+    <string name="h4" value="MP -18; damage 310%, attacks up to 4 enemies"/>
+    <string name="h5" value="MP -18; damage 325%, attacks up to 4 enemies"/>
+    <string name="h6" value="MP -22; damage 340%, attacks up to 4 enemies"/>
+    <string name="h7" value="MP -22; damage 355%, attacks up to 4 enemies"/>
+    <string name="h8" value="MP -22; damage 370%, attacks up to 4 enemies"/>
+    <string name="h9" value="MP -22; damage 385%, attacks up to 4 enemies"/>
+    <string name="h10" value="MP -22; damage 400%, attacks up to 4 enemies"/>
+    <string name="h11" value="MP -26; damage 415%, attacks up to 5 enemies"/>
+    <string name="h12" value="MP -26; damage 430%, attacks up to 5 enemies"/>
+    <string name="h13" value="MP -26; damage 445%, attacks up to 5 enemies"/>
+    <string name="h14" value="MP -26; damage 460%, attacks up to 5 enemies"/>
+    <string name="h15" value="MP -26; damage 475%, attacks up to 5 enemies"/>
+    <string name="h16" value="MP -30; damage 490%, attacks up to 5 enemies"/>
+    <string name="h17" value="MP -30; damage 505%, attacks up to 5 enemies"/>
+    <string name="h18" value="MP -30; damage 520%, attacks up to 5 enemies"/>
+    <string name="h19" value="MP -30; damage 535%, attacks up to 5 enemies"/>
+    <string name="h20" value="MP -30; damage 550%, attacks up to 5 enemies"/>
+    <string name="h21" value="MP -34; damage 565%, attacks up to 6 enemies"/>
+    <string name="h22" value="MP -34; damage 580%, attacks up to 6 enemies"/>
+    <string name="h23" value="MP -34; damage 595%, attacks up to 6 enemies"/>
+    <string name="h24" value="MP -34; damage 610%, attacks up to 6 enemies"/>
+    <string name="h25" value="MP -34; damage 625%, attacks up to 6 enemies"/>
+    <string name="h26" value="MP -38; damage 640%, attacks up to 6 enemies"/>
+    <string name="h27" value="MP -38; damage 655%, attacks up to 6 enemies"/>
+    <string name="h28" value="MP -38; damage 670%, attacks up to 6 enemies"/>
+    <string name="h29" value="MP -38; damage 685%, attacks up to 6 enemies"/>
+    <string name="h30" value="MP -38; damage 700%, attacks up to 6 enemies"/>
   </imgdir>
   <imgdir name="521">
     <string name="bookName" value="The Path of the Outlaw"/>
   </imgdir>
   <imgdir name="5210000">
     <string name="name" value="Burst Fire"/>
-    <string name="desc" value="[Master Level : 20]\nIncreases the potency and the number of bullets fired when using Double Shot.\nRequired Skill : #cLevel 20 of Double Shot# "/>
-    <string name="h1" value="MP -13, damage 95%"/>
-    <string name="h2" value="MP -13, damage 100%"/>
-    <string name="h3" value="MP -14, damage 105%"/>
-    <string name="h4" value="MP -14, damage 110%"/>
-    <string name="h5" value="MP -15, damage 115%"/>
-    <string name="h6" value="MP -15, damage 120%"/>
-    <string name="h7" value="MP -16, damage 125%"/>
-    <string name="h8" value="MP -16, damage 130%"/>
-    <string name="h9" value="MP -17, damage 135%"/>
-    <string name="h10" value="MP -17, damage 140%"/>
-    <string name="h11" value="MP -18, damage 145%"/>
-    <string name="h12" value="MP -18, damage 150%"/>
-    <string name="h13" value="MP -19, damage 155%"/>
-    <string name="h14" value="MP -19, damage 160%"/>
-    <string name="h15" value="MP -20, damage 165%"/>
-    <string name="h16" value="MP -20, damage 170%"/>
-    <string name="h17" value="MP -21, damage 175%"/>
-    <string name="h18" value="MP -21, damage 180%"/>
-    <string name="h19" value="MP -22, damage 185%"/>
-    <string name="h20" value="MP -22, damage 190%"/>
+    <string name="desc" value="[Master Level: 20]\nEnhances Double Shot into a 3-shot attack. Requires Double Shot Lv.20."/>
+    <string name="h1" value="MP -13; damage 115% per shot, fires 3 shots"/>
+    <string name="h2" value="MP -13; damage 120% per shot, fires 3 shots"/>
+    <string name="h3" value="MP -14; damage 125% per shot, fires 3 shots"/>
+    <string name="h4" value="MP -14; damage 130% per shot, fires 3 shots"/>
+    <string name="h5" value="MP -15; damage 135% per shot, fires 3 shots"/>
+    <string name="h6" value="MP -15; damage 140% per shot, fires 3 shots"/>
+    <string name="h7" value="MP -16; damage 145% per shot, fires 3 shots"/>
+    <string name="h8" value="MP -16; damage 150% per shot, fires 3 shots"/>
+    <string name="h9" value="MP -17; damage 155% per shot, fires 3 shots"/>
+    <string name="h10" value="MP -17; damage 160% per shot, fires 3 shots"/>
+    <string name="h11" value="MP -18; damage 165% per shot, fires 3 shots"/>
+    <string name="h12" value="MP -18; damage 170% per shot, fires 3 shots"/>
+    <string name="h13" value="MP -19; damage 175% per shot, fires 3 shots"/>
+    <string name="h14" value="MP -19; damage 180% per shot, fires 3 shots"/>
+    <string name="h15" value="MP -20; damage 185% per shot, fires 3 shots"/>
+    <string name="h16" value="MP -20; damage 190% per shot, fires 3 shots"/>
+    <string name="h17" value="MP -21; damage 195% per shot, fires 3 shots"/>
+    <string name="h18" value="MP -21; damage 200% per shot, fires 3 shots"/>
+    <string name="h19" value="MP -22; damage 205% per shot, fires 3 shots"/>
+    <string name="h20" value="MP -22; damage 210% per shot, fires 3 shots"/>
   </imgdir>
   <imgdir name="5211001">
     <string name="name" value="Octopus"/>
-    <string name="desc" value="[Master Level : 30]\nSummons a loyal octopus that&apos;ll aid your attacks. The summoned octopus will not move, however.\n#cWaiting time until the next summon : 10 sec#"/>
-    <string name="h1" value="MP -11, attack rate 84, sustained for 10 sec."/>
-    <string name="h2" value="MP -11, attack rate 88, sustained for 10 sec."/>
-    <string name="h3" value="MP -12, attack rate 92, sustained for 10 sec."/>
-    <string name="h4" value="MP -12, attack rate 96, sustained for 10 sec."/>
-    <string name="h5" value="MP -13, attack rate 100, sustained for 10 sec."/>
-    <string name="h6" value="MP -13, attack rate 104, sustained for 10 sec."/>
-    <string name="h7" value="MP -14, attack rate 108, sustained for 10 sec."/>
-    <string name="h8" value="MP -14, attack rate 112, sustained for 10 sec."/>
-    <string name="h9" value="MP -15, attack rate 116, sustained for 10 sec."/>
-    <string name="h10" value="MP -15, attack rate 120, sustained for 10 sec."/>
-    <string name="h11" value="MP -16, attack rate 124, sustained for 20 sec."/>
-    <string name="h12" value="MP -16, attack rate 128, sustained for 20 sec."/>
-    <string name="h13" value="MP -17, attack rate 132, sustained for 20 sec."/>
-    <string name="h14" value="MP -17, attack rate 136, sustained for 20 sec."/>
-    <string name="h15" value="MP -18, attack rate 140, sustained for 20 sec."/>
-    <string name="h16" value="MP -18, attack rate 144, sustained for 20 sec."/>
-    <string name="h17" value="MP -19, attack rate 148, sustained for 20 sec."/>
-    <string name="h18" value="MP -19, attack rate 152, sustained for 20 sec."/>
-    <string name="h19" value="MP -20, attack rate 156, sustained for 20 sec."/>
-    <string name="h20" value="MP -20, attack rate 160, sustained for 20 sec."/>
-    <string name="h21" value="MP -21, attack rate 164, sustained for 30 sec."/>
-    <string name="h22" value="MP -21, attack rate 168, sustained for 30 sec."/>
-    <string name="h23" value="MP -22, attack rate 172, sustained for 30 sec."/>
-    <string name="h24" value="MP -22, attack rate 176, sustained for 30 sec."/>
-    <string name="h25" value="MP -23, attack rate 180, sustained for 30 sec."/>
-    <string name="h26" value="MP -23, attack rate 184, sustained for 30 sec."/>
-    <string name="h27" value="MP -24, attack rate 188, sustained for 30 sec."/>
-    <string name="h28" value="MP -24, attack rate 192, sustained for 30 sec."/>
-    <string name="h29" value="MP -25, attack rate 196, sustained for 30 sec."/>
-    <string name="h30" value="MP -25, attack rate 200, sustained for 30 sec."/>
+    <string name="desc" value="[Master Level: 30]\nSummons a stationary Octopus that attacks enemies. Cooldown applies."/>
+    <string name="h1" value="MP -11; summon attack 84, lasts 10 sec; cooldown 10 sec"/>
+    <string name="h2" value="MP -11; summon attack 88, lasts 10 sec; cooldown 10 sec"/>
+    <string name="h3" value="MP -12; summon attack 92, lasts 10 sec; cooldown 10 sec"/>
+    <string name="h4" value="MP -12; summon attack 96, lasts 10 sec; cooldown 10 sec"/>
+    <string name="h5" value="MP -13; summon attack 100, lasts 10 sec; cooldown 10 sec"/>
+    <string name="h6" value="MP -13; summon attack 104, lasts 10 sec; cooldown 10 sec"/>
+    <string name="h7" value="MP -14; summon attack 108, lasts 10 sec; cooldown 10 sec"/>
+    <string name="h8" value="MP -14; summon attack 112, lasts 10 sec; cooldown 10 sec"/>
+    <string name="h9" value="MP -15; summon attack 116, lasts 10 sec; cooldown 10 sec"/>
+    <string name="h10" value="MP -15; summon attack 120, lasts 10 sec; cooldown 10 sec"/>
+    <string name="h11" value="MP -16; summon attack 124, lasts 20 sec; cooldown 10 sec"/>
+    <string name="h12" value="MP -16; summon attack 128, lasts 20 sec; cooldown 10 sec"/>
+    <string name="h13" value="MP -17; summon attack 132, lasts 20 sec; cooldown 10 sec"/>
+    <string name="h14" value="MP -17; summon attack 136, lasts 20 sec; cooldown 10 sec"/>
+    <string name="h15" value="MP -18; summon attack 140, lasts 20 sec; cooldown 10 sec"/>
+    <string name="h16" value="MP -18; summon attack 144, lasts 20 sec; cooldown 10 sec"/>
+    <string name="h17" value="MP -19; summon attack 148, lasts 20 sec; cooldown 10 sec"/>
+    <string name="h18" value="MP -19; summon attack 152, lasts 20 sec; cooldown 10 sec"/>
+    <string name="h19" value="MP -20; summon attack 156, lasts 20 sec; cooldown 10 sec"/>
+    <string name="h20" value="MP -20; summon attack 160, lasts 20 sec; cooldown 10 sec"/>
+    <string name="h21" value="MP -21; summon attack 164, lasts 30 sec; cooldown 10 sec"/>
+    <string name="h22" value="MP -21; summon attack 168, lasts 30 sec; cooldown 10 sec"/>
+    <string name="h23" value="MP -22; summon attack 172, lasts 30 sec; cooldown 10 sec"/>
+    <string name="h24" value="MP -22; summon attack 176, lasts 30 sec; cooldown 10 sec"/>
+    <string name="h25" value="MP -23; summon attack 180, lasts 30 sec; cooldown 10 sec"/>
+    <string name="h26" value="MP -23; summon attack 184, lasts 30 sec; cooldown 10 sec"/>
+    <string name="h27" value="MP -24; summon attack 188, lasts 30 sec; cooldown 10 sec"/>
+    <string name="h28" value="MP -24; summon attack 192, lasts 30 sec; cooldown 10 sec"/>
+    <string name="h29" value="MP -25; summon attack 196, lasts 30 sec; cooldown 10 sec"/>
+    <string name="h30" value="MP -25; summon attack 200, lasts 30 sec; cooldown 10 sec"/>
   </imgdir>
   <imgdir name="5211002">
     <string name="name" value="Gaviota"/>
-    <string name="desc" value="[Master Level : 30]\nSummons Gaviota, who&apos;s trained to throw a grenade at monsters. The summoned Gaviota will seek a monster, and when it finds one, it&apos;ll toss the grenade and disappear. \n#cWaiting time : 5 sec.#"/>
-    <string name="h1" value="MP -11, attack rate 218, sustained for 10 sec."/>
-    <string name="h2" value="MP -11, attack rate 226, sustained for 10 sec."/>
-    <string name="h3" value="MP -11, attack rate 234, sustained for 10 sec."/>
-    <string name="h4" value="MP -12, attack rate 242, sustained for 10 sec."/>
-    <string name="h5" value="MP -12, attack rate 250, sustained for 10 sec."/>
-    <string name="h6" value="MP -12, attack rate 258, sustained for 10 sec."/>
-    <string name="h7" value="MP -13, attack rate 266, sustained for 10 sec."/>
-    <string name="h8" value="MP -13, attack rate 274, sustained for 10 sec."/>
-    <string name="h9" value="MP -13, attack rate 282, sustained for 10 sec."/>
-    <string name="h10" value="MP -14, attack rate 290, sustained for 10 sec."/>
-    <string name="h11" value="MP -14, attack rate 298, sustained for 20 sec."/>
-    <string name="h12" value="MP -14, attack rate 306, sustained for 20 sec."/>
-    <string name="h13" value="MP -15, attack rate 314, sustained for 20 sec."/>
-    <string name="h14" value="MP -15, attack rate 322, sustained for 20 sec."/>
-    <string name="h15" value="MP -15, attack rate 330, sustained for 20 sec."/>
-    <string name="h16" value="MP -16, attack rate 338, sustained for 20 sec."/>
-    <string name="h17" value="MP -16, attack rate 346, sustained for 20 sec."/>
-    <string name="h18" value="MP -16, attack rate 354, sustained for 20 sec."/>
-    <string name="h19" value="MP -17, attack rate 362, sustained for 20 sec."/>
-    <string name="h20" value="MP -17, attack rate 370, sustained for 20 sec."/>
-    <string name="h21" value="MP -17, attack rate 378, sustained for 30 sec."/>
-    <string name="h22" value="MP -18, attack rate 386, sustained for 30 sec."/>
-    <string name="h23" value="MP -18, attack rate 394, sustained for 30 sec."/>
-    <string name="h24" value="MP -18, attack rate 402, sustained for 30 sec."/>
-    <string name="h25" value="MP -19, attack rate 410, sustained for 30 sec."/>
-    <string name="h26" value="MP -19, attack rate 418, sustained for 30 sec."/>
-    <string name="h27" value="MP -19, attack rate 426, sustained for 30 sec."/>
-    <string name="h28" value="MP -20, attack rate 434, sustained for 30 sec."/>
-    <string name="h29" value="MP -20, attack rate 442, sustained for 30 sec."/>
-    <string name="h30" value="MP -20, attack rate 450, sustained for 30 sec."/>
+    <string name="desc" value="[Master Level: 30]\nSummons Gaviota to seek an enemy, throw a grenade, and disappear. Cooldown applies."/>
+    <string name="h1" value="MP -11; summon attack 218, lasts 10 sec; cooldown 5 sec"/>
+    <string name="h2" value="MP -11; summon attack 226, lasts 10 sec; cooldown 5 sec"/>
+    <string name="h3" value="MP -11; summon attack 234, lasts 10 sec; cooldown 5 sec"/>
+    <string name="h4" value="MP -12; summon attack 242, lasts 10 sec; cooldown 5 sec"/>
+    <string name="h5" value="MP -12; summon attack 250, lasts 10 sec; cooldown 5 sec"/>
+    <string name="h6" value="MP -12; summon attack 258, lasts 10 sec; cooldown 5 sec"/>
+    <string name="h7" value="MP -13; summon attack 266, lasts 10 sec; cooldown 5 sec"/>
+    <string name="h8" value="MP -13; summon attack 274, lasts 10 sec; cooldown 5 sec"/>
+    <string name="h9" value="MP -13; summon attack 282, lasts 10 sec; cooldown 5 sec"/>
+    <string name="h10" value="MP -14; summon attack 290, lasts 10 sec; cooldown 5 sec"/>
+    <string name="h11" value="MP -14; summon attack 298, lasts 20 sec; cooldown 5 sec"/>
+    <string name="h12" value="MP -14; summon attack 306, lasts 20 sec; cooldown 5 sec"/>
+    <string name="h13" value="MP -15; summon attack 314, lasts 20 sec; cooldown 5 sec"/>
+    <string name="h14" value="MP -15; summon attack 322, lasts 20 sec; cooldown 5 sec"/>
+    <string name="h15" value="MP -15; summon attack 330, lasts 20 sec; cooldown 5 sec"/>
+    <string name="h16" value="MP -16; summon attack 338, lasts 20 sec; cooldown 5 sec"/>
+    <string name="h17" value="MP -16; summon attack 346, lasts 20 sec; cooldown 5 sec"/>
+    <string name="h18" value="MP -16; summon attack 354, lasts 20 sec; cooldown 5 sec"/>
+    <string name="h19" value="MP -17; summon attack 362, lasts 20 sec; cooldown 5 sec"/>
+    <string name="h20" value="MP -17; summon attack 370, lasts 20 sec; cooldown 5 sec"/>
+    <string name="h21" value="MP -17; summon attack 378, lasts 30 sec; cooldown 5 sec"/>
+    <string name="h22" value="MP -18; summon attack 386, lasts 30 sec; cooldown 5 sec"/>
+    <string name="h23" value="MP -18; summon attack 394, lasts 30 sec; cooldown 5 sec"/>
+    <string name="h24" value="MP -18; summon attack 402, lasts 30 sec; cooldown 5 sec"/>
+    <string name="h25" value="MP -19; summon attack 410, lasts 30 sec; cooldown 5 sec"/>
+    <string name="h26" value="MP -19; summon attack 418, lasts 30 sec; cooldown 5 sec"/>
+    <string name="h27" value="MP -19; summon attack 426, lasts 30 sec; cooldown 5 sec"/>
+    <string name="h28" value="MP -20; summon attack 434, lasts 30 sec; cooldown 5 sec"/>
+    <string name="h29" value="MP -20; summon attack 442, lasts 30 sec; cooldown 5 sec"/>
+    <string name="h30" value="MP -20; summon attack 450, lasts 30 sec; cooldown 5 sec"/>
   </imgdir>
   <imgdir name="5211004">
     <string name="name" value="Flamethrower"/>
-    <string name="desc" value="[Master Level : 30]\nAttacks a monster nearby with a fire-based attack. The affected monster will keep receiving damage for a short period of time."/>
-    <string name="h1" value="MP -25, damage 73%, attacks 2 monsters"/>
-    <string name="h2" value="MP -25, damage 76%, attacks 2 monsters"/>
-    <string name="h3" value="MP -25, damage 79%, attacks 2 monsters"/>
-    <string name="h4" value="MP -25, damage 82%, attacks 2 monsters"/>
-    <string name="h5" value="MP -25, damage 85%, attacks 2 monsters"/>
-    <string name="h6" value="MP -25, damage 88%, attacks 2 monsters"/>
-    <string name="h7" value="MP -25, damage 91%, attacks 3 monsters"/>
-    <string name="h8" value="MP -25, damage 94%, attacks 3 monsters"/>
-    <string name="h9" value="MP -25, damage 97%, attacks 3 monsters"/>
-    <string name="h10" value="MP -25, damage 100%, attacks 3 monsters"/>
-    <string name="h11" value="MP -30, damage 103%, attacks 3 monsters"/>
-    <string name="h12" value="MP -30, damage 106%, attacks 3 monsters"/>
-    <string name="h13" value="MP -30, damage 109%, attacks 4 monsters"/>
-    <string name="h14" value="MP -30, damage 112%, attacks 4 monsters"/>
-    <string name="h15" value="MP -30, damage 115%, attacks 4 monsters"/>
-    <string name="h16" value="MP -30, damage 118%, attacks 4 monsters"/>
-    <string name="h17" value="MP -30, damage 121%, attacks 4 monsters"/>
-    <string name="h18" value="MP -30, damage 124%, attacks 4 monsters"/>
-    <string name="h19" value="MP -30, damage 127%, attacks 5 monsters"/>
-    <string name="h20" value="MP -30, damage 130%, attacks 5 monsters"/>
-    <string name="h21" value="MP -35, damage 133%, attacks 5 monsters"/>
-    <string name="h22" value="MP -35, damage 136%, attacks 5 monsters"/>
-    <string name="h23" value="MP -35, damage 139%, attacks 5 monsters"/>
-    <string name="h24" value="MP -35, damage 142%, attacks 5 monsters"/>
-    <string name="h25" value="MP -35, damage 145%, attacks 6 monsters"/>
-    <string name="h26" value="MP -35, damage 148%, attacks 6 monsters"/>
-    <string name="h27" value="MP -35, damage 151%, attacks 6 monsters"/>
-    <string name="h28" value="MP -35, damage 154%, attacks 6 monsters"/>
-    <string name="h29" value="MP -35, damage 157%, attacks 6 monsters"/>
-    <string name="h30" value="MP -35, damage 160%, attacks 6 monsters"/>
+    <string name="desc" value="[Master Level: 30]\nAttacks nearby enemies with fire. Non-boss enemies receive fire damage over time."/>
+    <string name="h1" value="MP -25; damage 73%, attacks up to 2 enemies; burn lasts 3 sec"/>
+    <string name="h2" value="MP -25; damage 76%, attacks up to 2 enemies; burn lasts 3 sec"/>
+    <string name="h3" value="MP -25; damage 79%, attacks up to 2 enemies; burn lasts 3 sec"/>
+    <string name="h4" value="MP -25; damage 82%, attacks up to 2 enemies; burn lasts 3 sec"/>
+    <string name="h5" value="MP -25; damage 85%, attacks up to 2 enemies; burn lasts 3 sec"/>
+    <string name="h6" value="MP -25; damage 88%, attacks up to 2 enemies; burn lasts 3 sec"/>
+    <string name="h7" value="MP -25; damage 91%, attacks up to 3 enemies; burn lasts 3 sec"/>
+    <string name="h8" value="MP -25; damage 94%, attacks up to 3 enemies; burn lasts 3 sec"/>
+    <string name="h9" value="MP -25; damage 97%, attacks up to 3 enemies; burn lasts 3 sec"/>
+    <string name="h10" value="MP -25; damage 100%, attacks up to 3 enemies; burn lasts 3 sec"/>
+    <string name="h11" value="MP -30; damage 103%, attacks up to 3 enemies; burn lasts 4 sec"/>
+    <string name="h12" value="MP -30; damage 106%, attacks up to 3 enemies; burn lasts 4 sec"/>
+    <string name="h13" value="MP -30; damage 109%, attacks up to 4 enemies; burn lasts 4 sec"/>
+    <string name="h14" value="MP -30; damage 112%, attacks up to 4 enemies; burn lasts 4 sec"/>
+    <string name="h15" value="MP -30; damage 115%, attacks up to 4 enemies; burn lasts 4 sec"/>
+    <string name="h16" value="MP -30; damage 118%, attacks up to 4 enemies; burn lasts 4 sec"/>
+    <string name="h17" value="MP -30; damage 121%, attacks up to 4 enemies; burn lasts 4 sec"/>
+    <string name="h18" value="MP -30; damage 124%, attacks up to 4 enemies; burn lasts 4 sec"/>
+    <string name="h19" value="MP -30; damage 127%, attacks up to 5 enemies; burn lasts 4 sec"/>
+    <string name="h20" value="MP -30; damage 130%, attacks up to 5 enemies; burn lasts 4 sec"/>
+    <string name="h21" value="MP -35; damage 133%, attacks up to 5 enemies; burn lasts 5 sec"/>
+    <string name="h22" value="MP -35; damage 136%, attacks up to 5 enemies; burn lasts 5 sec"/>
+    <string name="h23" value="MP -35; damage 139%, attacks up to 5 enemies; burn lasts 5 sec"/>
+    <string name="h24" value="MP -35; damage 142%, attacks up to 5 enemies; burn lasts 5 sec"/>
+    <string name="h25" value="MP -35; damage 145%, attacks up to 6 enemies; burn lasts 5 sec"/>
+    <string name="h26" value="MP -35; damage 148%, attacks up to 6 enemies; burn lasts 5 sec"/>
+    <string name="h27" value="MP -35; damage 151%, attacks up to 6 enemies; burn lasts 5 sec"/>
+    <string name="h28" value="MP -35; damage 154%, attacks up to 6 enemies; burn lasts 5 sec"/>
+    <string name="h29" value="MP -35; damage 157%, attacks up to 6 enemies; burn lasts 5 sec"/>
+    <string name="h30" value="MP -35; damage 160%, attacks up to 6 enemies; burn lasts 5 sec"/>
   </imgdir>
   <imgdir name="5211005">
     <string name="name" value="Ice Splitter"/>
-    <string name="desc" value="[Master Level : 30]\nAttacks the closest monster with an ice-based attack. The affected monster will be frozen for a short period of time."/>
-    <string name="h1" value="MP -25, damage 72%, attacks 2 monsters"/>
-    <string name="h2" value="MP -25, damage 74%, attacks 2 monsters"/>
-    <string name="h3" value="MP -25, damage 76%, attacks 2 monsters"/>
-    <string name="h4" value="MP -25, damage 78%, attacks 2 monsters"/>
-    <string name="h5" value="MP -25, damage 80%, attacks 2 monsters"/>
-    <string name="h6" value="MP -25, damage 82%, attacks 2 monsters"/>
-    <string name="h7" value="MP -25, damage 84%, attacks 3 monsters"/>
-    <string name="h8" value="MP -25, damage 86%, attacks 3 monsters"/>
-    <string name="h9" value="MP -25, damage 88%, attacks 3 monsters"/>
-    <string name="h10" value="MP -25, damage 90%, attacks 3 monsters"/>
-    <string name="h11" value="MP -30, damage 92%, attacks 3 monsters"/>
-    <string name="h12" value="MP -30, damage 94%, attacks 3 monsters"/>
-    <string name="h13" value="MP -30, damage 96%, attacks 4 monsters"/>
-    <string name="h14" value="MP -30, damage 98%, attacks 4 monsters"/>
-    <string name="h15" value="MP -30, damage 100%, attacks 4 monsters"/>
-    <string name="h16" value="MP -30, damage 102%, attacks 4 monsters"/>
-    <string name="h17" value="MP -30, damage 104%, attacks 4 monsters"/>
-    <string name="h18" value="MP -30, damage 106%, attacks 4 monsters"/>
-    <string name="h19" value="MP -30, damage 108%, attacks 5 monsters"/>
-    <string name="h20" value="MP -30, damage 110%, attacks 5 monsters"/>
-    <string name="h21" value="MP -35, damage 112%, attacks 5 monsters"/>
-    <string name="h22" value="MP -35, damage 114%, attacks 5 monsters"/>
-    <string name="h23" value="MP -35, damage 116%, attacks 5 monsters"/>
-    <string name="h24" value="MP -35, damage 118%, attacks 5 monsters"/>
-    <string name="h25" value="MP -35, damage 120%, attacks 6 monsters"/>
-    <string name="h26" value="MP -35, damage 122%, attacks 6 monsters"/>
-    <string name="h27" value="MP -35, damage 124%, attacks 6 monsters"/>
-    <string name="h28" value="MP -35, damage 126%, attacks 6 monsters"/>
-    <string name="h29" value="MP -35, damage 128%, attacks 6 monsters"/>
-    <string name="h30" value="MP -35, damage 130%, attacks 6 monsters"/>
+    <string name="desc" value="[Master Level: 30]\nAttacks nearby enemies with ice and freezes them. Server freeze duration is twice the listed skill time."/>
+    <string name="h1" value="MP -25; damage 72%, attacks up to 2 enemies; freezes for 2 sec"/>
+    <string name="h2" value="MP -25; damage 74%, attacks up to 2 enemies; freezes for 2 sec"/>
+    <string name="h3" value="MP -25; damage 76%, attacks up to 2 enemies; freezes for 2 sec"/>
+    <string name="h4" value="MP -25; damage 78%, attacks up to 2 enemies; freezes for 2 sec"/>
+    <string name="h5" value="MP -25; damage 80%, attacks up to 2 enemies; freezes for 2 sec"/>
+    <string name="h6" value="MP -25; damage 82%, attacks up to 2 enemies; freezes for 2 sec"/>
+    <string name="h7" value="MP -25; damage 84%, attacks up to 3 enemies; freezes for 2 sec"/>
+    <string name="h8" value="MP -25; damage 86%, attacks up to 3 enemies; freezes for 2 sec"/>
+    <string name="h9" value="MP -25; damage 88%, attacks up to 3 enemies; freezes for 2 sec"/>
+    <string name="h10" value="MP -25; damage 90%, attacks up to 3 enemies; freezes for 2 sec"/>
+    <string name="h11" value="MP -30; damage 92%, attacks up to 3 enemies; freezes for 4 sec"/>
+    <string name="h12" value="MP -30; damage 94%, attacks up to 3 enemies; freezes for 4 sec"/>
+    <string name="h13" value="MP -30; damage 96%, attacks up to 4 enemies; freezes for 4 sec"/>
+    <string name="h14" value="MP -30; damage 98%, attacks up to 4 enemies; freezes for 4 sec"/>
+    <string name="h15" value="MP -30; damage 100%, attacks up to 4 enemies; freezes for 4 sec"/>
+    <string name="h16" value="MP -30; damage 102%, attacks up to 4 enemies; freezes for 4 sec"/>
+    <string name="h17" value="MP -30; damage 104%, attacks up to 4 enemies; freezes for 4 sec"/>
+    <string name="h18" value="MP -30; damage 106%, attacks up to 4 enemies; freezes for 4 sec"/>
+    <string name="h19" value="MP -30; damage 108%, attacks up to 5 enemies; freezes for 4 sec"/>
+    <string name="h20" value="MP -30; damage 110%, attacks up to 5 enemies; freezes for 4 sec"/>
+    <string name="h21" value="MP -35; damage 112%, attacks up to 5 enemies; freezes for 6 sec"/>
+    <string name="h22" value="MP -35; damage 114%, attacks up to 5 enemies; freezes for 6 sec"/>
+    <string name="h23" value="MP -35; damage 116%, attacks up to 5 enemies; freezes for 6 sec"/>
+    <string name="h24" value="MP -35; damage 118%, attacks up to 5 enemies; freezes for 6 sec"/>
+    <string name="h25" value="MP -35; damage 120%, attacks up to 6 enemies; freezes for 6 sec"/>
+    <string name="h26" value="MP -35; damage 122%, attacks up to 6 enemies; freezes for 6 sec"/>
+    <string name="h27" value="MP -35; damage 124%, attacks up to 6 enemies; freezes for 6 sec"/>
+    <string name="h28" value="MP -35; damage 126%, attacks up to 6 enemies; freezes for 6 sec"/>
+    <string name="h29" value="MP -35; damage 128%, attacks up to 6 enemies; freezes for 6 sec"/>
+    <string name="h30" value="MP -35; damage 130%, attacks up to 6 enemies; freezes for 6 sec"/>
   </imgdir>
   <imgdir name="5211006">
     <string name="name" value="Homing Beacon"/>
-    <string name="desc" value="[Master Level : 30]\nSends a parrot that&apos;ll mark a target on a monster. From then on out, all attacks will be focused on that monster."/>
-    <string name="h1" value="MP -20, damage 148%"/>
-    <string name="h2" value="MP -20, damage 156%"/>
-    <string name="h3" value="MP -20, damage 164%"/>
-    <string name="h4" value="MP -20, damage 172%"/>
-    <string name="h5" value="MP -20, damage 180%"/>
-    <string name="h6" value="MP -20, damage 188%"/>
-    <string name="h7" value="MP -20, damage 196%"/>
-    <string name="h8" value="MP -20, damage 204%"/>
-    <string name="h9" value="MP -20, damage 212%"/>
-    <string name="h10" value="MP -20, damage 220%"/>
-    <string name="h11" value="MP -25, damage 228%"/>
-    <string name="h12" value="MP -25, damage 236%"/>
-    <string name="h13" value="MP -25, damage 244%"/>
-    <string name="h14" value="MP -25, damage 252%"/>
-    <string name="h15" value="MP -25, damage 260%"/>
-    <string name="h16" value="MP -25, damage 268%"/>
-    <string name="h17" value="MP -25, damage 276%"/>
-    <string name="h18" value="MP -25, damage 284%"/>
-    <string name="h19" value="MP -25, damage 292%"/>
-    <string name="h20" value="MP -25, damage 300%"/>
-    <string name="h21" value="MP -30, damage 308%"/>
-    <string name="h22" value="MP -30, damage 316%"/>
-    <string name="h23" value="MP -30, damage 324%"/>
-    <string name="h24" value="MP -30, damage 332%"/>
-    <string name="h25" value="MP -30, damage 340%"/>
-    <string name="h26" value="MP -30, damage 348%"/>
-    <string name="h27" value="MP -30, damage 356%"/>
-    <string name="h28" value="MP -30, damage 364%"/>
-    <string name="h29" value="MP -30, damage 372%"/>
-    <string name="h30" value="MP -30, damage 380%"/>
+    <string name="desc" value="[Master Level: 30]\nMarks one enemy. Attacks focus on the marked target until the mark is lost."/>
+    <string name="h1" value="MP -20; marks one enemy with damage 148%, range 350"/>
+    <string name="h2" value="MP -20; marks one enemy with damage 156%, range 350"/>
+    <string name="h3" value="MP -20; marks one enemy with damage 164%, range 350"/>
+    <string name="h4" value="MP -20; marks one enemy with damage 172%, range 350"/>
+    <string name="h5" value="MP -20; marks one enemy with damage 180%, range 350"/>
+    <string name="h6" value="MP -20; marks one enemy with damage 188%, range 350"/>
+    <string name="h7" value="MP -20; marks one enemy with damage 196%, range 350"/>
+    <string name="h8" value="MP -20; marks one enemy with damage 204%, range 350"/>
+    <string name="h9" value="MP -20; marks one enemy with damage 212%, range 350"/>
+    <string name="h10" value="MP -20; marks one enemy with damage 220%, range 350"/>
+    <string name="h11" value="MP -25; marks one enemy with damage 228%, range 350"/>
+    <string name="h12" value="MP -25; marks one enemy with damage 236%, range 350"/>
+    <string name="h13" value="MP -25; marks one enemy with damage 244%, range 350"/>
+    <string name="h14" value="MP -25; marks one enemy with damage 252%, range 350"/>
+    <string name="h15" value="MP -25; marks one enemy with damage 260%, range 350"/>
+    <string name="h16" value="MP -25; marks one enemy with damage 268%, range 350"/>
+    <string name="h17" value="MP -25; marks one enemy with damage 276%, range 350"/>
+    <string name="h18" value="MP -25; marks one enemy with damage 284%, range 350"/>
+    <string name="h19" value="MP -25; marks one enemy with damage 292%, range 350"/>
+    <string name="h20" value="MP -25; marks one enemy with damage 300%, range 350"/>
+    <string name="h21" value="MP -30; marks one enemy with damage 308%, range 350"/>
+    <string name="h22" value="MP -30; marks one enemy with damage 316%, range 350"/>
+    <string name="h23" value="MP -30; marks one enemy with damage 324%, range 350"/>
+    <string name="h24" value="MP -30; marks one enemy with damage 332%, range 350"/>
+    <string name="h25" value="MP -30; marks one enemy with damage 340%, range 350"/>
+    <string name="h26" value="MP -30; marks one enemy with damage 348%, range 350"/>
+    <string name="h27" value="MP -30; marks one enemy with damage 356%, range 350"/>
+    <string name="h28" value="MP -30; marks one enemy with damage 364%, range 350"/>
+    <string name="h29" value="MP -30; marks one enemy with damage 372%, range 350"/>
+    <string name="h30" value="MP -30; marks one enemy with damage 380%, range 350"/>
   </imgdir>
   <imgdir name="512">
     <string name="bookName" value="The Perfect Buccaneer"/>
   </imgdir>
   <imgdir name="5121000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
-    <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
-    <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
-    <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
-    <string name="h4" value="MP - 10 ,  For 120Secs, all stats + 2% "/>
-    <string name="h5" value="MP - 10 ,  For 150Secs, all stats + 3% "/>
-    <string name="h6" value="MP - 20 ,  For 180Secs, all stats + 3% "/>
-    <string name="h7" value="MP - 20 ,  For 210Secs, all stats + 4% "/>
-    <string name="h8" value="MP - 20 ,  For 240Secs, all stats + 4% "/>
-    <string name="h9" value="MP - 20 ,  For 270Secs, all stats + 5% "/>
-    <string name="h10" value="MP - 20 ,  For 300Secs, all stats + 5% "/>
-    <string name="h11" value="MP - 30 ,  For 330Secs, all stats + 6% "/>
-    <string name="h12" value="MP - 30 ,  For 360Secs, all stats + 6% "/>
-    <string name="h13" value="MP - 30 ,  For 390Secs, all stats + 7% "/>
-    <string name="h14" value="MP - 30 ,  For 420Secs, all stats + 7% "/>
-    <string name="h15" value="MP - 30 ,  For 450Secs, all stats + 8% "/>
-    <string name="h16" value="MP - 40 ,  For 480Secs, all stats + 8% "/>
-    <string name="h17" value="MP - 40 ,  For 510Secs, all stats + 9% "/>
-    <string name="h18" value="MP - 40 ,  For 540Secs, all stats + 9% "/>
-    <string name="h19" value="MP - 40 ,  For 570Secs, all stats + 10% "/>
-    <string name="h20" value="MP - 40 ,  For 600Secs, all stats + 10% "/>
-    <string name="h21" value="MP - 50 ,  For 630Secs, all stats + 11% "/>
-    <string name="h22" value="MP - 50 ,  For 660Secs, all stats + 11% "/>
-    <string name="h23" value="MP - 50 ,  For 690Secs, all stats + 12% "/>
-    <string name="h24" value="MP - 50 ,  For 720Secs, all stats + 12% "/>
-    <string name="h25" value="MP - 50 ,  For 750Secs, all stats + 13% "/>
-    <string name="h26" value="MP - 60 ,  For 780Secs, all stats + 13% "/>
-    <string name="h27" value="MP - 60 ,  For 810Secs, all stats + 14% "/>
-    <string name="h28" value="MP - 60 ,  For 840Secs, all stats + 14% "/>
-    <string name="h29" value="MP - 60 ,  For 870Secs, all stats + 15% "/>
-    <string name="h30" value="MP - 60 ,  For 900Secs, all stats + 15% "/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily increases all stats of yourself and nearby party members by a percentage."/>
+    <string name="h1" value="MP -10; All stats +1% for 30 sec"/>
+    <string name="h2" value="MP -10; All stats +1% for 60 sec"/>
+    <string name="h3" value="MP -10; All stats +2% for 90 sec"/>
+    <string name="h4" value="MP -10; All stats +2% for 120 sec"/>
+    <string name="h5" value="MP -10; All stats +3% for 150 sec"/>
+    <string name="h6" value="MP -20; All stats +3% for 180 sec"/>
+    <string name="h7" value="MP -20; All stats +4% for 210 sec"/>
+    <string name="h8" value="MP -20; All stats +4% for 240 sec"/>
+    <string name="h9" value="MP -20; All stats +5% for 270 sec"/>
+    <string name="h10" value="MP -20; All stats +5% for 300 sec"/>
+    <string name="h11" value="MP -30; All stats +6% for 330 sec"/>
+    <string name="h12" value="MP -30; All stats +6% for 360 sec"/>
+    <string name="h13" value="MP -30; All stats +7% for 390 sec"/>
+    <string name="h14" value="MP -30; All stats +7% for 420 sec"/>
+    <string name="h15" value="MP -30; All stats +8% for 450 sec"/>
+    <string name="h16" value="MP -40; All stats +8% for 480 sec"/>
+    <string name="h17" value="MP -40; All stats +9% for 510 sec"/>
+    <string name="h18" value="MP -40; All stats +9% for 540 sec"/>
+    <string name="h19" value="MP -40; All stats +10% for 570 sec"/>
+    <string name="h20" value="MP -40; All stats +10% for 600 sec"/>
+    <string name="h21" value="MP -50; All stats +11% for 630 sec"/>
+    <string name="h22" value="MP -50; All stats +11% for 660 sec"/>
+    <string name="h23" value="MP -50; All stats +12% for 690 sec"/>
+    <string name="h24" value="MP -50; All stats +12% for 720 sec"/>
+    <string name="h25" value="MP -50; All stats +13% for 750 sec"/>
+    <string name="h26" value="MP -60; All stats +13% for 780 sec"/>
+    <string name="h27" value="MP -60; All stats +14% for 810 sec"/>
+    <string name="h28" value="MP -60; All stats +14% for 840 sec"/>
+    <string name="h29" value="MP -60; All stats +15% for 870 sec"/>
+    <string name="h30" value="MP -60; All stats +15% for 900 sec"/>
   </imgdir>
   <imgdir name="5121001">
     <string name="name" value="Dragon Strike"/>
-    <string name="desc" value="Summons a sleeping dragon from the depths of the ground to apply damage to a number of monsters."/>
-    <string name="h1" value="MP -21, damage 275%, attacks 4 monsters"/>
-    <string name="h2" value="MP -21, damage 290%, attacks 4 monsters"/>
-    <string name="h3" value="MP -22, damage 305%, attacks 4 monsters"/>
-    <string name="h4" value="MP -22, damage 320%, attacks 4 monsters"/>
-    <string name="h5" value="MP -23, damage 335%, attacks 4 monsters"/>
-    <string name="h6" value="MP -23, damage 350%, attacks 4 monsters"/>
-    <string name="h7" value="MP -24, damage 365%, attacks 4 monsters"/>
-    <string name="h8" value="MP -24, damage 380%, attacks 4 monsters"/>
-    <string name="h9" value="MP -25, damage 395%, attacks 4 monsters"/>
-    <string name="h10" value="MP -25, damage 410%, attacks 4 monsters"/>
-    <string name="h11" value="MP -26, damage 475%, attacks 5 monsters"/>
-    <string name="h12" value="MP -26, damage 490%, attacks 5 monsters"/>
-    <string name="h13" value="MP -27, damage 505%, attacks 5 monsters"/>
-    <string name="h14" value="MP -27, damage 520%, attacks 5 monsters"/>
-    <string name="h15" value="MP -28, damage 535%, attacks 5 monsters"/>
-    <string name="h16" value="MP -28, damage 550%, attacks 5 monsters"/>
-    <string name="h17" value="MP -29, damage 565%, attacks 5 monsters"/>
-    <string name="h18" value="MP -29, damage 580%, attacks 5 monsters"/>
-    <string name="h19" value="MP -30, damage 595%, attacks 5 monsters"/>
-    <string name="h20" value="MP -30, damage 610%, attacks 5 monsters"/>
-    <string name="h21" value="MP -31, damage 675%, attacks 6 monsters"/>
-    <string name="h22" value="MP -31, damage 690%, attacks 6 monsters"/>
-    <string name="h23" value="MP -32, damage 705%, attacks 6 monsters"/>
-    <string name="h24" value="MP -32, damage 720%, attacks 6 monsters"/>
-    <string name="h25" value="MP -33, damage 735%, attacks 6 monsters"/>
-    <string name="h26" value="MP -33, damage 750%, attacks 6 monsters"/>
-    <string name="h27" value="MP -34, damage 765%, attacks 6 monsters"/>
-    <string name="h28" value="MP -34, damage 780%, attacks 6 monsters"/>
-    <string name="h29" value="MP -35, damage 795%, attacks 6 monsters"/>
-    <string name="h30" value="MP -35, damage 810%, attacks 6 monsters"/>
+    <string name="desc" value="[Master Level: 30]\nSummons a dragon from the ground to attack multiple enemies."/>
+    <string name="h1" value="MP -21; damage 275%, attacks up to 4 enemies"/>
+    <string name="h2" value="MP -21; damage 290%, attacks up to 4 enemies"/>
+    <string name="h3" value="MP -22; damage 305%, attacks up to 4 enemies"/>
+    <string name="h4" value="MP -22; damage 320%, attacks up to 4 enemies"/>
+    <string name="h5" value="MP -23; damage 335%, attacks up to 4 enemies"/>
+    <string name="h6" value="MP -23; damage 350%, attacks up to 4 enemies"/>
+    <string name="h7" value="MP -24; damage 365%, attacks up to 4 enemies"/>
+    <string name="h8" value="MP -24; damage 380%, attacks up to 4 enemies"/>
+    <string name="h9" value="MP -25; damage 395%, attacks up to 4 enemies"/>
+    <string name="h10" value="MP -25; damage 410%, attacks up to 4 enemies"/>
+    <string name="h11" value="MP -26; damage 475%, attacks up to 5 enemies"/>
+    <string name="h12" value="MP -26; damage 490%, attacks up to 5 enemies"/>
+    <string name="h13" value="MP -27; damage 505%, attacks up to 5 enemies"/>
+    <string name="h14" value="MP -27; damage 520%, attacks up to 5 enemies"/>
+    <string name="h15" value="MP -28; damage 535%, attacks up to 5 enemies"/>
+    <string name="h16" value="MP -28; damage 550%, attacks up to 5 enemies"/>
+    <string name="h17" value="MP -29; damage 565%, attacks up to 5 enemies"/>
+    <string name="h18" value="MP -29; damage 580%, attacks up to 5 enemies"/>
+    <string name="h19" value="MP -30; damage 595%, attacks up to 5 enemies"/>
+    <string name="h20" value="MP -30; damage 610%, attacks up to 5 enemies"/>
+    <string name="h21" value="MP -31; damage 675%, attacks up to 6 enemies"/>
+    <string name="h22" value="MP -31; damage 690%, attacks up to 6 enemies"/>
+    <string name="h23" value="MP -32; damage 705%, attacks up to 6 enemies"/>
+    <string name="h24" value="MP -32; damage 720%, attacks up to 6 enemies"/>
+    <string name="h25" value="MP -33; damage 735%, attacks up to 6 enemies"/>
+    <string name="h26" value="MP -33; damage 750%, attacks up to 6 enemies"/>
+    <string name="h27" value="MP -34; damage 765%, attacks up to 6 enemies"/>
+    <string name="h28" value="MP -34; damage 780%, attacks up to 6 enemies"/>
+    <string name="h29" value="MP -35; damage 795%, attacks up to 6 enemies"/>
+    <string name="h30" value="MP -35; damage 810%, attacks up to 6 enemies"/>
   </imgdir>
   <imgdir name="5121002">
     <string name="name" value="Energy Orb"/>
-    <string name="desc" value="Uses a blast of powerful energy to strike a monster. If there are other monsters around the affected monster, they will also be affected by this potent ball of energy. Only available when the #cenergy is fully charged#.\nRequired Skill : #cLevel 1 of Ener"/>
-    <string name="h1" value="damage 300%, attacks 2 monsters"/>
-    <string name="h2" value="damage 320%, attacks 2 monsters"/>
-    <string name="h3" value="damage 340%, attacks 2 monsters"/>
-    <string name="h4" value="damage 360%, attacks 2 monsters"/>
-    <string name="h5" value="damage 380%, attacks 2 monsters"/>
-    <string name="h6" value="damage 400%, attacks 2 monsters"/>
-    <string name="h7" value="damage 420%, attacks 3 monsters"/>
-    <string name="h8" value="damage 440%, attacks 3 monsters"/>
-    <string name="h9" value="damage 460%, attacks 3 monsters"/>
-    <string name="h10" value="damage 480%, attacks 3 monsters"/>
-    <string name="h11" value="damage 510%, attacks 3 monsters"/>
-    <string name="h12" value="damage 530%, attacks 3 monsters"/>
-    <string name="h13" value="damage 550%, attacks 4 monsters"/>
-    <string name="h14" value="damage 570%, attacks 4 monsters"/>
-    <string name="h15" value="damage 590%, attacks 4 monsters"/>
-    <string name="h16" value="damage 610%, attacks 4 monsters"/>
-    <string name="h17" value="damage 630%, attacks 4 monsters"/>
-    <string name="h18" value="damage 650%, attacks 4 monsters"/>
-    <string name="h19" value="damage 670%, attacks 5 monsters"/>
-    <string name="h20" value="damage 690%, attacks 5 monsters"/>
-    <string name="h21" value="damage 720%, attacks 5 monsters"/>
-    <string name="h22" value="damage 740%, attacks 5 monsters"/>
-    <string name="h23" value="damage 760%, attacks 5 monsters"/>
-    <string name="h24" value="damage 780%, attacks 5 monsters"/>
-    <string name="h25" value="damage 800%, attacks 6 monsters"/>
-    <string name="h26" value="damage 820%, attacks 6 monsters"/>
-    <string name="h27" value="damage 840%, attacks 6 monsters"/>
-    <string name="h28" value="damage 860%, attacks 6 monsters"/>
-    <string name="h29" value="damage 880%, attacks 6 monsters"/>
-    <string name="h30" value="damage 900%, attacks 6 monsters"/>
+    <string name="desc" value="[Master Level: 30]\nFires a charged energy orb that can chain to nearby enemies. Can only be used while Energy Charge is full."/>
+    <string name="h1" value="; damage 300%, attacks up to 2 enemies"/>
+    <string name="h2" value="; damage 320%, attacks up to 2 enemies"/>
+    <string name="h3" value="; damage 340%, attacks up to 2 enemies"/>
+    <string name="h4" value="; damage 360%, attacks up to 2 enemies"/>
+    <string name="h5" value="; damage 380%, attacks up to 2 enemies"/>
+    <string name="h6" value="; damage 400%, attacks up to 2 enemies"/>
+    <string name="h7" value="; damage 420%, attacks up to 3 enemies"/>
+    <string name="h8" value="; damage 440%, attacks up to 3 enemies"/>
+    <string name="h9" value="; damage 460%, attacks up to 3 enemies"/>
+    <string name="h10" value="; damage 480%, attacks up to 3 enemies"/>
+    <string name="h11" value="; damage 510%, attacks up to 3 enemies"/>
+    <string name="h12" value="; damage 530%, attacks up to 3 enemies"/>
+    <string name="h13" value="; damage 550%, attacks up to 4 enemies"/>
+    <string name="h14" value="; damage 570%, attacks up to 4 enemies"/>
+    <string name="h15" value="; damage 590%, attacks up to 4 enemies"/>
+    <string name="h16" value="; damage 610%, attacks up to 4 enemies"/>
+    <string name="h17" value="; damage 630%, attacks up to 4 enemies"/>
+    <string name="h18" value="; damage 650%, attacks up to 4 enemies"/>
+    <string name="h19" value="; damage 670%, attacks up to 5 enemies"/>
+    <string name="h20" value="; damage 690%, attacks up to 5 enemies"/>
+    <string name="h21" value="; damage 720%, attacks up to 5 enemies"/>
+    <string name="h22" value="; damage 740%, attacks up to 5 enemies"/>
+    <string name="h23" value="; damage 760%, attacks up to 5 enemies"/>
+    <string name="h24" value="; damage 780%, attacks up to 5 enemies"/>
+    <string name="h25" value="; damage 800%, attacks up to 6 enemies"/>
+    <string name="h26" value="; damage 820%, attacks up to 6 enemies"/>
+    <string name="h27" value="; damage 840%, attacks up to 6 enemies"/>
+    <string name="h28" value="; damage 860%, attacks up to 6 enemies"/>
+    <string name="h29" value="; damage 880%, attacks up to 6 enemies"/>
+    <string name="h30" value="; damage 900%, attacks up to 6 enemies"/>
   </imgdir>
   <imgdir name="5121003">
     <string name="name" value="Super Transformation"/>
-    <string name="desc" value="Increases power to extreme levels for 120 seconds. \nAvailable skills : Changes have been made so that while using the Viper skill, Super Transform, you can now use all skills excluding the Oak Barrel and the Double Fire. \nRequired Skill : #cLevel 20 of Transformation#"/>
-    <string name="h1" value="MP -22; weapon &amp; magic def. +41, waiting time until next use : 740 sec."/>
-    <string name="h2" value="MP -24; weapon &amp; magic def. +42, waiting time until next use : 720 sec."/>
-    <string name="h3" value="MP -26; weapon &amp; magic def. +43, waiting time until next use : 700 sec."/>
-    <string name="h4" value="MP -28; weapon &amp; magic def. +44, waiting time until next use : 680 sec."/>
-    <string name="h5" value="MP -30; weapon &amp; magic def. +45, waiting time until next use : 660 sec."/>
-    <string name="h6" value="MP -32; weapon &amp; magic def. +46, waiting time until next use : 640 sec."/>
-    <string name="h7" value="MP -34; weapon &amp; magic def. +47, waiting time until next use : 620 sec."/>
-    <string name="h8" value="MP -36; weapon &amp; magic def. +48, waiting time until next use : 600 sec."/>
-    <string name="h9" value="MP -38; weapon &amp; magic def. +49, waiting time until next use : 580 sec."/>
-    <string name="h10" value="MP -40; weapon &amp; magic def. +50, waiting time until next use : 560 sec."/>
-    <string name="h11" value="MP -42; weapon &amp; magic def. +51, waiting time until next use : 540 sec."/>
-    <string name="h12" value="MP -44; weapon &amp; magic def. +52, waiting time until next use : 520 sec."/>
-    <string name="h13" value="MP -46; weapon &amp; magic def. +53, waiting time until next use : 500 sec."/>
-    <string name="h14" value="MP -48; weapon &amp; magic def. +54, waiting time until next use : 480 sec."/>
-    <string name="h15" value="MP -50; weapon &amp; magic def. +55, waiting time until next use : 460 sec."/>
-    <string name="h16" value="MP -52; weapon &amp; magic def. +56, waiting time until next use : 440 sec."/>
-    <string name="h17" value="MP -54; weapon &amp; magic def. +57, waiting time until next use : 420 sec."/>
-    <string name="h18" value="MP -56; weapon &amp; magic def. +58, waiting time until next use : 400 sec."/>
-    <string name="h19" value="MP -58; weapon &amp; magic def. +59, waiting time until next use : 380 sec."/>
-    <string name="h20" value="MP -60; weapon &amp; magic def. +60, waiting time until next use : 360 sec."/>
+    <string name="desc" value="[Master Level: 20]\nTransforms into a stronger form for 120 seconds, increasing STR, weapon defense, magic defense, speed, and jump. Requires Transformation Lv.20."/>
+    <string name="h1" value="MP -22; STR +21, weapon def. +41, magic def. +41, Speed +40, Jump +20 for 120 sec; cooldown 430 sec"/>
+    <string name="h2" value="MP -24; STR +21, weapon def. +42, magic def. +42, Speed +40, Jump +20 for 120 sec; cooldown 420 sec"/>
+    <string name="h3" value="MP -26; STR +22, weapon def. +43, magic def. +43, Speed +40, Jump +20 for 120 sec; cooldown 410 sec"/>
+    <string name="h4" value="MP -28; STR +22, weapon def. +44, magic def. +44, Speed +40, Jump +20 for 120 sec; cooldown 400 sec"/>
+    <string name="h5" value="MP -30; STR +23, weapon def. +45, magic def. +45, Speed +40, Jump +20 for 120 sec; cooldown 390 sec"/>
+    <string name="h6" value="MP -32; STR +23, weapon def. +46, magic def. +46, Speed +40, Jump +20 for 120 sec; cooldown 380 sec"/>
+    <string name="h7" value="MP -34; STR +24, weapon def. +47, magic def. +47, Speed +40, Jump +20 for 120 sec; cooldown 370 sec"/>
+    <string name="h8" value="MP -36; STR +24, weapon def. +48, magic def. +48, Speed +40, Jump +20 for 120 sec; cooldown 360 sec"/>
+    <string name="h9" value="MP -38; STR +25, weapon def. +49, magic def. +49, Speed +40, Jump +20 for 120 sec; cooldown 350 sec"/>
+    <string name="h10" value="MP -40; STR +25, weapon def. +50, magic def. +50, Speed +40, Jump +20 for 120 sec; cooldown 340 sec"/>
+    <string name="h11" value="MP -42; STR +26, weapon def. +51, magic def. +51, Speed +40, Jump +20 for 120 sec; cooldown 330 sec"/>
+    <string name="h12" value="MP -44; STR +26, weapon def. +52, magic def. +52, Speed +40, Jump +20 for 120 sec; cooldown 320 sec"/>
+    <string name="h13" value="MP -46; STR +27, weapon def. +53, magic def. +53, Speed +40, Jump +20 for 120 sec; cooldown 310 sec"/>
+    <string name="h14" value="MP -48; STR +27, weapon def. +54, magic def. +54, Speed +40, Jump +20 for 120 sec; cooldown 300 sec"/>
+    <string name="h15" value="MP -50; STR +28, weapon def. +55, magic def. +55, Speed +40, Jump +20 for 120 sec; cooldown 290 sec"/>
+    <string name="h16" value="MP -52; STR +28, weapon def. +56, magic def. +56, Speed +40, Jump +20 for 120 sec; cooldown 280 sec"/>
+    <string name="h17" value="MP -54; STR +29, weapon def. +57, magic def. +57, Speed +40, Jump +20 for 120 sec; cooldown 270 sec"/>
+    <string name="h18" value="MP -56; STR +29, weapon def. +58, magic def. +58, Speed +40, Jump +20 for 120 sec; cooldown 260 sec"/>
+    <string name="h19" value="MP -58; STR +30, weapon def. +59, magic def. +59, Speed +40, Jump +20 for 120 sec; cooldown 250 sec"/>
+    <string name="h20" value="MP -60; STR +30, weapon def. +60, magic def. +60, Speed +40, Jump +20 for 120 sec; cooldown 240 sec"/>
   </imgdir>
   <imgdir name="5121004">
     <string name="name" value="Demolition"/>
-    <string name="desc" value="Apply a significant damage to a single monster by attacking it in a blinding speed. Only available when under a state of #cSuper Transformation#.\nRequired Skill : #cLevel 1 of Super Transformation#"/>
-    <string name="h1" value="MP -20; attacks a monster 8 times with damage 90% per hit"/>
-    <string name="h2" value="MP -20; attacks a monster 8 times with damage 100% per hit"/>
-    <string name="h3" value="MP -20; attacks a monster 8 times with damage 110% per hit"/>
-    <string name="h4" value="MP -20; attacks a monster 8 times with damage 120% per hit"/>
-    <string name="h5" value="MP -20; attacks a monster 8 times with damage 130% per hit"/>
-    <string name="h6" value="MP -20; attacks a monster 8 times with damage 140% per hit"/>
-    <string name="h7" value="MP -20; attacks a monster 8 times with damage 150% per hit"/>
-    <string name="h8" value="MP -20; attacks a monster 8 times with damage 160% per hit"/>
-    <string name="h9" value="MP -20; attacks a monster 8 times with damage 170% per hit"/>
-    <string name="h10" value="MP -20; attacks a monster 8 times with damage 180% per hit"/>
-    <string name="h11" value="MP -35; attacks a monster 8 times with damage 200% per hit"/>
-    <string name="h12" value="MP -35; attacks a monster 8 times with damage 210% per hit"/>
-    <string name="h13" value="MP -35; attacks a monster 8 times with damage 220% per hit"/>
-    <string name="h14" value="MP -35; attacks a monster 8 times with damage 230% per hit"/>
-    <string name="h15" value="MP -35; attacks a monster 8 times with damage 240% per hit"/>
-    <string name="h16" value="MP -35; attacks a monster 8 times with damage 250% per hit"/>
-    <string name="h17" value="MP -35; attacks a monster 8 times with damage 260% per hit"/>
-    <string name="h18" value="MP -35; attacks a monster 8 times with damage 270% per hit"/>
-    <string name="h19" value="MP -35; attacks a monster 8 times with damage 280% per hit"/>
-    <string name="h20" value="MP -35; attacks a monster 8 times with damage 290% per hit"/>
-    <string name="h21" value="MP -50; attacks a monster 8 times with damage 310% per hit"/>
-    <string name="h22" value="MP -50; attacks a monster 8 times with damage 320% per hit"/>
-    <string name="h23" value="MP -50; attacks a monster 8 times with damage 330% per hit"/>
-    <string name="h24" value="MP -50; attacks a monster 8 times with damage 340% per hit"/>
-    <string name="h25" value="MP -50; attacks a monster 8 times with damage 350% per hit"/>
-    <string name="h26" value="MP -50; attacks a monster 8 times with damage 360% per hit"/>
-    <string name="h27" value="MP -50; attacks a monster 8 times with damage 370% per hit"/>
-    <string name="h28" value="MP -50; attacks a monster 8 times with damage 380% per hit"/>
-    <string name="h29" value="MP -50; attacks a monster 8 times with damage 390% per hit"/>
-    <string name="h30" value="MP -50; attacks a monster 8 times with damage 400% per hit"/>
+    <string name="desc" value="[Master Level: 30]\nAttacks one enemy 8 times and stuns it. Can only be used during Super Transformation."/>
+    <string name="h1" value="MP -20; damage 90% x 8 hits, stuns for 1 sec"/>
+    <string name="h2" value="MP -20; damage 100% x 8 hits, stuns for 1 sec"/>
+    <string name="h3" value="MP -20; damage 110% x 8 hits, stuns for 1 sec"/>
+    <string name="h4" value="MP -20; damage 120% x 8 hits, stuns for 1 sec"/>
+    <string name="h5" value="MP -20; damage 130% x 8 hits, stuns for 1 sec"/>
+    <string name="h6" value="MP -20; damage 140% x 8 hits, stuns for 1 sec"/>
+    <string name="h7" value="MP -20; damage 150% x 8 hits, stuns for 1 sec"/>
+    <string name="h8" value="MP -20; damage 160% x 8 hits, stuns for 1 sec"/>
+    <string name="h9" value="MP -20; damage 170% x 8 hits, stuns for 1 sec"/>
+    <string name="h10" value="MP -20; damage 180% x 8 hits, stuns for 1 sec"/>
+    <string name="h11" value="MP -35; damage 200% x 8 hits, stuns for 1 sec"/>
+    <string name="h12" value="MP -35; damage 210% x 8 hits, stuns for 1 sec"/>
+    <string name="h13" value="MP -35; damage 220% x 8 hits, stuns for 1 sec"/>
+    <string name="h14" value="MP -35; damage 230% x 8 hits, stuns for 1 sec"/>
+    <string name="h15" value="MP -35; damage 240% x 8 hits, stuns for 1 sec"/>
+    <string name="h16" value="MP -35; damage 250% x 8 hits, stuns for 1 sec"/>
+    <string name="h17" value="MP -35; damage 260% x 8 hits, stuns for 1 sec"/>
+    <string name="h18" value="MP -35; damage 270% x 8 hits, stuns for 1 sec"/>
+    <string name="h19" value="MP -35; damage 280% x 8 hits, stuns for 1 sec"/>
+    <string name="h20" value="MP -35; damage 290% x 8 hits, stuns for 1 sec"/>
+    <string name="h21" value="MP -50; damage 310% x 8 hits, stuns for 1 sec"/>
+    <string name="h22" value="MP -50; damage 320% x 8 hits, stuns for 1 sec"/>
+    <string name="h23" value="MP -50; damage 330% x 8 hits, stuns for 1 sec"/>
+    <string name="h24" value="MP -50; damage 340% x 8 hits, stuns for 1 sec"/>
+    <string name="h25" value="MP -50; damage 350% x 8 hits, stuns for 1 sec"/>
+    <string name="h26" value="MP -50; damage 360% x 8 hits, stuns for 1 sec"/>
+    <string name="h27" value="MP -50; damage 370% x 8 hits, stuns for 1 sec"/>
+    <string name="h28" value="MP -50; damage 380% x 8 hits, stuns for 1 sec"/>
+    <string name="h29" value="MP -50; damage 390% x 8 hits, stuns for 1 sec"/>
+    <string name="h30" value="MP -50; damage 400% x 8 hits, stuns for 1 sec"/>
   </imgdir>
   <imgdir name="5121005">
     <string name="name" value="Snatch"/>
-    <string name="desc" value="Applies damage to a monster that&apos;s far away, and drags it right in front of you. Only available when under a state of #cSuper Transformation#.\nRequired Skill : #cLevel 1 of Super Transformation#"/>
-    <string name="h1" value="MP -11, damage 210%, attacks 2 monsters"/>
-    <string name="h2" value="MP -12, damage 220%, attacks 2 monsters"/>
-    <string name="h3" value="MP -13, damage 230%, attacks 2 monsters"/>
-    <string name="h4" value="MP -14, damage 240%, attacks 2 monsters"/>
-    <string name="h5" value="MP -15, damage 250%, attacks 2 monsters"/>
-    <string name="h6" value="MP -16, damage 260%, attacks 2 monsters"/>
-    <string name="h7" value="MP -17, damage 270%, attacks 3 monsters"/>
-    <string name="h8" value="MP -18, damage 280%, attacks 3 monsters"/>
-    <string name="h9" value="MP -19, damage 290%, attacks 3 monsters"/>
-    <string name="h10" value="MP -20, damage 300%, attacks 3 monsters"/>
-    <string name="h11" value="MP -21, damage 360%, attacks 3 monsters"/>
-    <string name="h12" value="MP -22, damage 370%, attacks 3 monsters"/>
-    <string name="h13" value="MP -23, damage 380%, attacks 4 monsters"/>
-    <string name="h14" value="MP -24, damage 390%, attacks 4 monsters"/>
-    <string name="h15" value="MP -25, damage 400%, attacks 4 monsters"/>
-    <string name="h16" value="MP -26, damage 410%, attacks 4 monsters"/>
-    <string name="h17" value="MP -27, damage 420%, attacks 4 monsters"/>
-    <string name="h18" value="MP -28, damage 430%, attacks 4 monsters"/>
-    <string name="h19" value="MP -29, damage 440%, attacks 5 monsters"/>
-    <string name="h20" value="MP -30, damage 450%, attacks 5 monsters"/>
-    <string name="h21" value="MP -31, damage 510%, attacks 5 monsters"/>
-    <string name="h22" value="MP -32, damage 520%, attacks 5 monsters"/>
-    <string name="h23" value="MP -33, damage 530%, attacks 5 monsters"/>
-    <string name="h24" value="MP -34, damage 540%, attacks 5 monsters"/>
-    <string name="h25" value="MP -35, damage 550%, attacks 6 monsters"/>
-    <string name="h26" value="MP -36, damage 560%, attacks 6 monsters"/>
-    <string name="h27" value="MP -37, damage 570%, attacks 6 monsters"/>
-    <string name="h28" value="MP -38, damage 580%, attacks 6 monsters"/>
-    <string name="h29" value="MP -39, damage 590%, attacks 6 monsters"/>
-    <string name="h30" value="MP -40, damage 600%, attacks 6 monsters"/>
+    <string name="desc" value="[Master Level: 30]\nDamages distant enemies and pulls them toward you, stunning them. Can only be used during Super Transformation."/>
+    <string name="h1" value="MP -11; damage 210%, attacks up to 2 enemies"/>
+    <string name="h2" value="MP -12; damage 220%, attacks up to 2 enemies"/>
+    <string name="h3" value="MP -13; damage 230%, attacks up to 2 enemies"/>
+    <string name="h4" value="MP -14; damage 240%, attacks up to 2 enemies"/>
+    <string name="h5" value="MP -15; damage 250%, attacks up to 2 enemies"/>
+    <string name="h6" value="MP -16; damage 260%, attacks up to 2 enemies"/>
+    <string name="h7" value="MP -17; damage 270%, attacks up to 3 enemies"/>
+    <string name="h8" value="MP -18; damage 280%, attacks up to 3 enemies"/>
+    <string name="h9" value="MP -19; damage 290%, attacks up to 3 enemies"/>
+    <string name="h10" value="MP -20; damage 300%, attacks up to 3 enemies"/>
+    <string name="h11" value="MP -21; damage 360%, attacks up to 3 enemies"/>
+    <string name="h12" value="MP -22; damage 370%, attacks up to 3 enemies"/>
+    <string name="h13" value="MP -23; damage 380%, attacks up to 4 enemies"/>
+    <string name="h14" value="MP -24; damage 390%, attacks up to 4 enemies"/>
+    <string name="h15" value="MP -25; damage 400%, attacks up to 4 enemies"/>
+    <string name="h16" value="MP -26; damage 410%, attacks up to 4 enemies"/>
+    <string name="h17" value="MP -27; damage 420%, attacks up to 4 enemies"/>
+    <string name="h18" value="MP -28; damage 430%, attacks up to 4 enemies"/>
+    <string name="h19" value="MP -29; damage 440%, attacks up to 5 enemies"/>
+    <string name="h20" value="MP -30; damage 450%, attacks up to 5 enemies"/>
+    <string name="h21" value="MP -31; damage 510%, attacks up to 5 enemies"/>
+    <string name="h22" value="MP -32; damage 520%, attacks up to 5 enemies"/>
+    <string name="h23" value="MP -33; damage 530%, attacks up to 5 enemies"/>
+    <string name="h24" value="MP -34; damage 540%, attacks up to 5 enemies"/>
+    <string name="h25" value="MP -35; damage 550%, attacks up to 6 enemies"/>
+    <string name="h26" value="MP -36; damage 560%, attacks up to 6 enemies"/>
+    <string name="h27" value="MP -37; damage 570%, attacks up to 6 enemies"/>
+    <string name="h28" value="MP -38; damage 580%, attacks up to 6 enemies"/>
+    <string name="h29" value="MP -39; damage 590%, attacks up to 6 enemies"/>
+    <string name="h30" value="MP -40; damage 600%, attacks up to 6 enemies"/>
   </imgdir>
   <imgdir name="5121007">
     <string name="name" value="Barrage"/>
-    <string name="desc" value="Attacks a monster nearby 6 times in quick succession."/>
-    <string name="h1" value="MP -21, damage 94%"/>
-    <string name="h2" value="MP -21, damage 98%"/>
-    <string name="h3" value="MP -22, damage 102%"/>
-    <string name="h4" value="MP -22, damage 106%"/>
-    <string name="h5" value="MP -23, damage 110%"/>
-    <string name="h6" value="MP -23, damage 114%"/>
-    <string name="h7" value="MP -24, damage 118%"/>
-    <string name="h8" value="MP -24, damage 122%"/>
-    <string name="h9" value="MP -25, damage 126%"/>
-    <string name="h10" value="MP -25, damage 130%"/>
-    <string name="h11" value="MP -26, damage 144%"/>
-    <string name="h12" value="MP -26, damage 148%"/>
-    <string name="h13" value="MP -27, damage 152%"/>
-    <string name="h14" value="MP -27, damage 156%"/>
-    <string name="h15" value="MP -28, damage 160%"/>
-    <string name="h16" value="MP -28, damage 164%"/>
-    <string name="h17" value="MP -29, damage 168%"/>
-    <string name="h18" value="MP -29, damage 172%"/>
-    <string name="h19" value="MP -30, damage 176%"/>
-    <string name="h20" value="MP -30, damage 180%"/>
-    <string name="h21" value="MP -31, damage 194%"/>
-    <string name="h22" value="MP -31, damage 198%"/>
-    <string name="h23" value="MP -32, damage 202%"/>
-    <string name="h24" value="MP -32, damage 206%"/>
-    <string name="h25" value="MP -33, damage 210%"/>
-    <string name="h26" value="MP -33, damage 214%"/>
-    <string name="h27" value="MP -34, damage 218%"/>
-    <string name="h28" value="MP -34, damage 222%"/>
-    <string name="h29" value="MP -35, damage 226%"/>
-    <string name="h30" value="MP -35, damage 230%"/>
+    <string name="desc" value="[Master Level: 30]\nAttacks one nearby enemy 6 times. The last two hits receive additional server-side damage scaling."/>
+    <string name="h1" value="MP -21; damage 94% x 6 hits"/>
+    <string name="h2" value="MP -21; damage 98% x 6 hits"/>
+    <string name="h3" value="MP -22; damage 102% x 6 hits"/>
+    <string name="h4" value="MP -22; damage 106% x 6 hits"/>
+    <string name="h5" value="MP -23; damage 110% x 6 hits"/>
+    <string name="h6" value="MP -23; damage 114% x 6 hits"/>
+    <string name="h7" value="MP -24; damage 118% x 6 hits"/>
+    <string name="h8" value="MP -24; damage 122% x 6 hits"/>
+    <string name="h9" value="MP -25; damage 126% x 6 hits"/>
+    <string name="h10" value="MP -25; damage 130% x 6 hits"/>
+    <string name="h11" value="MP -26; damage 144% x 6 hits"/>
+    <string name="h12" value="MP -26; damage 148% x 6 hits"/>
+    <string name="h13" value="MP -27; damage 152% x 6 hits"/>
+    <string name="h14" value="MP -27; damage 156% x 6 hits"/>
+    <string name="h15" value="MP -28; damage 160% x 6 hits"/>
+    <string name="h16" value="MP -28; damage 164% x 6 hits"/>
+    <string name="h17" value="MP -29; damage 168% x 6 hits"/>
+    <string name="h18" value="MP -29; damage 172% x 6 hits"/>
+    <string name="h19" value="MP -30; damage 176% x 6 hits"/>
+    <string name="h20" value="MP -30; damage 180% x 6 hits"/>
+    <string name="h21" value="MP -31; damage 194% x 6 hits"/>
+    <string name="h22" value="MP -31; damage 198% x 6 hits"/>
+    <string name="h23" value="MP -32; damage 202% x 6 hits"/>
+    <string name="h24" value="MP -32; damage 206% x 6 hits"/>
+    <string name="h25" value="MP -33; damage 210% x 6 hits"/>
+    <string name="h26" value="MP -33; damage 214% x 6 hits"/>
+    <string name="h27" value="MP -34; damage 218% x 6 hits"/>
+    <string name="h28" value="MP -34; damage 222% x 6 hits"/>
+    <string name="h29" value="MP -35; damage 226% x 6 hits"/>
+    <string name="h30" value="MP -35; damage 230% x 6 hits"/>
   </imgdir>
   <imgdir name="5121008">
-    <string name="name" value="Pirate&apos;s Rage"/>
-    <string name="desc" value="Allows you to break out of an abnormal state. As its level increases, the number of abnormal states that can be broken out increases. \n#cWaiting time : 10 min.#"/>
-    <string name="h1" value="MP -30, cured from the state of being seduced"/>
+    <string name="name" value="Pirate&#x27;s Rage"/>
+    <string name="desc" value="[Master Level: 5]\nRemoves seduce from yourself. Cooldown decreases as skill level increases."/>
+    <string name="h1" value="MP -30; cooldown 600 sec"/>
+    <string name="h2" value="MP -30; cooldown 540 sec"/>
+    <string name="h3" value="MP -30; cooldown 480 sec"/>
+    <string name="h4" value="MP -30; cooldown 420 sec"/>
+    <string name="h5" value="MP -30; cooldown 360 sec"/>
   </imgdir>
   <imgdir name="5121009">
     <string name="name" value="Speed Infusion"/>
-    <string name="desc" value="Uses HP and MP to temporarily increase the attacking speed of a weapon. This can be combined with other boosters, and everyone in the party will have their attacking speed increased.\nRequired Skill : #cLevel 20 of Knuckle Booster#"/>
-    <string name="h1" value="HP -78, MP -78; boosts weapon attack speed for 110 sec."/>
-    <string name="h2" value="HP -76, MP -76; boosts weapon attack speed for 120 sec."/>
-    <string name="h3" value="HP -74, MP -74; boosts weapon attack speed for 130 sec."/>
-    <string name="h4" value="HP -72, MP -72; boosts weapon attack speed for 140 sec."/>
-    <string name="h5" value="HP -70, MP -70; boosts weapon attack speed for 150 sec."/>
-    <string name="h6" value="HP -68, MP -68; boosts weapon attack speed for 160 sec."/>
-    <string name="h7" value="HP -66, MP -66; boosts weapon attack speed for 170 sec."/>
-    <string name="h8" value="HP -64, MP -64; boosts weapon attack speed for 180 sec."/>
-    <string name="h9" value="HP -62, MP -62; boosts weapon attack speed for 190 sec."/>
-    <string name="h10" value="HP -60, MP -60; boosts weapon attack speed for 200 sec."/>
-    <string name="h11" value="HP -58, MP -58; boosts weapon attack speed for 210 sec."/>
-    <string name="h12" value="HP -56, MP -56; boosts weapon attack speed for 220 sec."/>
-    <string name="h13" value="HP -54, MP -54; boosts weapon attack speed for 230 sec."/>
-    <string name="h14" value="HP -52, MP -52; boosts weapon attack speed for 240 sec."/>
-    <string name="h15" value="HP -50, MP -50; boosts weapon attack speed for 250 sec."/>
-    <string name="h16" value="HP -48, MP -48; boosts weapon attack speed for 260 sec."/>
-    <string name="h17" value="HP -46, MP -46; boosts weapon attack speed for 270 sec."/>
-    <string name="h18" value="HP -44, MP -44; boosts weapon attack speed for 280 sec."/>
-    <string name="h19" value="HP -42, MP -42; boosts weapon attack speed for 290 sec."/>
-    <string name="h20" value="HP -40, MP -40; boosts weapon attack speed for 300 sec."/>
+    <string name="desc" value="[Master Level: 20]\nConsumes HP and MP to increase weapon attack speed by 1 to 2 stages for all party members. Stacks with booster skills. Requires Knuckler Booster Lv.20."/>
+    <string name="h1" value="HP -78, MP -78; weapon attack speed +1 stage(s) for 110 sec"/>
+    <string name="h2" value="HP -76, MP -76; weapon attack speed +1 stage(s) for 120 sec"/>
+    <string name="h3" value="HP -74, MP -74; weapon attack speed +1 stage(s) for 130 sec"/>
+    <string name="h4" value="HP -72, MP -72; weapon attack speed +1 stage(s) for 140 sec"/>
+    <string name="h5" value="HP -70, MP -70; weapon attack speed +1 stage(s) for 150 sec"/>
+    <string name="h6" value="HP -68, MP -68; weapon attack speed +1 stage(s) for 160 sec"/>
+    <string name="h7" value="HP -66, MP -66; weapon attack speed +1 stage(s) for 170 sec"/>
+    <string name="h8" value="HP -64, MP -64; weapon attack speed +1 stage(s) for 180 sec"/>
+    <string name="h9" value="HP -62, MP -62; weapon attack speed +1 stage(s) for 190 sec"/>
+    <string name="h10" value="HP -60, MP -60; weapon attack speed +1 stage(s) for 200 sec"/>
+    <string name="h11" value="HP -58, MP -58; weapon attack speed +2 stage(s) for 210 sec"/>
+    <string name="h12" value="HP -56, MP -56; weapon attack speed +2 stage(s) for 220 sec"/>
+    <string name="h13" value="HP -54, MP -54; weapon attack speed +2 stage(s) for 230 sec"/>
+    <string name="h14" value="HP -52, MP -52; weapon attack speed +2 stage(s) for 240 sec"/>
+    <string name="h15" value="HP -50, MP -50; weapon attack speed +2 stage(s) for 250 sec"/>
+    <string name="h16" value="HP -48, MP -48; weapon attack speed +2 stage(s) for 260 sec"/>
+    <string name="h17" value="HP -46, MP -46; weapon attack speed +2 stage(s) for 270 sec"/>
+    <string name="h18" value="HP -44, MP -44; weapon attack speed +2 stage(s) for 280 sec"/>
+    <string name="h19" value="HP -42, MP -42; weapon attack speed +2 stage(s) for 290 sec"/>
+    <string name="h20" value="HP -40, MP -40; weapon attack speed +2 stage(s) for 300 sec"/>
   </imgdir>
   <imgdir name="5121010">
     <string name="name" value="Time Leap"/>
-    <string name="desc" value="Resets the waiting time for skills for yourself and everyone in the party. This does not reset the waiting time for Time Leap."/>
-    <string name="h1" value="MP -195; waiting time until next use : 49 min."/>
-    <string name="h2" value="MP -190; waiting time until next use : 48 min."/>
-    <string name="h3" value="MP -185; waiting time until next use : 47 min."/>
-    <string name="h4" value="MP -180; waiting time until next use : 46 min."/>
-    <string name="h5" value="MP -175; waiting time until next use : 45 min."/>
-    <string name="h6" value="MP -170; waiting time until next use : 44 min."/>
-    <string name="h7" value="MP -165; waiting time until next use : 43 min."/>
-    <string name="h8" value="MP -160; waiting time until next use : 42 min."/>
-    <string name="h9" value="MP -155; waiting time until next use : 41 min."/>
-    <string name="h10" value="MP -150; waiting time until next use : 40 min."/>
-    <string name="h11" value="MP -145; waiting time until next use : 39 min."/>
-    <string name="h12" value="MP -140; waiting time until next use : 38 min."/>
-    <string name="h13" value="MP -135; waiting time until next use : 37 min."/>
-    <string name="h14" value="MP -130; waiting time until next use : 36 min."/>
-    <string name="h15" value="MP -125; waiting time until next use : 35 min."/>
-    <string name="h16" value="MP -120; waiting time until next use : 34 min."/>
-    <string name="h17" value="MP -115; waiting time until next use : 33 min."/>
-    <string name="h18" value="MP -110; waiting time until next use : 32 min."/>
-    <string name="h19" value="MP -105; waiting time until next use : 31 min."/>
-    <string name="h20" value="MP -100; waiting time until next use : 30 min."/>
-    <string name="h21" value="MP -95; waiting time until next use : 29 min."/>
-    <string name="h22" value="MP -90; waiting time until next use : 28 min."/>
-    <string name="h23" value="MP -85; waiting time until next use : 27 min."/>
-    <string name="h24" value="MP -80; waiting time until next use : 26 min."/>
-    <string name="h26" value="MP -70; waiting time until next use : 24 min."/>
-    <string name="h27" value="MP -65; waiting time until next use : 23 min."/>
-    <string name="h28" value="MP -60; waiting time until next use : 22 min."/>
-    <string name="h29" value="MP -55; waiting time until next use : 21 min."/>
-    <string name="h30" value="MP -50;waiting time until next use : 20 min."/>
+    <string name="desc" value="[Master Level: 30]\nResets skill cooldowns for yourself and party members, except Time Leap itself."/>
+    <string name="h1" value="MP -195; cooldown 49 min"/>
+    <string name="h2" value="MP -190; cooldown 48 min"/>
+    <string name="h3" value="MP -185; cooldown 47 min"/>
+    <string name="h4" value="MP -180; cooldown 46 min"/>
+    <string name="h5" value="MP -175; cooldown 45 min"/>
+    <string name="h6" value="MP -170; cooldown 44 min"/>
+    <string name="h7" value="MP -165; cooldown 43 min"/>
+    <string name="h8" value="MP -160; cooldown 42 min"/>
+    <string name="h9" value="MP -155; cooldown 41 min"/>
+    <string name="h10" value="MP -150; cooldown 40 min"/>
+    <string name="h11" value="MP -145; cooldown 39 min"/>
+    <string name="h12" value="MP -140; cooldown 38 min"/>
+    <string name="h13" value="MP -135; cooldown 37 min"/>
+    <string name="h14" value="MP -130; cooldown 36 min"/>
+    <string name="h15" value="MP -125; cooldown 35 min"/>
+    <string name="h16" value="MP -120; cooldown 34 min"/>
+    <string name="h17" value="MP -115; cooldown 33 min"/>
+    <string name="h18" value="MP -110; cooldown 32 min"/>
+    <string name="h19" value="MP -105; cooldown 31 min"/>
+    <string name="h20" value="MP -100; cooldown 30 min"/>
+    <string name="h21" value="MP -95; cooldown 29 min"/>
+    <string name="h22" value="MP -90; cooldown 28 min"/>
+    <string name="h23" value="MP -85; cooldown 27 min"/>
+    <string name="h24" value="MP -80; cooldown 26 min"/>
+    <string name="h25" value="MP -75; cooldown 25 min"/>
+    <string name="h26" value="MP -70; cooldown 24 min"/>
+    <string name="h27" value="MP -65; cooldown 23 min"/>
+    <string name="h28" value="MP -60; cooldown 22 min"/>
+    <string name="h29" value="MP -55; cooldown 21 min"/>
+    <string name="h30" value="MP -50; cooldown 20 min"/>
   </imgdir>
   <imgdir name="522">
     <string name="bookName" value="The Perfect Corsair"/>
   </imgdir>
   <imgdir name="5221000">
     <string name="name" value="Maple Warrior"/>
-    <string name="desc" value="Temporarily increases all stats of yourself and party members by a percentage."/>
-    <string name="h1" value="MP - 10 ,  For 30Secs, all stats + 1% "/>
-    <string name="h2" value="MP - 10 ,  For 60Secs, all stats + 1% "/>
-    <string name="h3" value="MP - 10 ,  For 90Secs, all stats + 2% "/>
-    <string name="h4" value="MP - 10 ,  For 120Secs, all stats + 2% "/>
-    <string name="h5" value="MP - 10 ,  For 150Secs, all stats + 3% "/>
-    <string name="h6" value="MP - 20 ,  For 180Secs, all stats + 3% "/>
-    <string name="h7" value="MP - 20 ,  For 210Secs, all stats + 4% "/>
-    <string name="h8" value="MP - 20 ,  For 240Secs, all stats + 4% "/>
-    <string name="h9" value="MP - 20 ,  For 270Secs, all stats + 5% "/>
-    <string name="h10" value="MP - 20 ,  For 300Secs, all stats + 5% "/>
-    <string name="h11" value="MP - 30 ,  For 330Secs, all stats + 6% "/>
-    <string name="h12" value="MP - 30 ,  For 360Secs, all stats + 6% "/>
-    <string name="h13" value="MP - 30 ,  For 390Secs, all stats + 7% "/>
-    <string name="h14" value="MP - 30 ,  For 420Secs, all stats + 7% "/>
-    <string name="h15" value="MP - 30 ,  For 450Secs, all stats + 8% "/>
-    <string name="h16" value="MP - 40 ,  For 480Secs, all stats + 8% "/>
-    <string name="h17" value="MP - 40 ,  For 510Secs, all stats + 9% "/>
-    <string name="h18" value="MP - 40 ,  For 540Secs, all stats + 9% "/>
-    <string name="h19" value="MP - 40 ,  For 570Secs, all stats + 10% "/>
-    <string name="h20" value="MP - 40 ,  For 600Secs, all stats + 10% "/>
-    <string name="h21" value="MP - 50 ,  For 630Secs, all stats + 11% "/>
-    <string name="h22" value="MP - 50 ,  For 660Secs, all stats + 11% "/>
-    <string name="h23" value="MP - 50 ,  For 690Secs, all stats + 12% "/>
-    <string name="h24" value="MP - 50 ,  For 720Secs, all stats + 12% "/>
-    <string name="h25" value="MP - 50 ,  For 750Secs, all stats + 13% "/>
-    <string name="h26" value="MP - 60 ,  For 780Secs, all stats + 13% "/>
-    <string name="h27" value="MP - 60 ,  For 810Secs, all stats + 14% "/>
-    <string name="h28" value="MP - 60 ,  For 840Secs, all stats + 14% "/>
-    <string name="h29" value="MP - 60 ,  For 870Secs, all stats + 15% "/>
-    <string name="h30" value="MP - 60 ,  For 900Secs, all stats + 15% "/>
+    <string name="desc" value="[Master Level: 30]\nTemporarily increases all stats of yourself and nearby party members by a percentage."/>
+    <string name="h1" value="MP -10; All stats +1% for 30 sec"/>
+    <string name="h2" value="MP -10; All stats +1% for 60 sec"/>
+    <string name="h3" value="MP -10; All stats +2% for 90 sec"/>
+    <string name="h4" value="MP -10; All stats +2% for 120 sec"/>
+    <string name="h5" value="MP -10; All stats +3% for 150 sec"/>
+    <string name="h6" value="MP -20; All stats +3% for 180 sec"/>
+    <string name="h7" value="MP -20; All stats +4% for 210 sec"/>
+    <string name="h8" value="MP -20; All stats +4% for 240 sec"/>
+    <string name="h9" value="MP -20; All stats +5% for 270 sec"/>
+    <string name="h10" value="MP -20; All stats +5% for 300 sec"/>
+    <string name="h11" value="MP -30; All stats +6% for 330 sec"/>
+    <string name="h12" value="MP -30; All stats +6% for 360 sec"/>
+    <string name="h13" value="MP -30; All stats +7% for 390 sec"/>
+    <string name="h14" value="MP -30; All stats +7% for 420 sec"/>
+    <string name="h15" value="MP -30; All stats +8% for 450 sec"/>
+    <string name="h16" value="MP -40; All stats +8% for 480 sec"/>
+    <string name="h17" value="MP -40; All stats +9% for 510 sec"/>
+    <string name="h18" value="MP -40; All stats +9% for 540 sec"/>
+    <string name="h19" value="MP -40; All stats +10% for 570 sec"/>
+    <string name="h20" value="MP -40; All stats +10% for 600 sec"/>
+    <string name="h21" value="MP -50; All stats +11% for 630 sec"/>
+    <string name="h22" value="MP -50; All stats +11% for 660 sec"/>
+    <string name="h23" value="MP -50; All stats +12% for 690 sec"/>
+    <string name="h24" value="MP -50; All stats +12% for 720 sec"/>
+    <string name="h25" value="MP -50; All stats +13% for 750 sec"/>
+    <string name="h26" value="MP -60; All stats +13% for 780 sec"/>
+    <string name="h27" value="MP -60; All stats +14% for 810 sec"/>
+    <string name="h28" value="MP -60; All stats +14% for 840 sec"/>
+    <string name="h29" value="MP -60; All stats +15% for 870 sec"/>
+    <string name="h30" value="MP -60; All stats +15% for 900 sec"/>
   </imgdir>
   <imgdir name="5220001">
     <string name="name" value="Elemental Boost"/>
-    <string name="desc" value="Increases the potency of Flamethrower and Ice Splitter."/>
-    <string name="h1" value="Damage +6%, dot damage +1%, freeze time +1 sec."/>
-    <string name="h2" value="Damage +12%, dot damage +1%, freeze time +1 sec."/>
-    <string name="h3" value="Damage +18%, dot damage +1%, freeze time +1 sec."/>
-    <string name="h4" value="Damage +24%, dot damage +1%, freeze time +1 sec."/>
-    <string name="h5" value="Damage +30%, dot damage +1%, freeze time +1 sec."/>
-    <string name="h6" value="Damage +36%, dot damage +1%, freeze time +1 sec."/>
-    <string name="h7" value="Damage +42%, dot damage +2%, freeze time +1 sec."/>
-    <string name="h8" value="Damage +48%, dot damage +2%, freeze time +1 sec."/>
-    <string name="h9" value="Damage +54%, dot damage +2%, freeze time +1 sec."/>
-    <string name="h10" value="Damage +60%, dot damage +2%, freeze time +1 sec."/>
-    <string name="h11" value="Damage +76%, dot damage +2%, freeze time +1 sec."/>
-    <string name="h12" value="Damage +82%, dot damage +2%, freeze time +1 sec."/>
-    <string name="h13" value="Damage +88%, dot damage +3%, freeze time +1 sec."/>
-    <string name="h14" value="Damage +94%, dot damage +3%, freeze time +1 sec."/>
-    <string name="h15" value="Damage +100%, dot damage +3%, freeze time +1 sec."/>
-    <string name="h16" value="Damage +106%, dot damage +3%, freeze time +2 sec."/>
-    <string name="h17" value="Damage +112%, dot damage +3%, freeze time +2 sec."/>
-    <string name="h18" value="Damage +118%, dot damage +3%, freeze time +2 sec."/>
-    <string name="h19" value="Damage +124%, dot damage +4%, freeze time +2 sec."/>
-    <string name="h20" value="Damage +130%, dot damage +4%, freeze time +2 sec."/>
-    <string name="h21" value="Damage +146%, dot damage +4%, freeze time +2 sec."/>
-    <string name="h22" value="Damage +152%, dot damage +4%, freeze time +2 sec."/>
-    <string name="h23" value="Damage +158%, dot damage +4%, freeze time +2 sec."/>
-    <string name="h24" value="Damage +164%, dot damage +4%, freeze time +2 sec."/>
-    <string name="h25" value="Damage +170%, dot damage +5%, freeze time +2 sec."/>
-    <string name="h26" value="Damage +176%, dot damage +5%, freeze time +2 sec."/>
-    <string name="h27" value="Damage +182%, dot damage +5%, freeze time +2 sec."/>
-    <string name="h28" value="Damage +188%, dot damage +5%, freeze time +2 sec."/>
-    <string name="h29" value="Damage +194%, dot damage +5%, freeze time +2 sec."/>
-    <string name="h30" value="Damage +200%, dot damage +5%, freeze time +2 sec."/>
+    <string name="desc" value="[Master Level: 30]\nIncreases Flamethrower and Ice Splitter damage, fire damage over time, and freeze duration."/>
+    <string name="h1" value="Damage +6%, fire DoT +1%, freeze time +1 sec"/>
+    <string name="h2" value="Damage +12%, fire DoT +1%, freeze time +1 sec"/>
+    <string name="h3" value="Damage +18%, fire DoT +1%, freeze time +1 sec"/>
+    <string name="h4" value="Damage +24%, fire DoT +1%, freeze time +1 sec"/>
+    <string name="h5" value="Damage +30%, fire DoT +1%, freeze time +1 sec"/>
+    <string name="h6" value="Damage +36%, fire DoT +1%, freeze time +1 sec"/>
+    <string name="h7" value="Damage +42%, fire DoT +2%, freeze time +1 sec"/>
+    <string name="h8" value="Damage +48%, fire DoT +2%, freeze time +1 sec"/>
+    <string name="h9" value="Damage +54%, fire DoT +2%, freeze time +1 sec"/>
+    <string name="h10" value="Damage +60%, fire DoT +2%, freeze time +1 sec"/>
+    <string name="h11" value="Damage +76%, fire DoT +2%, freeze time +1 sec"/>
+    <string name="h12" value="Damage +82%, fire DoT +2%, freeze time +1 sec"/>
+    <string name="h13" value="Damage +88%, fire DoT +3%, freeze time +1 sec"/>
+    <string name="h14" value="Damage +94%, fire DoT +3%, freeze time +1 sec"/>
+    <string name="h15" value="Damage +100%, fire DoT +3%, freeze time +1 sec"/>
+    <string name="h16" value="Damage +106%, fire DoT +3%, freeze time +2 sec"/>
+    <string name="h17" value="Damage +112%, fire DoT +3%, freeze time +2 sec"/>
+    <string name="h18" value="Damage +118%, fire DoT +3%, freeze time +2 sec"/>
+    <string name="h19" value="Damage +124%, fire DoT +4%, freeze time +2 sec"/>
+    <string name="h20" value="Damage +130%, fire DoT +4%, freeze time +2 sec"/>
+    <string name="h21" value="Damage +146%, fire DoT +4%, freeze time +2 sec"/>
+    <string name="h22" value="Damage +152%, fire DoT +4%, freeze time +2 sec"/>
+    <string name="h23" value="Damage +158%, fire DoT +4%, freeze time +2 sec"/>
+    <string name="h24" value="Damage +164%, fire DoT +4%, freeze time +2 sec"/>
+    <string name="h25" value="Damage +170%, fire DoT +5%, freeze time +2 sec"/>
+    <string name="h26" value="Damage +176%, fire DoT +5%, freeze time +2 sec"/>
+    <string name="h27" value="Damage +182%, fire DoT +5%, freeze time +2 sec"/>
+    <string name="h28" value="Damage +188%, fire DoT +5%, freeze time +2 sec"/>
+    <string name="h29" value="Damage +194%, fire DoT +5%, freeze time +2 sec"/>
+    <string name="h30" value="Damage +200%, fire DoT +5%, freeze time +2 sec"/>
   </imgdir>
   <imgdir name="5220002">
     <string name="name" value="Wrath of the Octopi"/>
-    <string name="desc" value="An additional octopus is summoned, increasing the fire rate and the damage.\nRequired Skill : #cLevel 30 of Octopus#"/>
-    <string name="h1" value="MP -26; attack rate 210, available for 35 sec., 10 sec. until next use"/>
-    <string name="h2" value="MP -26; attack rate 220, available for 35 sec., 10 sec. until next use"/>
-    <string name="h3" value="MP -27; attack rate 230, available for 35 sec., 10 sec. until next use"/>
-    <string name="h4" value="MP -27; attack rate 240, available for 35 sec., 10 sec. until next use"/>
-    <string name="h5" value="MP -28; attack rate 250, available for 35 sec., 10 sec. until next use"/>
-    <string name="h6" value="MP -28; attack rate 260, available for 35 sec., 10 sec. until next use"/>
-    <string name="h7" value="MP -29; attack rate 270, available for 35 sec., 10 sec. until next use"/>
-    <string name="h8" value="MP -29; attack rate 280, available for 35 sec., 10 sec. until next use"/>
-    <string name="h9" value="MP -30; attack rate 290, available for 35 sec., 10 sec. until next use"/>
-    <string name="h10" value="MP -30; attack rate 300, available for 35 sec., 10 sec. until next use"/>
-    <string name="h11" value="MP -31; attack rate 320, available for 40 sec., 10 sec. until next use"/>
-    <string name="h12" value="MP -31; attack rate 340, available for 40 sec., 10 sec. until next use"/>
-    <string name="h13" value="MP -32; attack rate 360, available for 40 sec., 10 sec. until next use"/>
-    <string name="h14" value="MP -32; attack rate 380, available for 40 sec., 10 sec. until next use"/>
-    <string name="h15" value="MP -33; attack rate 400, available for 40 sec., 10 sec. until next use"/>
-    <string name="h16" value="MP -33; attack rate 420, available for 40 sec., 10 sec. until next use."/>
-    <string name="h17" value="MP -34; attack rate 440, available for 40 sec., 10 sec. until next use"/>
-    <string name="h18" value="MP -34; attack rate 460, available for 40 sec., 10 sec. until next use"/>
-    <string name="h19" value="MP -35; attack rate 480, available for 40 sec., 10 sec. until next use"/>
-    <string name="h20" value="MP -35; attack rate 500, available for 40 sec., 10 sec. until next use"/>
+    <string name="desc" value="[Master Level: 30]\nSummons an additional stationary Octopus with stronger attack power. Requires Octopus Lv.30."/>
+    <string name="h1" value="MP -26; summon attack 210, lasts 35 sec; cooldown 10 sec"/>
+    <string name="h2" value="MP -26; summon attack 220, lasts 35 sec; cooldown 10 sec"/>
+    <string name="h3" value="MP -27; summon attack 230, lasts 35 sec; cooldown 10 sec"/>
+    <string name="h4" value="MP -27; summon attack 240, lasts 35 sec; cooldown 10 sec"/>
+    <string name="h5" value="MP -28; summon attack 250, lasts 35 sec; cooldown 10 sec"/>
+    <string name="h6" value="MP -28; summon attack 260, lasts 35 sec; cooldown 10 sec"/>
+    <string name="h7" value="MP -29; summon attack 270, lasts 35 sec; cooldown 10 sec"/>
+    <string name="h8" value="MP -29; summon attack 280, lasts 35 sec; cooldown 10 sec"/>
+    <string name="h9" value="MP -30; summon attack 290, lasts 35 sec; cooldown 10 sec"/>
+    <string name="h10" value="MP -30; summon attack 300, lasts 35 sec; cooldown 10 sec"/>
+    <string name="h11" value="MP -31; summon attack 320, lasts 40 sec; cooldown 10 sec"/>
+    <string name="h12" value="MP -31; summon attack 340, lasts 40 sec; cooldown 10 sec"/>
+    <string name="h13" value="MP -32; summon attack 360, lasts 40 sec; cooldown 10 sec"/>
+    <string name="h14" value="MP -32; summon attack 380, lasts 40 sec; cooldown 10 sec"/>
+    <string name="h15" value="MP -33; summon attack 400, lasts 40 sec; cooldown 10 sec"/>
+    <string name="h16" value="MP -33; summon attack 420, lasts 40 sec; cooldown 10 sec"/>
+    <string name="h17" value="MP -34; summon attack 440, lasts 40 sec; cooldown 10 sec"/>
+    <string name="h18" value="MP -34; summon attack 460, lasts 40 sec; cooldown 10 sec"/>
+    <string name="h19" value="MP -35; summon attack 480, lasts 40 sec; cooldown 10 sec"/>
+    <string name="h20" value="MP -35; summon attack 500, lasts 40 sec; cooldown 10 sec"/>
   </imgdir>
   <imgdir name="5221003">
     <string name="name" value="Aerial Strike"/>
-    <string name="desc" value="Uses the grenade attack of Gaviota to damage up to 6 monsters. \nRequired Skill : #cLevel 15 of Gaviota#"/>
-    <string name="h1" value="MP -31, damage 520%, 5 sec. until next use"/>
-    <string name="h2" value="MP -32, damage 540%, 5 sec. until next use"/>
-    <string name="h3" value="MP -33, damage 560%, 5 sec. until next use"/>
-    <string name="h4" value="MP -34, damage 580%, 5 sec. until next use"/>
-    <string name="h5" value="MP -35, damage 600%, 5 sec. until next use"/>
-    <string name="h6" value="MP -36, damage 620%, 5 sec. until next use"/>
-    <string name="h7" value="MP -37, damage 640%, 5 sec. until next use"/>
-    <string name="h8" value="MP -38, damage 660%, 5 sec. until next use"/>
-    <string name="h9" value="MP -39, damage 680%, 5 sec. until next use"/>
-    <string name="h10" value="MP -40, damage 700%, 5 sec. until next use"/>
-    <string name="h11" value="MP -41, damage 770%, 5 sec. until next use"/>
-    <string name="h12" value="MP -42, damage 790%, 5 sec. until next use"/>
-    <string name="h13" value="MP -43, damage 810%, 5 sec. until next use"/>
-    <string name="h14" value="MP -44, damage 830%, 5 sec. until next use"/>
-    <string name="h15" value="MP -45, damage 850%, 5 sec. until next use"/>
-    <string name="h16" value="MP -46, damage 870%, 5 sec. until next use"/>
-    <string name="h17" value="MP -47, damage 890%, 5 sec. until next use"/>
-    <string name="h18" value="MP -48, damage 910%, 5 sec. until next use"/>
-    <string name="h19" value="MP -49, damage 930%, 5 sec. until next use"/>
-    <string name="h20" value="MP -50, damage 950%, 5 sec. until next use"/>
-    <string name="h21" value="MP -51, damage 1020%, 5 sec. until next use"/>
-    <string name="h22" value="MP -52, damage 1040%, 5 sec. until next use"/>
-    <string name="h23" value="MP -53, damage 1060%, 5 sec. until next use"/>
-    <string name="h24" value="MP -54, damage 1080%, 5 sec. until next use"/>
-    <string name="h25" value="MP -55, damage 1100%, 5 sec. until next use"/>
-    <string name="h26" value="MP -56, damage 1120%, 5 sec. until next use"/>
-    <string name="h27" value="MP -57, damage 1140%, 5 sec. until next use"/>
-    <string name="h28" value="MP -58, damage 1160%, 5 sec. until next use"/>
-    <string name="h29" value="MP -59, damage 1180%, 5 sec. until next use"/>
-    <string name="h30" value="MP -60, damage 1200%, 5 sec. until next use"/>
+    <string name="desc" value="[Master Level: 30]\nCalls an aerial bombardment that attacks up to 6 enemies. Requires Gaviota Lv.15."/>
+    <string name="h1" value="MP -31; damage 520%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h2" value="MP -32; damage 540%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h3" value="MP -33; damage 560%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h4" value="MP -34; damage 580%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h5" value="MP -35; damage 600%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h6" value="MP -36; damage 620%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h7" value="MP -37; damage 640%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h8" value="MP -38; damage 660%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h9" value="MP -39; damage 680%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h10" value="MP -40; damage 700%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h11" value="MP -41; damage 770%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h12" value="MP -42; damage 790%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h13" value="MP -43; damage 810%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h14" value="MP -44; damage 830%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h15" value="MP -45; damage 850%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h16" value="MP -46; damage 870%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h17" value="MP -47; damage 890%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h18" value="MP -48; damage 910%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h19" value="MP -49; damage 930%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h20" value="MP -50; damage 950%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h21" value="MP -51; damage 1020%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h22" value="MP -52; damage 1040%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h23" value="MP -53; damage 1060%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h24" value="MP -54; damage 1080%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h25" value="MP -55; damage 1100%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h26" value="MP -56; damage 1120%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h27" value="MP -57; damage 1140%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h28" value="MP -58; damage 1160%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h29" value="MP -59; damage 1180%, attacks up to 6 enemies; cooldown 5 sec"/>
+    <string name="h30" value="MP -60; damage 1200%, attacks up to 6 enemies; cooldown 5 sec"/>
   </imgdir>
   <imgdir name="5221004">
     <string name="name" value="Rapid Fire"/>
-    <string name="desc" value="Fires rounds of bullets very quickly. Hold on to the skill key for continued shooting.\nRequired Skill : #cLevel 20 of Burst Fire#"/>
-    <string name="h1" value="MP -6, damage 102%"/>
-    <string name="h2" value="MP -6, damage 104%"/>
-    <string name="h3" value="MP -6, damage 106%"/>
-    <string name="h4" value="MP -6, damage 108%"/>
-    <string name="h5" value="MP -6, damage 110%"/>
-    <string name="h6" value="MP -6, damage 112%"/>
-    <string name="h7" value="MP -6, damage 114%"/>
-    <string name="h8" value="MP -6, damage 116%"/>
-    <string name="h9" value="MP -6, damage 118%"/>
-    <string name="h10" value="MP -6, damage 120%"/>
-    <string name="h11" value="MP -8, damage 122%"/>
-    <string name="h12" value="MP -8, damage 124%"/>
-    <string name="h13" value="MP -8, damage 126%"/>
-    <string name="h14" value="MP -8, damage 128%"/>
-    <string name="h15" value="MP -8, damage 128%"/>
-    <string name="h16" value="MP -8, damage 130%"/>
-    <string name="h17" value="MP -8, damage 132%"/>
-    <string name="h18" value="MP -8, damage 134%"/>
-    <string name="h19" value="MP -8, damage 136%"/>
-    <string name="h20" value="MP -8, damage 138%"/>
-    <string name="h21" value="MP -10, damage 152%"/>
-    <string name="h22" value="MP -10, damage 154%"/>
-    <string name="h23" value="MP -10, damage 156%"/>
-    <string name="h24" value="MP -10, damage 158%"/>
-    <string name="h25" value="MP -10, damage 160%"/>
-    <string name="h26" value="MP -9, damage 162%"/>
-    <string name="h27" value="MP -9, damage 164%"/>
-    <string name="h28" value="MP -9, damage 166%"/>
-    <string name="h29" value="MP -9, damage 168%"/>
-    <string name="h30" value="MP -9, damage 170%"/>
+    <string name="desc" value="[Master Level: 30]\nContinuously fires bullets while the skill key is held. Requires Burst Fire Lv.20."/>
+    <string name="h1" value="MP -6; damage 102% per shot while held"/>
+    <string name="h2" value="MP -6; damage 104% per shot while held"/>
+    <string name="h3" value="MP -6; damage 106% per shot while held"/>
+    <string name="h4" value="MP -6; damage 108% per shot while held"/>
+    <string name="h5" value="MP -6; damage 110% per shot while held"/>
+    <string name="h6" value="MP -6; damage 112% per shot while held"/>
+    <string name="h7" value="MP -6; damage 114% per shot while held"/>
+    <string name="h8" value="MP -6; damage 116% per shot while held"/>
+    <string name="h9" value="MP -6; damage 118% per shot while held"/>
+    <string name="h10" value="MP -6; damage 120% per shot while held"/>
+    <string name="h11" value="MP -8; damage 122% per shot while held"/>
+    <string name="h12" value="MP -8; damage 124% per shot while held"/>
+    <string name="h13" value="MP -8; damage 126% per shot while held"/>
+    <string name="h14" value="MP -8; damage 128% per shot while held"/>
+    <string name="h15" value="MP -8; damage 130% per shot while held"/>
+    <string name="h16" value="MP -8; damage 132% per shot while held"/>
+    <string name="h17" value="MP -8; damage 134% per shot while held"/>
+    <string name="h18" value="MP -8; damage 136% per shot while held"/>
+    <string name="h19" value="MP -8; damage 138% per shot while held"/>
+    <string name="h20" value="MP -8; damage 140% per shot while held"/>
+    <string name="h21" value="MP -10; damage 152% per shot while held"/>
+    <string name="h22" value="MP -10; damage 154% per shot while held"/>
+    <string name="h23" value="MP -10; damage 156% per shot while held"/>
+    <string name="h24" value="MP -10; damage 158% per shot while held"/>
+    <string name="h25" value="MP -10; damage 160% per shot while held"/>
+    <string name="h26" value="MP -9; damage 162% per shot while held"/>
+    <string name="h27" value="MP -9; damage 164% per shot while held"/>
+    <string name="h28" value="MP -9; damage 166% per shot while held"/>
+    <string name="h29" value="MP -9; damage 168% per shot while held"/>
+    <string name="h30" value="MP -9; damage 170% per shot while held"/>
   </imgdir>
   <imgdir name="5221006">
     <string name="name" value="Battleship"/>
-    <string name="desc" value="Calls forth a ship that you can mount and launch attacks from. The durability of the ship decreases per damage received, and when it reaches 0, you will not be able to get back on board for a short period of time. \nAvailable Skills : Battleship skills, Grenades, Gun Booster, Flamethower. "/>
-    <string name="h1" value="MP -22, weapon &amp; magic def. +10"/>
-    <string name="h2" value="MP -24, weapon &amp; magic def. +20"/>
-    <string name="h3" value="MP -26, weapon &amp; magic def. +30"/>
-    <string name="h4" value="MP -28, weapon &amp; magic def. +40"/>
-    <string name="h5" value="MP -30, weapon &amp; magic def. +50"/>
-    <string name="h6" value="MP -32, weapon &amp; magic def. +60"/>
-    <string name="h7" value="MP -34, weapon &amp; magic def. +70"/>
-    <string name="h8" value="MP -36, weapon &amp; magic def. +80"/>
-    <string name="h9" value="MP -38, weapon &amp; magic def. +90"/>
-    <string name="h10" value="MP -40, weapon &amp; magic def. +100"/>
+    <string name="desc" value="[Master Level: 10]\nBoards the Battleship. Damage taken reduces Battleship durability; when durability reaches 0, Battleship enters cooldown. Durability is 400 x skill level + 200 x max(character level - 120, 0)."/>
+    <string name="h1" value="MP -22; weapon def. +10, magic def. +10; Battleship cooldown 90 sec"/>
+    <string name="h2" value="MP -24; weapon def. +20, magic def. +20; Battleship cooldown 90 sec"/>
+    <string name="h3" value="MP -26; weapon def. +30, magic def. +30; Battleship cooldown 90 sec"/>
+    <string name="h4" value="MP -28; weapon def. +40, magic def. +40; Battleship cooldown 90 sec"/>
+    <string name="h5" value="MP -30; weapon def. +50, magic def. +50; Battleship cooldown 90 sec"/>
+    <string name="h6" value="MP -32; weapon def. +60, magic def. +60; Battleship cooldown 90 sec"/>
+    <string name="h7" value="MP -34; weapon def. +70, magic def. +70; Battleship cooldown 90 sec"/>
+    <string name="h8" value="MP -36; weapon def. +80, magic def. +80; Battleship cooldown 90 sec"/>
+    <string name="h9" value="MP -38; weapon def. +90, magic def. +90; Battleship cooldown 90 sec"/>
+    <string name="h10" value="MP -40; weapon def. +100, magic def. +100; Battleship cooldown 90 sec"/>
   </imgdir>
   <imgdir name="5221007">
     <string name="name" value="Battleship Cannon"/>
-    <string name="desc" value="Rapidly fires a number of cannonballs. Only available when aboard the Battleship.\nRequired Skill : #cLevel 1 of Battleship#"/>
-    <string name="h1" value="MP -22, attacks 3 times with damage 205%"/>
-    <string name="h2" value="MP -22, attacks 3 times with damage 210%"/>
-    <string name="h3" value="MP -22, attacks 3 times with damage 215%"/>
-    <string name="h4" value="MP -24, attacks 3 times with damage 220%"/>
-    <string name="h5" value="MP -24, attacks 3 times with damage 225%"/>
-    <string name="h6" value="MP -24, attacks 3 times with damage 230%"/>
-    <string name="h7" value="MP -26, attacks 3 times with damage 235%"/>
-    <string name="h8" value="MP -26, attacks 3 times with damage 240%"/>
-    <string name="h9" value="MP -26, attacks 3 times with damage 245%"/>
-    <string name="h10" value="MP -28, attacks 3 times with damage 250%"/>
-    <string name="h11" value="MP -28, attacks 4 times with damage 265%"/>
-    <string name="h12" value="MP -28, attacks 4 times with damage 270%"/>
-    <string name="h13" value="MP -30, attacks 4 times with damage 275%"/>
-    <string name="h14" value="MP -30, attacks 4 times with damage 280%"/>
-    <string name="h15" value="MP -30, attacks 4 times with damage 285%"/>
-    <string name="h16" value="MP -32, attacks 4 times with damage 290%"/>
-    <string name="h17" value="MP -32, attacks 4 times with damage 295%"/>
-    <string name="h18" value="MP -32, attacks 4 times with damage 300%"/>
-    <string name="h19" value="MP -34, attacks 4 times with damage 305%"/>
-    <string name="h20" value="MP -34, attacks 4 times with damage 310%"/>
-    <string name="h21" value="MP -34, attacks 4 times with damage 335%"/>
-    <string name="h22" value="MP -36, attacks 4 times with damage 340%"/>
-    <string name="h23" value="MP -36, attacks 4 times with damage 345%"/>
-    <string name="h24" value="MP -36, attacks 4 times with damage 350%"/>
-    <string name="h25" value="MP -38, attacks 4 times with damage 355%"/>
-    <string name="h26" value="MP -38, attacks 4 times with damage 360%"/>
-    <string name="h27" value="MP -38, attacks 4 times with damage 365%"/>
-    <string name="h28" value="MP -40, attacks 4 times with damage 370%"/>
-    <string name="h29" value="MP -40, attacks 4 times with damage 375%"/>
-    <string name="h30" value="MP -40, attacks 4 times with damage 380%"/>
+    <string name="desc" value="[Master Level: 30]\nRapidly fires cannonballs from the Battleship. Can only be used aboard Battleship."/>
+    <string name="h1" value="MP -22; damage 205% per cannonball, fires 3 cannonballs"/>
+    <string name="h2" value="MP -22; damage 210% per cannonball, fires 3 cannonballs"/>
+    <string name="h3" value="MP -22; damage 215% per cannonball, fires 3 cannonballs"/>
+    <string name="h4" value="MP -24; damage 220% per cannonball, fires 3 cannonballs"/>
+    <string name="h5" value="MP -24; damage 225% per cannonball, fires 3 cannonballs"/>
+    <string name="h6" value="MP -24; damage 230% per cannonball, fires 3 cannonballs"/>
+    <string name="h7" value="MP -26; damage 235% per cannonball, fires 3 cannonballs"/>
+    <string name="h8" value="MP -26; damage 240% per cannonball, fires 3 cannonballs"/>
+    <string name="h9" value="MP -26; damage 245% per cannonball, fires 3 cannonballs"/>
+    <string name="h10" value="MP -28; damage 250% per cannonball, fires 3 cannonballs"/>
+    <string name="h11" value="MP -28; damage 265% per cannonball, fires 4 cannonballs"/>
+    <string name="h12" value="MP -28; damage 270% per cannonball, fires 4 cannonballs"/>
+    <string name="h13" value="MP -30; damage 275% per cannonball, fires 4 cannonballs"/>
+    <string name="h14" value="MP -30; damage 280% per cannonball, fires 4 cannonballs"/>
+    <string name="h15" value="MP -30; damage 285% per cannonball, fires 4 cannonballs"/>
+    <string name="h16" value="MP -32; damage 290% per cannonball, fires 4 cannonballs"/>
+    <string name="h17" value="MP -32; damage 295% per cannonball, fires 4 cannonballs"/>
+    <string name="h18" value="MP -32; damage 300% per cannonball, fires 4 cannonballs"/>
+    <string name="h19" value="MP -34; damage 305% per cannonball, fires 4 cannonballs"/>
+    <string name="h20" value="MP -34; damage 310% per cannonball, fires 4 cannonballs"/>
+    <string name="h21" value="MP -34; damage 335% per cannonball, fires 4 cannonballs"/>
+    <string name="h22" value="MP -36; damage 340% per cannonball, fires 4 cannonballs"/>
+    <string name="h23" value="MP -36; damage 345% per cannonball, fires 4 cannonballs"/>
+    <string name="h24" value="MP -36; damage 350% per cannonball, fires 4 cannonballs"/>
+    <string name="h25" value="MP -38; damage 355% per cannonball, fires 4 cannonballs"/>
+    <string name="h26" value="MP -38; damage 360% per cannonball, fires 4 cannonballs"/>
+    <string name="h27" value="MP -38; damage 365% per cannonball, fires 4 cannonballs"/>
+    <string name="h28" value="MP -40; damage 370% per cannonball, fires 4 cannonballs"/>
+    <string name="h29" value="MP -40; damage 375% per cannonball, fires 4 cannonballs"/>
+    <string name="h30" value="MP -40; damage 380% per cannonball, fires 4 cannonballs"/>
   </imgdir>
   <imgdir name="5221008">
     <string name="name" value="Battleship Torpedo"/>
-    <string name="desc" value="Fires a hardened cannonball that goes through monsters. Only available when aboard the Battleship.\nRequired Skill : #cLevel 1 of Battleship#"/>
-    <string name="h1" value="MP -22, damage 390%, attacks 4 monsters"/>
-    <string name="h2" value="MP -22, damage 400%, attacks 4 monsters"/>
-    <string name="h3" value="MP -22, damage 410%, attacks 4 monsters"/>
-    <string name="h4" value="MP -24, damage 420%, attacks 4 monsters"/>
-    <string name="h5" value="MP -24, damage 430%, attacks 4 monsters"/>
-    <string name="h6" value="MP -24, damage 440%, attacks 4 monsters"/>
-    <string name="h7" value="MP -26, damage 450%, attacks 4 monsters"/>
-    <string name="h8" value="MP -26, damage 460%, attacks 4 monsters"/>
-    <string name="h9" value="MP -26, damage 470%, attacks 4 monsters"/>
-    <string name="h10" value="MP -28, damage 480%, attacks 4 monsters"/>
-    <string name="h11" value="MP -28, damage 540%, attacks 5 monsters"/>
-    <string name="h12" value="MP -28, damage 550%, attacks 5 monsters"/>
-    <string name="h13" value="MP -30, damage 560%, attacks 5 monsters"/>
-    <string name="h14" value="MP -30, damage 570%, attacks 5 monsters"/>
-    <string name="h15" value="MP -30, damage 580%, attacks 5 monsters"/>
-    <string name="h16" value="MP -32, damage 590%, attacks 5 monsters"/>
-    <string name="h17" value="MP -32, damage 600%, attacks 5 monsters"/>
-    <string name="h18" value="MP -32, damage 610%, attacks 5 monsters"/>
-    <string name="h19" value="MP -34, damage 620%, attacks 5 monsters"/>
-    <string name="h20" value="MP -34, damage 630%, attacks 5 monsters"/>
-    <string name="h21" value="MP -34, damage 690%, attacks 6 monsters"/>
-    <string name="h22" value="MP -36, damage 700%, attacks 6 monsters"/>
-    <string name="h23" value="MP -36, damage 710%, attacks 6 monsters"/>
-    <string name="h24" value="MP -36, damage 720%, attacks 6 monsters"/>
-    <string name="h25" value="MP -38, damage 730%, attacks 6 monsters"/>
-    <string name="h26" value="MP -38, damage 740%, attacks 6 monsters"/>
-    <string name="h27" value="MP -38, damage 750%, attacks 6 monsters"/>
-    <string name="h28" value="MP -40, damage 760%, attacks 6 monsters"/>
-    <string name="h29" value="MP -40, damage 770%, attacks 6 monsters"/>
-    <string name="h30" value="MP -40, damage 780%, attacks 6 monsters"/>
+    <string name="desc" value="[Master Level: 30]\nFires a piercing torpedo from the Battleship. Can only be used aboard Battleship."/>
+    <string name="h1" value="MP -22; damage 390%, attacks up to 4 enemies"/>
+    <string name="h2" value="MP -22; damage 400%, attacks up to 4 enemies"/>
+    <string name="h3" value="MP -22; damage 410%, attacks up to 4 enemies"/>
+    <string name="h4" value="MP -24; damage 420%, attacks up to 4 enemies"/>
+    <string name="h5" value="MP -24; damage 430%, attacks up to 4 enemies"/>
+    <string name="h6" value="MP -24; damage 440%, attacks up to 4 enemies"/>
+    <string name="h7" value="MP -26; damage 450%, attacks up to 4 enemies"/>
+    <string name="h8" value="MP -26; damage 460%, attacks up to 4 enemies"/>
+    <string name="h9" value="MP -26; damage 470%, attacks up to 4 enemies"/>
+    <string name="h10" value="MP -28; damage 480%, attacks up to 4 enemies"/>
+    <string name="h11" value="MP -28; damage 540%, attacks up to 5 enemies"/>
+    <string name="h12" value="MP -28; damage 550%, attacks up to 5 enemies"/>
+    <string name="h13" value="MP -30; damage 560%, attacks up to 5 enemies"/>
+    <string name="h14" value="MP -30; damage 570%, attacks up to 5 enemies"/>
+    <string name="h15" value="MP -30; damage 580%, attacks up to 5 enemies"/>
+    <string name="h16" value="MP -32; damage 590%, attacks up to 5 enemies"/>
+    <string name="h17" value="MP -32; damage 600%, attacks up to 5 enemies"/>
+    <string name="h18" value="MP -32; damage 610%, attacks up to 5 enemies"/>
+    <string name="h19" value="MP -34; damage 620%, attacks up to 5 enemies"/>
+    <string name="h20" value="MP -34; damage 630%, attacks up to 5 enemies"/>
+    <string name="h21" value="MP -34; damage 690%, attacks up to 6 enemies"/>
+    <string name="h22" value="MP -36; damage 700%, attacks up to 6 enemies"/>
+    <string name="h23" value="MP -36; damage 710%, attacks up to 6 enemies"/>
+    <string name="h24" value="MP -36; damage 720%, attacks up to 6 enemies"/>
+    <string name="h25" value="MP -38; damage 730%, attacks up to 6 enemies"/>
+    <string name="h26" value="MP -38; damage 740%, attacks up to 6 enemies"/>
+    <string name="h27" value="MP -38; damage 750%, attacks up to 6 enemies"/>
+    <string name="h28" value="MP -40; damage 760%, attacks up to 6 enemies"/>
+    <string name="h29" value="MP -40; damage 770%, attacks up to 6 enemies"/>
+    <string name="h30" value="MP -40; damage 780%, attacks up to 6 enemies"/>
   </imgdir>
   <imgdir name="5221009">
     <string name="name" value="Hypnotize"/>
-    <string name="desc" value="Hypnotizes monsters to temporarily make it attack other monsters instead of you."/>
-    <string name="h1" value="MP -31, available for 21 sec., success rate 43 %"/>
-    <string name="h2" value="MP -32, available for 22 sec., success rate 46 %"/>
-    <string name="h3" value="MP -33, available for 23 sec., success rate 49 %"/>
-    <string name="h4" value="MP -34, available for 24 sec., success rate 52 %"/>
-    <string name="h5" value="MP -35, available for 25 sec., success rate 55 %"/>
-    <string name="h6" value="MP -36, available for 26 sec., success rate 58 %"/>
-    <string name="h7" value="MP -37, available for 27 sec., success rate 61 %"/>
-    <string name="h8" value="MP -38, available for 28 sec., success rate 64 %"/>
-    <string name="h9" value="MP -39, available for 29 sec., success rate 67 %"/>
-    <string name="h10" value="MP -40, available for 30 sec., success rate 70 %"/>
-    <string name="h11" value="MP -41, available for 31 sec., success rate 73 %"/>
-    <string name="h12" value="MP -42, available for 32 sec., success rate 76 %"/>
-    <string name="h13" value="MP -43, available for 33 sec., success rate 79 %"/>
-    <string name="h14" value="MP -44, available for 34 sec., success rate 82 %"/>
-    <string name="h15" value="MP -45, available for 35 sec., success rate 85 %"/>
-    <string name="h16" value="MP -46, available for 36 sec., success rate 88 %"/>
-    <string name="h17" value="MP -47, available for 37 sec., success rate 91 %"/>
-    <string name="h18" value="MP -48, available for 38 sec., success rate 94 %"/>
-    <string name="h19" value="MP -49, available for 39 sec., success rate 97 %"/>
-    <string name="h20" value="MP -50, available for 40 sec., success rate 100 %"/>
+    <string name="desc" value="[Master Level: 20]\nHypnotizes one monster, making it attack other monsters for a time."/>
+    <string name="h1" value="MP -31; 43% chance to hypnotize for 21 sec, range 350"/>
+    <string name="h2" value="MP -32; 46% chance to hypnotize for 22 sec, range 350"/>
+    <string name="h3" value="MP -33; 49% chance to hypnotize for 23 sec, range 350"/>
+    <string name="h4" value="MP -34; 52% chance to hypnotize for 24 sec, range 350"/>
+    <string name="h5" value="MP -35; 55% chance to hypnotize for 25 sec, range 350"/>
+    <string name="h6" value="MP -36; 58% chance to hypnotize for 26 sec, range 350"/>
+    <string name="h7" value="MP -37; 61% chance to hypnotize for 27 sec, range 350"/>
+    <string name="h8" value="MP -38; 64% chance to hypnotize for 28 sec, range 350"/>
+    <string name="h9" value="MP -39; 67% chance to hypnotize for 29 sec, range 350"/>
+    <string name="h10" value="MP -40; 70% chance to hypnotize for 30 sec, range 350"/>
+    <string name="h11" value="MP -41; 73% chance to hypnotize for 31 sec, range 350"/>
+    <string name="h12" value="MP -42; 76% chance to hypnotize for 32 sec, range 350"/>
+    <string name="h13" value="MP -43; 79% chance to hypnotize for 33 sec, range 350"/>
+    <string name="h14" value="MP -44; 82% chance to hypnotize for 34 sec, range 350"/>
+    <string name="h15" value="MP -45; 85% chance to hypnotize for 35 sec, range 350"/>
+    <string name="h16" value="MP -46; 88% chance to hypnotize for 36 sec, range 350"/>
+    <string name="h17" value="MP -47; 91% chance to hypnotize for 37 sec, range 350"/>
+    <string name="h18" value="MP -48; 94% chance to hypnotize for 38 sec, range 350"/>
+    <string name="h19" value="MP -49; 97% chance to hypnotize for 39 sec, range 350"/>
+    <string name="h20" value="MP -50; 100% chance to hypnotize for 40 sec, range 350"/>
   </imgdir>
   <imgdir name="5221010">
     <string name="name" value="Speed Infusion"/>
-    <string name="desc" value="Uses HP and MP to temporarily increase the attacking speed of a weapon. This can be combined with other boosters, and everyone in the party will be positively affected by this.\nRequired Skill : #cLevel 20 of Knuckler Booster#"/>
-    <string name="h1" value="MP -30, cured from the state of being seduced."/>
-    <string name="h25" value="MP -75, waiting time until next use: 25 min."/>
+    <string name="desc" value="[Master Level: 5]\nConsumes MP to activate the server-side Corsair Speed Infusion buff slot. Current WZ values provide cooldown only."/>
+    <string name="h1" value="MP -30; cooldown 600 sec"/>
+    <string name="h2" value="MP -30; cooldown 540 sec"/>
+    <string name="h3" value="MP -30; cooldown 480 sec"/>
+    <string name="h4" value="MP -30; cooldown 420 sec"/>
+    <string name="h5" value="MP -30; cooldown 360 sec"/>
   </imgdir>
   <imgdir name="5220011">
     <string name="name" value="Bullseye"/>
-    <string name="desc" value="Applies more damage to monsters under the effect of Homing Beacon.\nRequired Skill : #cLevel 30 of Homing Beacon#"/>
-    <string name="h1" value="MP -35, damage 390%, additional damage +1%"/>
-    <string name="h2" value="MP -35, damage 400%, additional damage +2%"/>
-    <string name="h3" value="MP -35, damage 410%, additional damage +3%"/>
-    <string name="h4" value="MP -35, damage 420%, additional damage +4%"/>
-    <string name="h5" value="MP -35, damage 430%, additional damage +5%"/>
-    <string name="h6" value="MP -35, damage 440%, additional damage +6%"/>
-    <string name="h7" value="MP -35, damage 450%, additional damage +7%"/>
-    <string name="h8" value="MP -35, damage 460%, additional damage +8%"/>
-    <string name="h9" value="MP -35, damage 470%, additional damage +9%"/>
-    <string name="h10" value="MP -35, damage 480%, additional damage +10%"/>
-    <string name="h11" value="MP -40, damage 490%, additional damage +11%"/>
-    <string name="h12" value="MP -40, damage 500%, additional damage +12%"/>
-    <string name="h13" value="MP -40, damage 510%, additional damage +13%"/>
-    <string name="h14" value="MP -40, damage 520%, additional damage +14%"/>
-    <string name="h15" value="MP -40, damage 530%, additional damage +15%"/>
-    <string name="h16" value="MP -40, damage 540%, additional damage +16%"/>
-    <string name="h17" value="MP -40, damage 550%, additional damage +17%"/>
-    <string name="h18" value="MP -40, damage 560%, additional damage +18%"/>
-    <string name="h19" value="MP -40, damage 570%, additional damage +19%"/>
-    <string name="h20" value="MP -40, damage 580%, additional damage +20%"/>
+    <string name="desc" value="[Master Level: 20]\nMarks one enemy and increases damage dealt to the marked target. Requires Homing Beacon Lv.30."/>
+    <string name="h1" value="MP -35; marks one enemy, damage 390%, additional damage +1%, range 350"/>
+    <string name="h2" value="MP -35; marks one enemy, damage 400%, additional damage +2%, range 350"/>
+    <string name="h3" value="MP -35; marks one enemy, damage 410%, additional damage +3%, range 350"/>
+    <string name="h4" value="MP -35; marks one enemy, damage 420%, additional damage +4%, range 350"/>
+    <string name="h5" value="MP -35; marks one enemy, damage 430%, additional damage +5%, range 350"/>
+    <string name="h6" value="MP -35; marks one enemy, damage 440%, additional damage +6%, range 350"/>
+    <string name="h7" value="MP -35; marks one enemy, damage 450%, additional damage +7%, range 350"/>
+    <string name="h8" value="MP -35; marks one enemy, damage 460%, additional damage +8%, range 350"/>
+    <string name="h9" value="MP -35; marks one enemy, damage 470%, additional damage +9%, range 350"/>
+    <string name="h10" value="MP -35; marks one enemy, damage 480%, additional damage +10%, range 350"/>
+    <string name="h11" value="MP -40; marks one enemy, damage 490%, additional damage +11%, range 350"/>
+    <string name="h12" value="MP -40; marks one enemy, damage 500%, additional damage +12%, range 350"/>
+    <string name="h13" value="MP -40; marks one enemy, damage 510%, additional damage +13%, range 350"/>
+    <string name="h14" value="MP -40; marks one enemy, damage 520%, additional damage +14%, range 350"/>
+    <string name="h15" value="MP -40; marks one enemy, damage 530%, additional damage +15%, range 350"/>
+    <string name="h16" value="MP -40; marks one enemy, damage 540%, additional damage +16%, range 350"/>
+    <string name="h17" value="MP -40; marks one enemy, damage 550%, additional damage +17%, range 350"/>
+    <string name="h18" value="MP -40; marks one enemy, damage 560%, additional damage +18%, range 350"/>
+    <string name="h19" value="MP -40; marks one enemy, damage 570%, additional damage +19%, range 350"/>
+    <string name="h20" value="MP -40; marks one enemy, damage 580%, additional damage +20%, range 350"/>
   </imgdir>
   <imgdir name="0001009">
     <string name="name" value="Bamboo Rain"/>


### PR DESCRIPTION
## 改动内容
- 校正海盗职业一转至四转技能的中英文技能名称、基础说明与各等级说明。
- 按当前技能数据补全伤害、命中、回避、持续时间、冷却时间、消耗、攻击次数、召唤持续时间等数值描述。
- 补充与服务端实际逻辑相关的说明，包括能量获得、能量耗转恢复、寒冰喷射冻结时间、战舰耐久与冷却、光速拳额外倍率等。
- 本次不涉及任务、NPC、道具或地图。
- 本次为英文与中文 String 技能文本的对称修复。

## 影响范围
- 影响技能说明文本与客户端显示内容。
- 不修改技能执行逻辑，不修改脚本流程，不修改掉落、任务或地图数据。
- 本次改动需要同步客户端资源包。

## 验证情况
- 已执行 XML 解析检查。
- 已校验海盗技能说明条目数量与技能等级数据一致。
- 已校验技能说明中的换行使用字面量 `\\n`。
- 已执行中文乱码检查。
- 已执行 Git diff 空白检查。
- 未重新构建 Jar，未执行客户端资源包打包。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。
