### PR TITLE
fix: 修复尼克斯挑战刷怪与萨比特拉玛任务文本

### DIFF
--- a/gms-server/scripts-zh-CN/event/GuardianNex.js
+++ b/gms-server/scripts-zh-CN/event/GuardianNex.js
@@ -4,6 +4,8 @@ var eventTimer = 1000 * 60 * timeLimit;
 var exitMap = 240070000;
 var eventMap = 240070010;
 var eventBossIds = [7120100, 7120101, 7120102, 8120100, 8120101, 8140510];
+var bossSpawnX = 277;
+var bossSpawnY = 379;
 
 function init() {}
 
@@ -11,8 +13,11 @@ function setup(difficulty, lobbyId) {
     var eim = em.newInstance("Nex_" + lobbyId);
     eim.setIntProperty("nex", lobbyId);
 
-    eim.getInstanceMap(eventMap + 10 * lobbyId).resetFully();
-    eim.getInstanceMap(eventMap + 10 * lobbyId).allowSummonState(false);
+    var map = eim.getInstanceMap(eventMap + 10 * lobbyId);
+    map.allowSummonState(true);
+    map.resetFully();
+    ensureBossSpawned(eim);
+    map.allowSummonState(false);
     respawn(eim);
     eim.startEventTimer(eventTimer);
     return eim;
@@ -24,6 +29,7 @@ function respawn(eim) {}
 
 function playerEntry(eim, player) {
     var cave = eim.getMapInstance(eventMap + 10 * eim.getIntProperty("nex"));
+    ensureBossSpawned(eim);
     player.changeMap(cave, 1);
 }
 
@@ -104,6 +110,17 @@ function monsterKilled(mob, eim) {
 }
 
 function allMonstersDead(eim) {}
+
+function ensureBossSpawned(eim) {
+    var lobbyId = eim.getIntProperty("nex");
+    var bossId = eventBossIds[lobbyId];
+    var map = eim.getInstanceMap(eventMap + 10 * lobbyId);
+    if (map.getMonsterById(bossId) == null) {
+        var LifeFactory = Java.type("org.gms.server.life.LifeFactory");
+        var Point = Java.type("java.awt.Point");
+        map.spawnMonsterOnGroundBelow(LifeFactory.getMonster(bossId), new Point(bossSpawnX, bossSpawnY));
+    }
+}
 
 // ---------- FILLER FUNCTIONS ----------
 

--- a/gms-server/scripts-zh-CN/portal/TD_neo_inTree.js
+++ b/gms-server/scripts-zh-CN/portal/TD_neo_inTree.js
@@ -1,7 +1,7 @@
 function enter(pi) {
     var nex = pi.getEventManager("GuardianNex");
     if (nex == null) {
-        pi.message("守护者布索 特挑战系统发生错误，当前不可用");  // 保留原意同时符合中文语序‌:ml-citation{ref="1,8" data="citationList"}
+        pi.message("守护者尼克斯挑战系统发生错误，当前不可用。");
         return false;
     }
 
@@ -11,12 +11,12 @@ function enter(pi) {
     for (var i = 0; i < quests.length; i++) {
         if (pi.isQuestActive(quests[i])) {
             if (pi.getQuestProgressInt(quests[i], mobs[i]) != 0) {
-                pi.message("你已挑战过布索，请先完成当前任务");
+                pi.message("你已经挑战过尼克斯，请先完成当前任务。");
                 return false;
             }
 
             if (!nex.startInstance(i, pi.getPlayer())) {
-                pi.message("布索 正在被挑战，请等待其他玩家完成挑战");
+                pi.message("尼克斯正在被挑战，请等待其他玩家完成挑战。");
                 return false;
             } else {
                 pi.playPortalSound();
@@ -25,6 +25,6 @@ function enter(pi) {
         }
     }
 
-    pi.message("一股神秘的力量阻止你进入。");
+    pi.message("一股神秘的力量阻止你进入塔拉古树。");
     return false;
 }

--- a/gms-server/scripts/event/GuardianNex.js
+++ b/gms-server/scripts/event/GuardianNex.js
@@ -4,6 +4,8 @@ var eventTimer = 1000 * 60 * timeLimit;
 var exitMap = 240070000;
 var eventMap = 240070010;
 var eventBossIds = [7120100, 7120101, 7120102, 8120100, 8120101, 8140510];
+var bossSpawnX = 277;
+var bossSpawnY = 379;
 
 function init() {}
 
@@ -11,8 +13,11 @@ function setup(difficulty, lobbyId) {
     var eim = em.newInstance("Nex_" + lobbyId);
     eim.setIntProperty("nex", lobbyId);
 
-    eim.getInstanceMap(eventMap + 10 * lobbyId).resetFully();
-    eim.getInstanceMap(eventMap + 10 * lobbyId).allowSummonState(false);
+    var map = eim.getInstanceMap(eventMap + 10 * lobbyId);
+    map.allowSummonState(true);
+    map.resetFully();
+    ensureBossSpawned(eim);
+    map.allowSummonState(false);
     respawn(eim);
     eim.startEventTimer(eventTimer);
     return eim;
@@ -24,6 +29,7 @@ function respawn(eim) {}
 
 function playerEntry(eim, player) {
     var cave = eim.getMapInstance(eventMap + 10 * eim.getIntProperty("nex"));
+    ensureBossSpawned(eim);
     player.changeMap(cave, 1);
 }
 
@@ -104,6 +110,17 @@ function monsterKilled(mob, eim) {
 }
 
 function allMonstersDead(eim) {}
+
+function ensureBossSpawned(eim) {
+    var lobbyId = eim.getIntProperty("nex");
+    var bossId = eventBossIds[lobbyId];
+    var map = eim.getInstanceMap(eventMap + 10 * lobbyId);
+    if (map.getMonsterById(bossId) == null) {
+        var LifeFactory = Java.type("org.gms.server.life.LifeFactory");
+        var Point = Java.type("java.awt.Point");
+        map.spawnMonsterOnGroundBelow(LifeFactory.getMonster(bossId), new Point(bossSpawnX, bossSpawnY));
+    }
+}
 
 // ---------- FILLER FUNCTIONS ----------
 

--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -18180,28 +18180,28 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8076">
-        <string name="name" value="The Committee Challenges"/>
-        <string name="parent" value="The Committee Challenges"/>
+        <string name="name" value="委员会的挑战"/>
+        <string name="parent" value="委员会的挑战"/>
         <int name="order" value="1"/>
-        <string name="0" value="Sabitrama of Sleepywood has been looking for me. Something must have happened. I should drop by when there&apos;s time."/>
-        <string name="1" value="Sabitrama found the clues needed for the 3rd Herb.\nThe message was still too hard to understand. The archive said something like this! ...\nWhat kind of an ominous herb is this?? This herb cannot be placed near a human being, so seal up the force in a spherical object, and never let it see the day of light again...\n\nIf it&apos;s anything like the herbs before, then I&apos;ll still have to obtain this through monsters again. Arrgh, this is frustrating!"/>
-        <string name="2" value="We found the 3rd Herb, but it is tightly sealed inside Lazy Buffy&apos;s Marble. It seems like it&apos;s been attached for so long, that I don&apos;t think we can just pluck it out of the sphere. Sabitrama then mentioned something like applying modern science to opening this. We&apos;ve come so far, that there&apos;s no way we&apos;re about to give up.\nBut then again, who am I supposed to find?&quot;"/>
+        <string name="0" value="林中城的萨比特拉玛正在找我。一定又发生了什么事，有空时去看看吧。"/>
+        <string name="1" value="萨比特拉玛找到了第三药草的线索。\n内容依旧很难理解，档案上大概是这样写的：\n这是什么不祥的药草？这种药草不能靠近人类，所以要把力量封入球形之物，永远不要让它再见天日……\n\n如果和之前的药草一样，看来还是得从怪物身上寻找。真让人头疼！"/>
+        <string name="2" value="我们找到了第三药草，但它被严密封在懒惰巴菲的珠子里。它似乎已经附着太久，不能直接从球体里取出来。萨比特拉玛提到，也许可以用现代科学打开它。既然已经走到这里，就不能轻易放弃。\n不过，我该去找谁呢？"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8077">
-        <string name="name" value="The Father of Modern Science"/>
-        <string name="parent" value="The Committee Challenges"/>
+        <string name="name" value="现代科学之父"/>
+        <string name="parent" value="委员会的挑战"/>
         <int name="order" value="2"/>
-        <string name="0" value="We found the 3rd Herb, but it is tightly sealed inside Lazy Buffy&apos;s Marble. It seems like it&apos;s been attached for so long, that I don&apos;t think we can just pluck it out of the sphere. Sabitrama then mentioned something like applying modern science to opening this. We&apos;ve come so far, that there&apos;s no way we&apos;re about to give up.\nBut then again, who am I supposed to find?&quot;"/>
-        <string name="1" value="He may have talked too candidly on some things, but I think the herb can be plucked out of the marble. As part of the deal, I have to gather up #b500 #t04000133#s#k.\n\n\n#t04000133#  #b#c04000133##k/500"/>
-        <string name="2" value="The seal is disabled, but since the marble itself isn&apos;t very stable, Dr. Kim made a device called &quot;Open Sesami&quot; and sent it to Sabitrama. I should go see him later. \nAnyway, he&apos;s pretty good at what he does, but man he&apos;s terrible at naming his inventions!"/>
+        <string name="0" value="我们找到了第三药草，但它被严密封在懒惰巴菲的珠子里。它似乎已经附着太久，不能直接从球体里取出来。萨比特拉玛提到，也许可以用现代科学打开它。既然已经走到这里，就不能轻易放弃。\n不过，我该去找谁呢？"/>
+        <string name="1" value="虽然他说话有点直接，但我觉得他确实能把药草从珠子里取出来。作为交换，我必须收集 #b500个 #t04000133##k。\n\n\n#t04000133#  #b#c04000133##k/500"/>
+        <string name="2" value="封印已经解除，但珠子本身并不稳定。金博士制作了一个名叫“芝麻开门”的装置，并把它送到了萨比特拉玛那里。我之后应该去见见萨比特拉玛。\n不管怎么说，金博士确实很有本事，只是给发明取名的品味实在糟糕！"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8078">
-        <string name="name" value="Open Sesami"/>
-        <string name="0" value="The device known as &quot;Open Sesame&quot; should arrive at Sabitrama house any minute. I better go see him right now."/>
-        <string name="1" value="I&apos;ll need 1,000,000 mesos to open up &quot;Open Sesami&quot;. I have a feeling that, even after making the investment, we may not get to touch the herb. Even with great hesitation, I must decide right now."/>
-        <string name="2" value=" I think, as soon as the seal was disabled with the 3rd Herb, it perished the moment it touched the open air. Sabitrama seemed content with it, but ... I must admit, he&apos;s one heck of an enthusiast in terms of herbs. 1,000,000 mesos was a stiff price to pay, but I got the Magic Collection, so I&apos;m good with that!"/>
+        <string name="name" value="芝麻开门"/>
+        <string name="0" value="名为“芝麻开门”的装置应该快送到萨比特拉玛那里了。我最好现在就去见他。"/>
+        <string name="1" value="打开“芝麻开门”需要1,000,000金币。我有种预感，就算付出这笔钱，我们也未必能真正触碰到药草。虽然非常犹豫，但现在必须作出决定。"/>
+        <string name="2" value="第三药草解除封印后，似乎一接触外界空气就枯萎了。萨比特拉玛看起来很满足，不过……我不得不承认，他真是个药草狂热者。1,000,000金币的代价很高，但我得到了魔法收藏，也算值得了！"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8079">
@@ -22567,9 +22567,9 @@
         <string name="name" value="今天的日程安排"/>
     </imgdir>
     <imgdir name="8075">
-        <string name="0" value="林中城的萨比特拉玛显然因为某些事情而失眠。那是什么事呢?"/>
-        <string name="1" value="委员会成员?什么……\n我觉得好像是被萨比特拉玛骗进去的，但我觉得解开古代档案的谜题会很有趣。档案馆是这样说的。 \n\n关于第一草：\n黑白之灵告别大地，出现在我面前。在两个沉默的精灵身上做标记，精灵就会融合成第一草。\n\n关于第二草：\n你怎么看待那个在摇篮里扼杀孤独和黑暗，而灵魂却从身体里解放出来的人无法回归的灵魂必须找到一个可以共度永恒的灵魂伴侣。你是玩偶，在里面，你会发现第二草药。\n\n嗯…我从哪里开始?"/>
-        <string name="2" value="被称为委员会成员很臭，但我得到了丰厚的报酬，而且很有趣。第三草药的线索仍然找不到，但是。。。我真的想再帮他一次。\n过一会儿我会来的。"/>
+        <string name="0" value="林中城的萨比特拉玛似乎因为某件事失眠了。到底是什么事呢？"/>
+        <string name="1" value="研究委员？什么啊……\n总觉得是被萨比特拉玛半推半就拉进了委员会，不过解开古代档案中的谜题应该会很有趣。档案上是这样写的。\n\n关于第一药草：\n黑与白之灵告别大地，出现在我面前。在两个沉默的灵体上留下印记，灵体相融，化为第一药草。\n\n关于第二药草：\n你如何看待那个在摇篮中吞噬孤独与黑暗、灵魂早已离开身体的存在？无法回归的灵魂必须找到能共度永恒的伴侣。你是人偶，而第二药草就在其中。\n\n嗯……该从哪里开始呢？"/>
+        <string name="2" value="虽然被叫作研究委员有点不好意思，但报酬很丰厚，过程也很有趣。第三药草的线索还没有找到，不过……如果有机会，我真的还想再帮他一次。\n过一阵子再来看看吧。"/>
         <int name="area" value="30"/>
         <string name="name" value="萨比特拉玛的毕生作品"/>
     </imgdir>


### PR DESCRIPTION
## 改动内容
- 修复“时间守护者尼克斯”挑战进入塔拉古树后可能不生成 Boss 的问题，为事件副本增加 Boss 兜底生成逻辑。
- 修正塔拉古树入口脚本中的中文提示，避免出现错误的守护者名称和异常残留文本。
- 重译并修正“萨比特拉玛的毕生作品”及后续任务链的中文任务说明与对话文本，覆盖任务 8075、8076、8077、8078。
- 涉及 NPC：安迪、萨比特拉玛、金博士；涉及地图：塔拉森林古树；涉及怪物：时间守护者尼克斯相关挑战 Boss。
- 事件逻辑改动已保持中英文脚本目录对称；文本修正仅修改中文 WZ 目录。

## 影响范围
- 影响服务端事件脚本和中文入口脚本。
- 影响客户端显示文本，因为修改了 Quest.wz 的任务说明与对话文本。
- 需要同步客户端资源包。

## 验证情况
- 已执行 JS 语法检查。
- 已执行 XML 解析检查。
- 已执行目标任务文本乱码检查。
- 已执行 PR diff 新增中文文本检查。
- 已确认服务端启动后 WZ 加载、频道端口、登录端口与事件脚本加载完成。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。