### PR TITLE
fix: upgrade io.undertow:undertow-core to 2.3.21.Final, 2.2.39.Final (CVE-2025-12543)

### DIFF
--- a/gms-server/pom.xml
+++ b/gms-server/pom.xml
@@ -61,6 +61,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-core</artifactId>
+                <version>2.3.21.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Summary
Upgrade io.undertow:undertow-core from 2.3.12.Final to 2.3.21.Final, 2.2.39.Final to fix CVE-2025-12543.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2025-12543 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2025-12543` |
| **File** | `gms-server/pom.xml` (dependency: `io.undertow:undertow-core`) |
| **Assessment** | Likely exploitable |

**Description**: undertow-core: Undertow HTTP Server Fails to Reject Malformed Host Headers Leading to Potential Cache Poisoning and SSRF

## Evidence

**Scanner confirmation**: trivy rule `CVE-2025-12543` flagged this pattern.

## Changes
- `gms-server/pom.xml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
