### PR TITLE
fix: 汉化未来之城与亚华任务文本

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -13467,206 +13467,206 @@
         <string name="rewardSummary" value="经验值 90,000\r\n可以开始“隐藏在过去的真相”任务。\r\n"/>
     </imgdir>
     <imgdir name="3725">
-        <string name="name" value="The Hidden Truth about the Past"/>
+        <string name="name" value="隐藏在过去的真相"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2099- The Harbor"/>
+        <string name="parent" value="2099年 - 港口"/>
         <int name="order" value="2"/>
-        <string name="1" value="Andy the Time Traveler has requested that you travel to Midnight Harbor in the year 2099 to investigate and if possible, destroy the giant robot, if it exists."/>
-        <string name="2" value="You traveled to Midnight Harbor in the year 2099 as Andy the Time Traveler has requested, during which time you spotted a giant robot and destroyed it as instructed."/>
+        <string name="1" value="时间旅行者安迪请我前往2099年的深夜港口调查，并在可能的情况下摧毁那台巨型机器人。"/>
+        <string name="2" value="我按照时间旅行者安迪的请求前往2099年的深夜港口，并在那里发现了巨型机器人，将它摧毁了。"/>
         <string name="demandSummary" value="#o7220005# #a37251# "/>
-        <string name="rewardSummary" value="EXP 120,000\r\nCan participate in the &quot;Nex the Time Guard&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 120,000\r\n可以进行“时间守护者尼克斯”任务。\r\n"/>
     </imgdir>
     <imgdir name="3726">
-        <string name="name" value="Policeman in Danger"/>
+        <string name="name" value="陷入危机的警察"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2099- The Harbor"/>
+        <string name="parent" value="2099年 - 港口"/>
         <int name="order" value="3"/>
-        <string name="1" value="The Policeman you met at Midnight Harbor in the year 2099 wants you to help him eliminate some monsters that have been taking over the harbor. Specifically, 50 Overlord A and 40 Overlord B monsters."/>
-        <string name="2" value="The Policeman you met at Midnight Harbor in the year 2099 asked you to help him eliminate some monsters, so you eliminated Overlord A and Overlord B monsters."/>
+        <string name="1" value="我在2099年深夜港口遇到的警察，希望我帮他消灭占领港口的怪物。具体来说，要消灭50只欧贝隆A和40只欧贝隆B。"/>
+        <string name="2" value="我帮2099年深夜港口遇到的警察消灭了怪物，解决了欧贝隆A和欧贝隆B。"/>
         <string name="demandSummary" value="#o7120106# #a37261# #o7120107# #a37262# "/>
-        <string name="rewardSummary" value="EXP 72,000\r\nCan participate in the &quot;Shelter Key&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 72,000\r\n可以进行“避难所钥匙”任务。\r\n"/>
     </imgdir>
     <imgdir name="3727">
-        <string name="name" value="The Shelter Key"/>
+        <string name="name" value="避难所钥匙"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2099- The Harbor"/>
+        <string name="parent" value="2099年 - 港口"/>
         <int name="order" value="4"/>
-        <string name="1" value="The Policeman you met at Midnight Harbor in the year 2099 wants you to find the Shelter Key and deliver it to Captain Edmond, who is somewhere at the harbor."/>
-        <string name="2" value="The Policeman you met at Midnight Harbor in the year 2099 asked you to find the Shelter Key and deliver it to Captain Edmond. You retrieved the key from the monsters and gave it to Captain Edmond at the quayside."/>
+        <string name="1" value="我在2099年深夜港口遇到的警察，希望我找到避难所钥匙并交给港口某处的爱德蒙船长。"/>
+        <string name="2" value="我按照2099年深夜港口警察的请求找到避难所钥匙，并在码头边把它交给了爱德蒙船长。"/>
         <string name="demandSummary" value="#i4032514:# #t4032514:# #c4032514# / 1 "/>
-        <string name="rewardSummary" value="EXP 60,000\r\nCan participate in the &quot;Temporary Measure&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 60,000\r\n可以进行“临时措施”任务。\r\n"/>
     </imgdir>
     <imgdir name="3728">
-        <string name="name" value="Temporary Relief"/>
+        <string name="name" value="临时措施"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2099- The Harbor"/>
+        <string name="parent" value="2099年 - 港口"/>
         <int name="order" value="5"/>
-        <string name="1" value="When you meet Captain Edmond in 2099, he asks you bring him 20 Overlord A Radar Devices and 40 Overlord B Radar Devices to temporarily stop the monsters at the harbor."/>
-        <string name="2" value="When you met Captain Edmond in 2099, he complained that he didn&apos;t approve of the monsters that overtook the harbor. He then asked that you bring him their radar devices, which you did."/>
+        <string name="1" value="见到2099年的爱德蒙船长后，他让我带来20个欧贝隆A雷达装置和40个欧贝隆B雷达装置，以便暂时阻止港口的怪物。"/>
+        <string name="2" value="见到2099年的爱德蒙船长后，他抱怨那些占据港口的怪物令人难以接受，并让我带来它们的雷达装置。我照办了。"/>
         <string name="demandSummary" value="#i4000548:# #t4000548:# #c4000548# / 20 #i4000549:# #t4000549:# #c4000549# / 40 "/>
-        <string name="rewardSummary" value="EXP 75,000\r\n"/>
+        <string name="rewardSummary" value="经验值 75,000\r\n"/>
     </imgdir>
     <imgdir name="3730">
-        <string name="name" value="Nex the Time Guard"/>
+        <string name="name" value="时间守护者尼克斯"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2215- The Bombing"/>
+        <string name="parent" value="2215年 - 轰炸"/>
         <int name="order" value="1"/>
