### PR TITLE
fix: 修复中文任务与 Boss 传送提示文本

### DIFF
--- a/gms-server/scripts-zh-CN/reactor/2119004.js
+++ b/gms-server/scripts-zh-CN/reactor/2119004.js
@@ -20,5 +20,5 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 function act() {
-    rm.weakenAreaBoss(6090001, "The light at the altar appeases the hatred of the Snow Witch. The force of the Witch has weakened.");
+    rm.weakenAreaBoss(6090001, "祭坛上的光芒安抚了雪女的怨恨。雪女的力量减弱了。");
 }

--- a/gms-server/scripts-zh-CN/reactor/2119005.js
+++ b/gms-server/scripts-zh-CN/reactor/2119005.js
@@ -20,5 +20,5 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 function act() {
-    rm.weakenAreaBoss(6090001, "The light at the altar appeases the hatred of the Snow Witch. The force of the Witch has weakened.");
+    rm.weakenAreaBoss(6090001, "祭坛上的光芒安抚了雪女的怨恨。雪女的力量减弱了。");
 }

--- a/gms-server/scripts-zh-CN/reactor/2119006.js
+++ b/gms-server/scripts-zh-CN/reactor/2119006.js
@@ -20,5 +20,5 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 function act() {
-    rm.weakenAreaBoss(6090001, "The light at the altar appeases the hatred of the Snow Witch. The force of the Witch has weakened.");
+    rm.weakenAreaBoss(6090001, "祭坛上的光芒安抚了雪女的怨恨。雪女的力量减弱了。");
 }

