### PR TITLE
fix(memory-leak): 修复 EventLoopGroup 线程泄漏及定时任务异常保护

### DIFF
--- a/gms-server/src/main/java/org/gms/net/netty/ChannelServer.java
+++ b/gms-server/src/main/java/org/gms/net/netty/ChannelServer.java
@@ -10,6 +10,8 @@ public class ChannelServer extends AbstractServer {
     private final int world;
     private final int channel;
     private Channel nettyChannel;
+    private EventLoopGroup parentGroup;
+    private EventLoopGroup childGroup;
 
     public ChannelServer(int port, int world, int channel) {
         super(port);
@@ -19,8 +21,8 @@ public class ChannelServer extends AbstractServer {
 
     @Override
     public void start() {
-        EventLoopGroup parentGroup = new NioEventLoopGroup();
-        EventLoopGroup childGroup = new NioEventLoopGroup();
+        parentGroup = new NioEventLoopGroup();
+        childGroup = new NioEventLoopGroup();
         ServerBootstrap bootstrap = new ServerBootstrap()
                 .group(parentGroup, childGroup)
                 .channel(NioServerSocketChannel.class)
@@ -36,5 +38,7 @@ public class ChannelServer extends AbstractServer {
         }
 
         nettyChannel.close().syncUninterruptibly();
+        parentGroup.shutdownGracefully();
+        childGroup.shutdownGracefully();
     }
 }

--- a/gms-server/src/main/java/org/gms/net/netty/ChannelServerInitializer.java
+++ b/gms-server/src/main/java/org/gms/net/netty/ChannelServerInitializer.java
@@ -32,6 +32,7 @@ public class ChannelServerInitializer extends ServerChannelInitializer {
         if (!RateLimitUtil.getInstance().check(remoteAddress)) {
             log.warn(I18nUtil.getLogMessage("LoginServerInitializer.initChannel.warn1"), remoteAddress);
             socketChannel.close();
+            return;
         }
         final Client client = Client.createChannelClient(clientSessionId, remoteAddress, packetProcessor, world, channel);
 

--- a/gms-server/src/main/java/org/gms/net/netty/LoginServer.java
+++ b/gms-server/src/main/java/org/gms/net/netty/LoginServer.java
@@ -10,6 +10,8 @@ public class LoginServer extends AbstractServer {
     public static final int WORLD_ID = -1;
     public static final int CHANNEL_ID = -1;
     private Channel channel;
+    private EventLoopGroup parentGroup;
+    private EventLoopGroup childGroup;
 
     public LoginServer(int port) {
         super(port);
@@ -17,8 +19,8 @@ public class LoginServer extends AbstractServer {
 
     @Override
     public void start() {
-        EventLoopGroup parentGroup = new NioEventLoopGroup();
-        EventLoopGroup childGroup = new NioEventLoopGroup();
+        parentGroup = new NioEventLoopGroup();
+        childGroup = new NioEventLoopGroup();
         ServerBootstrap bootstrap = new ServerBootstrap()
                 .group(parentGroup, childGroup)
                 .channel(NioServerSocketChannel.class)
@@ -34,5 +36,7 @@ public class LoginServer extends AbstractServer {
         }
 
         channel.close().syncUninterruptibly();
+        parentGroup.shutdownGracefully();
+        childGroup.shutdownGracefully();
     }
 }

--- a/gms-server/src/main/java/org/gms/net/netty/LoginServerInitializer.java
+++ b/gms-server/src/main/java/org/gms/net/netty/LoginServerInitializer.java
@@ -23,6 +23,7 @@ public class LoginServerInitializer extends ServerChannelInitializer {
         if (!RateLimitUtil.getInstance().check(remoteAddress)) {
             log.warn(I18nUtil.getLogMessage("LoginServerInitializer.initChannel.warn1"), remoteAddress);
             socketChannel.close();
+            return;
         }
         final Client client = Client.createLoginClient(clientSessionId, remoteAddress, packetProcessor, LoginServer.WORLD_ID, LoginServer.CHANNEL_ID);
 

--- a/gms-server/src/main/java/org/gms/scripting/event/scheduler/EventScriptScheduler.java
+++ b/gms-server/src/main/java/org/gms/scripting/event/scheduler/EventScriptScheduler.java
@@ -23,6 +23,8 @@ import org.gms.config.GameConfig;
 import org.gms.net.server.Server;
 import org.gms.server.ThreadManager;
 import org.gms.server.TimerManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -37,6 +39,8 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author Ronan
  */
 public class EventScriptScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(EventScriptScheduler.class);
 
     private boolean disposed = false;
     private int idleProcs = 0;
@@ -76,7 +80,11 @@ public class EventScriptScheduler {
             if (rmd.getValue() < timeNow) {
                 Runnable r = rmd.getKey();
 
-                r.run();  // runs the scheduled action
+                try {
+                    r.run();  // runs the scheduled action
+                } catch (Exception e) {
+                    log.error("Exception occurred while running scheduled event task", e);
+                }
                 toRemove.add(r);
             }
         }


### PR DESCRIPTION
## 变更内容

### 1. EventLoopGroup 泄漏修复（ChannelServer/LoginServer）
- parentGroup/childGroup 从局部变量改为实例字段
- stop() 中增加 shutdownGracefully()，确保服务关闭时 Netty 线程组被正确回收

### 2. 速率限制后立即返回（ChannelServerInitializer/LoginServerInitializer）
- socketChannel.close() 后加 return，避免在已关闭连接上继续创建 Client 和 pipeline，防止资源泄漏

### 3. 定时任务异常保护（EventScriptScheduler）
- r.run() 包裹 try-catch，防止单个任务抛未捕获异常导致调度器线程崩溃