### PR TITLE
fix: 修复嵩山镇未编码 NPC 点击卡住问题

### DIFF
--- a/gms-server/scripts-zh-CN/npc/9050007.js
+++ b/gms-server/scripts-zh-CN/npc/9050007.js
@@ -1,0 +1,4 @@
+function start() {
+    cm.sendOk("召唤者飞猪的活动功能暂未开放。");
+    cm.dispose();
+}

--- a/gms-server/scripts-zh-CN/npc/9310100.js
+++ b/gms-server/scripts-zh-CN/npc/9310100.js
@@ -1,0 +1,4 @@
+function start() {
+    cm.sendOk("药水交换券兑换功能暂未开放。");
+    cm.dispose();
+}

--- a/gms-server/scripts/npc/9050007.js
+++ b/gms-server/scripts/npc/9050007.js
@@ -1,0 +1,4 @@
+function start() {
+    cm.sendOk("The Summoner Flying Pig event is not available yet.");
+    cm.dispose();
+}

--- a/gms-server/scripts/npc/9310100.js
+++ b/gms-server/scripts/npc/9310100.js
@@ -1,0 +1,4 @@
+function start() {
+    cm.sendOk("Potion coupon exchange is not available yet.");
+    cm.dispose();
+}

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/NPCTalkHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/NPCTalkHandler.java
@@ -83,6 +83,7 @@ public final class NPCTalkHandler extends AbstractPacketHandler {
                     if (!hasNpcScript) {
                         if (!npc.hasShop()) {
                             log.warn("NPC {} ({}) is not coded", npc.getName(), npc.getId());
+                            c.sendPacket(PacketCreator.enableActions());
                             return;
                         } else if (c.getPlayer().getShop() != null) {
                             c.sendPacket(PacketCreator.enableActions());


### PR DESCRIPTION
## 改动内容
- 为嵩山镇地图中的「召唤者飞猪」（NPC 9050007）和「浪漫」（NPC 9310100）补充基础对话脚本，避免点击后无响应。
- 在未编码且无商店的 NPC 兜底分支中恢复客户端操作状态，避免点击未编码 NPC 后产生客户端假死的情况。
- 对 `scripts` 与 `scripts-zh-CN` 同步新增对应脚本，保持中英文目录功能对称。

## 影响范围
- 影响服务端 NPC 脚本加载与 NPC 点击交互容错。
- 不涉及客户端 WZ/XML 或 Data 资源变更。
- 不需要同步客户端资源包。

## 验证情况
- 已执行 JS 语法检查。
- 本次不涉及 XML 变更，无需 XML 解析检查。
- 已执行中文脚本 UTF-8 乱码检查。
- 已完成游戏内点击验证，两个 NPC 可正常弹出提示，关闭后可继续与其他 NPC 交互。

## 客户端资源
本次改动不需要客户端资源包。