--- a/gms-server/wz-zh-CN/Mob.wz/5090001.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/5090001.img.xml
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="5090001.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="128"/>
+    <int name="maxHP" value="15375000"/>
+    <int name="maxMP" value="120000"/>
+    <int name="speed" value="-50"/>
+    <int name="PADamage" value="170"/>
+    <int name="PDDamage" value="180"/>
+    <int name="MADamage" value="190"/>
+    <int name="MDDamage" value="210"/>
+    <int name="acc" value="100"/>
+    <int name="eva" value="64"/>
+    <int name="exp" value="114200"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="600"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="removeAfter" value="1800"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="8"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="你被训斥的师傅木妖赶出了修炼场。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="250000000"/>
+          <string name="portal" value="sp"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="89" height="97">
+      <vector name="origin" x="38" y="97"/>
+      <vector name="lt" x="-38" y="-97"/>
+      <vector name="rb" x="51" y="0"/>
+      <vector name="head" x="-7" y="-90"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="1" width="89" height="99">
+      <vector name="origin" x="37" y="99"/>
+      <vector name="lt" x="-37" y="-99"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="-7" y="-92"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="2" width="89" height="99">
+      <vector name="origin" x="39" y="106"/>
+      <vector name="lt" x="-39" y="-106"/>
+      <vector name="rb" x="50" y="-7"/>
+      <vector name="head" x="-9" y="-98"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="3" width="89" height="99">
+      <vector name="origin" x="39" y="103"/>
+      <vector name="lt" x="-39" y="-103"/>
+      <vector name="rb" x="50" y="-4"/>
+      <vector name="head" x="-9" y="-95"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="4" width="89" height="99">
+      <vector name="origin" x="39" y="99"/>
+      <vector name="lt" x="-39" y="-99"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="-8" y="-91"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="5" width="89" height="97">
+      <vector name="origin" x="39" y="97"/>
+      <vector name="lt" x="-39" y="-97"/>
+      <vector name="rb" x="50" y="0"/>
+      <vector name="head" x="-9" y="-89"/>
+      <int name="delay" value="240"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="89" height="99">
+      <vector name="origin" x="37" y="99"/>
+      <vector name="lt" x="-37" y="-99"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="-8" y="-91"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="1" width="89" height="99">
+      <vector name="origin" x="36" y="99"/>
+      <vector name="lt" x="-36" y="-99"/>
+      <vector name="rb" x="53" y="0"/>
+      <vector name="head" x="-7" y="-91"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="2" width="89" height="99">
+      <vector name="origin" x="35" y="99"/>
+      <vector name="lt" x="-35" y="-99"/>
+      <vector name="rb" x="54" y="0"/>
+      <vector name="head" x="-5" y="-92"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="3" width="89" height="99">
+      <vector name="origin" x="36" y="99"/>
+      <vector name="lt" x="-36" y="-99"/>
+      <vector name="rb" x="53" y="0"/>
+      <vector name="head" x="-6" y="-91"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="4" width="89" height="99">
+      <vector name="origin" x="37" y="99"/>
+      <vector name="lt" x="-37" y="-99"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="-6" y="-92"/>
+      <int name="delay" value="210"/>
+    </canvas>
+    <canvas name="5" width="89" height="99">
+      <vector name="origin" x="38" y="99"/>
+      <vector name="lt" x="-38" y="-99"/>
+      <vector name="rb" x="51" y="0"/>
+      <vector name="head" x="-6" y="-91"/>
+      <int name="delay" value="210"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="89" height="99">
+      <vector name="origin" x="36" y="99"/>
+      <vector name="lt" x="-36" y="-99"/>
+      <vector name="rb" x="54" y="0"/>
+      <vector name="head" x="-5" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="95" height="105">
+      <vector name="origin" x="39" y="102"/>
+      <vector name="lt" x="-39" y="-102"/>
+      <vector name="rb" x="56" y="3"/>
+      <vector name="head" x="-5" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="101" height="110">
+      <vector name="origin" x="42" y="104"/>
+      <vector name="lt" x="-42" y="-104"/>
+      <vector name="rb" x="59" y="6"/>
+      <vector name="head" x="-5" y="-91"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="103" height="111">
+      <vector name="origin" x="43" y="104"/>
+      <vector name="lt" x="-43" y="-104"/>
+      <vector name="rb" x="60" y="7"/>
+      <vector name="head" x="-6" y="-90"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="103" height="113">
+      <vector name="origin" x="45" y="125"/>
+      <vector name="lt" x="-45" y="-125"/>
+      <vector name="rb" x="58" y="-12"/>
+      <vector name="head" x="-7" y="-111"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="103" height="113">
+      <vector name="origin" x="45" y="129"/>
+      <vector name="lt" x="-45" y="-129"/>
+      <vector name="rb" x="58" y="-16"/>
+      <vector name="head" x="-8" y="-114"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="103" height="113">
+      <vector name="origin" x="45" y="130"/>
+      <vector name="lt" x="-45" y="-130"/>
+      <vector name="rb" x="58" y="-17"/>
+      <vector name="head" x="-7" y="-116"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="103" height="113">
+      <vector name="origin" x="45" y="131"/>
+      <vector name="lt" x="-45" y="-131"/>
+      <vector name="rb" x="58" y="-18"/>
+      <vector name="head" x="-7" y="-116"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="105" height="113">
+      <vector name="origin" x="44" y="105"/>
+      <vector name="lt" x="-44" y="-105"/>
+      <vector name="rb" x="61" y="8"/>
+      <vector name="head" x="-5" y="-89"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="108" height="114">
+      <vector name="origin" x="47" y="106"/>
+      <vector name="lt" x="-47" y="-106"/>
+      <vector name="rb" x="61" y="8"/>
+      <vector name="head" x="-5" y="-90"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="109" height="113">
+      <vector name="origin" x="49" y="106"/>
+      <vector name="lt" x="-49" y="-106"/>
+      <vector name="rb" x="60" y="7"/>
+      <vector name="head" x="-5" y="-91"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="120" height="112">
+      <vector name="origin" x="57" y="105"/>
+      <vector name="lt" x="-57" y="-105"/>
+      <vector name="rb" x="63" y="7"/>
+      <vector name="head" x="-5" y="-91"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="126" height="110">
+      <vector name="origin" x="60" y="104"/>
+      <vector name="lt" x="-60" y="-104"/>
+      <vector name="rb" x="66" y="6"/>
+      <vector name="head" x="-5" y="-91"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="95" height="105">
+      <vector name="origin" x="39" y="102"/>
+      <vector name="lt" x="-39" y="-102"/>
+      <vector name="rb" x="56" y="3"/>
+      <vector name="head" x="-5" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="14" width="95" height="105">
+      <vector name="origin" x="39" y="102"/>
+      <vector name="lt" x="-39" y="-102"/>
+      <vector name="rb" x="56" y="3"/>
+      <vector name="head" x="-5" y="-92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="94" height="104">
+      <vector name="origin" x="32" y="104"/>
+      <vector name="lt" x="-32" y="-104"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="-2" y="-91"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="89" height="99">
+      <vector name="origin" x="37" y="99"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="89" height="99">
+      <vector name="origin" x="27" y="112"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="89" height="99">
+      <vector name="origin" x="23" y="113"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="89" height="99">
+      <vector name="origin" x="20" y="107"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="89" height="97">
+      <vector name="origin" x="12" y="97"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="89" height="92">
+      <vector name="origin" x="10" y="92"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="73" height="17">
+      <vector name="origin" x="7" y="16"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="76" height="17">
+      <vector name="origin" x="9" y="16"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="77" height="16">
+      <vector name="origin" x="9" y="18"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="77" height="14">
+      <vector name="origin" x="10" y="19"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/6090000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/6090000.img.xml
@@ -1,0 +1,583 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="6090000.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="74"/>
+    <int name="maxHP" value="11000"/>
+    <int name="maxMP" value="500"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="180"/>
+    <int name="PDDamage" value="200"/>
+    <int name="MADamage" value="270"/>
+    <int name="MDDamage" value="400"/>
+    <int name="acc" value="150"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="25000"/>
+    <int name="undead" value="1"/>
+    <int name="pushed" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="removeAfter" value="1800"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="1"/>
+        <int name="effectAfter" value="1000"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="114"/>
+        <int name="action" value="2"/>
+        <int name="level" value="12"/>
+        <int name="effectAfter" value="1000"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="你受到里奇的魔法影响，被传送到了其他地方。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="211040200"/>
+          <string name="portal" value="top00"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="7"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="107" height="125">
+      <vector name="origin" x="60" y="135"/>
+      <vector name="lt" x="-60" y="-135"/>
+      <vector name="rb" x="47" y="-10"/>
+      <vector name="head" x="-25" y="-93"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="1" width="111" height="131">
+      <vector name="origin" x="60" y="137"/>
+      <vector name="lt" x="-60" y="-137"/>
+      <vector name="rb" x="51" y="-6"/>
+      <vector name="head" x="-23" y="-95"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="2" width="113" height="129">
+      <vector name="origin" x="60" y="137"/>
+      <vector name="lt" x="-60" y="-137"/>
+      <vector name="rb" x="53" y="-8"/>
+      <vector name="head" x="-23" y="-94"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="3" width="115" height="130">
+      <vector name="origin" x="60" y="137"/>
+      <vector name="lt" x="-60" y="-136"/>
+      <vector name="rb" x="55" y="-6"/>
+      <vector name="head" x="-24" y="-93"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="4" width="111" height="132">
+      <vector name="origin" x="60" y="137"/>
+      <vector name="lt" x="-60" y="-137"/>
+      <vector name="rb" x="51" y="-5"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="5" width="113" height="128">
+      <vector name="origin" x="60" y="137"/>
+      <vector name="lt" x="-60" y="-137"/>
+      <vector name="rb" x="53" y="-9"/>
+      <vector name="head" x="-23" y="-95"/>
+      <int name="delay" value="200"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="102" height="135">
+      <vector name="origin" x="60" y="135"/>
+      <vector name="lt" x="-60" y="-135"/>
+      <vector name="rb" x="42" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="1" width="107" height="138">
+      <vector name="origin" x="61" y="137"/>
+      <vector name="lt" x="-61" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-23" y="-96"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="2" width="109" height="138">
+      <vector name="origin" x="61" y="137"/>
+      <vector name="lt" x="-61" y="-137"/>
+      <vector name="rb" x="48" y="1"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="3" width="110" height="139">
+      <vector name="origin" x="60" y="137"/>
+      <vector name="lt" x="-60" y="-137"/>
+      <vector name="rb" x="50" y="2"/>
+      <vector name="head" x="-24" y="-93"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="4" width="105" height="139">
+      <vector name="origin" x="59" y="137"/>
+      <vector name="lt" x="-59" y="-137"/>
+      <vector name="rb" x="46" y="2"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="5" width="107" height="139">
+      <vector name="origin" x="59" y="137"/>
+      <vector name="lt" x="-59" y="-137"/>
+      <vector name="rb" x="48" y="2"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="200"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-200" y="-150"/>
+        <vector name="rb" x="0" y="20"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="83" height="139">
+          <vector name="origin" x="98" y="192"/>
+        </canvas>
+        <canvas name="1" width="78" height="122">
+          <vector name="origin" x="76" y="149"/>
+        </canvas>
+        <canvas name="2" width="124" height="145">
+          <vector name="origin" x="65" y="126"/>
+        </canvas>
+        <canvas name="3" width="98" height="129">
+          <vector name="origin" x="56" y="111"/>
+        </canvas>
+        <canvas name="4" width="110" height="129">
+          <vector name="origin" x="55" y="109"/>
+        </canvas>
+        <canvas name="5" width="143" height="128">
+          <vector name="origin" x="67" y="105"/>
+        </canvas>
+        <canvas name="6" width="143" height="128">
+          <vector name="origin" x="74" y="105"/>
+        </canvas>
+        <int name="attachfacing" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="0"/>
+      <int name="magic" value="1"/>
+      <int name="attackAfter" value="1680"/>
+    </imgdir>
+    <canvas name="0" width="102" height="135">
+      <vector name="origin" x="60" y="135"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="107" height="138">
+      <vector name="origin" x="61" y="137"/>
+      <vector name="lt" x="-63" y="-137"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="108" height="138">
+      <vector name="origin" x="60" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="215" height="180">
+      <vector name="origin" x="145" y="171"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-93"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="209" height="172">
+      <vector name="origin" x="144" y="167"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="202" height="179">
+      <vector name="origin" x="141" y="177"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="183" height="186">
+      <vector name="origin" x="133" y="177"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-23" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="180" height="171">
+      <vector name="origin" x="129" y="165"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="186" height="172">
+      <vector name="origin" x="133" y="167"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="190" height="176">
+      <vector name="origin" x="135" y="169"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-23" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="187" height="178">
+      <vector name="origin" x="136" y="170"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-22" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="187" height="178">
+      <vector name="origin" x="136" y="170"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-23" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="181" height="174">
+      <vector name="origin" x="134" y="168"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-23" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="183" height="170">
+      <vector name="origin" x="132" y="166"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="4"/>
+      <vector name="head" x="-30" y="-98"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="181" height="162">
+      <vector name="origin" x="128" y="162"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="0"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="179" height="154">
+      <vector name="origin" x="124" y="158"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="-4"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="174" height="152">
+      <vector name="origin" x="123" y="157"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="-4"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="171" height="143">
+      <vector name="origin" x="118" y="152"/>
+      <vector name="lt" x="-62" y="-133"/>
+      <vector name="rb" x="47" y="-5"/>
+      <vector name="head" x="-25" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="102" height="135">
+      <vector name="origin" x="60" y="135"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="205" height="170">
+      <vector name="origin" x="152" y="145"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="51" y="0"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="202" height="164">
+      <vector name="origin" x="153" y="142"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="47" y="0"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="196" height="174">
+      <vector name="origin" x="146" y="143"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="48" y="0"/>
+      <vector name="head" x="-23" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="179" height="169">
+      <vector name="origin" x="133" y="141"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="169" height="172">
+      <vector name="origin" x="121" y="138"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="46" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="185" height="198">
+      <vector name="origin" x="143" y="144"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="210" height="232">
+      <vector name="origin" x="162" y="154"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="46" y="0"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="237" height="210">
+      <vector name="origin" x="189" y="164"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="46" y="4"/>
+      <vector name="head" x="-23" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="240" height="234">
+      <vector name="origin" x="190" y="189"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="48" y="4"/>
+      <vector name="head" x="-24" y="-93"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="232" height="236">
+      <vector name="origin" x="150" y="192"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="48" y="4"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="234" height="181">
+      <vector name="origin" x="149" y="137"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="48" y="4"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="12" value="../stand/0"/>
+    <uol name="13" value="../stand/1"/>
+    <uol name="14" value="../stand/2"/>
+    <uol name="15" value="../stand/3"/>
+    <uol name="16" value="../stand/4"/>
+    <uol name="17" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="102" height="135">
+      <vector name="origin" x="60" y="135"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="107" height="138">
+      <vector name="origin" x="61" y="137"/>
+      <vector name="lt" x="-63" y="-137"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="108" height="138">
+      <vector name="origin" x="60" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="123" height="139">
+      <vector name="origin" x="73" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="48" y="2"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="122" height="139">
+      <vector name="origin" x="76" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="2"/>
+      <vector name="head" x="-23" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="115" height="139">
+      <vector name="origin" x="67" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="2"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="113" height="135">
+      <vector name="origin" x="71" y="135"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="120" height="138">
+      <vector name="origin" x="74" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-25" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="124" height="138">
+      <vector name="origin" x="76" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="153" height="143">
+      <vector name="origin" x="103" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="48" y="3"/>
+      <vector name="head" x="-24" y="-93"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="145" height="144">
+      <vector name="origin" x="99" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="4"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="144" height="142">
+      <vector name="origin" x="96" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="5"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="136" height="137">
+      <vector name="origin" x="94" y="135"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="5"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="131" height="141">
+      <vector name="origin" x="85" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="4"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="129" height="139">
+      <vector name="origin" x="81" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="2"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="125" height="140">
+      <vector name="origin" x="75" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="48" y="3"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="105" height="139">
+      <vector name="origin" x="59" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="3"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="107" height="139">
+      <vector name="origin" x="59" y="137"/>
+      <vector name="lt" x="-61" y="-137"/>
+      <vector name="rb" x="46" y="2"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="108" height="135">
+      <vector name="origin" x="62" y="143"/>
+      <vector name="lt" x="-62" y="-143"/>
+      <vector name="rb" x="46" y="-8"/>
+      <vector name="head" x="-22" y="-97"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="110" height="135">
+      <vector name="origin" x="66" y="141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="1" width="108" height="135">
+      <vector name="origin" x="64" y="141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="2" width="108" height="140">
+      <vector name="origin" x="64" y="141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="3" width="108" height="139">
+      <vector name="origin" x="64" y="141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="4" width="104" height="140">
+      <vector name="origin" x="64" y="141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="5" width="81" height="140">
+      <vector name="origin" x="64" y="141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="6" width="81" height="141">
+      <vector name="origin" x="64" y="141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="7" width="78" height="141">
+      <vector name="origin" x="64" y="141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="8" width="81" height="141">
+      <vector name="origin" x="64" y="141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="9" width="74" height="141">
+      <vector name="origin" x="57" y="141"/>
+      <int name="delay" value="100"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/6090001.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/6090001.img.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="6090001.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="64"/>
+    <int name="maxHP" value="7700"/>
+    <int name="maxMP" value="200"/>
+    <int name="speed" value="-50"/>
+    <int name="PADamage" value="177"/>
+    <int name="PDDamage" value="190"/>
+    <int name="MADamage" value="230"/>
+    <int name="MDDamage" value="230"/>
+    <int name="acc" value="140"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="10320"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="800"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="removeAfter" value="1800"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="4"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="你受到雪女的诅咒，被传送到了其他地方。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="211000000"/>
+          <string name="portal" value="sp"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="141" height="158">
+      <vector name="origin" x="60" y="170"/>
+      <vector name="lt" x="-60" y="-170"/>
+      <vector name="rb" x="81" y="-12"/>
+      <vector name="head" x="-17" y="-112"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="1" width="141" height="158">
+      <vector name="origin" x="60" y="163"/>
+      <vector name="lt" x="-60" y="-163"/>
+      <vector name="rb" x="81" y="-5"/>
+      <vector name="head" x="-16" y="-105"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="2" width="141" height="158">
+      <vector name="origin" x="60" y="160"/>
+      <vector name="lt" x="-60" y="-160"/>
+      <vector name="rb" x="81" y="-2"/>
+      <vector name="head" x="-15" y="-101"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="3" width="141" height="158">
+      <vector name="origin" x="60" y="159"/>
+      <vector name="lt" x="-60" y="-159"/>
+      <vector name="rb" x="81" y="-1"/>
+      <vector name="head" x="-16" y="-99"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="4" width="141" height="158">
+      <vector name="origin" x="60" y="158"/>
+      <vector name="lt" x="-60" y="-158"/>
+      <vector name="rb" x="81" y="0"/>
+      <vector name="head" x="-15" y="-98"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="5" width="141" height="158">
+      <vector name="origin" x="60" y="159"/>
+      <vector name="lt" x="-60" y="-159"/>
+      <vector name="rb" x="81" y="-1"/>
+      <vector name="head" x="-16" y="-99"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="6" width="141" height="158">
+      <vector name="origin" x="60" y="164"/>
+      <vector name="lt" x="-60" y="-164"/>
+      <vector name="rb" x="81" y="-6"/>
+      <vector name="head" x="-16" y="-104"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="7" width="141" height="158">
+      <vector name="origin" x="60" y="169"/>
+      <vector name="lt" x="-60" y="-169"/>
+      <vector name="rb" x="81" y="-11"/>
+      <vector name="head" x="-16" y="-109"/>
+      <int name="delay" value="240"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="141" height="158">
+      <vector name="origin" x="60" y="170"/>
+      <vector name="lt" x="-60" y="-171"/>
+      <vector name="rb" x="81" y="-12"/>
+      <vector name="head" x="-16" y="-110"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="1" width="141" height="158">
+      <vector name="origin" x="60" y="169"/>
+      <vector name="lt" x="-60" y="-169"/>
+      <vector name="rb" x="81" y="-11"/>
+      <vector name="head" x="-16" y="-109"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="2" width="141" height="158">
+      <vector name="origin" x="60" y="168"/>
+      <vector name="lt" x="-60" y="-168"/>
+      <vector name="rb" x="81" y="-10"/>
+      <vector name="head" x="-15" y="-107"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="3" width="141" height="158">
+      <vector name="origin" x="60" y="167"/>
+      <vector name="lt" x="-60" y="-167"/>
+      <vector name="rb" x="81" y="-9"/>
+      <vector name="head" x="-15" y="-109"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="4" width="141" height="158">
+      <vector name="origin" x="60" y="168"/>
+      <vector name="lt" x="-60" y="-169"/>
+      <vector name="rb" x="81" y="-10"/>
+      <vector name="head" x="-16" y="-108"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="5" width="141" height="158">
+      <vector name="origin" x="60" y="169"/>
+      <vector name="lt" x="-60" y="-169"/>
+      <vector name="rb" x="81" y="-11"/>
+      <vector name="head" x="-16" y="-109"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="6" width="141" height="158">
+      <vector name="origin" x="60" y="170"/>
+      <vector name="lt" x="-60" y="-170"/>
+      <vector name="rb" x="81" y="-12"/>
+      <vector name="head" x="-16" y="-109"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="7" width="141" height="158">
+      <vector name="origin" x="60" y="171"/>
+      <vector name="lt" x="-60" y="-171"/>
+      <vector name="rb" x="81" y="-13"/>
+      <vector name="head" x="-15" y="-111"/>
+      <int name="delay" value="240"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="141" height="158">
+      <vector name="origin" x="60" y="170"/>
+      <vector name="lt" x="-60" y="-170"/>
+      <vector name="rb" x="81" y="-12"/>
+      <vector name="head" x="-16" y="-110"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="158" height="173">
+      <vector name="origin" x="68" y="187"/>
+      <vector name="lt" x="-68" y="-187"/>
+      <vector name="rb" x="90" y="-14"/>
+      <vector name="head" x="-16" y="-118"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="161" height="178">
+      <vector name="origin" x="70" y="195"/>
+      <vector name="lt" x="-70" y="-195"/>
+      <vector name="rb" x="91" y="-17"/>
+      <vector name="head" x="-16" y="-126"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="163" height="180">
+      <vector name="origin" x="71" y="200"/>
+      <vector name="lt" x="-71" y="-200"/>
+      <vector name="rb" x="92" y="-20"/>
+      <vector name="head" x="-16" y="-129"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="165" height="184">
+      <vector name="origin" x="72" y="203"/>
+      <vector name="lt" x="-72" y="-203"/>
+      <vector name="rb" x="93" y="-19"/>
+      <vector name="head" x="-16" y="-130"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="165" height="188">
+      <vector name="origin" x="72" y="205"/>
+      <vector name="lt" x="-72" y="-205"/>
+      <vector name="rb" x="93" y="-17"/>
+      <vector name="head" x="-16" y="-131"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="165" height="190">
+      <vector name="origin" x="72" y="206"/>
+      <vector name="lt" x="-72" y="-206"/>
+      <vector name="rb" x="93" y="-16"/>
+      <vector name="head" x="-16" y="-133"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="165" height="190">
+      <vector name="origin" x="72" y="206"/>
+      <vector name="lt" x="-72" y="-206"/>
+      <vector name="rb" x="93" y="-16"/>
+      <vector name="head" x="-16" y="-133"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="200" height="168">
+      <vector name="origin" x="92" y="162"/>
+      <vector name="lt" x="-92" y="-162"/>
+      <vector name="rb" x="108" y="6"/>
+      <vector name="head" x="-19" y="-76"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="202" height="179">
+      <vector name="origin" x="93" y="162"/>
+      <vector name="lt" x="-93" y="-163"/>
+      <vector name="rb" x="109" y="17"/>
+      <vector name="head" x="-16" y="-71"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="207" height="187">
+      <vector name="origin" x="93" y="162"/>
+      <vector name="lt" x="-93" y="-162"/>
+      <vector name="rb" x="114" y="25"/>
+      <vector name="head" x="-16" y="-69"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="11" width="206" height="187">
+      <vector name="origin" x="88" y="158"/>
+      <vector name="lt" x="-88" y="-158"/>
+      <vector name="rb" x="118" y="29"/>
+      <vector name="head" x="-15" y="-72"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="12" width="169" height="150">
+      <vector name="origin" x="76" y="147"/>
+      <vector name="lt" x="-76" y="-148"/>
+      <vector name="rb" x="93" y="3"/>
+      <vector name="head" x="-16" y="-80"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="13" width="151" height="159">
+      <vector name="origin" x="65" y="163"/>
+      <vector name="lt" x="-65" y="-163"/>
+      <vector name="rb" x="86" y="-4"/>
+      <vector name="head" x="-16" y="-103"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="155" height="184">
+      <vector name="origin" x="55" y="196"/>
+      <vector name="lt" x="-55" y="-197"/>
+      <vector name="rb" x="100" y="-12"/>
+      <vector name="head" x="-2" y="-110"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="155" height="184">
+      <vector name="origin" x="55" y="196"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="149" height="170">
+      <vector name="origin" x="53" y="182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="146" height="164">
+      <vector name="origin" x="52" y="176"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="146" height="158">
+      <vector name="origin" x="51" y="170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="154" height="158">
+      <vector name="origin" x="58" y="170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="159" height="158">
+      <vector name="origin" x="62" y="169"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="168" height="158">
+      <vector name="origin" x="65" y="152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="133" height="132">
+      <vector name="origin" x="29" y="126"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="138" height="132">
+      <vector name="origin" x="33" y="125"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="134" height="131">
+      <vector name="origin" x="37" y="124"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="136" height="126">
+      <vector name="origin" x="36" y="123"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="135" height="24">
+      <vector name="origin" x="38" y="28"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/6090002.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/6090002.img.xml
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="6090002.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="68"/>
+    <int name="maxHP" value="86890"/>
+    <int name="maxMP" value="2000"/>
+    <int name="speed" value="-20"/>
+    <int name="PADamage" value="200"/>
+    <int name="PDDamage" value="190"/>
+    <int name="MADamage" value="290"/>
+    <int name="MDDamage" value="270"/>
+    <int name="acc" value="130"/>
+    <int name="eva" value="70"/>
+    <int name="exp" value="17000"/>
+    <int name="undead" value="1"/>
+    <int name="pushed" value="1300"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="removeAfter" value="1800"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="7"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="竹武士的意志将你驱逐到了蘑菇神社。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="800000000"/>
+          <string name="portal" value="st00"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="123" height="107">
+      <vector name="origin" x="84" y="107"/>
+      <vector name="lt" x="-80" y="-107"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-85"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="1" width="123" height="109">
+      <vector name="origin" x="84" y="109"/>
+      <vector name="lt" x="-80" y="-109"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-86"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="2" width="123" height="107">
+      <vector name="origin" x="84" y="107"/>
+      <vector name="lt" x="-80" y="-108"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-6" y="-85"/>
+      <int name="delay" value="240"/>
+    </canvas>
+    <canvas name="3" width="123" height="109">
+      <vector name="origin" x="84" y="109"/>
+      <vector name="lt" x="-80" y="-109"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-87"/>
+      <int name="delay" value="240"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="123" height="109">
+      <vector name="origin" x="84" y="109"/>
+      <vector name="lt" x="-80" y="-109"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-8" y="-86"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="123" height="110">
+      <vector name="origin" x="84" y="110"/>
+      <vector name="lt" x="-80" y="-110"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-8" y="-88"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-111"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-8" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-111"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-5" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-112"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-111"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-111"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-112"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-111"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-112"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-111"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="11" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-111"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="12" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-112"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="13" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-111"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-6" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="14" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-111"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-6" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="15" width="123" height="111">
+      <vector name="origin" x="84" y="111"/>
+      <vector name="lt" x="-80" y="-111"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="16" width="123" height="110">
+      <vector name="origin" x="84" y="110"/>
+      <vector name="lt" x="-80" y="-110"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-6" y="-88"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="17" width="123" height="109">
+      <vector name="origin" x="84" y="109"/>
+      <vector name="lt" x="-80" y="-109"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-88"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="123" height="109">
+      <vector name="origin" x="84" y="109"/>
+      <vector name="lt" x="-80" y="-109"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-6" y="-88"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="128" height="110">
+      <vector name="origin" x="89" y="110"/>
+      <vector name="lt" x="-85" y="-110"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-88"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="153" height="168">
+      <vector name="origin" x="112" y="166"/>
+      <vector name="lt" x="-108" y="-166"/>
+      <vector name="rb" x="45" y="2"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="146" height="174">
+      <vector name="origin" x="103" y="169"/>
+      <vector name="lt" x="-100" y="-169"/>
+      <vector name="rb" x="47" y="5"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="136" height="173">
+      <vector name="origin" x="92" y="168"/>
+      <vector name="lt" x="-88" y="-168"/>
+      <vector name="rb" x="48" y="5"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="133" height="169">
+      <vector name="origin" x="88" y="163"/>
+      <vector name="lt" x="-84" y="-163"/>
+      <vector name="rb" x="49" y="6"/>
+      <vector name="head" x="-7" y="-88"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="128" height="162">
+      <vector name="origin" x="82" y="155"/>
+      <vector name="lt" x="-78" y="-155"/>
+      <vector name="rb" x="50" y="7"/>
+      <vector name="head" x="-7" y="-87"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="121" height="152">
+      <vector name="origin" x="75" y="145"/>
+      <vector name="lt" x="-71" y="-145"/>
+      <vector name="rb" x="50" y="8"/>
+      <vector name="head" x="-7" y="-86"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="112" height="142">
+      <vector name="origin" x="66" y="134"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="50" y="8"/>
+      <vector name="head" x="-7" y="-87"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="107" height="137">
+      <vector name="origin" x="61" y="129"/>
+      <vector name="lt" x="-57" y="-129"/>
+      <vector name="rb" x="50" y="8"/>
+      <vector name="head" x="-7" y="-86"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="107" height="137">
+      <vector name="origin" x="61" y="129"/>
+      <vector name="lt" x="-57" y="-129"/>
+      <vector name="rb" x="50" y="8"/>
+      <vector name="head" x="-6" y="-87"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="147" height="149">
+      <vector name="origin" x="101" y="141"/>
+      <vector name="lt" x="-97" y="-142"/>
+      <vector name="rb" x="50" y="8"/>
+      <vector name="head" x="-7" y="-93"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="152" height="149">
+      <vector name="origin" x="106" y="141"/>
+      <vector name="lt" x="-102" y="-141"/>
+      <vector name="rb" x="50" y="8"/>
+      <vector name="head" x="-7" y="-86"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="154" height="148">
+      <vector name="origin" x="108" y="141"/>
+      <vector name="lt" x="-104" y="-141"/>
+      <vector name="rb" x="50" y="7"/>
+      <vector name="head" x="-7" y="-87"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="149" height="151">
+      <vector name="origin" x="105" y="145"/>
+      <vector name="lt" x="-101" y="-146"/>
+      <vector name="rb" x="48" y="6"/>
+      <vector name="head" x="-7" y="-90"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="145" height="134">
+      <vector name="origin" x="104" y="131"/>
+      <vector name="lt" x="-101" y="-131"/>
+      <vector name="rb" x="45" y="3"/>
+      <vector name="head" x="-7" y="-90"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="144" height="114">
+      <vector name="origin" x="105" y="114"/>
+      <vector name="lt" x="-102" y="-115"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-90"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="125" height="110">
+      <vector name="origin" x="86" y="110"/>
+      <vector name="lt" x="-82" y="-110"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-7" y="-89"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="149" height="123">
+      <vector name="origin" x="90" y="122"/>
+      <vector name="lt" x="-86" y="-122"/>
+      <vector name="rb" x="63" y="1"/>
+      <vector name="head" x="6" y="-86"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="123" height="107">
+      <vector name="origin" x="84" y="107"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="149" height="123">
+      <vector name="origin" x="90" y="122"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="149" height="116">
+      <vector name="origin" x="94" y="115"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="148" height="111">
+      <vector name="origin" x="96" y="110"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="95" height="108">
+      <vector name="origin" x="42" y="107"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="97" height="109">
+      <vector name="origin" x="35" y="107"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="103" height="108">
+      <vector name="origin" x="39" y="106"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="110" height="101">
+      <vector name="origin" x="42" y="98"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="116" height="36">
+      <vector name="origin" x="47" y="33"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="118" height="33">
+      <vector name="origin" x="46" y="32"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="115" height="31">
+      <vector name="origin" x="46" y="31"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/6090003.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/6090003.img.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="6090003.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="62"/>
+    <int name="maxHP" value="6000"/>
+    <int name="maxMP" value="100"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="185"/>
+    <int name="PDDamage" value="170"/>
+    <int name="MADamage" value="200"/>
+    <int name="MDDamage" value="130"/>
+    <int name="acc" value="80"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="3984"/>
+    <int name="undead" value="1"/>
+    <int name="pushed" value="700"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="removeAfter" value="1800"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="9"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="你被书生幽灵的怨念传送到了其他地方。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="222000000"/>
+          <string name="portal" value="sp"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="7"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="126" height="173">
+      <vector name="origin" x="64" y="174"/>
+      <vector name="lt" x="-65" y="-174"/>
+      <vector name="rb" x="61" y="-1"/>
+      <vector name="head" x="-17" y="-147"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="125" height="173">
+      <vector name="origin" x="64" y="175"/>
+      <vector name="lt" x="-65" y="-175"/>
+      <vector name="rb" x="60" y="-2"/>
+      <vector name="head" x="-16" y="-148"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="125" height="171">
+      <vector name="origin" x="64" y="172"/>
+      <vector name="lt" x="-65" y="-172"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-17" y="-145"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="126" height="167">
+      <vector name="origin" x="65" y="167"/>
+      <vector name="lt" x="-66" y="-167"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-17" y="-140"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="128" height="169">
+      <vector name="origin" x="67" y="170"/>
+      <vector name="lt" x="-68" y="-170"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-17" y="-143"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="125" height="171">
+      <vector name="origin" x="64" y="172"/>
+      <vector name="lt" x="-65" y="-172"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-17" y="-145"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="124" height="172">
+      <vector name="origin" x="63" y="173"/>
+      <vector name="lt" x="-63" y="-173"/>
+      <vector name="rb" x="61" y="-1"/>
+      <vector name="head" x="-9" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="123" height="170">
+      <vector name="origin" x="63" y="172"/>
+      <vector name="lt" x="-63" y="-172"/>
+      <vector name="rb" x="60" y="-2"/>
+      <vector name="head" x="-11" y="-145"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="123" height="170">
+      <vector name="origin" x="63" y="171"/>
+      <vector name="lt" x="-63" y="-171"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-10" y="-143"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="123" height="170">
+      <vector name="origin" x="63" y="170"/>
+      <vector name="lt" x="-63" y="-170"/>
+      <vector name="rb" x="60" y="0"/>
+      <vector name="head" x="-10" y="-143"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="123" height="170">
+      <vector name="origin" x="63" y="171"/>
+      <vector name="lt" x="-63" y="-171"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-11" y="-144"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="123" height="171">
+      <vector name="origin" x="63" y="172"/>
+      <vector name="lt" x="-63" y="-172"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-10" y="-146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="128" height="172">
+      <vector name="origin" x="67" y="173"/>
+      <vector name="lt" x="-67" y="-173"/>
+      <vector name="rb" x="61" y="-1"/>
+      <vector name="head" x="-11" y="-146"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="181" height="170">
+      <vector name="origin" x="82" y="174"/>
+      <vector name="lt" x="-82" y="-174"/>
+      <vector name="rb" x="99" y="-4"/>
+      <vector name="head" x="-10" y="-147"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="157" height="180">
+      <vector name="origin" x="71" y="175"/>
+      <vector name="lt" x="-71" y="-175"/>
+      <vector name="rb" x="86" y="5"/>
+      <vector name="head" x="-8" y="-148"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="148" height="178">
+      <vector name="origin" x="67" y="176"/>
+      <vector name="lt" x="-67" y="-176"/>
+      <vector name="rb" x="81" y="2"/>
+      <vector name="head" x="-5" y="-149"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="142" height="172">
+      <vector name="origin" x="69" y="177"/>
+      <vector name="lt" x="-69" y="-177"/>
+      <vector name="rb" x="73" y="-5"/>
+      <vector name="head" x="-2" y="-150"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="129" height="173">
+      <vector name="origin" x="66" y="178"/>
+      <vector name="lt" x="-66" y="-178"/>
+      <vector name="rb" x="63" y="-5"/>
+      <vector name="head" x="-1" y="-151"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="125" height="172">
+      <vector name="origin" x="66" y="179"/>
+      <vector name="lt" x="-66" y="-179"/>
+      <vector name="rb" x="59" y="-7"/>
+      <vector name="head" x="1" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="125" height="172">
+      <vector name="origin" x="66" y="179"/>
+      <vector name="lt" x="-66" y="-179"/>
+      <vector name="rb" x="59" y="-7"/>
+      <vector name="head" x="1" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="160" height="181">
+      <vector name="origin" x="87" y="172"/>
+      <vector name="lt" x="-87" y="-172"/>
+      <vector name="rb" x="73" y="9"/>
+      <vector name="head" x="-12" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="165" height="182">
+      <vector name="origin" x="90" y="173"/>
+      <vector name="lt" x="-90" y="-173"/>
+      <vector name="rb" x="75" y="9"/>
+      <vector name="head" x="-13" y="-140"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="139" height="173">
+      <vector name="origin" x="73" y="170"/>
+      <vector name="lt" x="-73" y="-170"/>
+      <vector name="rb" x="66" y="3"/>
+      <vector name="head" x="-13" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="125" height="176">
+      <vector name="origin" x="63" y="173"/>
+      <vector name="lt" x="-63" y="-173"/>
+      <vector name="rb" x="62" y="3"/>
+      <vector name="head" x="-12" y="-147"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="125" height="172">
+      <vector name="origin" x="63" y="172"/>
+      <vector name="lt" x="-63" y="-172"/>
+      <vector name="rb" x="62" y="0"/>
+      <vector name="head" x="-12" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="123" height="170">
+      <vector name="origin" x="63" y="171"/>
+      <vector name="lt" x="-63" y="-171"/>
+      <vector name="rb" x="60" y="-1"/>
+      <vector name="head" x="-12" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="134" height="196">
+      <vector name="origin" x="88" y="201"/>
+      <vector name="lt" x="-88" y="-201"/>
+      <vector name="rb" x="46" y="-5"/>
+      <vector name="head" x="-24" y="-146"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="134" height="196">
+      <vector name="origin" x="88" y="201"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="209" height="227">
+      <vector name="origin" x="111" y="209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="212" height="227">
+      <vector name="origin" x="112" y="208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="166" height="199">
+      <vector name="origin" x="90" y="204"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="140" height="185">
+      <vector name="origin" x="76" y="197"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="117" height="157">
+      <vector name="origin" x="66" y="167"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="109" height="152">
+      <vector name="origin" x="59" y="174"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="97" height="141">
+      <vector name="origin" x="47" y="179"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="133" height="133">
+      <vector name="origin" x="79" y="159"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="147" height="147">
+      <vector name="origin" x="86" y="166"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="157" height="157">
+      <vector name="origin" x="91" y="171"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/6090004.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/6090004.img.xml
@@ -1,0 +1,376 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="6090004.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="63"/>
+    <int name="maxHP" value="7600000"/>
+    <int name="maxMP" value="100"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="190"/>
+    <int name="PDDamage" value="190"/>
+    <int name="MADamage" value="220"/>
+    <int name="MDDamage" value="220"/>
+    <int name="acc" value="150"/>
+    <int name="eva" value="100"/>
+    <int name="exp" value="245"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="removeAfter" value="1800"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="11"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="你中了鲁鲁莫的恶作剧，被传送到了其他地方。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="261000000"/>
+          <string name="portal" value="sp"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="7"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="79" height="106">
+      <vector name="origin" x="37" y="106"/>
+      <vector name="lt" x="-37" y="-107"/>
+      <vector name="rb" x="42" y="0"/>
+      <vector name="head" x="-6" y="-96"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="69" height="109">
+      <vector name="origin" x="33" y="109"/>
+      <vector name="lt" x="-33" y="-109"/>
+      <vector name="rb" x="36" y="0"/>
+      <vector name="head" x="-5" y="-95"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="62" height="107">
+      <vector name="origin" x="29" y="110"/>
+      <vector name="lt" x="-30" y="-110"/>
+      <vector name="rb" x="33" y="-3"/>
+      <vector name="head" x="-3" y="-97"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="66" height="113">
+      <vector name="origin" x="34" y="113"/>
+      <vector name="lt" x="-34" y="-113"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-7" y="-104"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="76" height="109">
+      <vector name="origin" x="35" y="109"/>
+      <vector name="lt" x="-35" y="-109"/>
+      <vector name="rb" x="41" y="0"/>
+      <vector name="head" x="-7" y="-97"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="82" height="103">
+      <vector name="origin" x="39" y="103"/>
+      <vector name="lt" x="-39" y="-103"/>
+      <vector name="rb" x="43" y="0"/>
+      <vector name="head" x="-10" y="-94"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="82" height="103">
+      <vector name="origin" x="38" y="103"/>
+      <vector name="lt" x="-38" y="-103"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-9" y="-93"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="82" height="103">
+      <vector name="origin" x="38" y="103"/>
+      <vector name="lt" x="-38" y="-103"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-9" y="-94"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="82" height="104">
+      <vector name="origin" x="38" y="104"/>
+      <vector name="lt" x="-38" y="-104"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-9" y="-94"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="82" height="105">
+      <vector name="origin" x="38" y="105"/>
+      <vector name="lt" x="-38" y="-105"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-9" y="-95"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="82" height="105">
+      <vector name="origin" x="38" y="105"/>
+      <vector name="lt" x="-38" y="-105"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-8" y="-95"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="82" height="104">
+      <vector name="origin" x="38" y="104"/>
+      <vector name="lt" x="-38" y="-104"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-8" y="-93"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="82" height="103">
+      <vector name="origin" x="38" y="103"/>
+      <vector name="lt" x="-38" y="-104"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-8" y="-93"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="82" height="103">
+      <vector name="origin" x="38" y="103"/>
+      <vector name="lt" x="-38" y="-103"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-8" y="-93"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="82" height="104">
+      <vector name="origin" x="38" y="104"/>
+      <vector name="lt" x="-38" y="-104"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-9" y="-95"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="82" height="105">
+      <vector name="origin" x="38" y="105"/>
+      <vector name="lt" x="-38" y="-105"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-9" y="-95"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="82" height="105">
+      <vector name="origin" x="38" y="105"/>
+      <vector name="lt" x="-38" y="-105"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-8" y="-94"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="11" width="82" height="104">
+      <vector name="origin" x="38" y="104"/>
+      <vector name="lt" x="-38" y="-104"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-8" y="-94"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="82" height="105">
+      <vector name="origin" x="38" y="105"/>
+      <vector name="lt" x="-38" y="-105"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-7" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="82" height="105">
+      <vector name="origin" x="38" y="105"/>
+      <vector name="lt" x="-38" y="-105"/>
+      <vector name="rb" x="44" y="0"/>
+      <vector name="head" x="-8" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="84" height="106">
+      <vector name="origin" x="39" y="106"/>
+      <vector name="lt" x="-38" y="-106"/>
+      <vector name="rb" x="45" y="0"/>
+      <vector name="head" x="-9" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="193" height="170">
+      <vector name="origin" x="96" y="119"/>
+      <vector name="lt" x="-96" y="-119"/>
+      <vector name="rb" x="97" y="51"/>
+      <vector name="head" x="-8" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="192" height="164">
+      <vector name="origin" x="95" y="116"/>
+      <vector name="lt" x="-96" y="-116"/>
+      <vector name="rb" x="97" y="48"/>
+      <vector name="head" x="-9" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="182" height="170">
+      <vector name="origin" x="88" y="115"/>
+      <vector name="lt" x="-88" y="-115"/>
+      <vector name="rb" x="94" y="55"/>
+      <vector name="head" x="-8" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="157" height="168">
+      <vector name="origin" x="76" y="115"/>
+      <vector name="lt" x="-76" y="-115"/>
+      <vector name="rb" x="81" y="53"/>
+      <vector name="head" x="-8" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="138" height="164">
+      <vector name="origin" x="62" y="114"/>
+      <vector name="lt" x="-63" y="-114"/>
+      <vector name="rb" x="76" y="50"/>
+      <vector name="head" x="-8" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="125" height="155">
+      <vector name="origin" x="57" y="113"/>
+      <vector name="lt" x="-57" y="-113"/>
+      <vector name="rb" x="68" y="42"/>
+      <vector name="head" x="-8" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="107" height="145">
+      <vector name="origin" x="49" y="114"/>
+      <vector name="lt" x="-49" y="-114"/>
+      <vector name="rb" x="58" y="31"/>
+      <vector name="head" x="-8" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="102" height="134">
+      <vector name="origin" x="48" y="115"/>
+      <vector name="lt" x="-48" y="-115"/>
+      <vector name="rb" x="54" y="19"/>
+      <vector name="head" x="-8" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="102" height="125">
+      <vector name="origin" x="48" y="115"/>
+      <vector name="lt" x="-48" y="-115"/>
+      <vector name="rb" x="54" y="10"/>
+      <vector name="head" x="-8" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="102" height="125">
+      <vector name="origin" x="48" y="115"/>
+      <vector name="lt" x="-48" y="-115"/>
+      <vector name="rb" x="54" y="10"/>
+      <vector name="head" x="-8" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="102" height="125">
+      <vector name="origin" x="48" y="115"/>
+      <vector name="lt" x="-48" y="-115"/>
+      <vector name="rb" x="54" y="10"/>
+      <vector name="head" x="-7" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="169" height="165">
+      <vector name="origin" x="83" y="128"/>
+      <vector name="lt" x="-83" y="-128"/>
+      <vector name="rb" x="86" y="37"/>
+      <vector name="head" x="-8" y="-101"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="170" height="161">
+      <vector name="origin" x="84" y="126"/>
+      <vector name="lt" x="-84" y="-126"/>
+      <vector name="rb" x="86" y="35"/>
+      <vector name="head" x="-8" y="-103"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="171" height="165">
+      <vector name="origin" x="87" y="129"/>
+      <vector name="lt" x="-87" y="-129"/>
+      <vector name="rb" x="84" y="36"/>
+      <vector name="head" x="-7" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="167" height="160">
+      <vector name="origin" x="91" y="133"/>
+      <vector name="lt" x="-92" y="-133"/>
+      <vector name="rb" x="76" y="27"/>
+      <vector name="head" x="-7" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="164" height="158">
+      <vector name="origin" x="90" y="131"/>
+      <vector name="lt" x="-91" y="-131"/>
+      <vector name="rb" x="74" y="27"/>
+      <vector name="head" x="-7" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="111" height="110">
+      <vector name="origin" x="43" y="110"/>
+      <vector name="lt" x="-43" y="-110"/>
+      <vector name="rb" x="68" y="0"/>
+      <vector name="head" x="-6" y="-95"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="82" height="103">
+      <vector name="origin" x="38" y="103"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="111" height="137">
+      <vector name="origin" x="32" y="137"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="111" height="157">
+      <vector name="origin" x="38" y="157"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="106" height="167">
+      <vector name="origin" x="39" y="167"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="82" height="172">
+      <vector name="origin" x="21" y="172"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="89" height="166">
+      <vector name="origin" x="26" y="166"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="101" height="141">
+      <vector name="origin" x="33" y="141"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="112" height="126">
+      <vector name="origin" x="38" y="125"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="96" height="112">
+      <vector name="origin" x="23" y="109"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="100" height="97">
+      <vector name="origin" x="25" y="94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="106" height="72">
+      <vector name="origin" x="28" y="68"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="111" height="71">
+      <vector name="origin" x="31" y="67"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="113" height="67">
+      <vector name="origin" x="31" y="66"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="112" height="65">
+      <vector name="origin" x="32" y="65"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/7090000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/7090000.img.xml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="7090000.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="75"/>
+    <int name="maxHP" value="150000"/>
+    <int name="maxMP" value="500"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="300"/>
+    <int name="PDDamage" value="550"/>
+    <int name="MADamage" value="380"/>
+    <int name="MDDamage" value="290"/>
+    <int name="acc" value="130"/>
+    <int name="eva" value="110"/>
+    <int name="exp" value="350"/>
+    <int name="undead" value="1"/>
+    <int name="pushed" value="1500"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="removeAfter" value="1800"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="6"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="你被自动安保系统赶出了卡帕莱特研究所。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="261000000"/>
+          <string name="portal" value="in02"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="149" height="169">
+      <vector name="origin" x="87" y="178"/>
+      <vector name="lt" x="-87" y="-178"/>
+      <vector name="rb" x="62" y="-9"/>
+      <vector name="head" x="-19" y="-144"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="149" height="166">
+      <vector name="origin" x="87" y="178"/>
+      <vector name="lt" x="-87" y="-179"/>
+      <vector name="rb" x="62" y="-12"/>
+      <vector name="head" x="-19" y="-146"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="149" height="167">
+      <vector name="origin" x="87" y="181"/>
+      <vector name="lt" x="-87" y="-181"/>
+      <vector name="rb" x="62" y="-14"/>
+      <vector name="head" x="-19" y="-147"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="149" height="166">
+      <vector name="origin" x="87" y="182"/>
+      <vector name="lt" x="-87" y="-183"/>
+      <vector name="rb" x="62" y="-16"/>
+      <vector name="head" x="-19" y="-148"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="149" height="166">
+      <vector name="origin" x="87" y="180"/>
+      <vector name="lt" x="-87" y="-180"/>
+      <vector name="rb" x="62" y="-14"/>
+      <vector name="head" x="-19" y="-147"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="149" height="166">
+      <vector name="origin" x="87" y="178"/>
+      <vector name="lt" x="-87" y="-179"/>
+      <vector name="rb" x="62" y="-12"/>
+      <vector name="head" x="-19" y="-146"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="149" height="169">
+      <vector name="origin" x="87" y="178"/>
+      <vector name="lt" x="-87" y="-179"/>
+      <vector name="rb" x="62" y="-9"/>
+      <vector name="head" x="-19" y="-144"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="149" height="167">
+      <vector name="origin" x="87" y="179"/>
+      <vector name="lt" x="-87" y="-179"/>
+      <vector name="rb" x="62" y="-12"/>
+      <vector name="head" x="-19" y="-146"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="149" height="167">
+      <vector name="origin" x="87" y="181"/>
+      <vector name="lt" x="-87" y="-181"/>
+      <vector name="rb" x="62" y="-14"/>
+      <vector name="head" x="-19" y="-147"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="149" height="165">
+      <vector name="origin" x="87" y="181"/>
+      <vector name="lt" x="-87" y="-181"/>
+      <vector name="rb" x="62" y="-16"/>
+      <vector name="head" x="-19" y="-147"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="149" height="166">
+      <vector name="origin" x="87" y="180"/>
+      <vector name="lt" x="-87" y="-180"/>
+      <vector name="rb" x="62" y="-14"/>
+      <vector name="head" x="-19" y="-146"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="11" width="149" height="167">
+      <vector name="origin" x="87" y="179"/>
+      <vector name="lt" x="-87" y="-179"/>
+      <vector name="rb" x="62" y="-12"/>
+      <vector name="head" x="-19" y="-145"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="149" height="170">
+      <vector name="origin" x="87" y="179"/>
+      <vector name="lt" x="-87" y="-180"/>
+      <vector name="rb" x="62" y="-9"/>
+      <vector name="head" x="-19" y="-144"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="147" height="170">
+      <vector name="origin" x="85" y="177"/>
+      <vector name="lt" x="-85" y="-177"/>
+      <vector name="rb" x="62" y="-7"/>
+      <vector name="head" x="-19" y="-142"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="144" height="169">
+      <vector name="origin" x="82" y="174"/>
+      <vector name="lt" x="-82" y="-174"/>
+      <vector name="rb" x="62" y="-5"/>
+      <vector name="head" x="-19" y="-140"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="147" height="168">
+      <vector name="origin" x="85" y="171"/>
+      <vector name="lt" x="-85" y="-171"/>
+      <vector name="rb" x="62" y="-3"/>
+      <vector name="head" x="-20" y="-138"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="149" height="168">
+      <vector name="origin" x="87" y="173"/>
+      <vector name="lt" x="-87" y="-173"/>
+      <vector name="rb" x="62" y="-5"/>
+      <vector name="head" x="-19" y="-140"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="148" height="166">
+      <vector name="origin" x="86" y="173"/>
+      <vector name="lt" x="-86" y="-173"/>
+      <vector name="rb" x="62" y="-7"/>
+      <vector name="head" x="-19" y="-142"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="146" height="168">
+      <vector name="origin" x="84" y="177"/>
+      <vector name="lt" x="-84" y="-177"/>
+      <vector name="rb" x="62" y="-9"/>
+      <vector name="head" x="-19" y="-145"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="148" height="168">
+      <vector name="origin" x="86" y="179"/>
+      <vector name="lt" x="-86" y="-179"/>
+      <vector name="rb" x="62" y="-11"/>
+      <vector name="head" x="-19" y="-146"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="149" height="169">
+      <vector name="origin" x="87" y="182"/>
+      <vector name="lt" x="-87" y="-182"/>
+      <vector name="rb" x="62" y="-13"/>
+      <vector name="head" x="-19" y="-148"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="149" height="170">
+      <vector name="origin" x="87" y="181"/>
+      <vector name="lt" x="-87" y="-181"/>
+      <vector name="rb" x="62" y="-11"/>
+      <vector name="head" x="-19" y="-146"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="149" height="167">
+      <vector name="origin" x="57" y="176"/>
+      <vector name="lt" x="-57" y="-176"/>
+      <vector name="rb" x="92" y="-9"/>
+      <vector name="head" x="11" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="200" height="167">
+      <vector name="origin" x="107" y="176"/>
+      <vector name="lt" x="-107" y="-176"/>
+      <vector name="rb" x="93" y="-9"/>
+      <vector name="head" x="12" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="190" height="183">
+      <vector name="origin" x="96" y="176"/>
+      <vector name="lt" x="-96" y="-176"/>
+      <vector name="rb" x="94" y="7"/>
+      <vector name="head" x="13" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="187" height="177">
+      <vector name="origin" x="92" y="176"/>
+      <vector name="lt" x="-92" y="-176"/>
+      <vector name="rb" x="95" y="1"/>
+      <vector name="head" x="13" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="171" height="167">
+      <vector name="origin" x="75" y="176"/>
+      <vector name="lt" x="-75" y="-176"/>
+      <vector name="rb" x="96" y="-9"/>
+      <vector name="head" x="15" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="161" height="169">
+      <vector name="origin" x="60" y="177"/>
+      <vector name="lt" x="-60" y="-177"/>
+      <vector name="rb" x="101" y="-8"/>
+      <vector name="head" x="15" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="163" height="173">
+      <vector name="origin" x="60" y="177"/>
+      <vector name="lt" x="-60" y="-177"/>
+      <vector name="rb" x="103" y="-4"/>
+      <vector name="head" x="15" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="163" height="174">
+      <vector name="origin" x="59" y="178"/>
+      <vector name="lt" x="-59" y="-178"/>
+      <vector name="rb" x="104" y="-4"/>
+      <vector name="head" x="15" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="163" height="173">
+      <vector name="origin" x="58" y="178"/>
+      <vector name="lt" x="-58" y="-178"/>
+      <vector name="rb" x="105" y="-5"/>
+      <vector name="head" x="15" y="-144"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="160" height="170">
+      <vector name="origin" x="55" y="179"/>
+      <vector name="lt" x="-55" y="-179"/>
+      <vector name="rb" x="105" y="-9"/>
+      <vector name="head" x="14" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="158" height="170">
+      <vector name="origin" x="53" y="179"/>
+      <vector name="lt" x="-54" y="-179"/>
+      <vector name="rb" x="105" y="-9"/>
+      <vector name="head" x="15" y="-143"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="172" height="173">
+      <vector name="origin" x="53" y="194"/>
+      <vector name="lt" x="-53" y="-194"/>
+      <vector name="rb" x="119" y="-21"/>
+      <vector name="head" x="14" y="-153"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="173" height="171">
+      <vector name="origin" x="55" y="190"/>
+      <vector name="lt" x="-55" y="-190"/>
+      <vector name="rb" x="118" y="-19"/>
+      <vector name="head" x="12" y="-151"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="186" height="176">
+      <vector name="origin" x="57" y="191"/>
+      <vector name="lt" x="-57" y="-191"/>
+      <vector name="rb" x="129" y="-15"/>
+      <vector name="head" x="10" y="-148"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="150" height="165">
+      <vector name="origin" x="57" y="175"/>
+      <vector name="lt" x="-57" y="-175"/>
+      <vector name="rb" x="93" y="-10"/>
+      <vector name="head" x="10" y="-142"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="189" height="172">
+      <vector name="origin" x="87" y="188"/>
+      <vector name="lt" x="-87" y="-188"/>
+      <vector name="rb" x="102" y="-16"/>
+      <vector name="head" x="1" y="-143"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="149" height="167">
+      <vector name="origin" x="87" y="176"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="189" height="163">
+      <vector name="origin" x="87" y="179"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="187" height="159">
+      <vector name="origin" x="87" y="179"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="171" height="163">
+      <vector name="origin" x="71" y="179"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="164" height="164">
+      <vector name="origin" x="65" y="179"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="162" height="155">
+      <vector name="origin" x="62" y="169"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="161" height="155">
+      <vector name="origin" x="60" y="169"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="160" height="108">
+      <vector name="origin" x="59" y="102"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="161" height="108">
+      <vector name="origin" x="58" y="102"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="165" height="111">
+      <vector name="origin" x="58" y="105"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="170" height="111">
+      <vector name="origin" x="61" y="105"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="174" height="90">
+      <vector name="origin" x="63" y="84"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="175" height="34">
+      <vector name="origin" x="66" y="28"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="13" width="90" height="31">
+      <vector name="origin" x="65" y="27"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="14" width="91" height="16">
+      <vector name="origin" x="67" y="17"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8090000.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8090000.img.xml
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="8090000.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="80"/>
+    <int name="maxHP" value="175000"/>
+    <int name="maxMP" value="300"/>
+    <int name="speed" value="-50"/>
+    <int name="PADamage" value="350"/>
+    <int name="PDDamage" value="650"/>
+    <int name="MADamage" value="410"/>
+    <int name="MDDamage" value="450"/>
+    <int name="acc" value="140"/>
+    <int name="eva" value="120"/>
+    <int name="exp" value="850"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="2800"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <int name="removeAfter" value="1800"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="10"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="你中了迪特和罗伊的调虎离山计，被传送到了其他地方。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="261000000"/>
+          <string name="portal" value="sp"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="8"/>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="103" height="145">
+      <vector name="origin" x="55" y="146"/>
+      <vector name="lt" x="-55" y="-146"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="9" y="-134"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="103" height="145">
+      <vector name="origin" x="55" y="145"/>
+      <vector name="lt" x="-55" y="-145"/>
+      <vector name="rb" x="48" y="0"/>
+      <vector name="head" x="9" y="-133"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="107" height="143">
+      <vector name="origin" x="59" y="143"/>
+      <vector name="lt" x="-59" y="-143"/>
+      <vector name="rb" x="48" y="0"/>
+      <vector name="head" x="9" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="114" height="145">
+      <vector name="origin" x="66" y="146"/>
+      <vector name="lt" x="-66" y="-146"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="9" y="-134"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="115" height="144">
+      <vector name="origin" x="67" y="144"/>
+      <vector name="lt" x="-67" y="-144"/>
+      <vector name="rb" x="48" y="0"/>
+      <vector name="head" x="9" y="-132"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="110" height="143">
+      <vector name="origin" x="62" y="143"/>
+      <vector name="lt" x="-62" y="-143"/>
+      <vector name="rb" x="48" y="0"/>
+      <vector name="head" x="9" y="-131"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="106" height="145">
+      <vector name="origin" x="58" y="146"/>
+      <vector name="lt" x="-58" y="-146"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="9" y="-134"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="107" height="144">
+      <vector name="origin" x="59" y="145"/>
+      <vector name="lt" x="-59" y="-145"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="8" y="-133"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="107" height="142">
+      <vector name="origin" x="59" y="143"/>
+      <vector name="lt" x="-59" y="-143"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="9" y="-131"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="107" height="142">
+      <vector name="origin" x="59" y="143"/>
+      <vector name="lt" x="-59" y="-143"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="8" y="-131"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="106" height="143">
+      <vector name="origin" x="58" y="144"/>
+      <vector name="lt" x="-58" y="-144"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="9" y="-132"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="106" height="145">
+      <vector name="origin" x="58" y="146"/>
+      <vector name="lt" x="-58" y="-146"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="8" y="-134"/>
+      <int name="delay" value="180"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="106" height="145">
+      <vector name="origin" x="58" y="146"/>
+      <vector name="lt" x="-58" y="-146"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="9" y="-134"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="1" width="106" height="151">
+      <vector name="origin" x="57" y="152"/>
+      <vector name="lt" x="-57" y="-152"/>
+      <vector name="rb" x="49" y="-1"/>
+      <vector name="head" x="11" y="-135"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="2" width="106" height="153">
+      <vector name="origin" x="56" y="154"/>
+      <vector name="lt" x="-56" y="-154"/>
+      <vector name="rb" x="50" y="-1"/>
+      <vector name="head" x="12" y="-136"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="3" width="106" height="154">
+      <vector name="origin" x="55" y="155"/>
+      <vector name="lt" x="-55" y="-155"/>
+      <vector name="rb" x="51" y="-1"/>
+      <vector name="head" x="15" y="-137"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="4" width="107" height="156">
+      <vector name="origin" x="55" y="157"/>
+      <vector name="lt" x="-55" y="-157"/>
+      <vector name="rb" x="52" y="-1"/>
+      <vector name="head" x="17" y="-138"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="5" width="107" height="157">
+      <vector name="origin" x="54" y="158"/>
+      <vector name="lt" x="-54" y="-158"/>
+      <vector name="rb" x="53" y="-1"/>
+      <vector name="head" x="19" y="-140"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="6" width="107" height="156">
+      <vector name="origin" x="54" y="157"/>
+      <vector name="lt" x="-54" y="-157"/>
+      <vector name="rb" x="53" y="-1"/>
+      <vector name="head" x="19" y="-140"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="7" width="107" height="156">
+      <vector name="origin" x="54" y="157"/>
+      <vector name="lt" x="-58" y="-146"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="9" y="-134"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="8" width="107" height="155">
+      <vector name="origin" x="54" y="156"/>
+      <vector name="lt" x="-54" y="-156"/>
+      <vector name="rb" x="53" y="-1"/>
+      <vector name="head" x="19" y="-139"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="9" width="107" height="150">
+      <vector name="origin" x="54" y="151"/>
+      <vector name="lt" x="-54" y="-151"/>
+      <vector name="rb" x="53" y="-1"/>
+      <vector name="head" x="19" y="-139"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="10" width="140" height="158">
+      <vector name="origin" x="77" y="152"/>
+      <vector name="lt" x="-77" y="-152"/>
+      <vector name="rb" x="63" y="6"/>
+      <vector name="head" x="5" y="-132"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="11" width="146" height="151">
+      <vector name="origin" x="84" y="145"/>
+      <vector name="lt" x="-85" y="-145"/>
+      <vector name="rb" x="62" y="6"/>
+      <vector name="head" x="3" y="-126"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="12" width="151" height="153">
+      <vector name="origin" x="89" y="148"/>
+      <vector name="lt" x="-89" y="-148"/>
+      <vector name="rb" x="62" y="5"/>
+      <vector name="head" x="4" y="-129"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="13" width="164" height="145">
+      <vector name="origin" x="98" y="143"/>
+      <vector name="lt" x="-98" y="-143"/>
+      <vector name="rb" x="66" y="2"/>
+      <vector name="head" x="4" y="-127"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="14" width="166" height="139">
+      <vector name="origin" x="103" y="139"/>
+      <vector name="lt" x="-103" y="-139"/>
+      <vector name="rb" x="63" y="0"/>
+      <vector name="head" x="4" y="-127"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="15" width="197" height="142">
+      <vector name="origin" x="138" y="141"/>
+      <vector name="lt" x="-138" y="-141"/>
+      <vector name="rb" x="59" y="1"/>
+      <vector name="head" x="9" y="-134"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="16" width="196" height="144">
+      <vector name="origin" x="150" y="143"/>
+      <vector name="lt" x="-150" y="-143"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="7" y="-131"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="17" width="217" height="146">
+      <vector name="origin" x="170" y="145"/>
+      <vector name="lt" x="-170" y="-145"/>
+      <vector name="rb" x="47" y="1"/>
+      <vector name="head" x="8" y="-133"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="18" width="226" height="146">
+      <vector name="origin" x="178" y="146"/>
+      <vector name="lt" x="-178" y="-146"/>
+      <vector name="rb" x="48" y="0"/>
+      <vector name="head" x="9" y="-134"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="19" width="106" height="145">
+      <vector name="origin" x="58" y="146"/>
+      <vector name="lt" x="-58" y="-146"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="9" y="-134"/>
+      <int name="delay" value="90"/>
+    </canvas>
+    <canvas name="20" width="106" height="145">
+      <vector name="origin" x="58" y="146"/>
+      <vector name="lt" x="-58" y="-146"/>
+      <vector name="rb" x="48" y="-1"/>
+      <vector name="head" x="9" y="-134"/>
+      <int name="delay" value="90"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="143" height="150">
+      <vector name="origin" x="76" y="151"/>
+      <vector name="lt" x="-76" y="-151"/>
+      <vector name="rb" x="67" y="-1"/>
+      <vector name="head" x="21" y="-133"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="106" height="145">
+      <vector name="origin" x="58" y="146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="143" height="150">
+      <vector name="origin" x="66" y="151"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="133" height="145">
+      <vector name="origin" x="61" y="146"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="127" height="142">
+      <vector name="origin" x="58" y="143"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="107" height="131">
+      <vector name="origin" x="39" y="132"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="107" height="131">
+      <vector name="origin" x="39" y="131"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="107" height="102">
+      <vector name="origin" x="39" y="98"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="108" height="101">
+      <vector name="origin" x="39" y="97"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="9" width="112" height="100">
+      <vector name="origin" x="39" y="96"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="10" width="113" height="98">
+      <vector name="origin" x="39" y="95"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="11" width="113" height="95">
+      <vector name="origin" x="39" y="94"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="12" width="107" height="94">
+      <vector name="origin" x="39" y="94"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8220004.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8220004.img.xml
@@ -39,7 +39,7 @@
       </imgdir>
     </imgdir>
     <imgdir name="ban">