-        <string name="0" value="Andy the Time Traveler says he has something to tell you before your third time travel."/>
-        <string name="1" value="Andy the Time Traveler has informed you that you must pass the test Nex the Gatekeeper of Time, who lives in the Old Tree of Tera, gives you before embarking on your third time travel. Enter the Old Tree of Tera and pass Nex&apos;s test."/>
-        <string name="2" value="You have passed the third test given by Nex the Gatekeeper of Time and earned the right to travel to another time. You can now teleport to the Bombed City Center in the year 2099. Go to the Time Gate with the Time Traveler&apos;s Pocket Watch."/>
+        <string name="0" value="时间旅行者安迪说，在我第三次时间旅行前有话要告诉我。"/>
+        <string name="1" value="时间旅行者安迪告诉我，开始第三次时间旅行前，必须先通过住在塔拉古树里的时间守护者尼克斯的考验。进入塔拉古树，通过尼克斯的考验吧。"/>
+        <string name="2" value="我通过了时间守护者尼克斯的第三次考验，获得了前往其他时代的资格。现在可以传送到2215年的遭轰炸城区中心。带着时间旅行者的怀表前往时间门吧。"/>
         <string name="demandSummary" value="#o7120102# #a37301# "/>
-        <string name="rewardSummary" value="EXP 110,000\r\nCan participate in the &quot;Identity of the Missile&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 110,000\r\n可以进行“导弹的真面目”任务。\r\n"/>
     </imgdir>
     <imgdir name="3731">
-        <string name="name" value="Identity of the Missile"/>
+        <string name="name" value="导弹的真面目"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2215- The Bombing"/>
+        <string name="parent" value="2215年 - 轰炸"/>
         <int name="order" value="2"/>
-        <string name="1" value="Andy the Time Traveler has asked you to travel to the year 2215 to investigate the Bombed City Center and destroy the A.I. missile known as Dunas."/>
-        <string name="2" value="Andy the Time Traveler asked you to travel to the year 2215 to investigate the Bombed City Center and destroy the A.I. missile known as Dunas. To your surprised, you discovered that Dunas was an android missile that closely resembled a human. You may have succeeded in destroying Dunas, but the Bombed City Center doesn&apos;t appear to be restorable."/>
+        <string name="1" value="时间旅行者安迪让我前往2215年，调查遭轰炸的城区中心，并摧毁名为杜纳斯的人工智能导弹。"/>
+        <string name="2" value="时间旅行者安迪让我前往2215年调查遭轰炸的城区中心，并摧毁名为杜纳斯的人工智能导弹。令人惊讶的是，杜纳斯竟是外形酷似人类的机器人导弹。虽然我成功摧毁了杜纳斯，但遭轰炸的城区中心似乎已经无法恢复了。"/>
         <string name="demandSummary" value="#o8220010# #a37311# "/>
-        <string name="rewardSummary" value="EXP 140,000\r\nCan participate in the &apos;&quot;Nex the Time Guard&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 140,000\r\n可以进行“时间守护者尼克斯”任务。\r\n"/>
     </imgdir>
     <imgdir name="3732">
-        <string name="name" value="Rambunctious Robots"/>
+        <string name="name" value="吵闹的机器人"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2215- The Bombing"/>
+        <string name="parent" value="2215年 - 轰炸"/>
         <int name="order" value="3"/>
-        <string name="1" value="You meet May in the middle of the Bombed City Center in the year 2215. What&apos;s she doing in the destroyed City Center? In any case, she asks you to defeat the Robbies that appeared after the bombing. She says they&apos;re so loud and rambunctious that she&apos;s about to have a nervous breakdown."/>
-        <string name="2" value="You met May in the middle of the Bombed City Center in the year 2215. She asked you to defeat the Robbies that appeared after the bombing. She said they were so loud and rambunctious that she was about to have a nervous breakdown. Well, that worked out since you were thinking about getting rid of those noisy robots anyway."/>
+        <string name="1" value="我在2215年遭轰炸的城区中心遇到了梅伊。她为什么会在被毁的市中心？总之，她让我消灭轰炸后出现的罗比。她说那些机器人又吵又闹，快把她逼到崩溃了。"/>
+        <string name="2" value="我在2215年遭轰炸的城区中心遇到了梅伊。她拜托我消灭轰炸后出现的罗比，说它们又吵又闹，快让她精神崩溃了。反正我也正想除掉这些吵闹的机器人，正好顺手解决。"/>
         <string name="demandSummary" value="#o7120108# #a37321# "/>
-        <string name="rewardSummary" value="EXP 90,000\r\nCan participate in the &quot;Survivor Search&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 90,000\r\n可以进行“寻找幸存者”任务。\r\n"/>
     </imgdir>
     <imgdir name="3733">
-        <string name="name" value="Survivor Search"/>
+        <string name="name" value="寻找幸存者"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2215- The Bombing"/>
+        <string name="parent" value="2215年 - 轰炸"/>
         <int name="order" value="4"/>
-        <string name="1" value="May was happy that you were able to reduce the population of the noisy Robbies, but was also concerned that she may be the only survivor left. She asks you to investigate the area where the missile landed and search for survivors."/>
-        <string name="2" value="You have searched the area all the way to the location where the missile landed, as May requested. Fortunately, you were able to find a male survivor named Bao. How is it that he doesn&apos;t even have a tiny scratch on him?"/>
-        <string name="rewardSummary" value="EXP 30,000\r\nCan participate in &quot;The Dangerous Android&quot; quest.\r\n"/>
+        <string name="1" value="梅伊很高兴我减少了吵闹罗比的数量，但也担心自己可能是唯一的幸存者。她让我调查导弹坠落的区域，寻找其他幸存者。"/>
+        <string name="2" value="我按照梅伊的请求，一直搜索到导弹坠落的地点。幸运的是，我找到了一名叫鲍的男性幸存者。他身上居然连一点擦伤都没有，真奇怪。"/>
+        <string name="rewardSummary" value="经验值 30,000\r\n可以进行“危险的机器人”任务。\r\n"/>
     </imgdir>
     <imgdir name="3734">
