### PR TITLE
fix: 修复蘑菇城任务链断档、结界推进与脚本化提示异常

### DIFF
--- a/gms-server/scripts-zh-CN/event/MK_PrimeMinister2.js
+++ b/gms-server/scripts-zh-CN/event/MK_PrimeMinister2.js
@@ -154,11 +154,11 @@ function playerExit(eim, player) {
 
 function changedMap(eim, chr, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
-        if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
-            eim.unregisterPlayer(player);
+        if (eim.isEventTeamLackingNow(true, minPlayers, chr)) {
+            eim.unregisterPlayer(chr);
             end(eim);
         } else {
-            eim.unregisterPlayer(player);
+            eim.unregisterPlayer(chr);
         }
     }
 }

--- a/gms-server/scripts-zh-CN/item/killarmush.js
+++ b/gms-server/scripts-zh-CN/item/killarmush.js
@@ -27,12 +27,12 @@ function start(){
             }
             im.removeAll(2430014);
             im.showInfo("Effect/OnUserEff/normalEffect/mushroomcastle/chatBalloon2");
-            im.dropMessage(6,'好像有什么动静...嗯？是结界被消除了');
+            im.dropMessage(6, '蘑菇的毒孢子与结界产生了反应，结界消散了。');
         } else {
-            im.message('尽可能的接近魔法结界才能将其消除');
+            im.message('请靠近魔法结界后再使用这个道具。');
         }
     } else {
-        im.message('这里似乎没有需要消除的魔法结界');
+        im.message('这里没有会对这个道具产生反应的魔法结界。');
     }
 
     im.dispose();

--- a/gms-server/scripts-zh-CN/item/removethorns.js
+++ b/gms-server/scripts-zh-CN/item/removethorns.js
@@ -26,7 +26,6 @@ function start() {
             im.forceCompleteQuest(2324);
             im.removeAll(2430015);
             im.playerMessage(6, "使用尖刺消除剂清除道路上的荆棘。");
-            im.warp(106020501);
         } else {
             im.playerMessage(5,"尽可能得离荆棘更近些才能完全清除");
         }