-      <string name="banMsg" value="You have been ousted by the force of Dodo."/>
+      <string name="banMsg" value="你被多多的力量驱逐到了其他地方。"/>
       <imgdir name="banMap">
         <imgdir name="0">
           <int name="field" value="270010410"/>

--- a/gms-server/wz-zh-CN/Mob.wz/8820006.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8820006.img.xml
@@ -1,0 +1,813 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="8820006.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="180"/>
+    <int name="maxHP" value="450000000"/>
+    <int name="maxMP" value="50000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="1600"/>
+    <int name="PDDamage" value="1580"/>
+    <int name="MADamage" value="950"/>
+    <int name="MDDamage" value="1880"/>
+    <int name="acc" value="260"/>
+    <int name="eva" value="53"/>
+    <int name="exp" value="3500000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="100000"/>
+    <int name="hpRecovery" value="100000"/>
+    <int name="mpRecovery" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="12"/>
+    <int name="firstAttack" value="1"/>
+    <int name="noFlip" value="1"/>
+    <int name="boss" value="1"/>
+    <string name="elemAttr" value="I2F3"/>
+    <int name="mobType" value="1"/>
+    <imgdir name="revive">
+      <int name="0" value="8820023"/>
+    </imgdir>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="128"/>
+        <int name="action" value="2"/>
+        <int name="level" value="8"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="128"/>
+        <int name="action" value="2"/>
+        <int name="level" value="9"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="128"/>
+        <int name="action" value="2"/>
+        <int name="level" value="10"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="122"/>
+        <int name="action" value="2"/>
+        <int name="level" value="6"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="你被穆宁的力量驱逐到了其他地方。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="270050200"/>
+          <string name="portal" value="sp"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="HPgaugeHide" value="1"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="hpTagColor" value="1"/>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-500" y="-400"/>
+        <vector name="rb" x="600" y="-50"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="117" height="105">
+          <vector name="origin" x="57" y="75"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="72" height="75">
+          <vector name="origin" x="37" y="66"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="82" height="88">
+          <vector name="origin" x="40" y="73"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="83" height="118">
+          <vector name="origin" x="40" y="88"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="52" height="156">
+          <vector name="origin" x="25" y="108"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="5"/>
+      <int name="attackAfter" value="1320"/>
+      <int name="disease" value="132"/>
+      <int name="level" value="1"/>
+      <int name="magic" value="1"/>
+      <string name="elemAttr" value="I"/>
+    </imgdir>
+    <canvas name="0" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="197" height="230">
+      <vector name="origin" x="-204" y="315"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="205" height="239">
+      <vector name="origin" x="-206" y="314"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="199" height="241">
+      <vector name="origin" x="-214" y="314"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="186" height="244">
+      <vector name="origin" x="-228" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="186" height="245">
+      <vector name="origin" x="-229" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="188" height="247">
+      <vector name="origin" x="-228" y="317"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="192" height="249">
+      <vector name="origin" x="-225" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="192" height="249">
+      <vector name="origin" x="-225" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="202" height="252">
+      <vector name="origin" x="-216" y="320"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="199" height="250">
+      <vector name="origin" x="-218" y="319"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="197" height="248">
+      <vector name="origin" x="-219" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="191" height="243">
+      <vector name="origin" x="-222" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="166" height="225">
+      <vector name="origin" x="-239" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-44" y="-400"/>
+        <vector name="rb" x="44" y="0"/>
+        <int name="start" value="-3"/>
+        <int name="areaCount" value="9"/>
+        <int name="attackCount" value="5"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="139" height="34">
+          <vector name="origin" x="69" y="20"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="75" height="12">
+          <vector name="origin" x="35" y="11"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="83" height="34">
+          <vector name="origin" x="37" y="29"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="83" height="37">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="83" height="38">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="83" height="41">
+          <vector name="origin" x="37" y="36"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="11" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="12" width="83" height="486">
+          <vector name="origin" x="37" y="480"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="13" width="86" height="500">
+          <vector name="origin" x="40" y="494"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="14" width="89" height="506">
+          <vector name="origin" x="42" y="500"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="15" width="91" height="489">
+          <vector name="origin" x="42" y="483"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="16" width="127" height="141">
+          <vector name="origin" x="66" y="137"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="17" width="134" height="140">
+          <vector name="origin" x="70" y="135"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="18" width="134" height="136">
+          <vector name="origin" x="69" y="131"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="19" width="139" height="130">
+          <vector name="origin" x="70" y="126"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="20" width="139" height="121">
+          <vector name="origin" x="69" y="119"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="21" width="139" height="34">
+          <vector name="origin" x="75" y="28"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="99" height="104">
+          <vector name="origin" x="56" y="85"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="96" height="98">
+          <vector name="origin" x="54" y="83"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="95" height="94">
+          <vector name="origin" x="56" y="79"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="96" height="85">
+          <vector name="origin" x="53" y="74"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="101" height="84">
+          <vector name="origin" x="56" y="71"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="105" height="85">
+          <vector name="origin" x="61" y="76"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="109" height="89">
+          <vector name="origin" x="61" y="84"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="conMP" value="5"/>
+      <int name="disease" value="123"/>
+      <int name="level" value="12"/>
+      <int name="attackAfter" value="1920"/>
+      <string name="PADamage" value="1000"/>
+    </imgdir>
+    <canvas name="0" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="-320" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="164" height="224">
+      <vector name="origin" x="-240" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="170" height="230">
+      <vector name="origin" x="-237" y="309"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="172" height="232">
+      <vector name="origin" x="-236" y="310"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="174" height="234">
+      <vector name="origin" x="-235" y="311"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="174" height="234">
+      <vector name="origin" x="-235" y="311"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="178" height="238">
+      <vector name="origin" x="-233" y="313"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="165" height="225">
+      <vector name="origin" x="-240" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="178" height="237">
+      <vector name="origin" x="-233" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="182" height="241">
+      <vector name="origin" x="-231" y="314"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="186" height="245">
+      <vector name="origin" x="-229" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="188" height="247">
+      <vector name="origin" x="-228" y="317"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="189" height="249">
+      <vector name="origin" x="-228" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="192" height="251">
+      <vector name="origin" x="-226" y="319"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="192" height="252">
+      <vector name="origin" x="-226" y="320"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="192" height="251">
+      <vector name="origin" x="-226" y="319"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="189" height="249">
+      <vector name="origin" x="-228" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="186" height="245">
+      <vector name="origin" x="-229" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="182" height="237">
+      <vector name="origin" x="-229" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="167" height="225">
+      <vector name="origin" x="-238" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="211" height="218">
+      <vector name="origin" x="-190" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="218" height="225">
+      <vector name="origin" x="-187" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="226" height="236">
+      <vector name="origin" x="-184" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="243" height="240">
+      <vector name="origin" x="-169" y="314"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="235" height="243">
+      <vector name="origin" x="-179" y="315"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="237" height="245">
+      <vector name="origin" x="-178" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="238" height="246">
+      <vector name="origin" x="-177" y="317"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="239" height="248">
+      <vector name="origin" x="-177" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="240" height="250">
+      <vector name="origin" x="-177" y="319"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="240" height="250">
+      <vector name="origin" x="-177" y="319"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="247" height="249">
+      <vector name="origin" x="-170" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="253" height="247">
+      <vector name="origin" x="-163" y="317"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="256" height="245">
+      <vector name="origin" x="-159" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="255" height="240">
+      <vector name="origin" x="-157" y="314"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="228" height="225">
+      <vector name="origin" x="-177" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="169" height="220">
+      <vector name="origin" x="-243" y="305"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="214" height="235">
+      <vector name="origin" x="-214" y="315"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="213" height="240">
+      <vector name="origin" x="-211" y="317"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="205" height="240">
+      <vector name="origin" x="-214" y="315"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="190" height="243">
+      <vector name="origin" x="-222" y="317"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="181" height="241">
+      <vector name="origin" x="-232" y="315"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="179" height="239">
+      <vector name="origin" x="-233" y="313"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="178" height="237">
+      <vector name="origin" x="-233" y="312"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="174" height="234">
+      <vector name="origin" x="-235" y="311"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="168" height="227">
+      <vector name="origin" x="-238" y="307"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="158" height="216">
+      <vector name="origin" x="-243" y="302"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/8820018.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/8820018.img.xml
@@ -1,0 +1,839 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="8820018.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="180"/>
+    <int name="maxHP" value="450000000"/>
+    <int name="maxMP" value="50000"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="1660"/>
+    <int name="PDDamage" value="1540"/>
+    <int name="MADamage" value="1010"/>
+    <int name="MDDamage" value="1940"/>
+    <int name="acc" value="265"/>
+    <int name="eva" value="55"/>
+    <int name="exp" value="3500000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="100000"/>
+    <int name="hpRecovery" value="100000"/>
+    <int name="mpRecovery" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="12"/>
+    <int name="firstAttack" value="1"/>
+    <int name="noFlip" value="1"/>
+    <int name="boss" value="1"/>
+    <string name="elemAttr" value="I2F3"/>
+    <int name="mobType" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="128"/>
+        <int name="action" value="2"/>
+        <int name="level" value="8"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="128"/>
+        <int name="action" value="2"/>
+        <int name="level" value="9"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="128"/>
+        <int name="action" value="2"/>
+        <int name="level" value="10"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="122"/>
+        <int name="action" value="2"/>
+        <int name="level" value="6"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <string name="banMsg" value="你被穆宁的力量驱逐到了其他地方。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="270050200"/>
+          <string name="portal" value="sp"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-500" y="-400"/>
+        <vector name="rb" x="600" y="-50"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="117" height="105">
+          <vector name="origin" x="57" y="75"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="72" height="75">
+          <vector name="origin" x="37" y="66"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="82" height="88">
+          <vector name="origin" x="40" y="73"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="83" height="118">
+          <vector name="origin" x="40" y="88"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="52" height="156">
+          <vector name="origin" x="25" y="108"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="5"/>
+      <int name="attackAfter" value="1320"/>
+      <int name="disease" value="132"/>
+      <int name="level" value="1"/>
+      <int name="magic" value="1"/>
+      <string name="elemAttr" value="I"/>
+    </imgdir>
+    <canvas name="0" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="197" height="230">
+      <vector name="origin" x="-204" y="315"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="205" height="239">
+      <vector name="origin" x="-206" y="314"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="199" height="241">
+      <vector name="origin" x="-214" y="314"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="186" height="244">
+      <vector name="origin" x="-228" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="186" height="245">
+      <vector name="origin" x="-229" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="188" height="247">
+      <vector name="origin" x="-228" y="317"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="192" height="249">
+      <vector name="origin" x="-225" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="192" height="249">
+      <vector name="origin" x="-225" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="202" height="252">
+      <vector name="origin" x="-216" y="320"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="199" height="250">
+      <vector name="origin" x="-218" y="319"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="197" height="248">
+      <vector name="origin" x="-219" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="191" height="243">
+      <vector name="origin" x="-222" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="166" height="225">
+      <vector name="origin" x="-239" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-44" y="-400"/>
+        <vector name="rb" x="44" y="0"/>
+        <int name="start" value="-3"/>
+        <int name="areaCount" value="9"/>
+        <int name="attackCount" value="5"/>
+      </imgdir>
+      <imgdir name="areaWarning">
+        <canvas name="0" width="139" height="34">
+          <vector name="origin" x="69" y="20"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="1" width="75" height="12">
+          <vector name="origin" x="35" y="11"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="2" width="83" height="34">
+          <vector name="origin" x="37" y="29"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="3" width="83" height="37">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="4" width="83" height="38">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="5" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="6" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="7" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="8" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="9" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="10" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="11" width="83" height="41">
+          <vector name="origin" x="37" y="35"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="12" width="83" height="486">
+          <vector name="origin" x="37" y="480"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="13" width="86" height="500">
+          <vector name="origin" x="40" y="494"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="14" width="89" height="506">
+          <vector name="origin" x="42" y="501"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="15" width="91" height="489">
+          <vector name="origin" x="42" y="483"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="16" width="127" height="141">
+          <vector name="origin" x="66" y="137"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="17" width="134" height="140">
+          <vector name="origin" x="70" y="136"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="18" width="134" height="136">
+          <vector name="origin" x="69" y="132"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="19" width="139" height="130">
+          <vector name="origin" x="70" y="126"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="20" width="139" height="121">
+          <vector name="origin" x="69" y="119"/>
+          <int name="delay" value="120"/>
+        </canvas>
+        <canvas name="21" width="139" height="34">
+          <vector name="origin" x="75" y="28"/>
+          <int name="delay" value="120"/>
+        </canvas>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="99" height="104">
+          <vector name="origin" x="56" y="85"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="1" width="96" height="98">
+          <vector name="origin" x="54" y="83"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="2" width="95" height="94">
+          <vector name="origin" x="56" y="79"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="3" width="96" height="85">
+          <vector name="origin" x="53" y="74"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="4" width="101" height="84">
+          <vector name="origin" x="56" y="71"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="5" width="105" height="85">
+          <vector name="origin" x="61" y="76"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <canvas name="6" width="109" height="89">
+          <vector name="origin" x="61" y="84"/>
+          <int name="delay" value="90"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="3"/>
+      <int name="conMP" value="5"/>
+      <int name="disease" value="123"/>
+      <int name="level" value="12"/>
+      <int name="attackAfter" value="1920"/>
+      <string name="PADamage" value="1000"/>
+    </imgdir>
+    <canvas name="0" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="-320" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="164" height="224">
+      <vector name="origin" x="-240" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="170" height="230">
+      <vector name="origin" x="-237" y="309"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="172" height="232">
+      <vector name="origin" x="-236" y="310"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="174" height="234">
+      <vector name="origin" x="-235" y="311"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="174" height="234">
+      <vector name="origin" x="-235" y="311"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="178" height="238">
+      <vector name="origin" x="-233" y="313"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="18" width="176" height="236">
+      <vector name="origin" x="-234" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="19" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="20" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="21" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="22" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="165" height="225">
+      <vector name="origin" x="-240" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="178" height="237">
+      <vector name="origin" x="-233" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="182" height="241">
+      <vector name="origin" x="-231" y="314"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="186" height="245">
+      <vector name="origin" x="-229" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="188" height="247">
+      <vector name="origin" x="-228" y="317"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="189" height="249">
+      <vector name="origin" x="-228" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="192" height="251">
+      <vector name="origin" x="-226" y="319"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="192" height="252">
+      <vector name="origin" x="-226" y="320"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="192" height="251">
+      <vector name="origin" x="-226" y="319"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="189" height="249">
+      <vector name="origin" x="-228" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="186" height="245">
+      <vector name="origin" x="-229" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="182" height="237">
+      <vector name="origin" x="-229" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="167" height="225">
+      <vector name="origin" x="-238" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="211" height="218">
+      <vector name="origin" x="-190" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="218" height="225">
+      <vector name="origin" x="-187" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="226" height="236">
+      <vector name="origin" x="-184" y="312"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="243" height="240">
+      <vector name="origin" x="-169" y="314"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="235" height="243">
+      <vector name="origin" x="-179" y="315"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="237" height="245">
+      <vector name="origin" x="-178" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="238" height="246">
+      <vector name="origin" x="-177" y="317"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="239" height="248">
+      <vector name="origin" x="-177" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="240" height="250">
+      <vector name="origin" x="-177" y="319"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="240" height="250">
+      <vector name="origin" x="-177" y="319"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="247" height="249">
+      <vector name="origin" x="-170" y="318"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="253" height="247">
+      <vector name="origin" x="-163" y="317"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="256" height="245">
+      <vector name="origin" x="-159" y="316"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="255" height="240">
+      <vector name="origin" x="-157" y="314"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="228" height="225">
+      <vector name="origin" x="-177" y="306"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="head" x="317" y="-306"/>
+      <vector name="rb" x="400" y="-97"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="169" height="220">
+      <vector name="origin" x="-243" y="305"/>
+      <vector name="lt" x="243" y="-293"/>
+      <vector name="rb" x="400" y="-97"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="214" height="235">
+      <vector name="origin" x="-214" y="315"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="2" width="158" height="218">
+      <vector name="origin" x="-243" y="303"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="3" width="158" height="223">
+      <vector name="origin" x="-243" y="308"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="4" width="158" height="224">
+      <vector name="origin" x="-243" y="309"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="5" width="158" height="225">
+      <vector name="origin" x="-243" y="310"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="6" width="158" height="316">
+      <vector name="origin" x="-243" y="310"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="7" width="158" height="317">
+      <vector name="origin" x="-243" y="311"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="8" width="158" height="316">
+      <vector name="origin" x="-243" y="311"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="9" width="158" height="307">
+      <vector name="origin" x="-243" y="302"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="10" width="165" height="307">
+      <vector name="origin" x="-243" y="302"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="11" width="166" height="307">
+      <vector name="origin" x="-243" y="302"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="12" width="167" height="306">
+      <vector name="origin" x="-243" y="302"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="13" width="167" height="306">
+      <vector name="origin" x="-243" y="302"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="14" width="168" height="304">
+      <vector name="origin" x="-243" y="302"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="15" width="167" height="302">
+      <vector name="origin" x="-243" y="302"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="16" width="158" height="217">
+      <vector name="origin" x="-243" y="302"/>
+      <vector name="head" x="317" y="-306"/>
+      <int name="delay" value="600"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300139.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300139.img.xml
@@ -1,0 +1,702 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9300139.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="81"/>
+    <int name="maxHP" value="660000"/>
+    <int name="maxMP" value="2500"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="400"/>
+    <int name="PDDamage" value="700"/>
+    <int name="MADamage" value="400"/>
+    <int name="MDDamage" value="990"/>
+    <int name="acc" value="170"/>
+    <int name="eva" value="28"/>
+    <int name="exp" value="12000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="6000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="13"/>
+    <int name="boss" value="1"/>
+    <int name="hpRecovery" value="3000"/>
+    <int name="mpRecovery" value="20"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="131"/>
+        <int name="action" value="1"/>
+        <int name="level" value="6"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="74"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="75"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="76"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="skill" value="121"/>
+        <int name="action" value="1"/>
+        <int name="level" value="5"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="6">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="3"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="926100400"/>
+        </imgdir>
+      </imgdir>
+      <string name="banMsg" value="你被黑暗魔法传送到了其他地方。请想办法回去帮助同伴！"/>
+    </imgdir>
+    <int name="hpTagColor" value="3"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="firstAttack" value="1"/>
+    <int name="rareItemDropLevel" value="2"/>
+    <imgdir name="default">
+      <canvas name="0" width="202" height="158">
+        <vector name="origin" x="101" y="79"/>
+        <int name="z" value="0"/>
+      </canvas>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="237" height="187">
+      <vector name="origin" x="125" y="185"/>
+      <vector name="lt" x="-98" y="-181"/>
+      <vector name="rb" x="76" y="2"/>
+      <vector name="head" x="-26" y="-181"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="1" width="235" height="182">
+      <vector name="origin" x="129" y="182"/>
+      <vector name="lt" x="-96" y="-183"/>
+      <vector name="rb" x="74" y="0"/>
+      <vector name="head" x="-27" y="-182"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="2" width="228" height="186">
+      <vector name="origin" x="122" y="186"/>
+      <vector name="lt" x="-95" y="-187"/>
+      <vector name="rb" x="74" y="-1"/>
+      <vector name="head" x="-26" y="-187"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="3" width="227" height="180">
+      <vector name="origin" x="121" y="179"/>
+      <vector name="lt" x="-97" y="-179"/>
+      <vector name="rb" x="75" y="0"/>
+      <vector name="head" x="-29" y="-181"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="4" width="234" height="183">
+      <vector name="origin" x="122" y="183"/>
+      <vector name="lt" x="-98" y="-182"/>
+      <vector name="rb" x="77" y="0"/>
+      <vector name="head" x="-23" y="-182"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="5" width="237" height="189">
+      <vector name="origin" x="129" y="189"/>
+      <vector name="lt" x="-100" y="-187"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="-25" y="-185"/>
+      <int name="delay" value="130"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="237" height="185">
+      <vector name="origin" x="125" y="185"/>
+      <vector name="lt" x="-126" y="-185"/>
+      <vector name="rb" x="112" y="0"/>
+      <vector name="head" x="-24" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="235" height="179">
+      <vector name="origin" x="129" y="179"/>
+      <vector name="lt" x="-129" y="-179"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-24" y="-179"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="228" height="178">
+      <vector name="origin" x="122" y="178"/>
+      <vector name="lt" x="-122" y="-178"/>
+      <vector name="rb" x="106" y="-1"/>
+      <vector name="head" x="-25" y="-178"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="227" height="179">
+      <vector name="origin" x="121" y="179"/>
+      <vector name="lt" x="-121" y="-179"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-26" y="-178"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="234" height="181">
+      <vector name="origin" x="122" y="181"/>
+      <vector name="lt" x="-122" y="-182"/>
+      <vector name="rb" x="112" y="-1"/>
+      <vector name="head" x="-27" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="237" height="184">
+      <vector name="origin" x="129" y="184"/>
+      <vector name="lt" x="-129" y="-185"/>
+      <vector name="rb" x="108" y="0"/>
+      <vector name="head" x="-27" y="-184"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="236" height="185">
+      <vector name="origin" x="124" y="185"/>
+      <vector name="lt" x="-125" y="-185"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-27" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="235" height="179">
+      <vector name="origin" x="129" y="179"/>
+      <vector name="lt" x="-129" y="-179"/>
+      <vector name="rb" x="105" y="0"/>
+      <vector name="head" x="-29" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="228" height="178">
+      <vector name="origin" x="122" y="178"/>
+      <vector name="lt" x="-122" y="-179"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-27" y="-178"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="227" height="179">
+      <vector name="origin" x="121" y="179"/>
+      <vector name="lt" x="-121" y="-179"/>
+      <vector name="rb" x="106" y="-1"/>
+      <vector name="head" x="-27" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="234" height="181">
+      <vector name="origin" x="122" y="181"/>
+      <vector name="lt" x="-122" y="-181"/>
+      <vector name="rb" x="111" y="0"/>
+      <vector name="head" x="-25" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="237" height="185">
+      <vector name="origin" x="129" y="185"/>
+      <vector name="lt" x="-129" y="-185"/>
+      <vector name="rb" x="108" y="0"/>
+      <vector name="head" x="-27" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-11" y="-51"/>
+        <int name="r" value="200"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="141" height="124">
+          <vector name="origin" x="66" y="101"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="1" width="58" height="60">
+          <vector name="origin" x="29" y="59"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="2" width="65" height="71">
+          <vector name="origin" x="31" y="65"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="3" width="66" height="95">
+          <vector name="origin" x="31" y="77"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="4" width="42" height="125">
+          <vector name="origin" x="20" y="92"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="5" width="31" height="131">
+          <vector name="origin" x="16" y="95"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="1"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="720"/>
+      <int name="magic" value="1"/>
+      <int name="deadlyAttack" value="1"/>
+    </imgdir>
+    <canvas name="0" width="229" height="180">
+      <vector name="origin" x="123" y="180"/>
+      <vector name="lt" x="-124" y="-181"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-24" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="229" height="180">
+      <vector name="origin" x="123" y="180"/>
+      <vector name="lt" x="-123" y="-180"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-28" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="229" height="180">
+      <vector name="origin" x="123" y="180"/>
+      <vector name="lt" x="-123" y="-180"/>
+      <vector name="rb" x="105" y="0"/>
+      <vector name="head" x="-25" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="227" height="177">
+      <vector name="origin" x="122" y="177"/>
+      <vector name="lt" x="-123" y="-177"/>
+      <vector name="rb" x="105" y="-1"/>
+      <vector name="head" x="-26" y="-179"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="229" height="207">
+      <vector name="origin" x="123" y="207"/>
+      <vector name="lt" x="-123" y="-208"/>
+      <vector name="rb" x="105" y="-1"/>
+      <vector name="head" x="-26" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="341" height="224">
+      <vector name="origin" x="229" y="224"/>
+      <vector name="lt" x="-230" y="-224"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-24" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="337" height="223">
+      <vector name="origin" x="226" y="223"/>
+      <vector name="lt" x="-226" y="-223"/>
+      <vector name="rb" x="112" y="0"/>
+      <vector name="head" x="-24" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="319" height="223">
+      <vector name="origin" x="208" y="223"/>
+      <vector name="lt" x="-208" y="-223"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-29" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="237" height="203">
+      <vector name="origin" x="129" y="203"/>
+      <vector name="lt" x="-129" y="-203"/>
+      <vector name="rb" x="108" y="0"/>
+      <vector name="head" x="-23" y="-197"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="237" height="173">
+      <vector name="origin" x="129" y="173"/>
+      <vector name="lt" x="-130" y="-173"/>
+      <vector name="rb" x="108" y="-1"/>
+      <vector name="head" x="-26" y="-171"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="10" value="../stand/0"/>
+    <uol name="11" value="../stand/1"/>
+    <uol name="12" value="../stand/2"/>
+    <uol name="13" value="../stand/3"/>
+    <uol name="14" value="../stand/4"/>
+    <uol name="15" value="../stand/5"/>
+    <uol name="16" value="../stand/6"/>
+    <uol name="17" value="../stand/7"/>
+    <uol name="18" value="../stand/8"/>
+    <uol name="19" value="../stand/9"/>
+    <uol name="20" value="../stand/10"/>
+    <uol name="21" value="../stand/11"/>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-320" y="-140"/>
+        <vector name="rb" x="30" y="10"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="56" height="58">
+          <vector name="origin" x="27" y="48"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="1" width="64" height="72">
+          <vector name="origin" x="31" y="53"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="2" width="84" height="83">
+          <vector name="origin" x="40" y="61"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="1440"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="420"/>
+    </imgdir>
+    <canvas name="0" width="173" height="180">
+      <vector name="origin" x="98" y="180"/>
+      <vector name="lt" x="-98" y="-180"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-25" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="189" height="187">
+      <vector name="origin" x="108" y="184"/>
+      <vector name="lt" x="-109" y="-184"/>
+      <vector name="rb" x="81" y="3"/>
+      <vector name="head" x="-24" y="-183"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="204" height="201">
+      <vector name="origin" x="115" y="192"/>
+      <vector name="lt" x="-109" y="-181"/>
+      <vector name="rb" x="76" y="8"/>
+      <vector name="head" x="-26" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="208" height="207">
+      <vector name="origin" x="117" y="195"/>
+      <vector name="lt" x="-105" y="-181"/>
+      <vector name="rb" x="74" y="0"/>
+      <vector name="head" x="-27" y="-183"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="210" height="208">
+      <vector name="origin" x="118" y="196"/>
+      <vector name="lt" x="-105" y="-179"/>
+      <vector name="rb" x="68" y="-1"/>
+      <vector name="head" x="-24" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="212" height="209">
+      <vector name="origin" x="119" y="196"/>
+      <vector name="lt" x="-110" y="-179"/>
+      <vector name="rb" x="71" y="1"/>
+      <vector name="head" x="-24" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="199" height="204">
+      <vector name="origin" x="111" y="191"/>
+      <vector name="lt" x="-94" y="-175"/>
+      <vector name="rb" x="64" y="0"/>
+      <vector name="head" x="-25" y="-179"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="193" height="198">
+      <vector name="origin" x="108" y="186"/>
+      <vector name="lt" x="-91" y="-167"/>
+      <vector name="rb" x="63" y="-1"/>
+      <vector name="head" x="-25" y="-172"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="241" height="202">
+      <vector name="origin" x="130" y="250"/>
+      <vector name="lt" x="-118" y="-243"/>
+      <vector name="rb" x="104" y="-49"/>
+      <vector name="head" x="-25" y="-238"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="235" height="185">
+      <vector name="origin" x="126" y="260"/>
+      <vector name="lt" x="-118" y="-251"/>
+      <vector name="rb" x="100" y="-76"/>
+      <vector name="head" x="-27" y="-244"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="235" height="185">
+      <vector name="origin" x="126" y="258"/>
+      <vector name="lt" x="-104" y="-241"/>
+      <vector name="rb" x="101" y="-75"/>
+      <vector name="head" x="-24" y="-245"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="232" height="163">
+      <vector name="origin" x="127" y="161"/>
+      <vector name="lt" x="-111" y="-152"/>
+      <vector name="rb" x="90" y="1"/>
+      <vector name="head" x="-25" y="-158"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="221" height="155">
+      <vector name="origin" x="122" y="153"/>
+      <vector name="lt" x="-119" y="-150"/>
+      <vector name="rb" x="87" y="2"/>
+      <vector name="head" x="-24" y="-155"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="204" height="153">
+      <vector name="origin" x="112" y="151"/>
+      <vector name="lt" x="-103" y="-147"/>
+      <vector name="rb" x="85" y="2"/>
+      <vector name="head" x="-23" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="239" height="161">
+      <vector name="origin" x="126" y="160"/>
+      <vector name="lt" x="-118" y="-154"/>
+      <vector name="rb" x="102" y="0"/>
+      <vector name="head" x="-26" y="-159"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="264" height="185">
+      <vector name="origin" x="140" y="185"/>
+      <vector name="lt" x="-133" y="-186"/>
+      <vector name="rb" x="115" y="0"/>
+      <vector name="head" x="-25" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="260" height="184">
+      <vector name="origin" x="138" y="184"/>
+      <vector name="lt" x="-122" y="-183"/>
+      <vector name="rb" x="102" y="-1"/>
+      <vector name="head" x="-26" y="-184"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="174" height="183">
+      <vector name="origin" x="98" y="183"/>
+      <vector name="lt" x="-96" y="-182"/>
+      <vector name="rb" x="70" y="0"/>
+      <vector name="head" x="-26" y="-183"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+    <uol name="24" value="../stand/6"/>
+    <uol name="25" value="../stand/7"/>
+    <uol name="26" value="../stand/8"/>
+    <uol name="27" value="../stand/9"/>
+    <uol name="28" value="../stand/10"/>
+    <uol name="29" value="../stand/11"/>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="229" height="180">
+      <vector name="origin" x="123" y="180"/>
+      <vector name="lt" x="-124" y="-180"/>
+      <vector name="rb" x="104" y="0"/>
+      <vector name="head" x="-25" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="229" height="180">
+      <vector name="origin" x="123" y="180"/>
+      <vector name="lt" x="-123" y="-182"/>
+      <vector name="rb" x="106" y="-1"/>
+      <vector name="head" x="-25" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="227" height="177">
+      <vector name="origin" x="122" y="177"/>
+      <vector name="lt" x="-122" y="-177"/>
+      <vector name="rb" x="104" y="-1"/>
+      <vector name="head" x="-26" y="-177"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="235" height="257">
+      <vector name="origin" x="129" y="207"/>
+      <vector name="lt" x="-122" y="-207"/>
+      <vector name="rb" x="105" y="-1"/>
+      <vector name="head" x="-23" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="237" height="265">
+      <vector name="origin" x="125" y="224"/>
+      <vector name="lt" x="-123" y="-222"/>
+      <vector name="rb" x="112" y="0"/>
+      <vector name="head" x="-24" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="235" height="244">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-125" y="-223"/>
+      <vector name="rb" x="110" y="0"/>
+      <vector name="head" x="-24" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="233" height="222">
+      <vector name="origin" x="123" y="222"/>
+      <vector name="lt" x="-124" y="-222"/>
+      <vector name="rb" x="109" y="0"/>
+      <vector name="head" x="-23" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="235" height="224">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-123" y="-218"/>
+      <vector name="rb" x="110" y="1"/>
+      <vector name="head" x="-26" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="235" height="269">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-125" y="-223"/>
+      <vector name="rb" x="110" y="-1"/>
+      <vector name="head" x="-24" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="235" height="259">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-223"/>
+      <vector name="rb" x="110" y="1"/>
+      <vector name="head" x="-24" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="235" height="248">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-223"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-26" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="235" height="236">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-222"/>
+      <vector name="rb" x="110" y="0"/>
+      <vector name="head" x="-25" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="235" height="239">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-221"/>
+      <vector name="rb" x="110" y="-1"/>
+      <vector name="head" x="-25" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="235" height="235">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-219"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-23" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="235" height="236">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-221"/>
+      <vector name="rb" x="110" y="-2"/>
+      <vector name="head" x="-26" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="237" height="210">
+      <vector name="origin" x="129" y="203"/>
+      <vector name="lt" x="-129" y="-201"/>
+      <vector name="rb" x="108" y="1"/>
+      <vector name="head" x="-24" y="-198"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="237" height="180">
+      <vector name="origin" x="129" y="173"/>
+      <vector name="lt" x="-128" y="-170"/>
+      <vector name="rb" x="107" y="-1"/>
+      <vector name="head" x="-24" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="229" height="180">
+      <vector name="origin" x="123" y="180"/>
+      <vector name="lt" x="-124" y="-180"/>
+      <vector name="rb" x="106" y="-1"/>
+      <vector name="head" x="-24" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+    <uol name="24" value="../stand/6"/>
+    <uol name="25" value="../stand/7"/>
+    <uol name="26" value="../stand/8"/>
+    <uol name="27" value="../stand/9"/>
+    <uol name="28" value="../stand/10"/>
+    <uol name="29" value="../stand/11"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="200" height="196">
+      <vector name="origin" x="93" y="198"/>
+      <vector name="lt" x="-93" y="-192"/>
+      <vector name="rb" x="107" y="-3"/>
+      <vector name="head" x="-8" y="-199"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="204" height="196">
+      <vector name="origin" x="93" y="198"/>
+      <vector name="head" x="-5" y="-198"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="233" height="212">
+      <vector name="origin" x="111" y="244"/>
+      <vector name="head" x="-4" y="-245"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="252" height="211">
+      <vector name="origin" x="119" y="238"/>
+      <vector name="head" x="-2" y="-237"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="270" height="236">
+      <vector name="origin" x="129" y="237"/>
+      <vector name="head" x="2" y="-237"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="266" height="228">
+      <vector name="origin" x="128" y="231"/>
+      <vector name="head" x="7" y="-232"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="249" height="226">
+      <vector name="origin" x="123" y="225"/>
+      <vector name="head" x="9" y="-225"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="135" height="206">
+      <vector name="origin" x="63" y="219"/>
+      <vector name="head" x="15" y="-220"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="104" height="201">
+      <vector name="origin" x="29" y="214"/>
+      <vector name="head" x="22" y="-215"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="109" height="96">
+      <vector name="origin" x="39" y="98"/>
+      <vector name="head" x="15" y="-99"/>
+      <int name="delay" value="210"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300140.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300140.img.xml
@@ -1,0 +1,723 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9300140.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="84"/>
+    <int name="maxHP" value="850000"/>
+    <int name="maxMP" value="2500"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="440"/>
+    <int name="PDDamage" value="800"/>
+    <int name="MADamage" value="440"/>
+    <int name="MDDamage" value="990"/>
+    <int name="acc" value="190"/>
+    <int name="eva" value="33"/>
+    <int name="exp" value="25000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="6000"/>
+    <string name="elemAttr" value="L2S2"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="14"/>
+    <int name="boss" value="1"/>
+    <int name="hideName" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="131"/>
+        <int name="action" value="1"/>
+        <int name="level" value="6"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="74"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="75"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="76"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="skill" value="121"/>
+        <int name="action" value="1"/>
+        <int name="level" value="5"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="6">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="3"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="926100400"/>
+        </imgdir>
+      </imgdir>
+      <string name="banMsg" value="你被黑暗魔法传送到了其他地方。请想办法回去帮助同伴！"/>
+    </imgdir>
+    <int name="hpTagColor" value="3"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpRecovery" value="3000"/>
+    <int name="mpRecovery" value="20"/>
+    <int name="mobType" value="8"/>
+    <int name="rareItemDropLevel" value="2"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="237" height="187">
+      <vector name="origin" x="125" y="185"/>
+      <vector name="lt" x="-98" y="-181"/>
+      <vector name="rb" x="76" y="2"/>
+      <vector name="head" x="-26" y="-181"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="1" width="235" height="186">
+      <vector name="origin" x="129" y="186"/>
+      <vector name="lt" x="-96" y="-183"/>
+      <vector name="rb" x="74" y="0"/>
+      <vector name="head" x="-27" y="-182"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="2" width="228" height="190">
+      <vector name="origin" x="122" y="190"/>
+      <vector name="lt" x="-95" y="-187"/>
+      <vector name="rb" x="74" y="-1"/>
+      <vector name="head" x="-26" y="-187"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="3" width="227" height="184">
+      <vector name="origin" x="121" y="183"/>
+      <vector name="lt" x="-97" y="-179"/>
+      <vector name="rb" x="75" y="0"/>
+      <vector name="head" x="-29" y="-181"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="4" width="234" height="185">
+      <vector name="origin" x="122" y="185"/>
+      <vector name="lt" x="-98" y="-182"/>
+      <vector name="rb" x="77" y="0"/>
+      <vector name="head" x="-23" y="-182"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="5" width="237" height="190">
+      <vector name="origin" x="129" y="190"/>
+      <vector name="lt" x="-100" y="-187"/>
+      <vector name="rb" x="77" y="1"/>
+      <vector name="head" x="-25" y="-185"/>
+      <int name="delay" value="130"/>
+    </canvas>
+    <canvas name="6" width="237" height="187">
+      <vector name="origin" x="125" y="185"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="7" width="235" height="186">
+      <vector name="origin" x="129" y="186"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="8" width="228" height="190">
+      <vector name="origin" x="122" y="190"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="9" width="227" height="184">
+      <vector name="origin" x="121" y="183"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="10" width="234" height="185">
+      <vector name="origin" x="122" y="185"/>
+      <int name="z" value="0"/>
+    </canvas>
+    <canvas name="11" width="237" height="190">
+      <vector name="origin" x="129" y="190"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="237" height="185">
+      <vector name="origin" x="125" y="185"/>
+      <vector name="lt" x="-126" y="-185"/>
+      <vector name="rb" x="112" y="0"/>
+      <vector name="head" x="-24" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="235" height="183">
+      <vector name="origin" x="129" y="183"/>
+      <vector name="lt" x="-129" y="-179"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-24" y="-179"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="228" height="182">
+      <vector name="origin" x="122" y="182"/>
+      <vector name="lt" x="-122" y="-178"/>
+      <vector name="rb" x="106" y="-1"/>
+      <vector name="head" x="-25" y="-178"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="227" height="183">
+      <vector name="origin" x="121" y="183"/>
+      <vector name="lt" x="-121" y="-179"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-26" y="-178"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="234" height="184">
+      <vector name="origin" x="122" y="184"/>
+      <vector name="lt" x="-122" y="-182"/>
+      <vector name="rb" x="112" y="-1"/>
+      <vector name="head" x="-27" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="237" height="185">
+      <vector name="origin" x="129" y="185"/>
+      <vector name="lt" x="-129" y="-185"/>
+      <vector name="rb" x="108" y="0"/>
+      <vector name="head" x="-27" y="-184"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="236" height="185">
+      <vector name="origin" x="124" y="185"/>
+      <vector name="lt" x="-125" y="-185"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-27" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="235" height="183">
+      <vector name="origin" x="129" y="183"/>
+      <vector name="lt" x="-129" y="-179"/>
+      <vector name="rb" x="105" y="0"/>
+      <vector name="head" x="-29" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="228" height="182">
+      <vector name="origin" x="122" y="182"/>
+      <vector name="lt" x="-122" y="-179"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-27" y="-178"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="227" height="183">
+      <vector name="origin" x="121" y="183"/>
+      <vector name="lt" x="-121" y="-179"/>
+      <vector name="rb" x="106" y="-1"/>
+      <vector name="head" x="-27" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="234" height="184">
+      <vector name="origin" x="122" y="184"/>
+      <vector name="lt" x="-122" y="-181"/>
+      <vector name="rb" x="111" y="0"/>
+      <vector name="head" x="-25" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="237" height="185">
+      <vector name="origin" x="129" y="185"/>
+      <vector name="lt" x="-129" y="-185"/>
+      <vector name="rb" x="108" y="0"/>
+      <vector name="head" x="-27" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="attack1">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-11" y="-51"/>
+        <int name="r" value="200"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="141" height="124">
+          <vector name="origin" x="66" y="101"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="1" width="58" height="60">
+          <vector name="origin" x="29" y="59"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="2" width="65" height="71">
+          <vector name="origin" x="31" y="65"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="3" width="66" height="95">
+          <vector name="origin" x="31" y="77"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="4" width="42" height="125">
+          <vector name="origin" x="20" y="92"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="5" width="31" height="131">
+          <vector name="origin" x="16" y="95"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="1"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="720"/>
+      <int name="magic" value="1"/>
+      <int name="deadlyAttack" value="1"/>
+    </imgdir>
+    <canvas name="0" width="229" height="184">
+      <vector name="origin" x="123" y="184"/>
+      <vector name="lt" x="-124" y="-181"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-24" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="229" height="184">
+      <vector name="origin" x="123" y="184"/>
+      <vector name="lt" x="-123" y="-180"/>
+      <vector name="rb" x="106" y="0"/>
+      <vector name="head" x="-28" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="229" height="184">
+      <vector name="origin" x="123" y="184"/>
+      <vector name="lt" x="-123" y="-180"/>
+      <vector name="rb" x="105" y="0"/>
+      <vector name="head" x="-25" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="227" height="181">
+      <vector name="origin" x="122" y="181"/>
+      <vector name="lt" x="-123" y="-177"/>
+      <vector name="rb" x="105" y="-1"/>
+      <vector name="head" x="-26" y="-179"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="229" height="211">
+      <vector name="origin" x="123" y="211"/>
+      <vector name="lt" x="-123" y="-208"/>
+      <vector name="rb" x="105" y="-1"/>
+      <vector name="head" x="-26" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="341" height="224">
+      <vector name="origin" x="229" y="224"/>
+      <vector name="lt" x="-230" y="-224"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-24" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="337" height="223">
+      <vector name="origin" x="226" y="223"/>
+      <vector name="lt" x="-226" y="-223"/>
+      <vector name="rb" x="112" y="0"/>
+      <vector name="head" x="-24" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="319" height="223">
+      <vector name="origin" x="208" y="223"/>
+      <vector name="lt" x="-208" y="-223"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-29" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="237" height="203">
+      <vector name="origin" x="129" y="203"/>
+      <vector name="lt" x="-129" y="-203"/>
+      <vector name="rb" x="108" y="0"/>
+      <vector name="head" x="-23" y="-197"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="237" height="174">
+      <vector name="origin" x="129" y="174"/>
+      <vector name="lt" x="-130" y="-173"/>
+      <vector name="rb" x="108" y="-1"/>
+      <vector name="head" x="-26" y="-171"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="10" value="../stand/0"/>
+    <uol name="11" value="../stand/1"/>
+    <uol name="12" value="../stand/2"/>
+    <uol name="13" value="../stand/3"/>
+    <uol name="14" value="../stand/4"/>
+    <uol name="15" value="../stand/5"/>
+    <uol name="16" value="../stand/6"/>
+    <uol name="17" value="../stand/7"/>
+    <uol name="18" value="../stand/8"/>
+    <uol name="19" value="../stand/9"/>
+    <uol name="20" value="../stand/10"/>
+    <uol name="21" value="../stand/11"/>
+  </imgdir>
+  <imgdir name="attack2">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="lt" x="-320" y="-140"/>
+        <vector name="rb" x="30" y="10"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="56" height="58">
+          <vector name="origin" x="27" y="48"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="1" width="64" height="72">
+          <vector name="origin" x="31" y="53"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <canvas name="2" width="84" height="83">
+          <vector name="origin" x="40" y="61"/>
+          <int name="delay" value="60"/>
+        </canvas>
+        <int name="attach" value="1"/>
+      </imgdir>
+      <int name="type" value="0"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="1440"/>
+      <int name="jumpAttack" value="1"/>
+      <int name="PADamage" value="460"/>
+    </imgdir>
+    <canvas name="0" width="173" height="184">
+      <vector name="origin" x="97" y="184"/>
+      <vector name="lt" x="-98" y="-180"/>
+      <vector name="rb" x="75" y="-1"/>
+      <vector name="head" x="-25" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="189" height="188">
+      <vector name="origin" x="107" y="185"/>
+      <vector name="lt" x="-109" y="-184"/>
+      <vector name="rb" x="81" y="3"/>
+      <vector name="head" x="-24" y="-183"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="204" height="201">
+      <vector name="origin" x="114" y="192"/>
+      <vector name="lt" x="-109" y="-181"/>
+      <vector name="rb" x="76" y="8"/>
+      <vector name="head" x="-26" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="208" height="207">
+      <vector name="origin" x="116" y="195"/>
+      <vector name="lt" x="-105" y="-181"/>
+      <vector name="rb" x="74" y="0"/>
+      <vector name="head" x="-27" y="-183"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="210" height="208">
+      <vector name="origin" x="117" y="196"/>
+      <vector name="lt" x="-105" y="-179"/>
+      <vector name="rb" x="68" y="-1"/>
+      <vector name="head" x="-24" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="212" height="209">
+      <vector name="origin" x="118" y="196"/>
+      <vector name="lt" x="-110" y="-179"/>
+      <vector name="rb" x="71" y="1"/>
+      <vector name="head" x="-24" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="199" height="204">
+      <vector name="origin" x="110" y="191"/>
+      <vector name="lt" x="-94" y="-175"/>
+      <vector name="rb" x="64" y="0"/>
+      <vector name="head" x="-25" y="-179"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="193" height="198">
+      <vector name="origin" x="107" y="186"/>
+      <vector name="lt" x="-91" y="-167"/>
+      <vector name="rb" x="63" y="-1"/>
+      <vector name="head" x="-25" y="-172"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="241" height="202">
+      <vector name="origin" x="129" y="250"/>
+      <vector name="lt" x="-118" y="-243"/>
+      <vector name="rb" x="104" y="-49"/>
+      <vector name="head" x="-25" y="-238"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="235" height="186">
+      <vector name="origin" x="125" y="260"/>
+      <vector name="lt" x="-118" y="-251"/>
+      <vector name="rb" x="100" y="-76"/>
+      <vector name="head" x="-27" y="-244"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="235" height="186">
+      <vector name="origin" x="125" y="258"/>
+      <vector name="lt" x="-104" y="-241"/>
+      <vector name="rb" x="101" y="-75"/>
+      <vector name="head" x="-24" y="-245"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="232" height="165">
+      <vector name="origin" x="126" y="163"/>
+      <vector name="lt" x="-111" y="-152"/>
+      <vector name="rb" x="90" y="1"/>
+      <vector name="head" x="-25" y="-158"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="221" height="159">
+      <vector name="origin" x="121" y="157"/>
+      <vector name="lt" x="-119" y="-150"/>
+      <vector name="rb" x="87" y="2"/>
+      <vector name="head" x="-24" y="-155"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="204" height="157">
+      <vector name="origin" x="111" y="155"/>
+      <vector name="lt" x="-103" y="-147"/>
+      <vector name="rb" x="85" y="2"/>
+      <vector name="head" x="-23" y="-152"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="239" height="165">
+      <vector name="origin" x="125" y="164"/>
+      <vector name="lt" x="-118" y="-154"/>
+      <vector name="rb" x="102" y="0"/>
+      <vector name="head" x="-26" y="-159"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="264" height="189">
+      <vector name="origin" x="139" y="189"/>
+      <vector name="lt" x="-133" y="-186"/>
+      <vector name="rb" x="115" y="0"/>
+      <vector name="head" x="-25" y="-182"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="260" height="188">
+      <vector name="origin" x="137" y="188"/>
+      <vector name="lt" x="-122" y="-183"/>
+      <vector name="rb" x="102" y="-1"/>
+      <vector name="head" x="-26" y="-184"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="180" height="187">
+      <vector name="origin" x="97" y="187"/>
+      <vector name="lt" x="-96" y="-182"/>
+      <vector name="rb" x="70" y="0"/>
+      <vector name="head" x="-26" y="-183"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+    <uol name="24" value="../stand/6"/>
+    <uol name="25" value="../stand/7"/>
+    <uol name="26" value="../stand/8"/>
+    <uol name="27" value="../stand/9"/>
+    <uol name="28" value="../stand/10"/>
+    <uol name="29" value="../stand/11"/>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="229" height="184">
+      <vector name="origin" x="123" y="184"/>
+      <vector name="lt" x="-124" y="-180"/>
+      <vector name="rb" x="104" y="0"/>
+      <vector name="head" x="-25" y="-181"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="229" height="184">
+      <vector name="origin" x="123" y="184"/>
+      <vector name="lt" x="-123" y="-182"/>
+      <vector name="rb" x="106" y="-1"/>
+      <vector name="head" x="-25" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="229" height="184">
+      <vector name="origin" x="123" y="184"/>
+      <vector name="lt" x="-122" y="-177"/>
+      <vector name="rb" x="104" y="-1"/>
+      <vector name="head" x="-26" y="-177"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="227" height="181">
+      <vector name="origin" x="122" y="181"/>
+      <vector name="lt" x="-122" y="-207"/>
+      <vector name="rb" x="105" y="-1"/>
+      <vector name="head" x="-23" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="235" height="261">
+      <vector name="origin" x="129" y="211"/>
+      <vector name="lt" x="-123" y="-222"/>
+      <vector name="rb" x="112" y="0"/>
+      <vector name="head" x="-24" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="237" height="265">
+      <vector name="origin" x="125" y="224"/>
+      <vector name="lt" x="-125" y="-223"/>
+      <vector name="rb" x="110" y="0"/>
+      <vector name="head" x="-24" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="235" height="244">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-222"/>
+      <vector name="rb" x="109" y="0"/>
+      <vector name="head" x="-23" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="233" height="222">
+      <vector name="origin" x="123" y="222"/>
+      <vector name="lt" x="-123" y="-218"/>
+      <vector name="rb" x="110" y="1"/>
+      <vector name="head" x="-26" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="235" height="224">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-125" y="-223"/>
+      <vector name="rb" x="110" y="-1"/>
+      <vector name="head" x="-24" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="235" height="269">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-223"/>
+      <vector name="rb" x="110" y="1"/>
+      <vector name="head" x="-24" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="235" height="259">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-223"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-26" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="235" height="248">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-222"/>
+      <vector name="rb" x="110" y="0"/>
+      <vector name="head" x="-25" y="-208"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="235" height="236">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-221"/>
+      <vector name="rb" x="110" y="-1"/>
+      <vector name="head" x="-25" y="-207"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="235" height="239">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-219"/>
+      <vector name="rb" x="111" y="-1"/>
+      <vector name="head" x="-23" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="235" height="235">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-124" y="-221"/>
+      <vector name="rb" x="110" y="-2"/>
+      <vector name="head" x="-26" y="-209"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="235" height="236">
+      <vector name="origin" x="124" y="223"/>
+      <vector name="lt" x="-129" y="-201"/>
+      <vector name="rb" x="108" y="1"/>
+      <vector name="head" x="-24" y="-198"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="237" height="210">
+      <vector name="origin" x="129" y="203"/>
+      <vector name="lt" x="-128" y="-170"/>
+      <vector name="rb" x="107" y="-1"/>
+      <vector name="head" x="-24" y="-170"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="237" height="181">
+      <vector name="origin" x="129" y="174"/>
+      <vector name="lt" x="-124" y="-180"/>
+      <vector name="rb" x="106" y="-1"/>
+      <vector name="head" x="-24" y="-180"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+    <uol name="24" value="../stand/6"/>
+    <uol name="25" value="../stand/7"/>
+    <uol name="26" value="../stand/8"/>
+    <uol name="27" value="../stand/9"/>
+    <uol name="28" value="../stand/10"/>
+    <uol name="29" value="../stand/11"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="204" height="196">
+      <vector name="origin" x="93" y="198"/>
+      <vector name="lt" x="-93" y="-192"/>
+      <vector name="rb" x="107" y="-3"/>
+      <vector name="head" x="-8" y="-199"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="204" height="196">
+      <vector name="origin" x="93" y="198"/>
+      <vector name="head" x="-5" y="-198"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="233" height="212">
+      <vector name="origin" x="106" y="249"/>
+      <vector name="head" x="-4" y="-245"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="252" height="215">
+      <vector name="origin" x="109" y="247"/>
+      <vector name="head" x="-2" y="-237"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="270" height="240">
+      <vector name="origin" x="116" y="246"/>
+      <vector name="head" x="2" y="-237"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="266" height="232">
+      <vector name="origin" x="115" y="240"/>
+      <vector name="head" x="7" y="-232"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="249" height="230">
+      <vector name="origin" x="110" y="234"/>
+      <vector name="head" x="9" y="-225"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="149" height="210">
+      <vector name="origin" x="64" y="228"/>
+      <vector name="head" x="15" y="-220"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="154" height="205">
+      <vector name="origin" x="66" y="223"/>
+      <vector name="head" x="22" y="-215"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="150" height="100">
+      <vector name="origin" x="67" y="107"/>
+      <vector name="head" x="15" y="-99"/>
+      <int name="delay" value="210"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300151.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300151.img.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9300151.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="81"/>
+    <int name="maxHP" value="660000"/>
+    <int name="maxMP" value="2500"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="400"/>
+    <int name="PDDamage" value="700"/>
+    <int name="MADamage" value="400"/>
+    <int name="MDDamage" value="990"/>
+    <int name="acc" value="170"/>
+    <int name="eva" value="28"/>
+    <int name="exp" value="12000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="8000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="13"/>
+    <int name="boss" value="1"/>
+    <int name="hideName" value="1"/>
+    <int name="hpRecovery" value="3000"/>
+    <int name="mpRecovery" value="20"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="125"/>
+        <int name="action" value="1"/>
+        <int name="level" value="8"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="74"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="75"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="76"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="skill" value="121"/>
+        <int name="action" value="1"/>
+        <int name="level" value="5"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="926110400"/>
+        </imgdir>
+      </imgdir>
+      <string name="banMsg" value="你被黑暗魔法传送到了其他地方。请想办法回去帮助同伴！"/>
+    </imgdir>
+    <string name="link" value="9300139"/>
+    <int name="hpTagColor" value="3"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="firstAttack" value="1"/>
+    <int name="mobType" value="8"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300152.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300152.img.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9300152.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="84"/>
+    <int name="maxHP" value="850000"/>
+    <int name="maxMP" value="2500"/>
+    <int name="speed" value="-30"/>
+    <int name="PADamage" value="440"/>
+    <int name="PDDamage" value="800"/>
+    <int name="MADamage" value="440"/>
+    <int name="MDDamage" value="990"/>
+    <int name="acc" value="190"/>
+    <int name="eva" value="33"/>
+    <int name="exp" value="25000"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="6000"/>
+    <string name="elemAttr" value="L2S2"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="14"/>
+    <int name="boss" value="1"/>
+    <int name="hideName" value="1"/>
+    <imgdir name="skill">
+      <imgdir name="0">
+        <int name="skill" value="125"/>
+        <int name="action" value="1"/>
+        <int name="level" value="8"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="1">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="74"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="2">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="75"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="3">
+        <int name="skill" value="200"/>
+        <int name="action" value="1"/>
+        <int name="level" value="76"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="4">
+        <int name="skill" value="129"/>
+        <int name="action" value="1"/>
+        <int name="level" value="2"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+      <imgdir name="5">
+        <int name="skill" value="121"/>
+        <int name="action" value="1"/>
+        <int name="level" value="5"/>
+        <int name="effectAfter" value="0"/>
+      </imgdir>
+    </imgdir>
+    <imgdir name="ban">
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="926110400"/>
+        </imgdir>
+      </imgdir>
+      <string name="banMsg" value="你被黑暗魔法传送到了其他地方。请想办法回去帮助同伴！"/>
+    </imgdir>
+    <string name="link" value="9300140"/>
+    <int name="hpTagColor" value="3"/>
+    <int name="hpTagBgcolor" value="5"/>
+    <int name="firstAttack" value="1"/>
+    <int name="hpRecovery" value="3000"/>
+    <int name="mpRecovery" value="20"/>
+    <int name="mobType" value="8"/>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300160.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300160.img.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9300160.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="45"/>
+    <int name="maxHP" value="2550"/>
+    <int name="maxMP" value="0"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="1"/>
+    <int name="PDDamage" value="0"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="0"/>
+    <int name="acc" value="200"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <imgdir name="ban">
+      <int name="banType" value="1"/>
+      <string name="banMsg" value="监视德利的红花蛇发现了你。你将被赶出去。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="925010000"/>
+          <string name="portal" value="sp"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="53" height="64">
+      <vector name="origin" x="27" y="63"/>
+      <vector name="lt" x="-27" y="-63"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-6" y="-58"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="53" height="64">
+      <vector name="origin" x="27" y="63"/>
+      <vector name="lt" x="-28" y="-63"/>
+      <vector name="rb" x="25" y="0"/>
+      <vector name="head" x="-6" y="-58"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="59" height="64">
+      <vector name="origin" x="29" y="63"/>
+      <vector name="lt" x="-29" y="-63"/>
+      <vector name="rb" x="30" y="1"/>
+      <vector name="head" x="-8" y="-58"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="55" height="64">
+      <vector name="origin" x="28" y="63"/>
+      <vector name="lt" x="-28" y="-63"/>
+      <vector name="rb" x="27" y="1"/>
+      <vector name="head" x="-7" y="-58"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="52" height="63">
+      <vector name="origin" x="25" y="62"/>
+      <int name="delay" value="200"/>
+      <vector name="lt" x="-25" y="-62"/>
+      <vector name="rb" x="27" y="1"/>
+      <vector name="head" x="-4" y="-57"/>
+    </canvas>
+    <canvas name="1" width="51" height="63">
+      <vector name="origin" x="26" y="62"/>
+      <int name="delay" value="200"/>
+      <vector name="lt" x="-26" y="-62"/>
+      <vector name="rb" x="25" y="1"/>
+      <vector name="head" x="-6" y="-56"/>
+    </canvas>
+    <canvas name="2" width="52" height="63">
+      <vector name="origin" x="25" y="62"/>
+      <int name="delay" value="200"/>
+      <vector name="lt" x="-25" y="-62"/>
+      <vector name="rb" x="27" y="1"/>
+      <vector name="head" x="-4" y="-57"/>
+    </canvas>
+    <canvas name="3" width="52" height="62">
+      <vector name="origin" x="23" y="61"/>
+      <int name="delay" value="200"/>
+      <vector name="lt" x="-23" y="-61"/>
+      <vector name="rb" x="29" y="1"/>
+      <vector name="head" x="-2" y="-56"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="71" height="69">
+      <vector name="origin" x="32" y="68"/>
+      <int name="delay" value="600"/>
+      <vector name="lt" x="-24" y="-68"/>
+      <vector name="rb" x="39" y="1"/>
+      <vector name="head" x="4" y="-63"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="60" height="80">
+      <vector name="origin" x="29" y="79"/>
+      <vector name="head" x="0" y="-74"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="65" height="93">
+      <vector name="origin" x="19" y="92"/>
+      <vector name="head" x="0" y="-74"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="67" height="99">
+      <vector name="origin" x="11" y="100"/>
+      <vector name="head" x="0" y="-74"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="74" height="103">
+      <vector name="origin" x="8" y="106"/>
+      <vector name="head" x="0" y="-74"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="78" height="104">
+      <vector name="origin" x="6" y="108"/>
+      <vector name="head" x="0" y="-74"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="65" height="44">
+      <vector name="origin" x="-12" y="110"/>
+      <vector name="head" x="0" y="-74"/>
+      <int name="delay" value="300"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9300161.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9300161.img.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9300161.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="45"/>
+    <int name="maxHP" value="2550"/>
+    <int name="maxMP" value="0"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="1"/>
+    <int name="PDDamage" value="0"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="0"/>
+    <int name="acc" value="200"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="0"/>
+    <int name="undead" value="0"/>
+    <int name="pushed" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="1"/>
+    <int name="boss" value="1"/>
+    <imgdir name="ban">
+      <int name="banType" value="1"/>
+      <string name="banMsg" value="监视德利的红花蛇发现了你。你将被赶出去。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="925010000"/>
+          <string name="portal" value="sp"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="mobType" value="1"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="50" height="58">
+      <vector name="origin" x="25" y="57"/>
+      <vector name="lt" x="-25" y="-57"/>
+      <vector name="rb" x="25" y="1"/>
+      <vector name="head" x="-6" y="-52"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="50" height="58">
+      <vector name="origin" x="26" y="57"/>
+      <vector name="lt" x="-26" y="-57"/>
+      <vector name="rb" x="24" y="1"/>
+      <vector name="head" x="-7" y="-52"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="56" height="58">
+      <vector name="origin" x="27" y="57"/>
+      <vector name="lt" x="-27" y="-57"/>
+      <vector name="rb" x="29" y="1"/>
+      <vector name="head" x="-8" y="-52"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="52" height="58">
+      <vector name="origin" x="26" y="57"/>
+      <vector name="lt" x="-26" y="-57"/>
+      <vector name="rb" x="26" y="1"/>
+      <vector name="head" x="-7" y="-52"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="47" height="57">
+      <vector name="origin" x="25" y="56"/>
+      <int name="delay" value="200"/>
+      <vector name="lt" x="-25" y="-56"/>
+      <vector name="rb" x="22" y="1"/>
+      <vector name="head" x="-6" y="-51"/>
+    </canvas>
+    <canvas name="1" width="46" height="56">
+      <vector name="origin" x="25" y="55"/>
+      <int name="delay" value="200"/>
+      <vector name="lt" x="-25" y="-56"/>
+      <vector name="rb" x="22" y="1"/>
+      <vector name="head" x="-6" y="-51"/>
+    </canvas>
+    <canvas name="2" width="47" height="57">
+      <vector name="origin" x="25" y="56"/>
+      <int name="delay" value="200"/>
+      <vector name="lt" x="-25" y="-56"/>
+      <vector name="rb" x="22" y="1"/>
+      <vector name="head" x="-6" y="-51"/>
+    </canvas>
+    <canvas name="3" width="48" height="56">
+      <vector name="origin" x="24" y="55"/>
+      <int name="delay" value="200"/>
+      <vector name="lt" x="-25" y="-56"/>
+      <vector name="rb" x="22" y="1"/>
+      <vector name="head" x="-6" y="-51"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="61" height="64">
+      <vector name="origin" x="25" y="63"/>
+      <int name="delay" value="600"/>
+      <vector name="lt" x="-24" y="-68"/>
+      <vector name="rb" x="39" y="1"/>
+      <vector name="head" x="4" y="-63"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="56" height="67">
+      <vector name="origin" x="21" y="66"/>
+      <vector name="head" x="-2" y="-59"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="65" height="71">
+      <vector name="origin" x="17" y="65"/>
+      <vector name="head" x="2" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="70" height="70">
+      <vector name="origin" x="15" y="65"/>
+      <vector name="head" x="4" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="80" height="70">
+      <vector name="origin" x="14" y="66"/>
+      <vector name="head" x="4" y="-63"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="20" height="21">
+      <vector name="origin" x="-54" y="30"/>
+      <vector name="head" x="4" y="-63"/>
+      <int name="delay" value="300"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9500182.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9500182.img.xml
@@ -1,0 +1,390 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9500182.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="35"/>
+    <int name="maxHP" value="330000000"/>
+    <int name="maxMP" value="500"/>
+    <int name="speed" value="-23"/>
+    <int name="PADamage" value="1"/>
+    <int name="PDDamage" value="1"/>
+    <int name="MADamage" value="1"/>
+    <int name="MDDamage" value="1"/>
+    <int name="acc" value="150"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="35"/>
+    <int name="pushed" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <imgdir name="ban">
+      <int name="banType" value="1"/>
+      <string name="banMsg" value="霍古尔发现了你，你被赶出了西瓜田。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="922210300"/>
+          <string name="portal" value="out00"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="91" height="89">
+      <vector name="origin" x="43" y="89"/>
+      <vector name="lt" x="-31" y="-74"/>
+      <vector name="rb" x="24" y="-2"/>
+      <vector name="head" x="-19" y="-79"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="1" width="94" height="100">
+      <vector name="origin" x="46" y="100"/>
+      <vector name="lt" x="-36" y="-86"/>
+      <vector name="rb" x="28" y="0"/>
+      <vector name="head" x="-21" y="-91"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="2" width="95" height="88">
+      <vector name="origin" x="48" y="88"/>
+      <vector name="lt" x="-40" y="-71"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-24" y="-79"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="3" width="99" height="90">
+      <vector name="origin" x="45" y="90"/>
+      <vector name="lt" x="-37" y="-74"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="-21" y="-81"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="4" width="110" height="98">
+      <vector name="origin" x="48" y="98"/>
+      <vector name="lt" x="-38" y="-81"/>
+      <vector name="rb" x="28" y="-1"/>
+      <vector name="head" x="-21" y="-89"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="5" width="101" height="90">
+      <vector name="origin" x="45" y="90"/>
+      <vector name="lt" x="-36" y="-72"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="-19" y="-82"/>
+      <int name="delay" value="170"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="91" height="89">
+      <vector name="origin" x="43" y="89"/>
+      <vector name="lt" x="-35" y="-73"/>
+      <vector name="rb" x="29" y="0"/>
+      <vector name="head" x="-18" y="-81"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="1" width="97" height="88">
+      <vector name="origin" x="43" y="88"/>
+      <vector name="lt" x="-34" y="-71"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="-18" y="-81"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="2" width="100" height="87">
+      <vector name="origin" x="43" y="87"/>
+      <vector name="lt" x="-33" y="-69"/>
+      <vector name="rb" x="29" y="0"/>
+      <vector name="head" x="-19" y="-79"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="3" width="102" height="86">
+      <vector name="origin" x="43" y="86"/>
+      <vector name="lt" x="-34" y="-69"/>
+      <vector name="rb" x="25" y="-1"/>
+      <vector name="head" x="-19" y="-77"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="4" width="110" height="87">
+      <vector name="origin" x="43" y="87"/>
+      <vector name="lt" x="-34" y="-70"/>
+      <vector name="rb" x="30" y="0"/>
+      <vector name="head" x="-18" y="-80"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="5" width="104" height="88">
+      <vector name="origin" x="43" y="88"/>
+      <vector name="lt" x="-35" y="-71"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-18" y="-80"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <uol name="6" value="0"/>
+    <uol name="7" value="1"/>
+    <uol name="8" value="2"/>
+    <uol name="9" value="3"/>
+    <uol name="10" value="4"/>
+    <uol name="11" value="5"/>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="91" height="89">
+      <vector name="origin" x="51" y="89"/>
+      <vector name="lt" x="-42" y="-72"/>
+      <vector name="rb" x="18" y="0"/>
+      <vector name="head" x="-27" y="-81"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="1" width="96" height="88">
+      <vector name="origin" x="50" y="88"/>
+      <vector name="lt" x="-43" y="-70"/>
+      <vector name="rb" x="19" y="0"/>
+      <vector name="head" x="-25" y="-80"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="2" width="103" height="103">
+      <vector name="origin" x="35" y="103"/>
+      <vector name="lt" x="-14" y="-85"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="3" y="-95"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="3" width="100" height="102">
+      <vector name="origin" x="34" y="102"/>
+      <vector name="lt" x="-14" y="-84"/>
+      <vector name="rb" x="29" y="0"/>
+      <vector name="head" x="3" y="-94"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="4" width="103" height="107">
+      <vector name="origin" x="35" y="103"/>
+      <vector name="lt" x="-14" y="-84"/>
+      <vector name="rb" x="35" y="0"/>
+      <vector name="head" x="2" y="-93"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="5" width="108" height="108">
+      <vector name="origin" x="42" y="104"/>
+      <vector name="lt" x="-14" y="-83"/>
+      <vector name="rb" x="39" y="2"/>
+      <vector name="head" x="2" y="-93"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="6" width="113" height="109">
+      <vector name="origin" x="45" y="105"/>
+      <vector name="lt" x="-12" y="-86"/>
+      <vector name="rb" x="35" y="1"/>
+      <vector name="head" x="3" y="-93"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="7" width="114" height="103">
+      <vector name="origin" x="48" y="101"/>
+      <vector name="lt" x="-12" y="-84"/>
+      <vector name="rb" x="35" y="0"/>
+      <vector name="head" x="5" y="-92"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="8" width="119" height="102">
+      <vector name="origin" x="51" y="102"/>
+      <vector name="lt" x="-14" y="-84"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="3" y="-94"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="9" width="121" height="102">
+      <vector name="origin" x="55" y="101"/>
+      <vector name="lt" x="-14" y="-82"/>
+      <vector name="rb" x="34" y="1"/>
+      <vector name="head" x="4" y="-93"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="10" width="122" height="102">
+      <vector name="origin" x="54" y="102"/>
+      <vector name="lt" x="-14" y="-85"/>
+      <vector name="rb" x="29" y="0"/>
+      <vector name="head" x="3" y="-94"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="11" width="120" height="101">
+      <vector name="origin" x="54" y="101"/>
+      <vector name="lt" x="-12" y="-84"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="3" y="-93"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="12" width="106" height="102">
+      <vector name="origin" x="38" y="102"/>
+      <vector name="lt" x="-14" y="-85"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="4" y="-93"/>
+      <int name="delay" value="60"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="102" height="135">
+      <vector name="origin" x="60" y="135"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="107" height="138">
+      <vector name="origin" x="61" y="137"/>
+      <vector name="lt" x="-63" y="-137"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="108" height="138">
+      <vector name="origin" x="60" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="123" height="139">
+      <vector name="origin" x="73" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="48" y="2"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="122" height="139">
+      <vector name="origin" x="76" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="2"/>
+      <vector name="head" x="-23" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="115" height="139">
+      <vector name="origin" x="67" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="2"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="113" height="135">
+      <vector name="origin" x="71" y="135"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="120" height="138">
+      <vector name="origin" x="74" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-25" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="124" height="138">
+      <vector name="origin" x="76" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="153" height="143">
+      <vector name="origin" x="103" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="48" y="3"/>
+      <vector name="head" x="-24" y="-93"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="145" height="144">
+      <vector name="origin" x="99" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="4"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="144" height="142">
+      <vector name="origin" x="96" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="5"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="136" height="137">
+      <vector name="origin" x="94" y="135"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="5"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="131" height="141">
+      <vector name="origin" x="85" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="4"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="129" height="139">
+      <vector name="origin" x="81" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="2"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="125" height="140">
+      <vector name="origin" x="75" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="48" y="3"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="105" height="139">
+      <vector name="origin" x="59" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="3"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="107" height="139">
+      <vector name="origin" x="59" y="137"/>
+      <vector name="lt" x="-61" y="-137"/>
+      <vector name="rb" x="46" y="2"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="121" height="99">
+      <vector name="origin" x="55" y="99"/>
+      <vector name="lt" x="-38" y="-73"/>
+      <vector name="rb" x="25" y="0"/>
+      <vector name="head" x="-24" y="-83"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="88" height="92">
+      <vector name="origin" x="41" y="92"/>
+      <vector name="head" x="-18" y="-84"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="92" height="86">
+      <vector name="origin" x="38" y="86"/>
+      <vector name="head" x="-14" y="-78"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="92" height="78">
+      <vector name="origin" x="36" y="76"/>
+      <vector name="head" x="-13" y="-69"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="92" height="78">
+      <vector name="origin" x="36" y="80"/>
+      <vector name="head" x="-12" y="-72"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="92" height="78">
+      <vector name="origin" x="36" y="78"/>
+      <vector name="head" x="-12" y="-70"/>
+      <int name="delay" value="300"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9500183.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9500183.img.xml
@@ -1,0 +1,391 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9500183.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="35"/>
+    <int name="maxHP" value="330000000"/>
+    <int name="maxMP" value="500"/>
+    <int name="speed" value="-23"/>
+    <int name="PADamage" value="1"/>
+    <int name="PDDamage" value="1"/>
+    <int name="MADamage" value="1"/>
+    <int name="MDDamage" value="1"/>
+    <int name="acc" value="150"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="35"/>
+    <int name="pushed" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <imgdir name="ban">
+      <int name="banType" value="1"/>
+      <string name="banMsg" value="霍古尔发现了你，你被赶出了西瓜田。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="922210300"/>
+          <string name="portal" value="out00"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+    <int name="removeAfter" value="10"/>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="91" height="89">
+      <vector name="origin" x="43" y="89"/>
+      <vector name="lt" x="-34" y="-72"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="-19" y="-79"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="1" width="94" height="100">
+      <vector name="origin" x="46" y="100"/>
+      <vector name="lt" x="-37" y="-83"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="-21" y="-91"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="2" width="95" height="88">
+      <vector name="origin" x="48" y="88"/>
+      <vector name="lt" x="-42" y="-70"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-24" y="-79"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="3" width="99" height="90">
+      <vector name="origin" x="45" y="90"/>
+      <vector name="lt" x="-36" y="-73"/>
+      <vector name="rb" x="30" y="0"/>
+      <vector name="head" x="-21" y="-81"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="4" width="110" height="98">
+      <vector name="origin" x="48" y="98"/>
+      <vector name="lt" x="-37" y="-80"/>
+      <vector name="rb" x="29" y="0"/>
+      <vector name="head" x="-21" y="-89"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="5" width="101" height="90">
+      <vector name="origin" x="45" y="90"/>
+      <vector name="lt" x="-37" y="-73"/>
+      <vector name="rb" x="30" y="0"/>
+      <vector name="head" x="-19" y="-82"/>
+      <int name="delay" value="170"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="91" height="89">
+      <vector name="origin" x="43" y="89"/>
+      <vector name="lt" x="-33" y="-71"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-18" y="-81"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="1" width="97" height="88">
+      <vector name="origin" x="43" y="88"/>
+      <vector name="lt" x="-35" y="-72"/>
+      <vector name="rb" x="33" y="-1"/>
+      <vector name="head" x="-18" y="-81"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="2" width="100" height="87">
+      <vector name="origin" x="43" y="87"/>
+      <vector name="lt" x="-33" y="-69"/>
+      <vector name="rb" x="30" y="0"/>
+      <vector name="head" x="-19" y="-79"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="3" width="102" height="86">
+      <vector name="origin" x="43" y="86"/>
+      <vector name="lt" x="-34" y="-69"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-19" y="-77"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="4" width="110" height="87">
+      <vector name="origin" x="43" y="87"/>
+      <vector name="lt" x="-33" y="-71"/>
+      <vector name="rb" x="29" y="0"/>
+      <vector name="head" x="-18" y="-80"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <canvas name="5" width="104" height="88">
+      <vector name="origin" x="43" y="88"/>
+      <vector name="lt" x="-35" y="-71"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="-18" y="-80"/>
+      <int name="delay" value="170"/>
+    </canvas>
+    <uol name="6" value="0"/>
+    <uol name="7" value="1"/>
+    <uol name="8" value="2"/>
+    <uol name="9" value="3"/>
+    <uol name="10" value="4"/>
+    <uol name="11" value="5"/>
+  </imgdir>
+  <imgdir name="skill1">
+    <canvas name="0" width="91" height="89">
+      <vector name="origin" x="51" y="89"/>
+      <vector name="lt" x="-51" y="-89"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="-27" y="-81"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="1" width="96" height="88">
+      <vector name="origin" x="50" y="88"/>
+      <vector name="lt" x="-50" y="-88"/>
+      <vector name="rb" x="32" y="0"/>
+      <vector name="head" x="-25" y="-80"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="2" width="103" height="103">
+      <vector name="origin" x="35" y="103"/>
+      <vector name="lt" x="-31" y="-103"/>
+      <vector name="rb" x="57" y="0"/>
+      <vector name="head" x="3" y="-95"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="3" width="100" height="102">
+      <vector name="origin" x="34" y="102"/>
+      <vector name="lt" x="-31" y="-102"/>
+      <vector name="rb" x="56" y="0"/>
+      <vector name="head" x="3" y="-94"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="4" width="103" height="107">
+      <vector name="origin" x="35" y="103"/>
+      <vector name="lt" x="-29" y="-103"/>
+      <vector name="rb" x="54" y="0"/>
+      <vector name="head" x="2" y="-93"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="5" width="108" height="108">
+      <vector name="origin" x="42" y="104"/>
+      <vector name="lt" x="-29" y="-102"/>
+      <vector name="rb" x="52" y="1"/>
+      <vector name="head" x="2" y="-93"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="6" width="113" height="109">
+      <vector name="origin" x="45" y="105"/>
+      <vector name="lt" x="-25" y="-103"/>
+      <vector name="rb" x="54" y="1"/>
+      <vector name="head" x="3" y="-93"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="7" width="114" height="103">
+      <vector name="origin" x="48" y="101"/>
+      <vector name="lt" x="-27" y="-100"/>
+      <vector name="rb" x="53" y="0"/>
+      <vector name="head" x="5" y="-92"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="8" width="119" height="102">
+      <vector name="origin" x="51" y="102"/>
+      <vector name="lt" x="-27" y="-102"/>
+      <vector name="rb" x="55" y="0"/>
+      <vector name="head" x="3" y="-94"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="9" width="121" height="102">
+      <vector name="origin" x="55" y="101"/>
+      <vector name="lt" x="-30" y="-101"/>
+      <vector name="rb" x="54" y="1"/>
+      <vector name="head" x="4" y="-93"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="10" width="122" height="102">
+      <vector name="origin" x="54" y="102"/>
+      <vector name="lt" x="-28" y="-101"/>
+      <vector name="rb" x="53" y="0"/>
+      <vector name="head" x="3" y="-94"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="11" width="120" height="101">
+      <vector name="origin" x="54" y="101"/>
+      <vector name="lt" x="-28" y="-101"/>
+      <vector name="rb" x="52" y="0"/>
+      <vector name="head" x="3" y="-93"/>
+      <int name="delay" value="70"/>
+    </canvas>
+    <canvas name="12" width="106" height="102">
+      <vector name="origin" x="38" y="102"/>
+      <vector name="lt" x="-31" y="-102"/>
+      <vector name="rb" x="56" y="0"/>
+      <vector name="head" x="4" y="-93"/>
+      <int name="delay" value="60"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="skill2">
+    <canvas name="0" width="102" height="135">
+      <vector name="origin" x="60" y="135"/>
+      <vector name="lt" x="-62" y="-135"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="107" height="138">
+      <vector name="origin" x="61" y="137"/>
+      <vector name="lt" x="-63" y="-137"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="108" height="138">
+      <vector name="origin" x="60" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="123" height="139">
+      <vector name="origin" x="73" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="48" y="2"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="122" height="139">
+      <vector name="origin" x="76" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="2"/>
+      <vector name="head" x="-23" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="115" height="139">
+      <vector name="origin" x="67" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="2"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="113" height="135">
+      <vector name="origin" x="71" y="135"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="40" y="0"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="120" height="138">
+      <vector name="origin" x="74" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="1"/>
+      <vector name="head" x="-25" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="124" height="138">
+      <vector name="origin" x="76" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="1"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="153" height="143">
+      <vector name="origin" x="103" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="48" y="3"/>
+      <vector name="head" x="-24" y="-93"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="10" width="145" height="144">
+      <vector name="origin" x="99" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="4"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="11" width="144" height="142">
+      <vector name="origin" x="96" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="5"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="12" width="136" height="137">
+      <vector name="origin" x="94" y="135"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="5"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="13" width="131" height="141">
+      <vector name="origin" x="85" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="4"/>
+      <vector name="head" x="-24" y="-95"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="14" width="129" height="139">
+      <vector name="origin" x="81" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="46" y="2"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="15" width="125" height="140">
+      <vector name="origin" x="75" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="48" y="3"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="16" width="105" height="139">
+      <vector name="origin" x="59" y="137"/>
+      <vector name="lt" x="-62" y="-137"/>
+      <vector name="rb" x="44" y="3"/>
+      <vector name="head" x="-24" y="-94"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="17" width="107" height="139">
+      <vector name="origin" x="59" y="137"/>
+      <vector name="lt" x="-61" y="-137"/>
+      <vector name="rb" x="46" y="2"/>
+      <vector name="head" x="-24" y="-96"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <uol name="18" value="../stand/0"/>
+    <uol name="19" value="../stand/1"/>
+    <uol name="20" value="../stand/2"/>
+    <uol name="21" value="../stand/3"/>
+    <uol name="22" value="../stand/4"/>
+    <uol name="23" value="../stand/5"/>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="121" height="99">
+      <vector name="origin" x="55" y="99"/>
+      <vector name="lt" x="-48" y="-96"/>
+      <vector name="rb" x="31" y="0"/>
+      <vector name="head" x="-24" y="-83"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="88" height="92">
+      <vector name="origin" x="41" y="92"/>
+      <vector name="head" x="-18" y="-84"/>
+      <int name="delay" value="180"/>
+    </canvas>
+    <canvas name="1" width="92" height="86">
+      <vector name="origin" x="38" y="86"/>
+      <vector name="head" x="-14" y="-78"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="92" height="78">
+      <vector name="origin" x="36" y="76"/>
+      <vector name="head" x="-13" y="-69"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="92" height="78">
+      <vector name="origin" x="36" y="80"/>
+      <vector name="head" x="-12" y="-72"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="92" height="78">
+      <vector name="origin" x="36" y="78"/>
+      <vector name="head" x="-12" y="-70"/>
+      <int name="delay" value="300"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9500194.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9500194.img.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9500194.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="20"/>
+    <string name="maxHP" value="350"/>
+    <int name="maxMP" value="30"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="1"/>
+    <int name="PDDamage" value="10"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="60"/>
+    <int name="acc" value="999"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="1"/>
+    <int name="undead" value="0"/>
+    <float name="fs" value="10.0"/>
+    <int name="noFlip" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="removeAfter" value="3"/>
+    <int name="boss" value="1"/>
+    <int name="invincible" value="1"/>
+    <int name="hideName" value="1"/>
+    <imgdir name="ban">
+      <int name="banType" value="1"/>
+      <string name="banMsg" value="镜中幽灵的恶作剧把你送回了原来的位置。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="229030100"/>
+          <string name="potal" value="out00"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-40" y="-66"/>
+        <int name="r" value="50"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="52" height="47">
+          <vector name="origin" x="26" y="23"/>
+          <int name="a0" value="255"/>
+          <int name="a1" value="150"/>
+        </canvas>
+        <canvas name="1" width="44" height="38">
+          <vector name="origin" x="22" y="19"/>
+          <int name="a0" value="150"/>
+          <int name="a1" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="1"/>
+      <int name="magic" value="1"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="430"/>
+      <string name="elemAttr" value="S"/>
+    </imgdir>
+    <canvas name="0" width="96" height="92">
+      <vector name="origin" x="44" y="123"/>
+      <vector name="head" x="0" y="-116"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="1" width="158" height="112">
+      <vector name="origin" x="78" y="138"/>
+      <vector name="head" x="0" y="-129"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="2" width="158" height="149">
+      <vector name="origin" x="78" y="188"/>
+      <vector name="head" x="1" y="-143"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="3" width="89" height="141">
+      <vector name="origin" x="36" y="192"/>
+      <vector name="head" x="0" y="-150"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="168" height="132">
+      <vector name="origin" x="85" y="194"/>
+      <vector name="head" x="0" y="-148"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="170" height="187">
+      <vector name="origin" x="84" y="187"/>
+      <vector name="lt" x="-127" y="-187"/>
+      <vector name="rb" x="128" y="0"/>
+      <vector name="head" x="-1" y="-102"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="101" height="139">
+      <vector name="origin" x="42" y="138"/>
+      <vector name="lt" x="-127" y="-187"/>
+      <vector name="rb" x="128" y="0"/>
+      <vector name="head" x="-1" y="-112"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="92" height="117">
+      <vector name="origin" x="38" y="127"/>
+      <vector name="head" x="0" y="-110"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="92" height="113">
+      <vector name="origin" x="38" y="121"/>
+      <vector name="head" x="0" y="-97"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="9" width="92" height="114">
+      <vector name="origin" x="38" y="121"/>
+      <vector name="head" x="0" y="-97"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="10" width="92" height="112">
+      <vector name="origin" x="38" y="120"/>
+      <vector name="head" x="0" y="-97"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="11" width="93" height="106">
+      <vector name="origin" x="39" y="115"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="12" width="94" height="108">
+      <vector name="origin" x="39" y="118"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="13" width="98" height="104">
+      <vector name="origin" x="45" y="117"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="14" width="119" height="124">
+      <vector name="origin" x="68" y="137"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="15" width="163" height="166">
+      <vector name="origin" x="94" y="183"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-121"/>
+    </canvas>
+    <canvas name="16" width="5" height="6">
+      <vector name="origin" x="-2" y="36"/>
+      <int name="delay" value="10000"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="5" height="6">
+      <vector name="origin" x="-2" y="36"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="5" height="6">
+      <vector name="origin" x="-2" y="36"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9500303.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9500303.img.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9500303.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="20"/>
+    <string name="maxHP" value="350"/>
+    <int name="maxMP" value="30"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="1"/>
+    <int name="PDDamage" value="10"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="60"/>
+    <int name="acc" value="999"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="1"/>
+    <int name="undead" value="0"/>
+    <float name="fs" value="10.0"/>
+    <int name="noFlip" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="removeAfter" value="3"/>
+    <int name="boss" value="1"/>
+    <int name="invincible" value="1"/>
+    <int name="hideName" value="1"/>
+    <imgdir name="ban">
+      <int name="banType" value="1"/>
+      <string name="banMsg" value="镜中幽灵的恶作剧把你送回了原来的位置。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="229030500"/>
+          <string name="potal" value="out00"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-40" y="-66"/>
+        <int name="r" value="50"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="52" height="47">
+          <vector name="origin" x="26" y="23"/>
+          <int name="a0" value="255"/>
+          <int name="a1" value="150"/>
+        </canvas>
+        <canvas name="1" width="44" height="38">
+          <vector name="origin" x="22" y="19"/>
+          <int name="a0" value="150"/>
+          <int name="a1" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="1"/>
+      <int name="magic" value="1"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="430"/>
+      <string name="elemAttr" value="S"/>
+    </imgdir>
+    <canvas name="0" width="96" height="92">
+      <vector name="origin" x="44" y="123"/>
+      <vector name="head" x="0" y="-116"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="1" width="158" height="112">
+      <vector name="origin" x="78" y="138"/>
+      <vector name="head" x="0" y="-129"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="2" width="158" height="149">
+      <vector name="origin" x="78" y="188"/>
+      <vector name="head" x="1" y="-143"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="3" width="89" height="141">
+      <vector name="origin" x="36" y="192"/>
+      <vector name="head" x="0" y="-150"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="168" height="132">
+      <vector name="origin" x="85" y="194"/>
+      <vector name="head" x="0" y="-148"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="170" height="187">
+      <vector name="origin" x="84" y="187"/>
+      <vector name="lt" x="-127" y="-187"/>
+      <vector name="rb" x="128" y="0"/>
+      <vector name="head" x="-1" y="-102"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="101" height="139">
+      <vector name="origin" x="42" y="138"/>
+      <vector name="lt" x="-127" y="-187"/>
+      <vector name="rb" x="128" y="0"/>
+      <vector name="head" x="-1" y="-112"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="92" height="117">
+      <vector name="origin" x="38" y="127"/>
+      <vector name="head" x="0" y="-110"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="92" height="113">
+      <vector name="origin" x="38" y="121"/>
+      <vector name="head" x="0" y="-97"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="9" width="92" height="114">
+      <vector name="origin" x="38" y="121"/>
+      <vector name="head" x="0" y="-97"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="10" width="92" height="112">
+      <vector name="origin" x="38" y="120"/>
+      <vector name="head" x="0" y="-97"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="11" width="93" height="106">
+      <vector name="origin" x="39" y="115"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="12" width="94" height="108">
+      <vector name="origin" x="39" y="118"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="13" width="98" height="104">
+      <vector name="origin" x="45" y="117"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="14" width="119" height="124">
+      <vector name="origin" x="68" y="137"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="15" width="163" height="166">
+      <vector name="origin" x="94" y="183"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-121"/>
+    </canvas>
+    <canvas name="16" width="5" height="6">
+      <vector name="origin" x="-2" y="36"/>
+      <int name="delay" value="10000"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="5" height="6">
+      <vector name="origin" x="-2" y="36"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="5" height="6">
+      <vector name="origin" x="-2" y="36"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9500304.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9500304.img.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9500304.img">
+  <imgdir name="info">
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="20"/>
+    <string name="maxHP" value="350"/>
+    <int name="maxMP" value="30"/>
+    <int name="speed" value="0"/>
+    <int name="PADamage" value="1"/>
+    <int name="PDDamage" value="10"/>
+    <int name="MADamage" value="0"/>
+    <int name="MDDamage" value="60"/>
+    <int name="acc" value="999"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="1"/>
+    <int name="undead" value="0"/>
+    <float name="fs" value="10.0"/>
+    <int name="noFlip" value="1"/>
+    <int name="firstAttack" value="1"/>
+    <int name="removeAfter" value="3"/>
+    <int name="boss" value="1"/>
+    <int name="invincible" value="1"/>
+    <int name="hideName" value="1"/>
+    <imgdir name="ban">
+      <int name="banType" value="1"/>
+      <string name="banMsg" value="镜中幽灵的恶作剧把你送回了原来的位置。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="229030800"/>
+          <string name="potal" value="out00"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="stand">
+    <imgdir name="info">
+      <imgdir name="range">
+        <vector name="sp" x="-40" y="-66"/>
+        <int name="r" value="50"/>
+      </imgdir>
+      <imgdir name="hit">
+        <canvas name="0" width="52" height="47">
+          <vector name="origin" x="26" y="23"/>
+          <int name="a0" value="255"/>
+          <int name="a1" value="150"/>
+        </canvas>
+        <canvas name="1" width="44" height="38">
+          <vector name="origin" x="22" y="19"/>
+          <int name="a0" value="150"/>
+          <int name="a1" value="0"/>
+          <int name="delay" value="100"/>
+        </canvas>
+      </imgdir>
+      <int name="type" value="1"/>
+      <int name="magic" value="1"/>
+      <int name="conMP" value="2"/>
+      <int name="attackAfter" value="430"/>
+      <string name="elemAttr" value="S"/>
+    </imgdir>
+    <canvas name="0" width="96" height="92">
+      <vector name="origin" x="44" y="123"/>
+      <vector name="head" x="0" y="-116"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="1" width="158" height="112">
+      <vector name="origin" x="78" y="138"/>
+      <vector name="head" x="0" y="-129"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="2" width="158" height="149">
+      <vector name="origin" x="78" y="188"/>
+      <vector name="head" x="1" y="-143"/>
+      <int name="delay" value="200"/>
+    </canvas>
+    <canvas name="3" width="89" height="141">
+      <vector name="origin" x="36" y="192"/>
+      <vector name="head" x="0" y="-150"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="168" height="132">
+      <vector name="origin" x="85" y="194"/>
+      <vector name="head" x="0" y="-148"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="170" height="187">
+      <vector name="origin" x="84" y="187"/>
+      <vector name="lt" x="-127" y="-187"/>
+      <vector name="rb" x="128" y="0"/>
+      <vector name="head" x="-1" y="-102"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="6" width="101" height="139">
+      <vector name="origin" x="42" y="138"/>
+      <vector name="lt" x="-127" y="-187"/>
+      <vector name="rb" x="128" y="0"/>
+      <vector name="head" x="-1" y="-112"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="7" width="92" height="117">
+      <vector name="origin" x="38" y="127"/>
+      <vector name="head" x="0" y="-110"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="8" width="92" height="113">
+      <vector name="origin" x="38" y="121"/>
+      <vector name="head" x="0" y="-97"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="9" width="92" height="114">
+      <vector name="origin" x="38" y="121"/>
+      <vector name="head" x="0" y="-97"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="10" width="92" height="112">
+      <vector name="origin" x="38" y="120"/>
+      <vector name="head" x="0" y="-97"/>
+      <int name="delay" value="100"/>
+    </canvas>
+    <canvas name="11" width="93" height="106">
+      <vector name="origin" x="39" y="115"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="12" width="94" height="108">
+      <vector name="origin" x="39" y="118"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="13" width="98" height="104">
+      <vector name="origin" x="45" y="117"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="14" width="119" height="124">
+      <vector name="origin" x="68" y="137"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-97"/>
+    </canvas>
+    <canvas name="15" width="163" height="166">
+      <vector name="origin" x="94" y="183"/>
+      <int name="delay" value="100"/>
+      <vector name="head" x="0" y="-121"/>
+    </canvas>
+    <canvas name="16" width="5" height="6">
+      <vector name="origin" x="-2" y="36"/>
+      <int name="delay" value="10000"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="5" height="6">
+      <vector name="origin" x="-2" y="36"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="5" height="6">
+      <vector name="origin" x="-2" y="36"/>
+      <int name="z" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9500323.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9500323.img.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9500323.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="70"/>
+    <int name="maxHP" value="5000000"/>
+    <int name="maxMP" value="1"/>
+    <int name="speed" value="5"/>
+    <int name="PADamage" value="1"/>
+    <int name="PDDamage" value="1"/>
+    <int name="MADamage" value="1"/>
+    <int name="MDDamage" value="1"/>
+    <int name="acc" value="999"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="0"/>
+    <int name="pushed" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <imgdir name="ban">
+      <int name="banType" value="1"/>
+      <string name="banMsg" value="猫发现了你，你被赶出了奶酪仓库。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="926120410"/>
+          <string name="portal" value="st00"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+  <imgdir name="regen">
+    <canvas name="0" width="37" height="14">
+      <vector name="origin" x="26" y="42"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="1" width="37" height="14">
+      <vector name="origin" x="26" y="41"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="2" width="37" height="14">
+      <vector name="origin" x="26" y="40"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="3" width="37" height="14">
+      <vector name="origin" x="26" y="39"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="4" width="57" height="69">
+      <vector name="origin" x="28" y="69"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="5" width="58" height="68">
+      <vector name="origin" x="28" y="68"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="6" width="55" height="67">
+      <vector name="origin" x="28" y="67"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="7" width="54" height="66">
+      <vector name="origin" x="28" y="66"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="8" width="52" height="67">
+      <vector name="origin" x="28" y="67"/>
+      <int name="delay" value="60"/>
+    </canvas>
+    <canvas name="9" width="54" height="68">
+      <vector name="origin" x="28" y="68"/>
+      <int name="delay" value="60"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="move">
+    <canvas name="0" width="51" height="68">
+      <vector name="origin" x="27" y="68"/>
+      <vector name="lt" x="-27" y="-68"/>
+      <vector name="rb" x="24" y="0"/>
+      <vector name="head" x="-6" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="54" height="67">
+      <vector name="origin" x="28" y="67"/>
+      <vector name="lt" x="-28" y="-67"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="56" height="69">
+      <vector name="origin" x="29" y="69"/>
+      <vector name="lt" x="-29" y="-69"/>
+      <vector name="rb" x="27" y="0"/>
+      <vector name="head" x="-8" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="58" height="68">
+      <vector name="origin" x="28" y="68"/>
+      <vector name="lt" x="-28" y="-68"/>
+      <vector name="rb" x="30" y="0"/>
+      <vector name="head" x="-7" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="56" height="67">
+      <vector name="origin" x="27" y="67"/>
+      <vector name="lt" x="-27" y="-67"/>
+      <vector name="rb" x="29" y="0"/>
+      <vector name="head" x="-6" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="52" height="69">
+      <vector name="origin" x="26" y="69"/>
+      <vector name="lt" x="-26" y="-69"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-5" y="-62"/>
+      <int name="delay" value="120"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="stand">
+    <canvas name="0" width="54" height="68">
+      <vector name="origin" x="28" y="68"/>
+      <vector name="lt" x="-29" y="-68"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-7" y="-61"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="1" width="52" height="67">
+      <vector name="origin" x="28" y="67"/>
+      <vector name="lt" x="-28" y="-67"/>
+      <vector name="rb" x="24" y="0"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="2" width="54" height="66">
+      <vector name="origin" x="28" y="66"/>
+      <vector name="lt" x="-28" y="-66"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-7" y="-59"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="3" width="55" height="67">
+      <vector name="origin" x="28" y="67"/>
+      <vector name="lt" x="-29" y="-67"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-8" y="-60"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="4" width="58" height="68">
+      <vector name="origin" x="28" y="68"/>
+      <vector name="lt" x="-29" y="-68"/>
+      <vector name="rb" x="29" y="0"/>
+      <vector name="head" x="-9" y="-61"/>
+      <int name="delay" value="150"/>
+    </canvas>
+    <canvas name="5" width="57" height="69">
+      <vector name="origin" x="28" y="69"/>
+      <vector name="lt" x="-29" y="-69"/>
+      <vector name="rb" x="28" y="0"/>
+      <vector name="head" x="-8" y="-62"/>
+      <int name="delay" value="150"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="hit1">
+    <canvas name="0" width="54" height="68">
+      <vector name="origin" x="28" y="68"/>
+      <vector name="lt" x="-29" y="-68"/>
+      <vector name="rb" x="26" y="0"/>
+      <vector name="head" x="-7" y="-61"/>
+      <int name="delay" value="600"/>
+    </canvas>
+  </imgdir>
+  <imgdir name="die1">
+    <canvas name="0" width="54" height="68">
+      <vector name="origin" x="28" y="68"/>
+      <vector name="head" x="-7" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="1" width="52" height="67">
+      <vector name="origin" x="28" y="67"/>
+      <vector name="head" x="-7" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="2" width="54" height="66">
+      <vector name="origin" x="28" y="66"/>
+      <vector name="head" x="-7" y="-59"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="3" width="55" height="67">
+      <vector name="origin" x="28" y="67"/>
+      <vector name="head" x="-6" y="-60"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="4" width="58" height="68">
+      <vector name="origin" x="28" y="68"/>
+      <vector name="head" x="-6" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="5" width="57" height="69">
+      <vector name="origin" x="28" y="69"/>
+      <vector name="head" x="-6" y="-61"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="6" width="37" height="14">
+      <vector name="origin" x="26" y="39"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="7" width="37" height="14">
+      <vector name="origin" x="26" y="40"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="8" width="37" height="14">
+      <vector name="origin" x="26" y="41"/>
+      <int name="delay" value="120"/>
+    </canvas>
+    <canvas name="9" width="37" height="14">
+      <vector name="origin" x="26" y="42"/>
+      <int name="delay" value="300"/>
+      <int name="a0" value="255"/>
+      <int name="a1" value="0"/>
+    </canvas>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Mob.wz/9500324.img.xml
+++ b/gms-server/wz-zh-CN/Mob.wz/9500324.img.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imgdir name="9500324.img">
+  <imgdir name="info">
+    <int name="boss" value="1"/>
+    <int name="bodyAttack" value="1"/>
+    <int name="level" value="70"/>
+    <int name="maxHP" value="5000000"/>
+    <int name="maxMP" value="1"/>
+    <int name="speed" value="5"/>
+    <int name="PADamage" value="1"/>
+    <int name="PDDamage" value="1"/>
+    <int name="MADamage" value="1"/>
+    <int name="MDDamage" value="1"/>
+    <int name="acc" value="999"/>
+    <int name="eva" value="999"/>
+    <int name="exp" value="0"/>
+    <int name="pushed" value="1000"/>
+    <float name="fs" value="10.0"/>
+    <int name="summonType" value="0"/>
+    <string name="link" value="9500323"/>
+    <int name="removeAfter" value="5"/>
+    <imgdir name="ban">
+      <int name="banType" value="1"/>
+      <string name="banMsg" value="猫发现了你，你被赶出了奶酪仓库。"/>
+      <imgdir name="banMap">
+        <imgdir name="0">
+          <int name="field" value="926120410"/>
+          <string name="portal" value="st00"/>
+        </imgdir>
+      </imgdir>
+    </imgdir>
+  </imgdir>
+</imgdir>

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -12090,16 +12090,16 @@
     <imgdir name="3379">
         <string name="name" value="罗密欧的求婚"/>
         <string name="0" value="正和朱丽叶处于热恋之中的玛加提亚的炼金术士罗密欧。他说他终于下定决心，要想朱丽叶求婚。去见见#b罗密欧#k吧。"/>