-        <string name="name" value="The Dangerous Android"/>
+        <string name="name" value="危险的机器人"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2215- The Bombing"/>
+        <string name="parent" value="2215年 - 轰炸"/>
         <int name="order" value="5"/>
-        <string name="1" value="May was right. When you went into the City Center, you found another survivor, Bao. Bao could not move an inch because he was so afraid of Iruvatas and asked that you help him. He appears to be a big guy, but really, he&apos;s just a softie inside."/>
-        <string name="2" value="You defeated Iruvatas that were scaring Bao. Bao thanked you for your help. What a softie."/>
+        <string name="1" value="梅伊说得没错。我进入市中心后，找到了另一个幸存者鲍。鲍因为害怕伊鲁瓦塔而寸步难行，请我帮帮他。他看起来很高大，其实内心很胆小。"/>
+        <string name="2" value="我打倒了吓到鲍的伊鲁瓦塔。鲍感谢了我的帮助。真是个外强中干的人。"/>
         <string name="demandSummary" value="#o7120109# #a37341# "/>
-        <string name="rewardSummary" value="EXP 90,000\r\nCan participate in the &quot;The Wreckage of the Missile&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 90,000\r\n可以进行“导弹残骸”任务。\r\n"/>
     </imgdir>
     <imgdir name="3735">
-        <string name="name" value="The Wreckage of the Missile"/>
+        <string name="name" value="导弹残骸"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2215- The Bombing"/>
+        <string name="parent" value="2215年 - 轰炸"/>
         <int name="order" value="6"/>
-        <string name="1" value="Bao says that the Iruvatas and Robbies seem to come from the place the missile landed and suggests you search around there. How did he know you were looking for something? He seemed a little dull and slow, but perhaps he actually has a perceptive side. Anyway, investigate and report your findings to Andy."/>
-        <string name="2" value="Bao said that the Iruvatas and Robbies seemed to come from the area the missile landed and suggested you search there. You then defeated Dunas the missile android in the bombed City Center and delivered the Time Sand you acquired to Andy."/>
+        <string name="1" value="鲍说伊鲁瓦塔和罗比似乎来自导弹坠落的地方，并建议我去那里搜索。他怎么知道我在找东西？他看起来有点迟钝，也许其实很敏锐。总之，去调查后向安迪报告吧。"/>
+        <string name="2" value="鲍说伊鲁瓦塔和罗比似乎来自导弹坠落的区域，并建议我去那里搜索。之后我击败了机器人导弹杜纳斯，并把获得的时间沙交给了安迪。"/>
         <string name="demandSummary" value="#i4032516:# #t4032516:# #c4032516# / 1 "/>
-        <string name="rewardSummary" value="EXP 60,000\r\n"/>
+        <string name="rewardSummary" value="经验值 60,000\r\n"/>
     </imgdir>
     <imgdir name="3736">
-        <string name="name" value="Nex the Time Guard"/>
+        <string name="name" value="时间守护者尼克斯"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2216- The Ruins"/>
+        <string name="parent" value="2216年 - 废墟"/>
         <int name="order" value="1"/>
-        <string name="0" value="Andy the Time Traveler says he has something to tell you before your fourth time travel."/>
-        <string name="1" value="Andy the Time Traveler has informed you that you must pass the test Next the Gatekeeper of Time, who lives in the Old Tree of Tera, gives you before embarking on your fourth time travel. Enter the Old Tree of Tera and pass Nex&apos;s test."/>
-        <string name="2" value="You have passed the fourth test given by Nex the Gatekeeper of Time and earned the right to travel to another time. You can now teleport to the ruins of the city in year 2216. Go to the Time Gate with the Time Traveler&apos;s Pocket Watch."/>
+        <string name="0" value="时间旅行者安迪说，在我第四次时间旅行前有话要告诉我。"/>
+        <string name="1" value="时间旅行者安迪告诉我，开始第四次时间旅行前，必须先通过住在塔拉古树里的时间守护者尼克斯的考验。进入塔拉古树，通过尼克斯的考验吧。"/>
+        <string name="2" value="我通过了时间守护者尼克斯的第四次考验，获得了前往其他时代的资格。现在可以传送到2216年的废墟之城。带着时间旅行者的怀表前往时间门吧。"/>
         <string name="demandSummary" value="#o8120100# #a37361# "/>
-        <string name="rewardSummary" value="EXP 130,000\r\nCan participate in the &quot;Central Robot Aufheben&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 130,000\r\n可以进行“中央机器人奥芙赫班”任务。\r\n"/>
     </imgdir>
     <imgdir name="3737">
-        <string name="name" value="Central Robot Aufheben"/>
+        <string name="name" value="中央机器人奥芙赫班"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2216 - The Ruins"/>
+        <string name="parent" value="2216年 - 废墟"/>
         <int name="order" value="2"/>
-        <string name="1" value="Andy has requested that you travel to the ruins of the city in the year 2216 and defeat Aufheben, the central robot that controls all electronic devices in the city. Andy says if Dunas was an android, it is very likely that Aufheben is also an android."/>
-        <string name="2" value="Andy requested that you travel to the ruins of the city in the year 2216 and defeat Aufheben, the central robot that controlled all electronic devices in the city. As suspected, Aufheben was an android. The battle between humans and robots seems interminable."/>
+        <string name="1" value="安迪让我前往2216年的废墟之城，击败控制城市中所有电子设备的中央机器人奥芙赫班。安迪说，如果杜纳斯是机器人，那么奥芙赫班很可能也是机器人。"/>
+        <string name="2" value="安迪让我前往2216年的废墟之城，击败控制城市中所有电子设备的中央机器人奥芙赫班。和预想一样，奥芙赫班也是机器人。人类与机器人的战斗似乎永无止境。"/>
         <string name="demandSummary" value="#o8220011# #a37371# "/>
