### PR TITLE
fix: 修复幻影森林到英雄谷传送目标

### DIFF
--- a/gms-server/wz/Map.wz/Map/Map6/610010005.img.xml
+++ b/gms-server/wz/Map.wz/Map/Map6/610010005.img.xml
@@ -5340,7 +5340,7 @@
       <int name="x" value="-1563"/>
       <int name="y" value="-759"/>
       <int name="tm" value="610020000"/>
-      <string name="tn" value="CM_AA"/>
+      <string name="tn" value="CM1_AA"/>
       <string name="script" value=""/>
       <int name="hideTooltip" value="0"/>
       <int name="onlyOnce" value="0"/>

--- a/gms-server/wz/Map.wz/Map/Map6/610020005.img.xml
+++ b/gms-server/wz/Map.wz/Map/Map6/610020005.img.xml
@@ -4759,7 +4759,7 @@
       <int name="x" value="1427"/>
       <int name="y" value="-456"/>
       <int name="tm" value="610020004"/>
-      <string name="tn" value="CM5_4"/>
+      <string name="tn" value="CM5_3"/>
     </imgdir>
     <imgdir name="3">
       <string name="pn" value="CM6_3"/>


### PR DESCRIPTION
## 改动内容
- 修复幻影森林「被遗忘的小路」通往绯红峡谷「英雄谷1」时目标传送点名称不匹配的问题。
- 修复绯红峡谷「高坡」返回「风险之路」时目标传送点名称不匹配的问题。
- 本次只调整地图传送目标字段，不涉及任务、NPC、道具或脚本流程改动。
- 本次改动位于英文原版 WZ 地图数据；未涉及文本汉化，因此没有 zh-CN 对称文本改动。

## 影响范围
- 影响服务端加载的地图传送数据。
- 由于本次改动属于 Map WZ/XML 地图数据修复，需要同步客户端资源包。
- 不涉及 Jar 构建、Release 打包或客户端资源包发布。

## 验证情况
- 已执行 XML 解析检查。
- 已执行乱码检查，未发现替换字符或中文乱码。
- 已执行静态传送目标检查，确认修复后的目标传送点存在。
- 已执行差异范围检查，确认仅包含本次地图传送修复文件。
- 已执行空白与补丁格式检查。
- 本次未修改 JS 脚本，因此未执行 JS 语法检查。
- 本次未修改 Java 代码，因此未执行 Maven/Jar 构建。

## 客户端资源
本次改动需要同步客户端资源包，但本次任务不包含客户端资源包打包与发布。