-        <string name="1" value="罗密欧说自己虽然有很多缺点，但是相信朱丽叶一定会理解自己，因此决定向她求婚。让我帮他去买结婚戒指。戒指好像只要去#b玛加提亚#k的#b阿尔雷哥#k那里购买就行。\n\n#i4031806##t4031806# #b#c4031806##k/1 "/>
+        <string name="1" value="罗密欧说自己虽然有很多缺点，但是相信朱丽叶一定会理解自己，因此决定向她求婚。让我帮他去买结婚戒指。戒指好像只要去#b婚礼村#k的#b穆尼#k那里购买就行。\n\n#i4031806##t4031806# #b#c4031806##k/1 "/>
         <string name="2" value="把买到的求婚戒指交给了罗密欧。好了，接下去的求婚，就是他自己的事情了。虽然有点惊世骇俗，但是比任何人都要般配的罗密欧和朱丽叶。两个人一定会成功的……"/>
         <int name="area" value="44"/>
         <string name="sortkey" value="70"/>
     </imgdir>
     <imgdir name="3380">
-        <string name="name" value="戒指匠人阿尔雷哥!"/>
-        <string name="0" value="决心向朱丽叶求婚的罗密欧。为了帮他进行求婚，帮他去购买戒指吧。据说婚礼桥的戒指匠人阿尔雷哥可以制作戒指。"/>
-        <string name="1" value="阿尔雷哥说最适合罗密欧和朱丽叶的是纯洁的银翼戒指，让我帮他去搜集制作戒指的材料。\n\n#i4021007##t4021007# #b#c4021007##k/2 \n#i4011004##t4011004# #b#c4011004##k/2"/>
-        <string name="2" value="从阿尔雷哥那里拿到了戒指。赶紧把它交给#b罗密欧#k吧。"/>
+        <string name="name" value="戒指匠人穆尼!"/>
+        <string name="0" value="决心向朱丽叶求婚的罗密欧。为了帮他进行求婚，帮他去购买戒指吧。据说婚礼村的戒指匠人穆尼可以制作戒指。"/>
+        <string name="1" value="穆尼说最适合罗密欧和朱丽叶的是纯洁的银翼戒指，让我帮他去搜集制作戒指的材料。\n\n#i4021007##t4021007# #b#c4021007##k/2 \n#i4011004##t4011004# #b#c4011004##k/2"/>
+        <string name="2" value="从穆尼那里拿到了戒指。赶紧把它交给#b罗密欧#k吧。"/>
         <int name="area" value="44"/>
         <string name="sortkey" value="70"/>
     </imgdir>
