### PR TITLE
fix(quest): 补充任务 8541 奖励物品 2022141（镇魂包子）的定义

### DIFF
--- a/gms-server/wz-zh-CN/String.wz/Consume.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Consume.img.xml
@@ -848,6 +848,10 @@
         <string name="name" value="桔梗浓缩液"/>
         <string name="desc" value="桔梗精的浓缩液体\nHP和MP各恢复200"/>
     </imgdir>
+    <imgdir name="2022141">
+        <string name="name" value="镇魂包子"/>
+        <string name="desc" value="以四圣兽之灵镇守魂魄的超级中华美味，吃一个HP、MP全恢复并且异常状态全消除"/>
+    </imgdir>
     <imgdir name="2022142">
         <string name="name" value="熊掌汤"/>
         <string name="desc" value="用熊掌为材料做的韩药，喝了之\n后会神清气爽，15分钟之内命中\n率增加10"/>

--- a/gms-server/wz/Item.wz/Consume/0202.img.xml
+++ b/gms-server/wz/Item.wz/Consume/0202.img.xml
@@ -2289,6 +2289,28 @@
       <int name="hp" value="200"/>
     </imgdir>
   </imgdir>
+  <imgdir name="02022141">
+    <imgdir name="info">
+      <canvas name="icon" width="31" height="28">
+        <vector name="origin" x="0" y="31"/>
+      </canvas>
+      <canvas name="iconRaw" width="31" height="24">
+        <vector name="origin" x="0" y="31"/>
+      </canvas>
+      <int name="price" value="300"/>
+      <int name="tradeBlock" value="1"/>
+      <int name="slotMax" value="3000"/>
+    </imgdir>
+    <imgdir name="spec">
+      <int name="hpR" value="100"/>
+      <int name="mpR" value="100"/>
+      <int name="poison" value="1"/>
+      <int name="seal" value="1"/>
+      <int name="darkness" value="1"/>
+      <int name="weakness" value="1"/>
+      <int name="curse" value="1"/>
+    </imgdir>
+  </imgdir>
   <imgdir name="02022142">
     <imgdir name="info">
       <canvas name="icon" width="31" height="31">

--- a/gms-server/wz/String.wz/Consume.img.xml
+++ b/gms-server/wz/String.wz/Consume.img.xml
@@ -848,6 +848,10 @@
         <string name="name" value="Bellflower Concentrate"/>
         <string name="desc" value="A Bellflower concentrate. Recovers both HP and MP by 200."/>
     </imgdir>
+    <imgdir name="2022141">
+        <string name="name" value="Soul-Steaming Bun"/>
+        <string name="desc" value="A super Chinese delicacy blessed by the four guardians. Recovers HP and MP completely and cures all abnormal statuses."/>
+    </imgdir>
     <imgdir name="2022142">
         <string name="name" value="Mind &amp; Heart Medicine"/>
         <string name="desc" value="A hot, soup-like medicine made out of bear paws. Drinking this will revitalize the brain to the tune of Accuracy +10 for 15 minutes."/>


### PR DESCRIPTION
﻿# 问题

任务 8541（佛珠2）提交时 V83 客户端闪退。

## 根因

任务奖励物品 2022141 在 Item.wz 和 String.wz 中均无定义，ItemInformationProvider.getSlotMax() 返回 0 导致 addById 失败，但 getShowItemGain 仍发送给客户端，客户端因查不到该物品崩溃。

## 修复

1. wz/Item.wz/Consume/0202.img.xml -- 新增物品 2022141（镇魂包子），slotMax=3000，hpR=100，mpR=100，全异常状态解除
2. wz/String.wz/Consume.img.xml -- 英文名 Soul-Steaming Bun
3. wz-zh-CN/String.wz/Consume.img.xml -- 中文名 镇魂包子

## 完整分析报告

详见 doc/quest8541_crash_report.md
