### PR TITLE
fix: 1052014 GraalJS -1*0 类型错误导致兑奖中断

### DIFF
--- a/gms-server/scripts-zh-CN/npc/1052014.js
+++ b/gms-server/scripts-zh-CN/npc/1052014.js
@@ -247,12 +247,13 @@ function givePrize() {
                 cm.gainItem(4001009 + i, -1 * tickets[i]);
             }
         }
-        if(hasCoin){
+        if(coins > 0){
             cm.gainItem(coinId, -1 * coins);
         }
 
-
         cm.gainItem(lvTarget[rnd], lvQty[rnd]);
+
+        cm.sendOk("恭喜！你获得了 #b#t" + lvTarget[rnd] + "##k x" + lvQty[rnd] + "！");
     }
 }
 

--- a/gms-server/scripts/npc/1052014.js
+++ b/gms-server/scripts/npc/1052014.js
@@ -243,11 +243,17 @@ function givePrize() {
         var rnd = Math.floor(Math.random() * lvTarget.length);
 
         for (var i = 0; i < tickets.length; i++) {
-            cm.gainItem(4001009 + i, -1 * tickets[i]);
+            if(tickets[i]&&tickets[i]>0){
+                cm.gainItem(4001009 + i, -1 * tickets[i]);
+            }
         }
-        cm.gainItem(coinId, -1 * coins);
+        if(coins > 0) {
+            cm.gainItem(coinId, -1 * coins);
+        }
 
         cm.gainItem(lvTarget[rnd], lvQty[rnd]);
+        
+        cm.sendOk("Congratulations! You received #b#t" + lvTarget[rnd] + "##k x" + lvQty[rnd] + "!");
     }
 }
 


### PR DESCRIPTION
废都橡皮擦兑换功能bug
## 根因

原版 HeavenMS 使用 Nashorn 引擎， 被转为 Integer `0`，调用 `gainItem(int, short)` 正常。BeiDou 改用 GraalJS 后 `-1 * 0` 保留为 Double `-0.0`，Java 找不到 `gainItem(int, double)` 重载，抛出 `ScriptException` 中断 `givePrize()` 流程。

结果：橡皮擦已扣除但奖励物品未发放。

## 改动

1. **橡皮擦扣减循环**：仅 `tickets[i] > 0` 时才调用 `gainItem`，避免 `-1 * 0` 类型错误（英文版新增，中文版已有守卫）
2. **硬币扣减**：从 `hasCoin`（包里有羽毛）改为 `coins > 0`（实际提交了才扣），防止 `coins=0` 时误执行
3. **兑奖成功后弹窗**显示具体获得的物品名和数量，避免玩家以为没给奖励