@@ -13375,24 +13375,24 @@
         <string name="rewardSummary" value="经验值 30,000\r\n可参加“流浪者的行踪1”任务。\r\n"/>
     </imgdir>
     <imgdir name="3716">
-        <string name="name" value="The Wanderer&apos;s Whereabouts 1"/>
+        <string name="name" value="流浪者的行踪1"/>
         <int name="area" value="41"/>
-        <string name="1" value="#bSyras the ticket agent#k at Ariant Station claims the suspicious wanderer headed to Orbis and that you should talk to #bIsa#k at Orbis Station."/>
-        <string name="parent" value="The Truth Behind that Man"/>
+        <string name="1" value="阿里安特车站售票员#b赛拉斯#k说，可疑的流浪者已经前往天空之城，让我去天空之城码头找#b艺斯#k打听。"/>
+        <string name="parent" value="那个人背后的真相"/>
         <int name="order" value="2"/>
-        <string name="2" value="You meet Isa the station guide as Syras instructed. Isa says an absent-minded man asked her directions to Leafre. She added that he was rather strange."/>
-        <string name="demandSummary" value="#bTalk to Isa the Station Guide in Orbis"/>
-        <string name="rewardSummary" value="EXP 30,000\r\nCan participate in the &quot;Wanderer&apos;s Whereabouts 2&quot; quest.\r\n"/>
+        <string name="2" value="按照赛拉斯的指示，我见到了天空之城码头的服务员艺斯。艺斯说，有个心神不宁的男人向他询问去神木村的路，还说那个人非常奇怪。"/>
+        <string name="demandSummary" value="#b与天空之城码头的服务员艺斯对话。"/>
+        <string name="rewardSummary" value="经验值 30,000\r\n可参加“流浪者的行踪2”任务。\r\n"/>
     </imgdir>
     <imgdir name="3717">
