### PR TITLE
Update MapleMap.java

### DIFF
--- a/gms-server/src/main/java/org/gms/server/maps/MapleMap.java
+++ b/gms-server/src/main/java/org/gms/server/maps/MapleMap.java
@@ -693,7 +693,7 @@ public class MapleMap {
                     if (ItemConstants.getInventoryType(de.itemId) == InventoryType.EQUIP) {
                         idrop = ii.randomizeStats((Equip) ii.getEquipById(de.itemId));
                     } else {
-                        idrop = new Item(de.itemId, (short) 0, (short) (de.Maximum != 1 ? Randomizer.nextInt(de.Maximum - de.Minimum) + de.Minimum : 1));
+                        idrop = new Item(de.itemId, (short) 0, (short) ((de.Maximum != 1 && de.Maximum > de.Minimum)? Randomizer.nextInt(de.Maximum - de.Minimum) + de.Minimum : de.Maximum));
                     }
                     spawnDrop(idrop, calcDropPos(pos, mob.getPosition()), mob, chr, droptype, de.questid);
                 }


### PR DESCRIPTION
修复一个潜在的bug，该bug导致怪物物品爆率最多和最少大于1且相等时，服务器报错。