### PR TITLE
fix: 修复中文 NPC、任务与书本道具文本问题

### DIFF
--- a/gms-server/scripts-zh-CN/npc/1092000.js
+++ b/gms-server/scripts-zh-CN/npc/1092000.js
@@ -29,7 +29,17 @@ function start() {
 }
 
 function action(mode, type, selection) {
-    if (mode == -1 || !cm.isQuestStarted(2180)) {
+    if (mode == -1) {
+        cm.dispose();
+        return;
+    }
+
+    if (!cm.isQuestStarted(2180)) {
+        if (cm.isQuestCompleted(2180)) {
+            cm.sendOk("牛奶已经顺利送到了。多亏了你，厨房又能继续准备料理了。以后有需要的话，我还会再请你帮忙。");
+        } else {
+            cm.sendOk("欢迎来到诺特勒斯号餐厅。我正在准备料理，如果有需要帮忙的事情，会再来找你的。");
+        }
         cm.dispose();
 
     } else {

--- a/gms-server/scripts-zh-CN/npc/1092091.js
+++ b/gms-server/scripts-zh-CN/npc/1092091.js
@@ -34,7 +34,7 @@ function start() {
 
         cm.setQuestProgress(2180, 1, 2);
     } else if (cm.canHold(4031849) && cm.haveItem(4031848)) {
-        cm.sendNext("现在用牛奶把瓶子装满。瓶子现在装了2/3 的牛奶。");
+        cm.sendNext("现在用牛奶把瓶子装满。瓶子现在装了三分之二的牛奶。");
         cm.gainItem(4031848, -1);
         cm.gainItem(4031849, 1);
 

--- a/gms-server/scripts-zh-CN/npc/1092094.js
+++ b/gms-server/scripts-zh-CN/npc/1092094.js
@@ -48,7 +48,7 @@ function action(mode, type, selection) {
         status++;
     }
     if (status == 0) {
-        cm.sendPrev("The hungry calf isn't interested in the empty bottle.");
+        cm.sendPrev("饥饿的小牛对空瓶子没有兴趣。");
     } else if (status == 1) {
         cm.dispose();
     }

--- a/gms-server/scripts-zh-CN/npc/9201018.js
+++ b/gms-server/scripts-zh-CN/npc/9201018.js
@@ -66,7 +66,7 @@ function action(mode, type, selection) {
                         pushIfItemExists(facenew, fface_v[i] + cm.getPlayer().getFace() % 1000 - (cm.getPlayer().getFace() % 100));
                     }
                 }
-                cm.sendStyle("Let's see... I can totally transform your face into something new. Don't you want to try it? For #b#t5152022##k, you can get the face of your liking. Take your time in choosing the face of your preference.", facenew);
+                cm.sendStyle("让我看看……我可以帮你换成全新的面容。使用#b#t5152022##k，就能选择你喜欢的脸型。慢慢挑，选一个最适合你的吧。", facenew);
             }
         } else if (status == 2) {
             if (cm.haveItem(5152022) == true) {

--- a/gms-server/scripts-zh-CN/portal/outPerrion_1.js
+++ b/gms-server/scripts-zh-CN/portal/outPerrion_1.js
@@ -1,5 +1,5 @@
 function enter(pi) {
-    pi.message("你发现了通往地下神殿入口的捷径");
+    pi.message("你发现了返回通往地下之路的捷径。");
     pi.playPortalSound();
     pi.warp(105100000, 2);
     return true;

--- a/gms-server/scripts-zh-CN/quest/3452.js
+++ b/gms-server/scripts-zh-CN/quest/3452.js
@@ -6,7 +6,7 @@ function end(mode, type, selection) {
         qm.dispose();
     } else {
         if (status == 0) {
-            qm.sendNext("接受这些 #b法力灵丹#k 作为我的感激之情。");
+            qm.sendNext("请收下这些#b魔力药水#k，就当作我的一点谢礼。");
         } else if (status == 1) {
             const InventoryType = Java.type('org.gms.client.inventory.InventoryType');
             if (qm.getPlayer().getInventory(InventoryType.USE).getNumFreeSlot() >= 1) {

--- a/gms-server/scripts-zh-CN/quest/3454.js
+++ b/gms-server/scripts-zh-CN/quest/3454.js
@@ -64,7 +64,7 @@ function end(mode, type, selection) {
                 qm.gainItem(4031927, 1);
             }
 
-            qm.sendOk("现在，去见灰色外星人，使用这个卧底装备来阅读他们的计划。如果失败，我们将需要重新收集一些材料.");
+            qm.sendOk("现在去接近灰色外星人，使用这个翻译器读取他们的计划。如果翻译失败，我们就得重新收集材料。");
             qm.forceCompleteQuest();
         } else if (status == 1) {
             qm.dispose();

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -3144,7 +3144,7 @@
         <int name="order" value="3"/>
     </imgdir>
     <imgdir name="2017">
-        <string name="name" value="艾温的玻璃鞋"/>
+        <string name="name" value="（重复）艾温的玻璃鞋"/>
         <null name="parent"/>
         <string name="0" value="听说魔法密林的艾温丢了什么。。。"/>
         <string name="1" value="魔法密林叫艾温的妖精告诉我，她几天前去勇士部落的路上受到了全身都是火焰的怪物的攻击。那怪物抢走了她贵重的#b玻璃鞋#k。妖精族非常喜欢那样闪闪发光的东西，所以她很想找回来。在勇士部落打怪物的话，说不定可以找回艾温的玻璃鞋。"/>
@@ -8962,7 +8962,7 @@
     <imgdir name="28282">
         <string name="name" value="如何躲避恶臭"/>
         <string name="0" value="#b林中之城#k的#b#@1061011:##k说，他已经得到了有关地狱大公的最新情报。"/>
-        <string name="1" value="他已经找到了#r地狱大公#k所在的位置，但是那里充满了强烈刺鼻的恶臭，普通人根本无法靠近。只要你搜集到下列材料，他就可以帮你制作一个防毒面具。\n\n30张#r野猪皮#k、30个#r火独眼兽的眼睛#k、30个#r道符#k\n\n搜集完成后，回到#b林中之城#k向#b#@1061011:##k报告。"/>
+        <string name="1" value="他已经找到了#r地狱大公#k所在的位置，但是那里充满了强烈刺鼻的恶臭，普通人根本无法靠近。只要你搜集到下列材料，他就可以帮你制作一个防毒面具。\n\n30张#r野猪皮#k、30个#r邪恶之眼的眼球#k、30个#r道符#k\n\n搜集完成后，回到#b林中之城#k向#b#@1061011:##k报告。"/>
         <string name="2" value="#r狂野之眼的防毒面具#k已经做好了。虽然面具本身也有点味道，但如果前方恶臭难以忍受，它应该能帮你顺利通过。"/>
         <int name="area" value="30"/>
         <string name="demandSummary" value="#i4001372:# #t4001372:# #c4001372# / 30 #i4000008:# #t4000008:# #c4000008# / 30 #i4001373:# #t4001373:# #c4001373# / 30 "/>
@@ -15500,27 +15500,27 @@
         <string name="name" value="苏白尼的遗物 - 发现"/>
         <string name="parent" value="苏白尼的遗物 "/>
         <int name="order" value="1"/>
-        <string name="0" value="我听说在大笨钟底下的内部齿轮装置上有一个探险家。哪里隐藏了什么奥秘之处呢？我得查清楚！"/>
-        <string name="1" value="我和世界知名的寻宝公司的强 贝瑞加德交谈过。跟他谈到了苏白尼，传说中负责整个枫之世界黑暗卷轴的巫师。他相信在内部齿轮装置内有某些东西可能是他的宝藏。我答应帮助清除道路。我必须要击败#b50 只杀人虎头蜂、30朵巨灵食人花和40 头火焰象#k，我就能更深入内部齿轮装置探险…"/>
-        <string name="2" value="我清出了一条直接通向内部齿轮装置的路，现在可以在哪里安静地探险。当我准备好的时候，就可以见到强 贝瑞加德继续这次冒险的下一个阶段！ "/>
+        <string name="0" value="听说大笨钟下方的内部齿轮装置里有一位探险家。那里似乎藏着什么秘密，我得去查清楚。"/>
+        <string name="1" value="我见到了闻名世界的寻宝人约翰·贝瑞加德。他提到传说中的巫师苏白尼，以及散落在枫之世界各地的黑暗卷轴。他认为内部齿轮装置里可能藏着苏白尼的遗物。为了继续深入调查，我答应帮他清出道路，需要击败#b50只杀人虎头蜂、30朵巨灵食人花和40头火焰象#k。"/>
+        <string name="2" value="我已经清出通往内部齿轮装置深处的道路。等准备好了，就去找约翰·贝瑞加德，继续下一阶段的冒险。"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="4914">
         <string name="name" value="苏白尼的遗物  - 侵入"/>
         <string name="parent" value="苏白尼的遗物 "/>
         <int name="order" value="2"/>
-        <string name="0" value="强 贝瑞加德正在等我！他已经有所发现了！"/>
-        <string name="1" value="我和强交谈过，他在内部齿轮装置中发现了一组他无法破解的神秘符文。他提到需要名为#b翻译水晶#k的特殊水晶。我答应捉 #b50#k 个给他用来破解符文。电击象…强认为牠们头上的机制内可能有翻译水晶。"/>
-        <string name="2" value="我拿到了 #b50个强所需要的翻译水晶#k，他正在努力破解那些符文。我必须快点回来看看他是否已经完成！"/>
+        <string name="0" value="约翰·贝瑞加德正在等我！他似乎有了新的发现。"/>
+        <string name="1" value="我和约翰·贝瑞加德谈过了。他在内部齿轮装置中发现了一组无法解读的神秘符文，需要一种叫做#b翻译水晶#k的特殊水晶来破解。强认为电击象头部的机械装置里可能藏有这种水晶，我答应帮他收集#b50个翻译水晶#k。"/>
+        <string name="2" value="我已经拿到约翰·贝瑞加德需要的#b50个翻译水晶#k。他正在尝试破解那些符文，我得尽快回去看看结果。"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="4915">
         <string name="name" value="苏白尼的遗物  - 释出"/>
         <string name="parent" value="苏白尼的遗物  "/>
         <int name="order" value="3"/>
-        <string name="0" value="强已经完成译码这些符文了！我现在必须回到他那边！"/>
-        <string name="1" value="强和我再度交谈，并且有意外事件发生。我将必须去搜寻内部齿轮装置地图片让他能汇集成地图！他提到了那些他「借来」帮忙的机器人发疯了，不停地说「#b我是机器人#k」 因为它们匆匆走入了克兰卡丛林... 最好小心 - 我可不想被吓到！"/>
-        <string name="2" value="终于完成了！我把这些碎片带回去给强，他开始拼成地图。不过，他的确偶然看到了一个奇怪的戒指，转交给我。 如果这是第一个宝物，我想知道其余的在哪里..."/>
+        <string name="0" value="约翰·贝瑞加德已经破解了那些符文！我得立刻回去找他。"/>
+        <string name="1" value="我再次见到约翰·贝瑞加德时，事情出现了意外。他需要我找回内部齿轮装置的地图碎片，才能拼出完整地图。他还提到，那些被他“借来”帮忙的机器人突然失控，嘴里不停喊着「#b我是机器人#k」，然后冲进了克兰卡丛林。最好小心一点，我可不想被它们吓到。"/>
+        <string name="2" value="终于完成了！我把地图碎片带回去交给约翰·贝瑞加德，他开始拼合地图。与此同时，他发现了一枚奇怪的戒指，并把它交给了我。如果这就是第一件宝物，那其他宝物又会藏在哪里呢……"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="4916">
@@ -15582,21 +15582,21 @@
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="4924">
-        <string name="name" value="Brand Materia"/>
-        <string name="parent" value="Brand Materia"/>
+        <string name="name" value="品牌魔石"/>
+        <string name="parent" value="品牌魔石"/>
         <int name="order" value="1"/>
-        <string name="0" value="Looks like the Glimmer Man is looking for a rare material from the alternate dimension of Versal, the very #b#t4031760##k that I now possess.  Perhaps I should visit him in New Leaf City and see what he wants with it.  Maybe he&apos;ll reward me for bringing him some..."/>
-        <string name="1" value="I visited the Glimmer Man, and discovered that he&apos;s an ultra-powerful mage whose ability to turn his entire body into pure diamond (hence his name) has allowed him to journey to space and other inhospitable environments.  Through the vast knowledge he&apos;s acquired during his explorations, he&apos;s also become somewhat of a renowned weapons creator and arms dealer.\r\nThe Glimmer Man has landed in Masteria looking for something called #b#t4031760##k, a rare element from the alternate dimension of Versal he&apos;s been dying to experiment with.  To thank me for recovering some and bringing it to him, he&apos;s promised to make me a weapon of my own from it. However, I&apos;ve got to also track down #b7 #t4021008#s#k and return these to him as well.  Only then can he reduce the naturally unstable Materia down to a useable form.  A weapon made from an otherwordly material! I wonder what it does..."/>
-        <string name="2" value="I returned to the Glimmer Man and he synthesized the #b#t4031760##k and the #b7 #t4021008#s#k I gave him to form a Materia Orb.  He&apos;s said his precocious friend Spindle can turn this into a weapon, so I should see him when I&apos;m ready to make the weapon...WOOT!  Spindle is currently residing in the Omega Sector.  Additionally, anytime I find more White Versal Materia, I can bring it to the Glimmer Man and he&apos;ll create another Materia Orb for me so I can make another weapon!"/>
+        <string name="0" value="微光人似乎正在寻找来自异界维萨尔的稀有材料，也就是我手上的#b#t4031760##k。也许我该去新叶城找他，问问他到底想用它做什么。带一些给他的话，说不定会有报酬……"/>
+        <string name="1" value="我拜访了微光人，发现他是一位极其强大的魔法师。他能把自己的身体变成纯钻石，因此才能前往宇宙和其他恶劣环境探索。凭借旅途中积累的知识，他也成了颇有名气的武器制作者和军火商。\r\n微光人来到玛斯特里亚，是为了寻找名为#b#t4031760##k的材料。这是来自异界维萨尔的稀有元素，他一直想拿来做实验。作为我帮他找回材料的谢礼，他答应为我制作一把专属武器。不过我还得再找来#b7个#t4021008##k交给他。只有这样，他才能把天生不稳定的魔石转化成可用形态。用异界材料制作的武器啊！真想知道它会有什么力量……"/>
+        <string name="2" value="我回去找微光人，他把我交给他的#b#t4031760##k和#b7个#t4021008##k合成为一颗魔石宝珠。他说他的朋友斯宾德尔可以把它打造成武器，所以等我准备好制作武器时，就去找斯宾德尔吧。斯宾德尔目前住在地球防御本部。另外，只要我以后再找到白色维萨尔魔石，也可以带给微光人，请他再制作一颗魔石宝珠。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4925">
-        <string name="name" value="Brand Materia Continued"/>
-        <string name="parent" value="Brand Materia"/>
+        <string name="name" value="品牌魔石 - 后续"/>
+        <string name="parent" value="品牌魔石"/>
         <int name="order" value="2"/>
-        <string name="0" value="Looks like the Glimmer Man is looking for a rare material from the alternate dimension of Versal, the very #b#t4031760##k that I now possess.  Perhaps I should visit him in New Leaf City and see what he wants with it.  Maybe he&apos;ll reward me for bringing him some..."/>
-        <string name="1" value="I visited the Glimmer Man, and discovered that he&apos;s an ultra-powerful mage whose ability to turn his entire body into pure diamond (hence his name) has allowed him to journey to space and other inhospitable environments.  Through the vast knowledge he&apos;s acquired during his explorations, he&apos;s also become somewhat of a renowned weapons creator and arms dealer.\r\nThe Glimmer Man has landed in Masteria looking for something called #b#t4031760##k, a rare element from the alternate dimension of Versal he&apos;s been dying to experiment with.  To thank me for recovering some and bringing it to him, he&apos;s promised to make me a weapon of my own from it. However, I&apos;ve got to also track down #b7 #t4021008#s#k and return these to him as well.  Only then can he reduce the naturally unstable Materia down to a useable form.  A weapon made from an otherwordly material! I wonder what it does..."/>
-        <string name="2" value="I returned to the Glimmer Man and he synthesized the #b#t4031760##k and the #b7 #t4021008#s#k I gave him to form a Materia Orb.  He&apos;s said his precocious friend Spindle can turn this into a weapon, so I should see him when I&apos;m ready to make the weapon...WOOT!  Spindle is currently residing in the Omega Sector.  Additionally, anytime I find more White Versal Materia, I can bring it to the Glimmer Man and he&apos;ll create another Materia Orb for me so I can make another weapon!"/>
+        <string name="0" value="微光人似乎正在寻找来自异界维萨尔的稀有材料，也就是我手上的#b#t4031760##k。也许我该去新叶城找他，问问他到底想用它做什么。带一些给他的话，说不定会有报酬……"/>
+        <string name="1" value="我拜访了微光人，发现他是一位极其强大的魔法师。他能把自己的身体变成纯钻石，因此才能前往宇宙和其他恶劣环境探索。凭借旅途中积累的知识，他也成了颇有名气的武器制作者和军火商。\r\n微光人来到玛斯特里亚，是为了寻找名为#b#t4031760##k的材料。这是来自异界维萨尔的稀有元素，他一直想拿来做实验。作为我帮他找回材料的谢礼，他答应为我制作一把专属武器。不过我还得再找来#b7个#t4021008##k交给他。只有这样，他才能把天生不稳定的魔石转化成可用形态。用异界材料制作的武器啊！真想知道它会有什么力量……"/>
+        <string name="2" value="我回去找微光人，他把我交给他的#b#t4031760##k和#b7个#t4021008##k合成为一颗魔石宝珠。他说他的朋友斯宾德尔可以把它打造成武器，所以等我准备好制作武器时，就去找斯宾德尔吧。斯宾德尔目前住在地球防御本部。另外，只要我以后再找到白色维萨尔魔石，也可以带给微光人，请他再制作一颗魔石宝珠。"/>
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="4926">
@@ -15607,10 +15607,10 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="4927">
-        <string name="name" value="Ancient Artifacts"/>
-        <string name="0" value="John Barricade has told me about the Ancient Artifacts I&apos;ve found in my offline travels (playing the MapleStory Trading Card Game).  He thinks that these can be used to construct powerful weapons and items.  If I bring him a valid set of those I find, he&apos;ll be able to tell me what I can make and how to make them."/>
-        <string name="1" value="John Barricade has told me about the Ancient Artifacts I&apos;ve found in my offline travels (playing the MapleStory Trading Card Game).  He thinks that these can be used to construct powerful weapons and items.  If I bring him a valid set of those I find, he&apos;ll be able to tell me what I can make and how to make them."/>
-        <string name="2" value="John Barricade has told me about the Ancient Artifacts I&apos;ve found in my offline travels (playing the MapleStory Trading Card Game).  He thinks that these can be used to construct powerful weapons and items.  If I bring him a valid set of those I find, he&apos;ll be able to tell me what I can make and how to make them."/>
+        <string name="name" value="远古遗物"/>
+        <string name="0" value="约翰·贝瑞加德听我说起在现实旅途中（冒险岛集换式卡牌游戏）发现的远古遗物。他认为这些遗物或许能用来打造强力武器和道具。如果我带来一组有效的遗物，他就能告诉我可以制作什么，以及该怎么制作。"/>
+        <string name="1" value="约翰·贝瑞加德听我说起在现实旅途中（冒险岛集换式卡牌游戏）发现的远古遗物。他认为这些遗物或许能用来打造强力武器和道具。如果我带来一组有效的遗物，他就能告诉我可以制作什么，以及该怎么制作。"/>
+        <string name="2" value="约翰·贝瑞加德听我说起在现实旅途中（冒险岛集换式卡牌游戏）发现的远古遗物。他认为这些遗物或许能用来打造强力武器和道具。如果我带来一组有效的遗物，他就能告诉我可以制作什么，以及该怎么制作。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="4928">
@@ -18299,10 +18299,10 @@
         <int name="area" value="50"/>
     </imgdir>
     <imgdir name="8213">
-        <string name="name" value="Ancient Artifacts"/>
-        <string name="0" value="John Barricade has told me about the Ancient Artifacts I&apos;ve found in my offline travels (playing the MapleStory Trading Card Game).  He thinks that these can be used to construct powerful weapons and items.  If I bring him a valid set of those I find, he&apos;ll be able to tell me what I can make and how to make them."/>
-        <string name="1" value="John Barricade has told me about the Ancient Artifacts I&apos;ve found in my offline travels (playing the MapleStory Trading Card Game).  He thinks that these can be used to construct powerful weapons and items.  If I bring him a valid set of those I find, he&apos;ll be able to tell me what I can make and how to make them."/>
-        <string name="2" value="John Barricade has told me about the Ancient Artifacts I&apos;ve found in my offline travels (playing the MapleStory Trading Card Game).  He thinks that these can be used to construct powerful weapons and items.  If I bring him a valid set of those I find, he&apos;ll be able to tell me what I can make and how to make them."/>
+        <string name="name" value="远古遗物"/>
+        <string name="0" value="约翰·贝瑞加德听我说起在现实旅途中（冒险岛集换式卡牌游戏）发现的远古遗物。他认为这些遗物或许能用来打造强力武器和道具。如果我带来一组有效的遗物，他就能告诉我可以制作什么，以及该怎么制作。"/>
+        <string name="1" value="约翰·贝瑞加德听我说起在现实旅途中（冒险岛集换式卡牌游戏）发现的远古遗物。他认为这些遗物或许能用来打造强力武器和道具。如果我带来一组有效的遗物，他就能告诉我可以制作什么，以及该怎么制作。"/>
+        <string name="2" value="约翰·贝瑞加德听我说起在现实旅途中（冒险岛集换式卡牌游戏）发现的远古遗物。他认为这些遗物或许能用来打造强力武器和道具。如果我带来一组有效的遗物，他就能告诉我可以制作什么，以及该怎么制作。"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8218">
@@ -18327,10 +18327,10 @@
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8221">
-        <string name="name" value="The Mark of Heroism"/>
-        <string name="0" value="Lukan told me about the Valley of Heroes and the giant Menhir columns barring the way through.  He mentioned that the Heroic Statues that line the valley would also act as teleporters, for only someone who had an artifact known as the Marker of Heroism.  Perhaps someone well-versed in ancient artifacts would know something about these Markers of Heroism... I think I may have an idea on who to ask.  Otherwise, it&apos;s time for some ledge hopping!"/>
-        <string name="1" value="I was right: John Barricade&apos;s extensive knowledge about ancient civilizations and items has paid off again!  He&apos;ll give me the Barricades&apos; Marker of Heroism if I reimburse him for the materials they had to acquire to recreate it: #b1 Power Crystal#k, #b10 Gold Ores#k and #b4 Typhon Feathers#k.  The only problem: Typhons nest in the upper reaches of the mountain!  To get up the mountain, I&apos;ll have to go through the Valley first!  Ugh!  Looks like a catch-22!  Hmmm, I guess I could see if someone else might have these feathers... I wonder if anyone else has already made it through the Valley on their own?"/>
-        <string name="2" value="John gave me the Marker of Heroism artifact after I brought him the hard-to-find Typhon feathers and the other materials.  Now I&apos;ll be able to the Heroic Statues to get through the Valley.  However, it&apos;s not all candy and cake yet; I still need to figure out the correct statues to use, but at least it&apos;ll make it easier for me to move around.  Guess I&apos;ll try each statue as I go along and see where they lead!"/>
+        <string name="name" value="英雄印记"/>
+        <string name="0" value="卢坎告诉我英雄峡谷的事，以及挡住道路的巨大石柱。他还说，峡谷里的英雄雕像其实也能当作传送点使用，但只有持有名为英雄印记的遗物的人才能启动它们。也许熟悉远古遗物的人会知道英雄印记的线索……我大概知道该去问谁。否则就只能一路跳过去了！"/>
+        <string name="1" value="我猜对了：约翰·贝瑞加德对远古文明和遗物的渊博知识又派上了用场！只要我补偿他们重制英雄印记时用掉的材料，他就愿意把贝瑞加德家的英雄印记交给我：#b1个力量水晶#k、#b10个黄金母矿#k和#b4根台风羽毛#k。问题是台风怪栖息在山的高处！想上山又得先穿过峡谷！真是两难。嗯……也许可以问问有没有人已经独自穿过峡谷，手里正好有这些羽毛。"/>
+        <string name="2" value="我带来了难找的台风羽毛和其他材料后，约翰·贝瑞加德把英雄印记交给了我。现在我可以利用英雄雕像穿过峡谷了。不过事情还没那么简单，我还得找出正确的雕像顺序。至少行动会方便许多，就一边前进一边试试看吧！"/>
         <int name="area" value="45"/>
     </imgdir>
     <imgdir name="8222">

--- a/gms-server/wz-zh-CN/String.wz/Etc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Etc.img.xml
@@ -4708,8 +4708,8 @@
             <string name="desc" value="童话村里的七诚丢失的斧头。"/>
         </imgdir>
         <imgdir name="4031317">
-            <string name="name" value="樵夫的铁斧"/>
-            <string name="desc" value="名叫树的青年丢失斧头。"/>
+            <string name="name" value="树的铁斧"/>
+            <string name="desc" value="名叫树的青年丢失的斧头。"/>
         </imgdir>
         <imgdir name="4031318">
             <string name="name" value="七南的铁斧"/>

--- a/gms-server/wz-zh-CN/String.wz/Npc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Npc.img.xml
@@ -948,10 +948,10 @@
         <string name="n1" value="请使用附近的其他车站。"/>
     </imgdir>
     <imgdir name="1052116">
-        <string name="name" value="Thompson"/>
-        <string name="func" value="General Merchant"/>
-        <string name="n0" value="How about a cold drink, hm?"/>
-        <string name="n1" value="I&apos;m going to become a certified barista soon..."/>
+        <string name="name" value="汤普森"/>
+        <string name="func" value="杂货商人"/>
+        <string name="n0" value="来点冰凉的饮料怎么样？"/>
+        <string name="n1" value="我很快就要成为正式的咖啡师了……"/>
     </imgdir>
     <imgdir name="1052117">
         <string name="name" value="阿赫"/>
@@ -6623,10 +6623,10 @@
         <string name="n1" value="不必担心, 这些镜片都是有临床证明的~! "/>
     </imgdir>
     <imgdir name="9201018">
-        <string name="name" value="90212 医生"/>
-        <string name="func" value="改头换面魔法师"/>
-        <string name="n0" value="准备好要化妆了吗？我有完美的工作用具!"/>
-        <string name="n1" value="我是化妆师, 而且能将你的脸孔塑造得非常漂亮."/>
+        <string name="name" value="阿莫利亚整形医生"/>
+        <string name="func" value="整形医生"/>
+        <string name="n0" value="准备好换一张全新的面容了吗？我会帮你打造最适合你的样子！"/>
+        <string name="n1" value="我是阿莫利亚的整形医生，让你的脸型更有魅力就是我的专业。"/>
     </imgdir>
     <imgdir name="9201019">
         <string name="name" value="手不稳 实习生"/>
@@ -7017,11 +7017,11 @@
         <string name="s0" value="嘿，你知道本服务器是谁开的游戏？"/>
     </imgdir>
     <imgdir name="9201083">
-        <string name="name" value="在微光曼"/>
-        <string name="d0" value="瞧，我很强大的微光人！其中一个最强大的魔法世界！"/>
-        <string name="d1" value="瞧，我很强大的微光人！其中一个最强大的魔法世界！但是，你知道了，对不对？"/>
-        <string name="n0" value="你见了阿莫斯纳曼强？他是我的朋友。"/>
-        <string name="n1" value="感觉新鲜这里... "/>
+        <string name="name" value="微光人"/>
+        <string name="d0" value="看见了吗？我就是微光人，掌握着来自异界的强大魔力。"/>
+        <string name="d1" value="看见了吗？我就是微光人，掌握着来自异界的强大魔力。你也感受到了吧？"/>
+        <string name="n0" value="你见过强大的阿莫斯吗？他是我的朋友。"/>
+        <string name="n1" value="这里的空气里有一种新鲜的魔力……"/>
     </imgdir>
     <imgdir name="9201084">
         <string name="name" value="墓碑"/>
@@ -7044,11 +7044,11 @@
     </imgdir>
     <imgdir name="9201087">
         <string name="name" value="凯特"/>
-        <string name="d0" value="你所需要的一切是正确的了！"/>
-        <string name="d1" value="我只是卖给我上次冒险岛游戏卡！您可能需要检查其他城市更多的冒险岛游戏卡！务必做家务杂事的爸爸妈妈第一次！"/>
-        <string name="func" value="在这里等少女?"/>
-        <string name="n0" value="你所需要的一切是正确的了！"/>
-        <string name="n1" value="冒险岛游戏卡作出巨大礼物送给您和您的朋友。节日快乐！"/>
+        <string name="d0" value="你来得正好，需要什么尽管告诉我。"/>
+        <string name="d1" value="我这里的冒险岛游戏卡已经卖得差不多了。也许你可以去其他城市看看。对了，出门前别忘了先把家里的事做好哦！"/>
+        <string name="func" value="等待中的少女"/>
+        <string name="n0" value="你来得正好，需要什么尽管告诉我。"/>
+        <string name="n1" value="冒险岛游戏卡是送给朋友的好礼物。祝你节日快乐！"/>
     </imgdir>
     <imgdir name="9201088">
         <string name="name" value="巴里"/>
@@ -7691,11 +7691,11 @@
         <string name="n1" value="你相信有圣诞老人吗？"/>
     </imgdir>
     <imgdir name="9250052">
-        <string name="name" value="Paperboy"/>
-        <string name="d0" value="跟上世界的事件〜"/>
-        <string name="d1" value="如此众多的事件正在发生的世界。"/>
-        <string name="n0" value="跟上世界的事件〜"/>
-        <string name="n1" value="如此众多的事件正在发生的世界。"/>
+        <string name="name" value="报童"/>
+        <string name="d0" value="想知道世界各地的新鲜事吗？"/>
+        <string name="d1" value="世界每天都有许多事情发生，读读报纸总不会错。"/>
+        <string name="n0" value="想知道世界各地的新鲜事吗？"/>
+        <string name="n1" value="世界每天都有许多事情发生，读读报纸总不会错。"/>
     </imgdir>
     <imgdir name="9250053">
         <string name="name" value="圣诞树"/>


### PR DESCRIPTION
## 改动内容
- 修复诺特勒斯号餐厅 NPC 唐云在任务完成或未开始时点击无响应的问题，补充普通对话框。
- 汉化牛棚小牛残留英文提示，并统一牛奶瓶进度描述。
- 优化阿莫利亚整形医生、废都广场汤普森、报童、强·贝瑞加德、微光人、凯特等 NPC 的名称、功能名和对话文本。
- 为魔法密林艾温的重复任务名称补充“（重复）”前缀。
- 统一任务“如何躲避恶臭”的道具描述，将需求文本与实际道具“邪恶之眼的眼球”保持一致。
- 优化童话村“金银斧”相关任务提示，并将另一个同名斧头道具区分为“树的铁斧”，降低交付误解。
- 优化阿莫利亚发型相关任务中“黏糊糊的液体”等不自然表述。
- 校对金博士相关任务文本，将“法力灵丹”等拗口表述改为更自然的说法。
- 调整“寺院地下”传送门提示，使其与返回“通往地下之路”的逻辑一致。
- 补充中文书本道具内容覆盖，汉化《新手指南》《女神日记本》《药材组合书》《锻造介绍书》的正文。
- 本次为文本汉化与中文覆盖修复，仅修改中文脚本目录和中文 WZ 目录；未修改英文原版目录。

## 影响范围
- 影响服务端中文 NPC/任务脚本，以及客户端显示用的中文 WZ 文本。
- 涉及 NPC 名称、任务说明、道具说明、书本道具正文和地图传送提示。
- 因修改了 String、Quest、Item 等 WZ 文本，客户端需要同步客户端资源包。

## 验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查。
- 已执行乱码检查，确认变更文件与 PR 正文没有替换字符乱码。
- 已执行 diff 空白检查。
- 未进行本地游戏内测试。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。