-        <string name="name" value="The Wanderer&apos;s Whereabouts 2"/>
+        <string name="name" value="流浪者的行踪2"/>
         <int name="area" value="41"/>
-        <string name="parent" value="The Truth Behind that Man"/>
+        <string name="parent" value="那个人背后的真相"/>
         <int name="order" value="3"/>
-        <string name="demandSummary" value="#bFind Tera Forest"/>
-        <string name="1" value="Isa the station guide at Orbis Station informs you that the strange man was heading to Tera Forest, located east of Minar Forest. Will you be able to find this foreign place called Tera Forest?"/>
-        <string name="2" value="You found the entrance to Tera Forest by searching the outskirts of east Minar Forest. There, you met the strange man you were searching for, Andy."/>
-        <string name="rewardSummary" value="EXP 30,000\r\nCan participate in the &quot;Andy the Time Traveler&quot; quest.\r\n"/>
+        <string name="demandSummary" value="#b寻找塔拉森林。"/>
+        <string name="1" value="天空之城码头的服务员艺斯说，那个奇怪的男人正前往米纳尔森林东边的塔拉森林。我能找到这个陌生的地方吗？"/>
+        <string name="2" value="我在米纳尔森林东边一带找到了塔拉森林的入口，并在那里见到了自己一直寻找的奇怪男人——安迪。"/>
+        <string name="rewardSummary" value="经验值 30,000\r\n可参加“时间旅行者安迪”任务。\r\n"/>
     </imgdir>
     <imgdir name="3718">
         <string name="name" value="Andy the Time Traveler"/>