-        <string name="rewardSummary" value="EXP 170,000\r\nCan participate in the &quot;Nex the Time Guard&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 170,000\r\n可以进行“时间守护者尼克斯”任务。\r\n"/>
     </imgdir>
     <imgdir name="3738">
-        <string name="name" value="Disturbing the Army of Robots"/>
+        <string name="name" value="扰乱机器人军团"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2216- The Ruins"/>
+        <string name="parent" value="2216年 - 废墟"/>
         <int name="order" value="3"/>
-        <string name="1" value="You have traveled to the year 2216 on your fourth time travel. Thanks to Ken, who assumes you are from the support unit, you must eliminate monsters. Things keep coming up and hindering you from doing what you&apos;re here to do. Keep in mind that you are here for a reason."/>
-        <string name="2" value="You traveled to the year 2216 on your fourth time travel. Thanks to Ken, who just assumed that you were from the support unit, you had to eliminate monsters. Conditions in the city appear to be deteriorating."/>
+        <string name="1" value="我第四次时间旅行来到了2216年。肯把我当成支援部队，让我去消灭怪物。事情总是一件接一件地妨碍我完成原本的目标。别忘了，我来到这里是有理由的。"/>
+        <string name="2" value="我第四次时间旅行来到了2216年。肯误以为我是支援部队，于是我只好去消灭怪物。城市的状况似乎正在持续恶化。"/>
         <string name="demandSummary" value="#o8120102# #a37381# #o8120103# #a37382# "/>
-        <string name="rewardSummary" value="EXP 105,000\r\nCan participate in &quot;Isabella&apos;s Search&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 105,000\r\n可以进行“寻找伊莎贝拉”任务。\r\n"/>
     </imgdir>
     <imgdir name="3739">
-        <string name="name" value="Isabella&apos;s Search"/>
+        <string name="name" value="寻找伊莎贝拉"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2216- The Ruins"/>
+        <string name="parent" value="2216年 - 废墟"/>
         <int name="order" value="4"/>
-        <string name="1" value="Ken, who you met in the ruins of the city in the year 2216, requests that you investigate the eastern regions where he received a rescue signal. You must hurry and find the person who he suspects to be a teenage female. Begin your search right away."/>
-        <string name="2" value="Ken, whom you met in the ruins of the city in year 2216, requested that you investigate the eastern regions where he received a rescue signal. You found a teenage female who appeared to be passed out from exhaustion. Fortunately, she was conscious when you talked to her."/>
-        <string name="rewardSummary" value="EXP 50,000\r\nCan participate in the &quot;What Was That I Saw?&quot; quest.\r\n"/>
+        <string name="1" value="我在2216年废墟之城遇到的肯，请我调查他收到求救信号的东部区域。他怀疑那里有一名少女，必须尽快找到她。立刻开始搜索吧。"/>
+        <string name="2" value="我按照在2216年废墟之城遇到的肯的请求，调查了收到求救信号的东部区域。我找到了一名似乎因疲惫而昏倒的少女。幸好和她说话时，她已经恢复了意识。"/>
+        <string name="rewardSummary" value="经验值 50,000\r\n可以进行“我刚才看到了什么？”任务。\r\n"/>
     </imgdir>
     <imgdir name="3740">
-        <string name="name" value="What Was That I Saw?"/>
+        <string name="name" value="我刚才看到了什么？"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2216- The Ruins"/>
+        <string name="parent" value="2216年 - 废墟"/>
         <int name="order" value="5"/>
-        <string name="1" value="When she regained consciousness, Isabella kept rambling nonsense about how she saw an angel to the east, where the high rise collapsed. An angel? Is she insane? The only way to confirm that is to go over and see for yourself. You may even find a Time Sand."/>
-        <string name="2" value="When she regained consciousness, Isabella kept rambling nonsense about how she saw an angel. The only way to confirm that was to go over and see for yourself. You did, and even found a Time Sand."/>
+        <string name="1" value="伊莎贝拉恢复意识后，一直语无伦次地说她在东边高楼倒塌的地方看到了天使。天使？她疯了吗？唯一能确认的方法就是亲自过去看看。也许还能找到时间沙。"/>
+        <string name="2" value="伊莎贝拉恢复意识后，一直语无伦次地说她看到了天使。唯一能确认的方法就是亲自过去看看。我去了那里，还找到了时间沙。"/>
         <string name="demandSummary" value="#i4032517:# #t4032517:# #c4032517# / 1 "/>
-        <string name="rewardSummary" value="EXP 70,000\r\n"/>
+        <string name="rewardSummary" value="经验值 70,000\r\n"/>
     </imgdir>
     <imgdir name="3742">
-        <string name="name" value="Nex the Time Guard"/>
+        <string name="name" value="时间守护者尼克斯"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2230- Imminent Collapse!"/>
+        <string name="parent" value="2230年 - 迫在眉睫的崩塌！"/>
         <int name="order" value="1"/>
-        <string name="0" value="Andy the Time Traveler says he has something to tell you before your fifth time travel."/>
-        <string name="1" value="Andy the Time Traveler has informed you that you must pass the test Nex the Gatekeeper of Time, who lives in the Old Tree of Tera, gives you before embarking on your fifth time travel. Enter the Old Tree of Tera and pass Nex&apos;s test."/>
-        <string name="2" value="You have passed the fifth test given by Nex the Gatekeeper of Time and earned the right to travel to another time. You can now teleport to the dangerous towers of the year 2230. Go to the Time Gate with the Time Traveler&apos;s Pocket Watch."/>
+        <string name="0" value="时间旅行者安迪说，在我第五次时间旅行前有话要告诉我。"/>
+        <string name="1" value="时间旅行者安迪告诉我，开始第五次时间旅行前，必须先通过住在塔拉古树里的时间守护者尼克斯的考验。进入塔拉古树，通过尼克斯的考验吧。"/>
+        <string name="2" value="我通过了时间守护者尼克斯的第五次考验，获得了前往其他时代的资格。现在可以传送到2230年的危险高塔。带着时间旅行者的怀表前往时间门吧。"/>
         <string name="demandSummary" value="#o8120101# #a37421# "/>
