### PR TITLE
fix: 优化白色精华与幽灵船长重复任务提示

### DIFF
--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/QuestActionHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/QuestActionHandler.java
@@ -30,6 +30,7 @@ import org.gms.scripting.quest.QuestScriptManager;
 import org.gms.server.life.NPC;
 import org.gms.server.quest.Quest;
 import org.gms.util.I18nUtil;
+import org.gms.util.PacketCreator;
 
 import java.awt.*;
 
@@ -38,7 +39,12 @@ import java.awt.*;
  */
 public final class QuestActionHandler extends AbstractPacketHandler {
     private static final short LOST_WHITE_ESSENCE_QUEST = 4522;
+    private static final short CAPTAIN_LATANICA_RETURN_QUEST = 4523;
     private static final int WHITE_ESSENCE = 4000381;
+
+    private static void sendNpcOk(Client c, int npc, String message) {
+        c.sendPacket(PacketCreator.getNPCTalk(npc, (byte) 0, message, "00 00", (byte) 0));
+    }
 
     // isNpcNearby thanks to GabrielSin
     private static boolean isNpcNearby(InPacket p, Character player, Quest quest, int npcId) {
@@ -100,7 +106,9 @@ public final class QuestActionHandler extends AbstractPacketHandler {
                         quest.start(player, npc);
                     }
                 } else if (questid == LOST_WHITE_ESSENCE_QUEST && player.haveItem(WHITE_ESSENCE)) {
-                    player.dropMessage(5, I18nUtil.getMessage("QuestActionHandler.hasWhiteEssence.message1"));
+                    sendNpcOk(c, npc, I18nUtil.getMessage("QuestActionHandler.hasWhiteEssence.message1"));
+                } else if (questid == CAPTAIN_LATANICA_RETURN_QUEST && player.haveItem(WHITE_ESSENCE)) {
+                    sendNpcOk(c, npc, I18nUtil.getMessage("QuestActionHandler.hasWhiteEssenceForLatanica.message1"));
                 }
                 break;
             }

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/QuestActionHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/QuestActionHandler.java
@@ -37,6 +37,8 @@ import java.awt.*;
  * @author Matze
  */
 public final class QuestActionHandler extends AbstractPacketHandler {
+    private static final short LOST_WHITE_ESSENCE_QUEST = 4522;
+    private static final int WHITE_ESSENCE = 4000381;
 
     // isNpcNearby thanks to GabrielSin
     private static boolean isNpcNearby(InPacket p, Character player, Quest quest, int npcId) {
@@ -97,6 +99,8 @@ public final class QuestActionHandler extends AbstractPacketHandler {
                     } else {
                         quest.start(player, npc);
                     }
+                } else if (questid == LOST_WHITE_ESSENCE_QUEST && player.haveItem(WHITE_ESSENCE)) {
+                    player.dropMessage(5, I18nUtil.getMessage("QuestActionHandler.hasWhiteEssence.message1"));
                 }
                 break;
             }

--- a/gms-server/src/main/resources/i18n/message_en_US.properties
+++ b/gms-server/src/main/resources/i18n/message_en_US.properties
@@ -882,6 +882,7 @@ Monster.applyDamage.message1 = Hitted MOB：
 # QuestActionHandler
 ##############################
 QuestActionHandler.isNpcNearby.message1 = Approach the NPC to fulfill this quest operation.
+QuestActionHandler.hasWhiteEssence.message1 = You already have White Essence, so there is no need to remake it.
 
 ##############################
 # FamilyEntitlement

--- a/gms-server/src/main/resources/i18n/message_en_US.properties
+++ b/gms-server/src/main/resources/i18n/message_en_US.properties
@@ -883,6 +883,7 @@ Monster.applyDamage.message1 = Hitted MOB：
 ##############################
 QuestActionHandler.isNpcNearby.message1 = Approach the NPC to fulfill this quest operation.
 QuestActionHandler.hasWhiteEssence.message1 = You already have White Essence, so there is no need to remake it.
+QuestActionHandler.hasWhiteEssenceForLatanica.message1 = You already have White Essence. You can go directly to the engine room to challenge Captain Latanica.
 
 ##############################
 # FamilyEntitlement

--- a/gms-server/src/main/resources/i18n/message_zh_CN.properties
+++ b/gms-server/src/main/resources/i18n/message_zh_CN.properties
@@ -880,6 +880,7 @@ Monster.applyDamage.message1 = 攻击怪物 ID:
 ##############################
 QuestActionHandler.isNpcNearby.message1 = 请接近NPC以完成任务
 QuestActionHandler.hasWhiteEssence.message1 = 你已经持有白色精华，不需要重新制作。
+QuestActionHandler.hasWhiteEssenceForLatanica.message1 = 你已经持有白色精华，可以直接前往轮机舱挑战幽灵船长。
 
 ##############################
 # FamilyEntitlement学院汉化

--- a/gms-server/src/main/resources/i18n/message_zh_CN.properties
+++ b/gms-server/src/main/resources/i18n/message_zh_CN.properties
@@ -879,6 +879,7 @@ Monster.applyDamage.message1 = 攻击怪物 ID:
 # QuestActionHandler任务提示
 ##############################
 QuestActionHandler.isNpcNearby.message1 = 请接近NPC以完成任务
+QuestActionHandler.hasWhiteEssence.message1 = 你已经持有白色精华，不需要重新制作。
 
 ##############################
 # FamilyEntitlement学院汉化

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -15092,7 +15092,7 @@
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="4523">
-        <string name="name" value="幽灵船长的回归"/>
+        <string name="name" value="幽灵船长的回归(重复)"/>
         <string name="0" value="#b流浪汉拉尔夫#k感到黑暗力量出没在幽灵船地区附近…我必须要再去跟他确认一次。"/>
         <string name="1" value="#b流浪汉拉尔夫#k相信，#r幽灵船长#k又回来了！！！他希望我再次回到轮机舱，不过他要确定我还能够胜任。我必须要向他证明自己一直在锻炼并且做好了准备。\n\n"/>
         <string name="2" value="我终于证明了自己还是那个为进入轮机舱做好准备的人。现在，看我怎么收拾幽灵船长吧！"/>


### PR DESCRIPTION
## 改动内容
- 修复任务 4522 在玩家已持有白色精华时的反馈方式，改为由当前 NPC 弹出对话框提示，避免聊天框提示被忽略。
- 修复任务 4523「幽灵船长的回归」在玩家已持有白色精华时没有明显反馈的问题，改为由流浪汉拉尔夫弹出对话框提示玩家可直接前往轮机舱挑战幽灵船长。
- 将任务 4523 的中文任务名标注为「幽灵船长的回归(重复)」，与已有重复任务命名格式保持一致。
- 同步补充英文与中文 i18n 提示文案；中文 QuestInfo 仅调整中文显示文本。

## 影响范围
- 影响服务端任务开始失败时的反馈逻辑，以及任务 4523 的中文客户端显示文本。
- 涉及 NPC：流浪汉拉尔夫。
- 涉及道具：白色精华。
- 涉及地图/入口提示：轮机舱挑战幽灵船长。
- 因修改了 QuestInfo 中文 WZ 文本，需要同步客户端资源包。

## 验证情况
- 已执行 git diff 空白与格式检查。
- 已执行 QuestInfo XML 解析检查。
- 已执行中文资源乱码检查。
- 已执行 Maven 编译检查。
- 本次未修改 JS 脚本，因此未执行 JS 语法检查。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。