@@ -18093,12 +18093,12 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8064">
-        <string name="name" value="Soul in the Dark"/>
-        <string name="0" value="I should ask #b#p1012109##k of #m100000000# how the book is coming along."/>
-        <string name="1" value="Just as I suspected, the stuff I gathered up for him last time didn&apos;t help much. This time, he wanted me to defeat #b#o6230500##k and gather up #b50 #t4000144#s#k for #p1012109# of #m100000000#.\n\n#t4000144#  #b#c4000144#/50#k"/>
-        <string name="2" value="I gave #p1012109# of #m100000000# #b50 #t4000144#s#k. Hopefully THIS will help me finish up the book."/>
+        <string name="name" value="黑暗中的灵魂"/>
+        <string name="0" value="我应该去问问#m100000000#的#b#p1012109##k，那本书写得怎么样了。"/>
+        <string name="1" value="果然和我想的一样，上次替他搜集的东西帮助不大。这一次，#m100000000#的#p1012109#希望我击败#b#o6230500##k，并搜集#b50个#t4000144##k。\n\n#t4000144#  #b#c4000144#/50#k"/>
+        <string name="2" value="我把#b50个#t4000144##k交给了#m100000000#的#p1012109#。希望这一次真的能帮助他完成那本书。"/>
         <int name="area" value="48"/>