--- a/gms-server/scripts-zh-CN/npc/1300005.js
+++ b/gms-server/scripts-zh-CN/npc/1300005.js
@@ -1,0 +1,79 @@
+var status = -1;
+var introQuestIds = [2300, 2301, 2302, 2303, 2304, 2305, 2306, 2307, 2308, 2309, 2310];
+
+function start() {
+    status = -1;
+    action(1, 0, 0);
+}
+
+function action(mode, type, selection) {
+    if (mode == -1) {
+        cm.dispose();
+        return;
+    }
+
+    if (mode == 0 && type > 0) {
+        cm.dispose();
+        return;
+    }
+
+    if (mode == 1) {
+        status++;
+    } else {
+        status--;
+    }
+
+    if (status == 0) {
+        if (!hasMushroomIntroCompleted()) {
+            cm.sendOk("请先去和管理员对话。");
+            cm.dispose();
+        } else if (!cm.isQuestStarted(2312) && !cm.isQuestCompleted(2312)) {
+            cm.sendAcceptDecline("勇士，我们王国正面临巨大的危机。在把拯救王国的重任交给你之前，我需要先确认你的实力。你愿意接受测试吗？");
+        } else if (cm.isQuestStarted(2312)) {
+            if (!cm.haveItem(4000499, 50)) {
+                cm.sendOk("请去消灭得意的蘑菇仔，并带回50个变种孢子。");
+                cm.dispose();
+            } else {
+                cm.sendNext("你已经教训过那些得意的蘑菇仔了吗？");
+            }
+        } else if (!cm.isQuestStarted(2313) && !cm.isQuestCompleted(2313)) {
+            cm.sendAcceptDecline("我已经把你的表现告诉内务大臣了。请你马上去见他吧。");
+        } else if (cm.isQuestStarted(2313)) {
+            cm.sendNext("请你一定要拯救我们的王国！");
+        } else {
+            cm.sendOk("请尽快去见内务大臣。");
+            cm.dispose();
+        }
+    } else if (status == 1) {
+        if (!cm.isQuestStarted(2312) && !cm.isQuestCompleted(2312)) {
+            cm.startQuest(2312);
+            cm.sendOk("从这里继续往前走，你会看到很多得意的蘑菇仔。请教训它们，并带回50个变种孢子作为证明。");
+            cm.dispose();
+        } else if (cm.isQuestStarted(2312)) {
+            cm.completeQuest(2312);
+            cm.gainExp(11500);
+            cm.gainItem(4000499, -50);
+            cm.sendOk("真了不起。请原谅我之前的怀疑。现在，请你拯救我们的蘑菇王国吧！");
+            cm.dispose();
+        } else if (!cm.isQuestStarted(2313) && !cm.isQuestCompleted(2313)) {
+            cm.startQuest(2313);
+            cm.sendOk("请你一定要拯救我们的王国！");
+            cm.dispose();
+        } else if (cm.isQuestStarted(2313)) {
+            cm.completeQuest(2313);
+            cm.gainExp(4000);
+            cm.dispose();
+        } else {
+            cm.dispose();
+        }
+    }
+}
+
+function hasMushroomIntroCompleted() {
+    for (var i = 0; i < introQuestIds.length; i++) {
+        if (cm.isQuestCompleted(introQuestIds[i])) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/gms-server/scripts-zh-CN/npc/1300014.js
+++ b/gms-server/scripts-zh-CN/npc/1300014.js
@@ -1,53 +1,62 @@
 /*
 ===========================================================
-			GitHub：@Magical-H
-	NPC Name: 		SELF
-	Map(s): 		Mushroom Castle: Deep inside Mushroom Forest(106020300) 蘑菇森林深处
-	Description: 	Upon reaching the magic barrier.    到达魔法孢子结界之后往回走即可触发
-	仅北·斗 Bei-dou服务端或其他支持NextLevel函数的服务端可用
+            GitHub: DMagical-H
+    NPC Name:       SELF
+    Map(s):         Mushroom Castle investigative trigger
+    Description:    Upon reaching the barrier or castle wall.
 =============================================================
 Version 1.0 - Script Done.(2024-10-23)
 =============================================================
 */
 
 function start() {
-    var MapId = cm.getMapId();
-    if(MapId == 106020300) {    //蘑菇森林深处
-        if (cm.isQuestActive(2314) && cm.getQuestProgressInt(2314) == 0) level2314();
-        else if (cm.haveItem(2430014)) level2430014();
-        else leveldispose();
-    } else if(MapId == 106020500) { //城墙中央
-        if(cm.isQuestActive(2322) && cm.getQuestProgressInt(2322) == 0) level2322();
-        else leveldispose();
+    var mapId = cm.getMapId();
+    if (mapId == 106020300) {
+        if (cm.isQuestActive(2314) && cm.getQuestProgressInt(2314) == 0) {
+            level2314();
+        } else if (cm.haveItem(2430014)) {
+            level2430014();
+        } else {
+            leveldispose();
+        }
+    } else if (mapId == 106020500) {
+        if (cm.isQuestActive(2322) && cm.getQuestProgressInt(2322) == 0) {
+            level2322();
+        } else {
+            leveldispose();
+        }
     } else {
         leveldispose();
     }
 }
 
-function level2314(){
+function level2314() {
     cm.showInfo("Effect/OnUserEff/normalEffect/mushroomcastle/chatBalloon3");
-    cm.sendNextLevel('2314_1','这里...似乎有点奇怪...？！',3);
-}
-function level2314_1(){
-    cm.sendNextLevel('2314_2','嗯...似乎有一种无形的力量在阻止我通过入口。',3);
-}
-function level2314_2(){
-    cm.sendNextLevel('2314_3','显然这不是普通的障碍，否则我不可能过不去，也许...这应该是 #e#b#p1300003##k#n 提到的结界了。',3);
-}
-function level2314_3(){
-    cm.sendOkLevel('dispose','看来还是得先回去跟 #e#b#p1300003##k#n 报告一下了。',3);
-    cm.setQuestProgress(2314,1);
+    cm.sendNextLevel("2314_1", "这里……似乎有些不对劲。", 3);
 }
 
-function level2322(){
-    cm.sendOkLevel('dispose','嗯...城墙爬满了#r长着尖刺得藤蔓#k，确实有点棘手，看来是过不去了。\r\n\r\n还是先回去跟 #e#b#p1300003##k#n 报告一下吧。',3);
-    cm.setQuestProgress(2322,1);
+function level2314_1() {
+    cm.sendNextLevel("2314_2", "我感觉到一股强大的魔力正挡在入口前。", 3);
 }
 
-function level2430014(){
-    cm.sendOkLevel('dispose','在这附近使用#e#b#v2430014##t2430014##n#k应该就能消除魔法结界了吧。',3);
+function level2314_2() {
+    cm.sendNextLevel("2314_3", "这显然不是普通的障碍，应该就是 #b#p1300003##k 提到的结界。", 3);
 }
 
-function leveldispose(){
+function level2314_3() {
+    cm.sendOkLevel("dispose", "先回去把这里的情况报告给 #b#p1300003##k 吧。", 3);
+    cm.setQuestProgress(2314, 1);
+}
+
+function level2322() {
+    cm.sendOkLevel("dispose", "城墙上长满了带刺的藤蔓，看来得先回去向 #b#p1300003##k 报告。", 3);
+    cm.setQuestProgress(2322, 1);
+}
+
+function level2430014() {
+    cm.sendOkLevel("dispose", "也许可以在这附近使用 #b#t2430014##k 来解除魔法结界。", 3);
+}
+
+function leveldispose() {
     cm.dispose();
 }

--- a/gms-server/scripts-zh-CN/npc/1300014.js
+++ b/gms-server/scripts-zh-CN/npc/1300014.js
@@ -12,7 +12,6 @@ Version 1.0 - Script Done.(2024-10-23)
 
 function start() {
     var MapId = cm.getMapId();
-    cm.setQuestProgress(2322,0);
     if(MapId == 106020300) {    //蘑菇森林深处
         if (cm.isQuestActive(2314) && cm.getQuestProgressInt(2314) == 0) level2314();
         else if (cm.haveItem(2430014)) level2430014();

--- a/gms-server/scripts-zh-CN/portal/TD_MC_jump.js
+++ b/gms-server/scripts-zh-CN/portal/TD_MC_jump.js
@@ -1,4 +1,9 @@
 function enter(pi) {
+    if (!pi.isQuestCompleted(2324)) {
+        pi.playerMessage(5, "城墙上仍然长满了荆棘。");
+        return false;
+    }
+
     pi.playPortalSound();
     pi.warp(106020501, 0);
     return true;

--- a/gms-server/scripts-zh-CN/portal/obstacle.js
+++ b/gms-server/scripts-zh-CN/portal/obstacle.js
@@ -1,23 +1,17 @@
 /*
  	Author: GitHub:@Magical-H
- 	Map: Mushroom Castle - Deep Inside Mushroom Forest (106020300)  蘑菇森林深处
- 	Right Portal    右传送点
+ 	Map: Mushroom Castle - Deep Inside Mushroom Forest (106020300)
+ 	Right Portal
  */
 
 function enter(pi) {
-    if (pi.isQuestStarted(100202)) {    //使用过奇拉蘑菇孢子后允许直接通过
+    if (pi.isQuestStarted(100202) || pi.isQuestCompleted(100202)) {
         pi.playPortalSound();
         pi.warp(106020400, 2);
         return true;
-    } else if (pi.hasItem(4000507)) {
-        pi.gainItem(4000507, -1);
-        pi.playPortalSound();
-        pi.warp(106020400, 2);
-        pi.message(`消耗一个 蘑菇的毒孢子 通过了结界。`);
-        return true;
-    } else {
-        pi.showInfo("Effect/OnUserEff/normalEffect/mushroomcastle/chatBalloon1");
-        pi.message("似乎有一个魔力强大的结界阻止你进入。");
     }
+
+    pi.showInfo("Effect/OnUserEff/normalEffect/mushroomcastle/chatBalloon1");
+    pi.message("\u4f3c\u4e4e\u6709\u4e00\u4e2a\u9b54\u529b\u5f3a\u5927\u7684\u7ed3\u754c\u963b\u6b62\u4f60\u8fdb\u5165\u3002");
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/obstacle.js
+++ b/gms-server/scripts-zh-CN/portal/obstacle.js
@@ -12,6 +12,6 @@ function enter(pi) {
     }
 
     pi.showInfo("Effect/OnUserEff/normalEffect/mushroomcastle/chatBalloon1");
-    pi.message("\u4f3c\u4e4e\u6709\u4e00\u4e2a\u9b54\u529b\u5f3a\u5927\u7684\u7ed3\u754c\u963b\u6b62\u4f60\u8fdb\u5165\u3002");
+    pi.message("似乎有一个魔力强大的结界阻止你进入。");
     return false;
 }

--- a/gms-server/scripts-zh-CN/quest/2342.js
+++ b/gms-server/scripts-zh-CN/quest/2342.js
@@ -29,7 +29,7 @@ function start(mode, type, selection) {
                         qm.sendOk("看起来你在与蘑菇大臣战斗时忘记拿起#b#t4001318##k了。给你，这对我们王国非常重要，请尽快把它交给我的父亲。");
                     } else {
                         qm.sendOk("请确保你的其他栏有一个空位");
-                        cm.dispose();
+                        qm.dispose();
                     }
                 } else {
                     qm.forceStartQuest();

--- a/gms-server/scripts/event/MK_PrimeMinister2.js
+++ b/gms-server/scripts/event/MK_PrimeMinister2.js
@@ -126,11 +126,11 @@ function playerExit(eim, player) {
 
 function changedMap(eim, chr, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
-        if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
-            eim.unregisterPlayer(player);
+        if (eim.isEventTeamLackingNow(true, minPlayers, chr)) {
+            eim.unregisterPlayer(chr);
             end(eim);
         } else {
-            eim.unregisterPlayer(player);
+            eim.unregisterPlayer(chr);
         }
     }
 }

--- a/gms-server/scripts/item/killarmush.js
+++ b/gms-server/scripts/item/killarmush.js
@@ -27,12 +27,12 @@ function start(){
             }
             im.removeAll(2430014);
             im.showInfo("Effect/OnUserEff/normalEffect/mushroomcastle/chatBalloon2");
-            im.dropMessage(6,'There seems to be some movement Hmm? The barrier has been eliminated');
+            im.dropMessage(6, 'The Poison Spore reacts with the barrier, causing it to dissipate.');
         } else {
-            im.message('Getting as close as possible to the magic barrier is necessary to eliminate it');
+            im.message('You need to get closer to the magic barrier before using this.');
         }
     } else {
-        im.message('There seems to be no magic barrier that needs to be eliminated here');
+        im.message('There is no magic barrier here that reacts to this item.');
     }
 
     im.dispose();

--- a/gms-server/scripts/npc/1300005.js
+++ b/gms-server/scripts/npc/1300005.js
@@ -1,0 +1,79 @@
+var status = -1;
+var introQuestIds = [2300, 2301, 2302, 2303, 2304, 2305, 2306, 2307, 2308, 2309, 2310];
+
+function start() {
+    status = -1;
+    action(1, 0, 0);
+}
+
+function action(mode, type, selection) {
+    if (mode == -1) {
+        cm.dispose();
+        return;
+    }
+
+    if (mode == 0 && type > 0) {
+        cm.dispose();
+        return;
+    }
+
+    if (mode == 1) {
+        status++;
+    } else {
+        status--;
+    }
+
+    if (status == 0) {
+        if (!hasMushroomIntroCompleted()) {
+            cm.sendOk("Please speak with the Maple Administrator first.");
+            cm.dispose();
+        } else if (!cm.isQuestStarted(2312) && !cm.isQuestCompleted(2312)) {
+            cm.sendAcceptDecline("We need your help, noble explorer. Our kingdom is currently facing a big threat, and we need to test your skills before placing our faith in you. Will you help us?");
+        } else if (cm.isQuestStarted(2312)) {
+            if (!cm.haveItem(4000499, 50)) {
+                cm.sendOk("Please bring me 50 Mutated Spores from the Renegade Spores.");
+                cm.dispose();
+            } else {
+                cm.sendNext("Did you teach those Renegade Spores a lesson?");
+            }
+        } else if (!cm.isQuestStarted(2313) && !cm.isQuestCompleted(2313)) {
+            cm.sendAcceptDecline("I have told our #bMinister of Home Affairs#k of your abilities. Please go pay a visit to him immediately.");
+        } else if (cm.isQuestStarted(2313)) {
+            cm.sendNext("Save our kingdom! We believe in you!");
+        } else {
+            cm.sendOk("Please hurry and meet the Minister of Home Affairs.");
+            cm.dispose();
+        }
+    } else if (status == 1) {
+        if (!cm.isQuestStarted(2312) && !cm.isQuestCompleted(2312)) {
+            cm.startQuest(2312);
+            cm.sendOk("Keep moving forward, and you'll see #bRenegade Spores#k. Please teach them a lesson and bring back #b50 Mutated Spores#k.");
+            cm.dispose();
+        } else if (cm.isQuestStarted(2312)) {
+            cm.completeQuest(2312);
+            cm.gainExp(11500);
+            cm.gainItem(4000499, -50);
+            cm.sendOk("That was amazing. I apologize for doubting your abilities. Please save our Kingdom of Mushroom from this crisis!");
+            cm.dispose();
+        } else if (!cm.isQuestStarted(2313) && !cm.isQuestCompleted(2313)) {
+            cm.startQuest(2313);
+            cm.sendOk("Save our kingdom! We believe in you!");
+            cm.dispose();
+        } else if (cm.isQuestStarted(2313)) {
+            cm.completeQuest(2313);
+            cm.gainExp(4000);
+            cm.dispose();
+        } else {
+            cm.dispose();
+        }
+    }
+}
+
+function hasMushroomIntroCompleted() {
+    for (var i = 0; i < introQuestIds.length; i++) {
+        if (cm.isQuestCompleted(introQuestIds[i])) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/gms-server/scripts/npc/1300014.js
+++ b/gms-server/scripts/npc/1300014.js
@@ -1,3 +1,62 @@
+/*
+===========================================================
+            GitHub: DMagical-H
+    NPC Name:       SELF
+    Map(s):         Mushroom Castle investigative trigger
+    Description:    Upon reaching the barrier or castle wall.
+=============================================================
+Version 1.0 - Script Done.(2024-10-23)
+=============================================================
+*/
+
 function start() {
+    var mapId = cm.getMapId();
+    if (mapId == 106020300) {
+        if (cm.isQuestActive(2314) && cm.getQuestProgressInt(2314) == 0) {
+            level2314();
+        } else if (cm.haveItem(2430014)) {
+            level2430014();
+        } else {
+            leveldispose();
+        }
+    } else if (mapId == 106020500) {
+        if (cm.isQuestActive(2322) && cm.getQuestProgressInt(2322) == 0) {
+            level2322();
+        } else {
+            leveldispose();
+        }
+    } else {
+        leveldispose();
+    }
+}
+
+function level2314() {
+    cm.showInfo("Effect/OnUserEff/normalEffect/mushroomcastle/chatBalloon3");
+    cm.sendNextLevel('2314_1', 'There is something strange here...', 3);
+}
+
+function level2314_1() {
+    cm.sendNextLevel('2314_2', 'Hmm... some sort of invisible force is blocking the entrance.', 3);
+}
+
+function level2314_2() {
+    cm.sendNextLevel('2314_3', 'This is clearly no ordinary obstacle. It must be the barrier #b#p1300003##k mentioned.', 3);
+}
+
+function level2314_3() {
+    cm.sendOkLevel('dispose', 'I should head back and report this to #b#p1300003##k.', 3);
+    cm.setQuestProgress(2314, 1);
+}
+
+function level2322() {
+    cm.sendOkLevel('dispose', 'The castle wall is covered in thorny vines. I should report this to #b#p1300003##k first.', 3);
+    cm.setQuestProgress(2322, 1);
+}
+
+function level2430014() {
+    cm.sendOkLevel('dispose', 'Maybe I can use #b#t2430014##k nearby to clear the magic barrier.', 3);
+}
+
+function leveldispose() {
     cm.dispose();
 }

--- a/gms-server/scripts/portal/TD_MC_jump.js
+++ b/gms-server/scripts/portal/TD_MC_jump.js
@@ -1,4 +1,9 @@
 function enter(pi) {
+    if (!pi.isQuestCompleted(2324)) {
+        pi.playerMessage(5, "The castle wall is still covered in thorns.");
+        return false;
+    }
+
     pi.playPortalSound();
     pi.warp(106020501, 0);
     return true;

--- a/gms-server/scripts/portal/investigate1.js
+++ b/gms-server/scripts/portal/investigate1.js
@@ -1,0 +1,7 @@
+function enter(pi) {
+    if (pi.isQuestActive(2314) || pi.isQuestCompleted(2314)) {
+        pi.openNpc(1300014);
+        return true;
+    }
+    return false;
+}

--- a/gms-server/scripts/portal/investigate2.js
+++ b/gms-server/scripts/portal/investigate2.js
@@ -1,0 +1,7 @@
+function enter(pi) {
+    if (pi.isQuestActive(2322) || pi.isQuestCompleted(2322)) {
+        pi.openNpc(1300014);
+        return true;
+    }
+    return false;
+}

--- a/gms-server/scripts/portal/obstacle.js
+++ b/gms-server/scripts/portal/obstacle.js
@@ -5,19 +5,12 @@
  */
 
 function enter(pi) {
-    if (pi.isQuestStarted(100202)) {
-        pi.playPortalSound();
-        pi.warp(106020400, 2);
-        return true;
-    } else if (pi.hasItem(4000507)) {
-        pi.gainItem(4000507, -1);
-        pi.message("You have used a Poison Spore to pass through the barrier.");
-
+    if (pi.isQuestStarted(100202) || pi.isQuestCompleted(100202)) {
         pi.playPortalSound();
         pi.warp(106020400, 2);
         return true;
     }
 
-    pi.message("The overgrown vines is blocking the way.");
+    pi.message("A powerful magic barrier is blocking the way.");
     return false;
 }

--- a/gms-server/scripts/quest/2314.js
+++ b/gms-server/scripts/quest/2314.js
@@ -24,14 +24,7 @@ function start(mode, type, selection) {
     if (status == 0) {
         qm.sendAcceptDecline("In order to rescue the princess, you must first navigate the Mushroom Forest. King Pepe set up a powerful barrier forbidding anyone from entering the castle. Please investigate this matter for us.");
     } else if (status == 1) {
-        qm.sendNext("You'll run into the barrier at the Mushroom Forest by heading east of where you are standing right now. Please be careful. I hear that the area is infested with crazy, fear-inducing monsters.");
-    } else if (status == 2) {
-        //qm.forceStartQuest();
-        //qm.forceStartQuest(2314,"1");
-        qm.gainExp(8300);
-        qm.sendOk("I see, so it was indeed not a regular barrier by any means. Great work there. If not for you help, we wouldn't have had a clue as to what that was all about.");
-        qm.forceCompleteQuest();
-    } else if (status == 3) {
+        qm.forceStartQuest();
         qm.dispose();
     }
 }
@@ -56,4 +49,3 @@ function end(mode, type, selection) {
         qm.dispose();
     }
 }
-	

--- a/gms-server/scripts/quest/2322.js
+++ b/gms-server/scripts/quest/2322.js
@@ -24,14 +24,7 @@ function start(mode, type, selection) {
     if (status == 0) {
         qm.sendYesNo("Like I told you, just breaking the barrier cannot be a cause for celebration. That's because our castle for the Kingdom of Mushroom completely denies entry of anyone outside our kingdom, so it'll be hard for you to do that. Hmmm... to figure out a way to enter, can you...investigate the outer walls of the castle first?");
     } else if (status == 1) {
-        qm.sendNext("Walk past the Mushroom Forest and when you reach the #bSplit Road of Choice#k, just walk towards the castle. Good luck.");
-    } else if (status == 2) {
-        //qm.forceStartQuest();
-        //qm.forceStartQuest(2322, "1");
-        qm.gainExp(11000);
-        qm.sendOk("Good job navigating through the area.");
-        qm.forceCompleteQuest();
-    } else if (status == 3) {
+        qm.forceStartQuest();
         qm.dispose();
     }
 }
@@ -56,4 +49,3 @@ function end(mode, type, selection) {
         qm.dispose();
     }
 }
-	

--- a/gms-server/src/main/java/org/gms/util/PacketCreator.java
+++ b/gms-server/src/main/java/org/gms/util/PacketCreator.java
@@ -57,6 +57,7 @@ import org.gms.constants.id.ItemId;
 import org.gms.constants.id.MapId;
 import org.gms.constants.id.NpcId;
 import org.gms.constants.inventory.ItemConstants;
+import org.gms.constants.string.CharsetConstants;
 import org.gms.constants.skills.Buccaneer;
 import org.gms.constants.skills.Corsair;
 import org.gms.constants.skills.ThunderBreaker;
@@ -7437,7 +7438,13 @@ public class PacketCreator {
         scriptableNpcIds.forEach((id, name) -> {
             p.writeInt(id);
             // The client needs a name for the npc conversation, which is displayed under etc when the npc has a quest available.
-            p.writeString(name);
+            if (CharsetConstants.isZhCN()) {
+                byte[] bytes = name.getBytes(CharsetConstants.getCharset(3));
+                p.writeShort(bytes.length);
+                p.writeBytes(bytes);
+            } else {
+                p.writeString(name);
+            }
             p.writeInt(0); // start time
             p.writeInt(Integer.MAX_VALUE); // end time
         });

--- a/gms-server/src/main/resources/db/migration/V1.11.6__sync_mushroom_castle_npc_label.sql
+++ b/gms-server/src/main/resources/db/migration/V1.11.6__sync_mushroom_castle_npc_label.sql
@@ -1,8 +1,0 @@
-UPDATE game_config
-SET config_value = CASE
-    WHEN config_value REGEXP '1300005:"[^"]*"' THEN REGEXP_REPLACE(config_value, '1300005:"[^"]*"', '1300005:"蘑菇王国"')
-    WHEN TRIM(config_value) = '{}' THEN '{9001105:"Rescue Gaga!",1300005:"蘑菇王国"}'
-    WHEN RIGHT(TRIM(config_value), 1) = '}' THEN CONCAT(LEFT(TRIM(config_value), LENGTH(TRIM(config_value)) - 1), ',1300005:"蘑菇王国"}')
-    ELSE '{9001105:"Rescue Gaga!",1300005:"蘑菇王国"}'
-END
-WHERE config_code = 'npcs_scriptable';

--- a/gms-server/src/main/resources/db/migration/V1.11.6__sync_mushroom_castle_npc_label.sql
+++ b/gms-server/src/main/resources/db/migration/V1.11.6__sync_mushroom_castle_npc_label.sql
@@ -1,0 +1,8 @@
+UPDATE game_config
+SET config_value = CASE
+    WHEN config_value REGEXP '1300005:"[^"]*"' THEN REGEXP_REPLACE(config_value, '1300005:"[^"]*"', '1300005:"蘑菇王国"')
+    WHEN TRIM(config_value) = '{}' THEN '{9001105:"Rescue Gaga!",1300005:"蘑菇王国"}'
+    WHEN RIGHT(TRIM(config_value), 1) = '}' THEN CONCAT(LEFT(TRIM(config_value), LENGTH(TRIM(config_value)) - 1), ',1300005:"蘑菇王国"}')
+    ELSE '{9001105:"Rescue Gaga!",1300005:"蘑菇王国"}'
+END
+WHERE config_code = 'npcs_scriptable';

--- a/gms-server/src/main/resources/db/migration/V1.8.7__update_game_config_npcs_scriptable.sql
+++ b/gms-server/src/main/resources/db/migration/V1.8.7__update_game_config_npcs_scriptable.sql
@@ -1,0 +1,8 @@
+UPDATE game_config
+SET config_value = CASE
+    WHEN config_value LIKE '%1300005%' THEN config_value
+    WHEN TRIM(config_value) = '{}' THEN '{9001105:"Rescue Gaga!",1300005:"The Test"}'
+    WHEN RIGHT(TRIM(config_value), 1) = '}' THEN CONCAT(LEFT(TRIM(config_value), LENGTH(TRIM(config_value)) - 1), ',1300005:"The Test"}')
+    ELSE '{9001105:"Rescue Gaga!",1300005:"The Test"}'
+END
+WHERE config_code = 'npcs_scriptable';

--- a/gms-server/src/main/resources/db/migration/V1.8.7__update_game_config_npcs_scriptable.sql
+++ b/gms-server/src/main/resources/db/migration/V1.8.7__update_game_config_npcs_scriptable.sql
@@ -1,8 +1,8 @@
 UPDATE game_config
 SET config_value = CASE
     WHEN config_value LIKE '%1300005%' THEN config_value
-    WHEN TRIM(config_value) = '{}' THEN '{9001105:"Rescue Gaga!",1300005:"The Test"}'
-    WHEN RIGHT(TRIM(config_value), 1) = '}' THEN CONCAT(LEFT(TRIM(config_value), LENGTH(TRIM(config_value)) - 1), ',1300005:"The Test"}')
-    ELSE '{9001105:"Rescue Gaga!",1300005:"The Test"}'
+    WHEN TRIM(config_value) = '{}' THEN '{9001105:"Rescue Gaga!",1300005:"蘑菇王国"}'
+    WHEN RIGHT(TRIM(config_value), 1) = '}' THEN CONCAT(LEFT(TRIM(config_value), LENGTH(TRIM(config_value)) - 1), ',1300005:"蘑菇王国"}')
+    ELSE '{9001105:"Rescue Gaga!",1300005:"蘑菇王国"}'
 END
 WHERE config_code = 'npcs_scriptable';

--- a/gms-server/src/main/resources/db/migration/V1.8.8__update_mushroom_castle_npc_label.sql
+++ b/gms-server/src/main/resources/db/migration/V1.8.8__update_mushroom_castle_npc_label.sql
@@ -1,0 +1,4 @@
+UPDATE game_config
+SET config_value = REPLACE(config_value, '1300005:"The Test"', '1300005:"蘑菇王国"')
+WHERE config_code = 'npcs_scriptable'
+  AND config_value LIKE '%1300005:"The Test"%';

--- a/gms-server/src/main/resources/db/migration/V1.8.8__update_mushroom_castle_npc_label.sql
+++ b/gms-server/src/main/resources/db/migration/V1.8.8__update_mushroom_castle_npc_label.sql
@@ -1,4 +1,0 @@
-UPDATE game_config
-SET config_value = REPLACE(config_value, '1300005:"The Test"', '1300005:"蘑菇王国"')
-WHERE config_code = 'npcs_scriptable'
-  AND config_value LIKE '%1300005:"The Test"%';

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -6853,7 +6853,7 @@
         <string name="1" value="为了证明自己可以成为拯救蘑菇王国的英雄，搜集#b50个#t4000499##k，交给#p1300005#。"/>
         <string name="2" value="证明了自己可以成为拯救蘑菇王国的英雄。"/>
         <string name="summary" value="消灭得意的蘑菇仔，搜集#b50个变种孢子#k，交给#p1300005#。"/>
-        <string name="rewardSummary" value="经验值11,500"/>
+        <string name="rewardSummary" value="经验值11,500&#xD;&#xA;可进行“事件的内幕”"/>
         <string name="demandSummary" value="#i4000499:# #t4000499:# #c4000499# / 50"/>
     </imgdir>
     <imgdir name="2313">
@@ -6864,7 +6864,7 @@
         <string name="1" value="去见见蘑菇王国的内务大臣。"/>
         <string name="2" value="从蘑菇王国的内务大臣那里了解了事件的概要。"/>
         <string name="summary" value="去见见蘑菇王国的#b内务大臣#k。"/>
-        <string name="rewardSummary" value="经验值4,000"/>
+        <string name="rewardSummary" value="经验值4,000&#xD;&#xA;可进行“探索蘑菇森林(1)”"/>
     </imgdir>
     <imgdir name="2314">
         <string name="name" value="探索蘑菇森林(1)"/>


### PR DESCRIPTION
改动内容
- 修复蘑菇城任务链中警卫队长 1300005 无法稳定重新接取起始任务的问题，补齐脚本化 NPC 注册，并同步调整中英文脚本目录中的相关流程。
- 修复蘑菇森林结界与城墙调查流程，限制未完成正确步骤时不能提前穿过结界或绕过城墙调查，并修正相关传送与任务推进条件。
- 修复城墙荆棘阶段中蘑菇的毒孢子、尖刺清除剂的提示文案与交互反馈，使其与真实任务步骤一致。
- 修复警卫队长 1300005 脚本化任务提示名称的中文编码问题，避免对话选项中显示为 ???。
- 修复第一个结界调查触发脚本的中文乱码，将角色自言自语改为正常中文提示。
- 调整 Quest.wz 中 2312、2313 任务奖励摘要，补充后续可接任务提示，帮助玩家理解任务链推进。
- 原本有 BUG 的流程：玩家可能在未正确调查结界或城墙前就提前推进，放弃起始任务后也可能无法重新接取，警卫队长的脚本化提示还会显示异常文本或 ???。
- 修改后的流程：先完成勇士考试并与内务大臣对话，调查蘑菇森林结界后使用蘑菇的毒孢子解除结界，再调查城墙、收集材料制作尖刺清除剂、在城墙附近消除荆棘后进入城内，随后由警卫队长继续发放进城后的后续任务。

影响范围
- 同时影响服务端与客户端显示。
- 服务端涉及任务脚本、NPC 脚本、传送门脚本、道具脚本、脚本化 NPC 提示发包以及任务配置迁移。
- 客户端显示涉及 Quest.wz 的任务摘要文本，因此需要同步客户端资源包。

验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查。
- 已执行中文乱码检查，并修复发现的任务脚本乱码与脚本化 NPC 名称编码问题。
- 已完成分支 diff 与提交范围检查，确认当前 diff 仅包含蘑菇城任务链相关修复。
- 已完成本地服务启动校验，确认 WZ 加载、频道端口与登录端口均可正常启动。

客户端资源
- 本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。
