### PR TITLE
修复脚本调用killMonster方法杀死怪物的一个BUG

### DIFF
--- a/gms-server/src/main/java/org/gms/server/maps/MapleMap.java
+++ b/gms-server/src/main/java/org/gms/server/maps/MapleMap.java
@@ -1505,14 +1505,17 @@ public class MapleMap {
     }
 
     public void killMonster(int mobId) {
-        Character chr = (Character) getPlayers().get(0);
-        List<Monster> mobList = getAllMonsters();
-
-        for (Monster mob : mobList) {
+		     Character chr = null;
+		     List<MapObject> players = getPlayers();
+       if (!players.isEmpty()) {
+ 			     chr = (Character) players.get(0);
+		     }
+       List<Monster> mobList = getAllMonsters();
+       for (Monster mob : mobList) {
             if (mob.getId() == mobId) {
                 this.killMonster(mob, chr, false);
             }
-        }
+       }
     }
 
     public void killMonsterWithDrops(int mobId) {


### PR DESCRIPTION
复现场景：

脚本召唤了一只怪物，需要在特定的时间让这个BOSS消失，在事件中调用了map.killMonster(mobId)，此地图无玩家时控制台出现错误且BOSS依然存在的情况