-        <string name="parent" value="Soul in the Dark"/>
+        <string name="parent" value="黑暗中的灵魂"/>
     </imgdir>
     <imgdir name="8065">
         <string name="name" value="The Ghost Whereabout"/>


### PR DESCRIPTION
## 改动内容
- 修复“罗密欧的求婚”任务链文本，将戒指相关提示统一指向婚礼村的 NPC 穆尼，避免显示为玛加提亚或阿尔雷哥。
- 汉化“黑暗中的灵魂”及其后续相关任务的任务名、父级任务名和任务描述。
- 汉化“那个人背后的真相”相关的流浪者行踪任务文本，补齐任务名、父级、摘要和奖励说明。
- 汉化冰峰雪域雪女祭坛提示，以及雪女等 Boss 的传送、驱逐类 banMsg 文本。
- 本次为中文资源与中文脚本修复，仅修改 zh-CN 目录；新增的中文 Mob WZ 文件来自英文原版对应文件并仅替换中文文本字段。

## 影响范围
- 影响服务端中文 WZ 资源和中文脚本。
- 影响客户端显示的任务文本和怪物传送提示，需要同步客户端资源包。
- 不涉及 Java 逻辑、数据库结构或中英文目录功能性对称改动。

## 验证情况
- 已执行 JS 语法检查，相关中文 reactor 脚本通过校验。
- 已执行 XML 解析检查，相关 Quest 与 Mob XML 通过校验。
- 已执行乱码检查，未发现常见乱码标记。
- 已在本地测试环境完成资源同步并启动服务，WZ 加载、频道端口和登录端口启动完成。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。