-        <string name="rewardSummary" value="EXP 140,000\r\nCan participate in &quot;The New and Improved, Oberon&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 140,000\r\n可以进行“全新改良型奥伯伦”任务。\r\n"/>
     </imgdir>
     <imgdir name="3743">
-        <string name="name" value="The New and Improved, Oberon"/>
+        <string name="name" value="全新改良型奥伯伦"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2230- Imminent Collapse!"/>
+        <string name="parent" value="2230年 - 迫在眉睫的崩塌！"/>
         <int name="order" value="2"/>
-        <string name="1" value="Andy says, based on the findings from the previous time travels, it is likely that the Fifth Time Sand is in the year 2230. He wants you to defeat Oberon, an android even more advanced than Aufheben, and bring back the Time Sand."/>
-        <string name="2" value="As Andy suspected, Oberon had the Fifth Time Sand. You have successfully defeated Oberon and found the Fifth Time Sand in the dangerous tower in the year 2230."/>
+        <string name="1" value="安迪说，根据之前几次时间旅行得到的线索，第五个时间沙很可能在2230年。他希望我击败比奥芙赫班更先进的机器人奥伯伦，并带回时间沙。"/>
+        <string name="2" value="正如安迪所料，奥伯伦持有第五个时间沙。我成功击败了奥伯伦，并在2230年的危险高塔中找到了第五个时间沙。"/>
         <string name="demandSummary" value="#i4032518:# #t4032518:# #c4032518# / 1 #o8220012# #a37431# "/>
-        <string name="rewardSummary" value="EXP 200,000\r\nCan participate in the &quot;Nex the Time Guard&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 200,000\r\n可以进行“时间守护者尼克斯”任务。\r\n"/>
     </imgdir>
     <imgdir name="3744">
-        <string name="name" value="Defeat the Mavericks"/>
+        <string name="name" value="击败马维里克"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2230- Imminent Collapse!"/>
+        <string name="parent" value="2230年 - 迫在眉睫的崩塌！"/>
         <int name="order" value="3"/>
-        <string name="1" value="Hoya, the boy you met at the lobby of the dangerous tower in the year 2230, has asked you to eliminate the pesky Mavericks and report it to Nalo."/>
-        <string name="2" value="Hoya, the boy you met at the lobby of the dangerous tower in the year 2230, asked you to eliminate some pesky Mavericks. You did so and reported it to Nalo at the top of the tower. Nalo seemed concerned about Hoya&apos;s immature and irresponsible actions."/>
+        <string name="1" value="我在2230年危险高塔大厅遇到的男孩霍亚，请我消灭烦人的马维里克，然后向纳洛报告。"/>
+        <string name="2" value="我在2230年危险高塔大厅遇到的男孩霍亚，请我消灭一些烦人的马维里克。我照做后到塔顶向纳洛报告。纳洛似乎很担心霍亚幼稚又不负责任的行动。"/>
         <string name="demandSummary" value="#o8120104# #a37441# #o8120105# #a37442# #o8120106# #a37443# "/>
-        <string name="rewardSummary" value="EXP 90,000\r\n"/>
+        <string name="rewardSummary" value="经验值 90,000\r\n"/>
     </imgdir>
     <imgdir name="3748">
-        <string name="name" value="Nex the Time Guard"/>
+        <string name="name" value="时间守护者尼克斯"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2503- From the Sky"/>
+        <string name="parent" value="2503年 - 来自天空"/>
         <int name="order" value="1"/>
-        <string name="0" value="Andy the Time Traveler says he has something to tell you before your sixth time travel."/>
-        <string name="1" value="Andy the Time Traveler has informed you that you must pass the test Nex the Gatekeeper of Time, who lives in the Old Tree of Tera, gives you before embarking on your sixth time travel. Enter the Old Tree of Tera and pass Nex&apos;s test."/>
-        <string name="2" value="You have passed the sixth test given by Nex the Gatekeeper of Time and earned the right to travel to another time. You can now teleport to the Air Battleship of the year 2503. Go to the Time Gate with the Time Traveler&apos;s Pocket Watch."/>
+        <string name="0" value="时间旅行者安迪说，在我第六次时间旅行前有话要告诉我。"/>
+        <string name="1" value="时间旅行者安迪告诉我，开始第六次时间旅行前，必须先通过住在塔拉古树里的时间守护者尼克斯的考验。进入塔拉古树，通过尼克斯的考验吧。"/>
+        <string name="2" value="我通过了时间守护者尼克斯的第六次考验，获得了前往其他时代的资格。现在可以传送到2503年的空中战舰。带着时间旅行者的怀表前往时间门吧。"/>
         <string name="demandSummary" value="#o8140510# #a37481# "/>
-        <string name="rewardSummary" value="EXP 150,000\r\nCan participate in the &quot;Nibelung&apos;s Song&quot; quest.\r\n"/>
+        <string name="rewardSummary" value="经验值 150,000\r\n可以进行“尼贝隆之歌”任务。\r\n"/>
     </imgdir>
     <imgdir name="3749">
-        <string name="name" value="Nibelung&apos;s Song"/>
+        <string name="name" value="尼贝隆之歌"/>
         <int name="area" value="41"/>
-        <string name="parent" value="Year 2503- From the Sky"/>
+        <string name="parent" value="2503年 - 来自天空"/>
         <int name="order" value="2"/>
