### PR TITLE
fix: 修复天空之城女神塔组队任务存在的已知问题

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2013002.js
+++ b/gms-server/scripts-zh-CN/npc/2013002.js
@@ -1,8 +1,8 @@
 /*
-	This file is part of the OdinMS Maple Story Server
+    This file is part of the OdinMS Maple Story Server
     Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+                   Matthias Butz <matze@odinms.de>
+                   Jan Christian Meyer <vimes@odinms.de>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as
@@ -22,8 +22,10 @@
 /**
  *2013002.js - Minerva the Goddess
  *@author Ronan
+ * Modified: Added hidden exchange for 10 diary pages -> completed diary (4161014) while keeping original rewards.
  */
 var status = 0;
+var exchangeConfirmed = false; // 标记是否确认兑换
 
 function start() {
     status = -1;
@@ -35,11 +37,12 @@ function action(mode, type, selection) {
         cm.dispose();
     } else {
         status++;
-        if (cm.getPlayer().getMapId() == 920010100) { //Center tower
+        if (cm.getPlayer().getMapId() == 920010100) { // Center tower
             if (status == 0) {
                 cm.sendYesNo("我已经解除了阻止通往塔楼监狱储藏室的咒语。你可能会在那里找到一些好东西……或者，你可能想现在离开。你准备好离开了吗？");
             } else if (status == 1) {
-                cm.warp(920011300, 0);
+                cm.getEventInstance().startEventTimer(60000); //bonus time 60s
+                cm.getEventInstance().warpEventTeam(920011100); // 奖励关
                 cm.dispose();
             }
 
@@ -52,17 +55,63 @@ function action(mode, type, selection) {
             }
 
         } else if (cm.getPlayer().getMapId() == 920011300) {
+            // ========== 通关地图 ==========
             if (status == 0) {
                 cm.sendNext("谢谢你不仅修复了雕像，还救出了我，让我脱离困境。愿女神的祝福与你同在，直到最后……作为感激之情，请接受这份纪念品，以表彰你的勇敢。");
             } else if (status == 1) {
-                if (cm.getEventInstance().giveEventReward(cm.getPlayer())) {
-                    cm.warp(200080101, 0);
-                    cm.dispose();
-                } else {
-                    cm.sendOk("请先在您的背包中腾出空间。");
-                    cm.dispose();
+                // 检查是否拥有全部10页日记
+                var pages = [4001064, 4001065, 4001066, 4001067, 4001068, 4001069, 4001070, 4001071, 4001072, 4001073];
+                var hasAll = true;
+                for (var i = 0; i < pages.length; i++) {
+                    if (!cm.haveItem(pages[i], 1)) {
+                        hasAll = false;
+                        break;
+                    }
                 }
+                // 只能持有一个，持有多个会报错
+                if (hasAll && !cm.haveItem(4161014)) {
+                    // 询问是否用10页合成日记本（额外选项，不影响原奖励）
+                    cm.sendYesNo("我注意到你收集了我散落的日记残页。你是否愿意将10张残页交给我，让我为你合成完整的《女神的日记本》？\r\n（合成后你依然可以获得原有的通关奖励）");
+                    exchangeConfirmed = true;
+                } else {
+                    // 没有页数，直接领取原奖励
+                    exchangeConfirmed = false;
+                    cm.sendOk("接下来，请接受我为你准备的通关奖励。");
+                }
+            } else if (status == 2) {
+                if (exchangeConfirmed) {
+                    // 用户确认兑换，执行合成
+                    var pages = [4001064, 4001065, 4001066, 4001067, 4001068, 4001069, 4001070, 4001071, 4001072, 4001073];
+                    for (var i = 0; i < pages.length; i++) {
+                        cm.gainItem(pages[i], -1);
+                    }
+                    cm.gainItem(4161014, 1); // 女神的日记本
+                    cm.sendOk("感谢你帮我找回这些珍贵的记忆。这是合成后的《女神的日记本》，请收好。\r\n接下来，请接受我为你准备的通关奖励。");
+
+                } else {
+                    // 用户拒绝兑换，直接发放原奖励
+                    giveOriginalReward();
+                }
+            } else if (status == 3)  {
+	         if (exchangeConfirmed) {
+	            // 合成后继续发放原奖励
+                    giveOriginalReward();
+		} else {
+			cm.dispose();
+		}
             }
         }
+    }
+}
+
+function giveOriginalReward() {
+    // 原有奖励：经验、女神的羽毛、传送出去（使用giveEventReward检查背包）
+    if (cm.getEventInstance() != null && cm.getEventInstance().giveEventReward(cm.getPlayer()) && cm.canHold(4001158)) {
+        cm.gainItem(4001158, 1); // 女神的羽毛
+        cm.warp(200080101, 0);
+        cm.dispose();
+    } else {
+        cm.sendOk("请先在您的背包中腾出空间（至少一个空位）。");
+        cm.dispose();
     }
 }

--- a/gms-server/scripts-zh-CN/portal/party3_jailin.js
+++ b/gms-server/scripts-zh-CN/portal/party3_jailin.js
@@ -1,4 +1,6 @@
-var leverSequenceExit = false;
+// dwang:
+// 感觉这一关有问题，好像可以控制操作杆让怪物死掉。也可以通过控制操控杆开门过关
+var leverSequenceExit = true;
 
 function enterLeverSequence(pi) {
     var map = pi.getMap();
@@ -65,11 +67,16 @@ function enterNoMobs(pi) {
 
 function enter(pi) {
     var ret;
-    if (leverSequenceExit) {
-        ret = enterLeverSequence(pi);
-    } else {
-        ret = enterNoMobs(pi);
+    // 兼容两种过关方式
+    // 如果可以通过打开关杀死所有怪物，直接进
+    var map = pi.getMap();
+    var mobcount = map.countMonster(9300044);
+    if (mobcount == 0) {
+        pi.playPortalSound();
+        pi.warp(pi.getMapId() + 2, 0);
+        return true;
     }
-
+    // 打开关过关
+    ret = enterLeverSequence(pi);
     return ret;
 }

--- a/gms-server/scripts-zh-CN/portal/party3_r6pt.js
+++ b/gms-server/scripts-zh-CN/portal/party3_r6pt.js
@@ -15,10 +15,16 @@
     GNU Affero General Public License for more details.
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    移动
 */
 /**
  *@author Ronan
  *party3_r4pt
+
+ * @update dwang
+ * @desc:use teleport replace warp
+ * @ 20260629
  */
 
 function enter(pi) {
@@ -36,7 +42,7 @@ function enter(pi) {
 
     var comb = eim.getProperty("stage6_comb");
 
-    var name = pi.getPortal().getName().substring(2, 5);
+    var name = pi.getPortal().getName().substring(2, 5); //获取名字 eg:rp013
     var portalId = parseInt(name, 10);
 
 
@@ -45,11 +51,22 @@ function enter(pi) {
 
     if (pCol == parseInt(comb.substring(pRow, pRow + 1), 10)) {    //climb
         pi.playPortalSound();
-        pi.warp(pi.getMapId(), (pRow % 4 != 0) ? pi.getPortal().getId() + 4 : (pRow / 4));
+        pi.goTeleport(false, pRow + 5);
+        return false;
+
     } else {    //fail
         pRow--;
         pi.playPortalSound();
-        pi.warp(pi.getMapId(), (pRow / 4) > 1 ? parseInt(pRow / 4) : 5);  // thanks Chloek3, seth1 for noticing next plaform issues
+        var level =  (pRow / 4) > 1 ? parseInt(pRow / 4) : 0;
+        // 最下面一层去22
+        if (level == 0) {
+           pi.goTeleport(false, 22);
+        } else {
+            // 9 13 17
+            pi.goTeleport(false,  9 + (level - 1)*4);
+        }
+        return false;
+
     }
 
     return true;

--- a/gms-server/scripts-zh-CN/reactor/2006001.js
+++ b/gms-server/scripts-zh-CN/reactor/2006001.js
@@ -25,6 +25,8 @@
  */
 
 function act() {
+    var eim = rm.getEventInstance();
+
     rm.spawnNpc(2013002);
     rm.getEventInstance().clearPQ();
 
@@ -32,5 +34,6 @@ function act() {
     eim.giveEventPlayersExp(3500);
     eim.showClearEffect(true);
 
-    rm.getEventInstance().startEventTimer(5 * 60000); //bonus time
+    // 10min
+    rm.getEventInstance().startEventTimer(10 * 60000); //bonus time
 }

--- a/gms-server/scripts-zh-CN/reactor/2008006.js
+++ b/gms-server/scripts-zh-CN/reactor/2008006.js
@@ -23,8 +23,44 @@
 /*@author Ronan
  *Reactor : Orbis PQ LP Player - 2008006.js
  * Makes Chamberlain Eak spawn box.
+
+ @update dwang
+ 周一	Beachway	可爱的音乐
+ 周二	WelcomeToTheHell	恐怖的音乐
+ 周三	Aquarium	有趣的音乐
+ 周四	CaveOfHontale	忧郁的音乐
+ 周五	EvilEyes	冰冷的音乐
+ 周六	MoonlightShadow	晴朗的音乐
+ 周日	ForTheGlory	雄壮的音乐
+
  */
 
 function act() {
-    rm.getEventInstance().setProperty("statusStg3", "0");
+    //
+    var eim = rm.getEventInstance();
+    var day = eim.getInstanceMap(920010400).getReactorByName("music").getEventState();
+    switch(day) {
+        case 0:
+             rm.changeMusic("Bgm08.img/ForTheGlory");
+            break;
+        case 1:
+             rm.changeMusic("Bgm03.img/Beachway");
+            break;
+        case 2:
+             rm.changeMusic("Bgm06.img/WelcomeToTheHell");
+            break;
+        case 3:
+             rm.changeMusic("Bgm11.img/Aquarium");
+            break;
+        case 4:
+             rm.changeMusic("Bgm14.img/CaveOfHontale");
+            break;
+        case 5:
+             rm.changeMusic("Bgm02.img/EvilEyes");
+            break;
+        case 6:
+             rm.changeMusic("Bgm01.img/MoonlightShadow");
+            break;
+    }
+    eim.setProperty("statusStg3", "0");
 }

--- a/gms-server/src/main/java/org/gms/net/opcodes/SendOpcode.java
+++ b/gms-server/src/main/java/org/gms/net/opcodes/SendOpcode.java
@@ -234,7 +234,7 @@ public enum SendOpcode implements Opcode {
     THROW_GRENADE(0xCC), // 抛掷手榴弹
     CANCEL_CHAIR(0xCD), // 取消椅子
     SHOW_ITEM_GAIN_INCHAT(0xCE), // 在聊天中显示获得物品
-    DOJO_WARP_UP(0xCF), // 武道馆传送准备
+    LP_UserTeleport(0xCF), // 地图内瞬移
     LUCKSACK_PASS(0xD0), // 幸运袋成功
     LUCKSACK_FAIL(0xD1), // 幸运袋失败
     MESO_BAG_MESSAGE(0xD2), // 金币背包消息

--- a/gms-server/src/main/java/org/gms/scripting/AbstractPlayerInteraction.java
+++ b/gms-server/src/main/java/org/gms/scripting/AbstractPlayerInteraction.java
@@ -1023,6 +1023,11 @@ public class AbstractPlayerInteraction {
         c.sendPacket(PacketCreator.dojoWarpUp());
     }
 
+    public void goTeleport(boolean exclRequest, int portalId) {
+        c.sendPacket(PacketCreator.teleport(exclRequest, portalId));
+    }
+
+
     public void resetDojoEnergy() {
         c.getPlayer().setDojoEnergy(0);
     }

--- a/gms-server/src/main/java/org/gms/util/PacketCreator.java
+++ b/gms-server/src/main/java/org/gms/util/PacketCreator.java
@@ -6726,10 +6726,17 @@ public class PacketCreator {
     }
 
     public static Packet dojoWarpUp() {
-        final OutPacket p = OutPacket.create(SendOpcode.DOJO_WARP_UP);
+        final OutPacket p = OutPacket.create(SendOpcode.LP_UserTeleport);
         p.writeByte(0);
         p.writeByte(6);
         return p;
+    }
+
+    public static Packet teleport(boolean exclRequest, int portalId) {
+        final OutPacket outPacket = OutPacket.create(SendOpcode.LP_UserTeleport);
+        outPacket.writeBool(exclRequest); // bool -> bExclRequestSent = 0
+        outPacket.writeByte(portalId);
+        return outPacket;
     }
 
     public static Packet itemExpired(int itemid) {


### PR DESCRIPTION
NPC: 2013002(雅典娜女神).js:
1. 新增日记本更换
2. 修复组队任务完成进入奖励关卡

Portal
party3_jailin.js
1. 修复监狱地图支持两种过关方式。即：打平台和通过平台的刺消灭地图怪物过关 

party3_r6pt.js
1. `雅典娜禁地<向上通道>`平台通过瞬移进行移动，替换过图加载不必要的资源

Reactor
2006001.js
1. 修复脚本调用错误，增加任务完成探索时间

2008006.js
1. 修复在地图`雅典娜禁地<休息室>` 丢CD不切换背景音乐的问题

fea:
1. 新增一个脚本方法goTeleport，地图内瞬移