-        <string name="1" value="In the end, Andy says the answer is in the year 2503, where he&apos;s from. He wants you to travel to the year 2503 to destroy Nibelung and report it to Ashura. Will this solve the problem?"/>
-        <string name="2" value="You destroyed Nibelung and reported that to Ashura. She showed her gratitude and wished for peaceful days in the future."/>
+        <string name="1" value="最后，安迪说答案就在他来自的2503年。他希望我前往2503年摧毁尼贝隆，并向阿修罗报告。这样真的能解决问题吗？"/>
+        <string name="2" value="我摧毁了尼贝隆，并向阿修罗报告了结果。她表达了感谢，并祈愿未来能迎来和平的日子。"/>
         <string name="demandSummary" value="#o8220015# #a37491# "/>
-        <string name="rewardSummary" value="EXP 220,000\r\n#Wbasic#\r\n#i1003039:# #t1003039:# 1\r\n"/>
+        <string name="rewardSummary" value="经验值 220,000\r\n#Wbasic#\r\n#i1003039:# #t1003039:# 1\r\n"/>
     </imgdir>
     <imgdir name="3800">
         <string name="name" value="诺功的教导1"/>
@@ -18101,39 +18101,39 @@
         <string name="parent" value="黑暗中的灵魂"/>
     </imgdir>
     <imgdir name="8065">
-        <string name="name" value="The Ghost Whereabout"/>
-        <string name="parent" value="Freed From Darkness"/>
+        <string name="name" value="幽灵的去向"/>
+        <string name="parent" value="摆脱黑暗"/>
         <int name="order" value="1"/>
-        <string name="0" value="#b#p1012109##k of #b#p1012109##k&apos;s book should be ready by now. I should go talk to him."/>
-        <string name="1" value="Apparenlty the #b#t4000144#s#k have disappeared to the direction of #b#m801000000##k. I need to find it and return it to its original state."/>
-        <string name="2" value="Apparently, #p9120011#&apos;s doll just went about on its one way. Maybe this has something to do with #b#t4000144##k that #p1012109# is looking for..."/>
+        <string name="0" value="#b#p1012109##k的书现在应该已经准备好了。去找他谈谈吧。"/>
+        <string name="1" value="听说#b#t4000144##k朝着#b#m801000000##k的方向消失了。我得找到它，并让它恢复原状。"/>
+        <string name="2" value="听说#p9120011#的玩偶自己跑走了。也许这和#p1012109#正在寻找的#b#t4000144##k有关……"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8066">
-        <string name="name" value="A Puppet"/>
-        <string name="parent" value="Freed From Darkness"/>
+        <string name="name" value="玩偶"/>
+        <string name="parent" value="摆脱黑暗"/>
         <int name="order" value="2"/>
-        <string name="0" value="Apparently #p9120011#&apos;s doll just walked out and disappeared. I better check out this story."/>
-        <string name="1" value="#p9120011#&apos;s doll apparently just walked out on her and disappeared. Maybe this has something to do with the #b#t4000144##k that #p1012109# is looking for. I should go to #b#p1012109##k&apos;s place and talk to him."/>
-        <string name="2" value="#b#p1012109##k seems to catch on to something here."/>
+        <string name="0" value="听说#p9120011#的玩偶自己走出去后消失了。我最好去查清楚这件事。"/>
+        <string name="1" value="#p9120011#的玩偶似乎自己走出去后消失了。也许这和#p1012109#正在寻找的#b#t4000144##k有关。我应该去找#b#p1012109##k谈谈。"/>
+        <string name="2" value="#b#p1012109##k似乎察觉到了什么。"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8067">
-        <string name="name" value="The Man of Convention"/>
-        <string name="parent" value="Freed From Darkness"/>
+        <string name="name" value="守规矩的人"/>
+        <string name="parent" value="摆脱黑暗"/>
         <int name="order" value="3"/>
-        <string name="0" value="#b#p1012109##k seems to catch on to something here. I&apos;ll need to hear this."/>
-        <string name="1" value="He said #p9120011#&apos;s doll that is laden with #t4000144# may be controlled by something. I can&apos;t just stand still listening to this! I&apos;ll have to gather up #b50 #t04000148#s#k from #b#o7130300##k, as well as #b50 #t04000147#s#k from #b#o7130010##k. \nSince #p9120011# is crying, I&apos;ll have to return #b#t04000147##k to her first and hand #b#t04000147##k to her, then go to where #b#p1012109##k is.\n\n#t04000148# #b#c04000148##k/50\n#t04000147# #b#c04000147##k/50"/>
-        <string name="2" value="After handing #b#t04000147##k to #p9120011#, a blinding light engulfted the dolls, and then they transformed back to their original state. Too bad #b#t04000148##k disappeared in the process. What should I do? I better go talk to #b#p9120011##k."/>
+        <string name="0" value="#b#p1012109##k似乎察觉到了什么。我得听听他的说法。"/>
+        <string name="1" value="他说，附着了#t4000144#的#p9120011#的玩偶可能正被某种东西控制。不能只是站着听下去！我得从#b#o7130300##k那里搜集#b50个#t04000148##k，并从#b#o7130010##k那里搜集#b50个#t04000147##k。\n#p9120011#还在哭，先把#b#t04000147##k交给她，再去找#b#p1012109##k吧。\n\n#t04000148# #b#c04000148##k/50\n#t04000147# #b#c04000147##k/50"/>
+        <string name="2" value="把#b#t04000147##k交给#p9120011#后，耀眼的光芒包围了玩偶，它们随后恢复了原状。可惜#b#t04000148##k也在过程中消失了。该怎么办？最好去问问#b#p9120011##k。"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8068">
-        <string name="name" value="Ray of Light"/>
-        <string name="parent" value="Freed From Darkness"/>
+        <string name="name" value="一线光芒"/>
+        <string name="parent" value="摆脱黑暗"/>
         <int name="order" value="4"/>
-        <string name="0" value="After handing #p9120011# the doll, #b#t04000148#k also disappeared! #b#p9120011##k said she&apos;ll tell me a story..."/>
-        <string name="1" value="#p9120011# suggested that I go to where #b#p1012109##k is and look for it. That&apos;s true, since standing pat doesn&apos;t do anything for me. I better go back and discuss this with him."/>
-        <string name="2" value="Apparently, #t04000148# and #t04000147# were both moved by warmth and compassion #p9120011# exudes. Isn&apos;t that nice to see? Just the way #p1012109# said, if everyone genuinely loves everything around them, then there would be no monster to begin with...? Anyway, it was nice to hear that #p1012109# may be ready to write the next chapter in the book. I&apos;m can&apos;t wait~!"/>
+        <string name="0" value="把玩偶交给#p9120011#后，#b#t04000148#k也消失了！#b#p9120011##k说她会告诉我一个故事……"/>
+        <string name="1" value="#p9120011#建议我去#b#p1012109##k那里找找看。说得没错，站在原地也解决不了问题。我最好回去和他商量。"/>
+        <string name="2" value="看来#t04000148#和#t04000147#都被#p9120011#散发出的温暖与善意打动了。这不是很好吗？正如#p1012109#所说，如果每个人都真心爱着身边的一切，也许一开始就不会有怪物了……不管怎样，听说#p1012109#准备写下一章了，真让人期待！"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8069">

--- a/gms-server/wz-zh-CN/String.wz/Npc.img.xml
+++ b/gms-server/wz-zh-CN/String.wz/Npc.img.xml
@@ -4043,92 +4043,92 @@
         <string name="n1" value="你必须找到线索，并把它带回来给我！"/>
     </imgdir>
     <imgdir name="2082005">
-        <string name="name" value="Brainy Boy"/>
-        <string name="d0" value="Who are you? I don&apos;t trust anyone."/>
-        <string name="d1" value="Don&apos;t come any closer!"/>
-        <string name="n0" value="Don&apos;t come any closer!"/>
-        <string name="n1" value="Who are you? I don&apos;t trust anyone."/>
+        <string name="name" value="聪明男孩"/>
+        <string name="d0" value="你是谁？我不相信任何人。"/>
+        <string name="d1" value="别再靠近了！"/>
+        <string name="n0" value="别再靠近了！"/>
+        <string name="n1" value="你是谁？我不相信任何人。"/>
     </imgdir>
     <imgdir name="2082006">
-        <string name="name" value="Crying Girl"/>
-        <string name="d0" value="Mommy... Daddy... Where are you?"/>
-        <string name="d1" value="I want my sketchbook back!"/>
-        <string name="n0" value="Mommy... Daddy... Where are you?"/>
-        <string name="n1" value="I want my sketchbook back!"/>
+        <string name="name" value="哭泣女孩"/>
+        <string name="d0" value="妈妈……爸爸……你们在哪里？"/>
+        <string name="d1" value="我想拿回我的画册！"/>
+        <string name="n0" value="妈妈……爸爸……你们在哪里？"/>
+        <string name="n1" value="我想拿回我的画册！"/>
     </imgdir>
     <imgdir name="2082007">
-        <string name="name" value="Policeman"/>
-        <string name="d0" value="Why isn&apos;t there an easy answer?"/>
-        <string name="d1" value="We have an emergency and we need you!"/>
-        <string name="n0" value="We have an emergency and we need you!"/>
-        <string name="n1" value="Why isn&apos;t there an easy answer?"/>
+        <string name="name" value="警察"/>
+        <string name="d0" value="为什么就没有简单一点的答案呢？"/>
+        <string name="d1" value="情况紧急，我们需要你的帮助！"/>
+        <string name="n0" value="情况紧急，我们需要你的帮助！"/>
+        <string name="n1" value="为什么就没有简单一点的答案呢？"/>
     </imgdir>
     <imgdir name="2082008">
-        <string name="name" value="Captain Edmond"/>
-        <string name="d0" value="There isn&apos;t a right way. It&apos;s a double-edged sword. Do you understand what I&apos;m saying?"/>
-        <string name="d1" value="Can you vouch that that is the truth?"/>
-        <string name="n0" value="Can you vouch that that is the truth?"/>
-        <string name="n1" value="There isn&apos;t a right way. It&apos;s a double-edged sword. Do you understand what I&apos;m saying?"/>
+        <string name="name" value="爱德蒙船长"/>
+        <string name="d0" value="没有绝对正确的办法。这是一把双刃剑。你懂我的意思吗？"/>
+        <string name="d1" value="你能保证那就是真相吗？"/>
+        <string name="n0" value="你能保证那就是真相吗？"/>
+        <string name="n1" value="没有绝对正确的办法。这是一把双刃剑。你懂我的意思吗？"/>
     </imgdir>
     <imgdir name="2082009">
-        <string name="name" value="May"/>
-        <string name="d0" value="Hello. Would you like a cup of tea?"/>
-        <string name="d1" value="Red tea, green tea, coffee...? A hot drink or a cold drink? Which do you prefer?"/>
-        <string name="n0" value="Hello. Would you like a cup of tea?"/>
-        <string name="n1" value="Red tea, green tea, coffee...? A hot drink or a cold drink? Which do you prefer?"/>
+        <string name="name" value="梅伊"/>
+        <string name="d0" value="你好。要来一杯茶吗？"/>
+        <string name="d1" value="红茶、绿茶、咖啡……？热饮还是冷饮？你喜欢哪一种？"/>
+        <string name="n0" value="你好。要来一杯茶吗？"/>
+        <string name="n1" value="红茶、绿茶、咖啡……？热饮还是冷饮？你喜欢哪一种？"/>
     </imgdir>
     <imgdir name="2082010">
-        <string name="name" value="Bao"/>
-        <string name="d0" value="May is polite, but she can be pretty cold."/>
-        <string name="d1" value="May is polite, but she can be pretty cold."/>
-        <string name="n0" value="You can&apos;t get information like this just anywhere."/>
-        <string name="n1" value="May is polite, but she can be pretty cold."/>
+        <string name="name" value="鲍"/>
+        <string name="d0" value="梅伊很有礼貌，但有时候也挺冷淡的。"/>
+        <string name="d1" value="梅伊很有礼貌，但有时候也挺冷淡的。"/>
+        <string name="n0" value="这种情报可不是随便哪里都能得到的。"/>
+        <string name="n1" value="梅伊很有礼貌，但有时候也挺冷淡的。"/>
     </imgdir>
     <imgdir name="2082011">
-        <string name="name" value="Hoya"/>
-        <string name="d0" value="I&apos;m bound to become a hero!"/>
-        <string name="d1" value="I&apos;m bound to become a hero!"/>
-        <string name="n0" value="I&apos;m not afraid of anything!"/>
-        <string name="n1" value="I&apos;m bound to become a hero!"/>
+        <string name="name" value="霍亚"/>
+        <string name="d0" value="我一定会成为英雄！"/>
+        <string name="d1" value="我一定会成为英雄！"/>
+        <string name="n0" value="我什么都不怕！"/>
+        <string name="n1" value="我一定会成为英雄！"/>
     </imgdir>
     <imgdir name="2082012">
-        <string name="name" value="Nalo"/>
-        <string name="d0" value="You must act with prudence."/>
-        <string name="d1" value="You must act with prudence."/>
-        <string name="n0" value="You must act with prudence."/>
-        <string name="n1" value="You never know what future has in store for you."/>
+        <string name="name" value="纳洛"/>
+        <string name="d0" value="行动必须谨慎。"/>
+        <string name="d1" value="行动必须谨慎。"/>
+        <string name="n0" value="行动必须谨慎。"/>
+        <string name="n1" value="谁也不知道未来会发生什么。"/>
     </imgdir>
     <imgdir name="2082013">
-        <string name="name" value="Ashura"/>
-        <string name="d0" value="Everything is still up in the air."/>
-        <string name="d1" value="Everything is still up in the air."/>
-        <string name="n0" value="What if it&apos;s too late?"/>
-        <string name="n1" value="Everything is still up in the air."/>
+        <string name="name" value="阿修罗"/>
+        <string name="d0" value="一切都还没有定论。"/>
+        <string name="d1" value="一切都还没有定论。"/>
+        <string name="n0" value="如果已经太迟了怎么办？"/>
+        <string name="n1" value="一切都还没有定论。"/>
     </imgdir>
     <imgdir name="2082014">
-        <string name="name" value="Asia"/>
-        <string name="d0" value="The future is filled with despair."/>
-        <string name="d1" value="I can&apos;t predict anything. It&apos;s up to fate."/>
-        <string name="n0" value="The future is filled with despair."/>
-        <string name="n1" value="I can&apos;t predict anything. It&apos;s up to fate."/>
+        <string name="name" value="阿夕亚"/>
+        <string name="d0" value="未来充满了绝望。"/>
+        <string name="d1" value="我无法预知任何事。一切只能交给命运。"/>
+        <string name="n0" value="未来充满了绝望。"/>
+        <string name="n1" value="我无法预知任何事。一切只能交给命运。"/>
     </imgdir>
     <imgdir name="2082015">
         <string name="name" value="Electronic Induction Device"/>
         <string name="d0" value="Bee-beep bee-beep"/>
     </imgdir>
     <imgdir name="2082016">
-        <string name="name" value="Isabella"/>
-        <string name="d0" value="He...Help."/>
-        <string name="d1" value="Ahhhh..."/>
-        <string name="n0" value="Ahhhh..."/>
-        <string name="n1" value="He...Help."/>
+        <string name="name" value="伊莎贝拉"/>
+        <string name="d0" value="救……救命。"/>
+        <string name="d1" value="啊啊啊……"/>
+        <string name="n0" value="啊啊啊……"/>
+        <string name="n1" value="救……救命。"/>
     </imgdir>
     <imgdir name="2082017">
-        <string name="name" value="Ken"/>
-        <string name="d0" value="Please go someplace safe!"/>
-        <string name="d1" value="It&apos;s dangerous here."/>
-        <string name="n0" value="It&apos;s dangerous here."/>
-        <string name="n1" value="Please go someplace safe!"/>
+        <string name="name" value="肯"/>
+        <string name="d0" value="请到安全的地方去！"/>
+        <string name="d1" value="这里很危险。"/>
+        <string name="n0" value="这里很危险。"/>
+        <string name="n1" value="请到安全的地方去！"/>
     </imgdir>
     <imgdir name="2083000">
         <string name="name" value="敢死队的暗号石板"/>


### PR DESCRIPTION
## 改动内容
- 汉化穿过时间门后的未来之城 NPC 名称与默认对话，覆盖聪明男孩、哭泣女孩、警察、爱德蒙船长、梅伊、鲍、霍亚等 NPC。
- 补充汉化未来之城后续任务文本，覆盖 2099 年、2215 年、2216 年、2230 年、2503 年相关任务说明与奖励摘要。
- 补充汉化射手村亚华相关任务 freed from the darkness 的中文任务文本。
- 修正少量残留英文和不自然中文描述，例如玩具塔提示和怪物消灭提示。

## 影响范围
- 影响服务端中文 WZ 文本以及客户端显示文本。
- 本次只修改简体中文 WZ 目录，没有修改英文原版目录。
- 由于涉及 String.wz 与 Quest.wz 文本，需要同步客户端资源包。

## 验证情况
- 已执行 XML 解析检查，相关 XML 文件均可正常解析。
- 已执行 diff 空白检查，未发现尾随空白或格式错误。
- 已执行中文乱码检查，未发现异常乱码字符。
- 已在本地测试环境完成增量同步验证，并确认服务端可正常启动、频道和登录端口可正常开放。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。