### PR TITLE
玛加提亚组队任务支持单人跳过多人关卡

### DIFF
--- a/gms-server/scripts-zh-CN/event/MagatiaPQ_A.js
+++ b/gms-server/scripts-zh-CN/event/MagatiaPQ_A.js
@@ -299,6 +299,61 @@ function playerLeft(eim, player) {
     }
 }
 
+function skipBeakerStage(eim) {
+    if (eim.getIntProperty("statusStg3") >= 3) {
+        return;
+    }
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    eim.setIntProperty("statusStg3", 3);
+    eim.showClearEffect();
+    eim.giveEventPlayersStageReward(3);
+
+    var map = eim.getMapInstance(926110100);
+    map.killAllMonsters();
+    var door = map.getReactorByName("jnr2_door");
+    if (door != null) {
+        door.forceHitReactor(1);
+    }
+}
+
+function skipDualLabStage(eim) {
+    if (eim.getIntProperty("statusStg4") >= 1) {
+        return;
+    }
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    eim.setIntProperty("statusStg4", 1);
+    eim.showClearEffect();
+    eim.giveEventPlayersStageReward(4);
+
+    var map = eim.getMapInstance(926110200);
+    map.killAllMonsters();
+    var door = map.getReactorByName("jnr3_out3");
+    if (door != null) {
+        door.forceHitReactor(1);
+    }
+}
+
+function skipMazeStage(eim, player) {
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    if (eim.getIntProperty("statusStg6") == 0) {
+        eim.setIntProperty("statusStg6", 1);
+        eim.showClearEffect();
+        eim.giveEventPlayersStageReward(6);
+    }
+
+    var next = eim.getMapInstance(926110400);
+    player.changeMap(next, next.getPortal(0));
+}
+
 function changedMap(eim, player, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
         if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
@@ -308,6 +363,12 @@ function changedMap(eim, player, mapid) {
             eim.unregisterPlayer(player);
         }
 
+    } else if (mapid == 926110100) {
+        skipBeakerStage(eim);
+    } else if (mapid == 926110200) {
+        skipDualLabStage(eim);
+    } else if (mapid == 926110300 || (mapid >= 926110301 && mapid <= 926110304)) {
+        skipMazeStage(eim, player);
     } else if (mapid == 926110203 && eim.getIntProperty("yuleteTimeout") == 0) {
         eim.setIntProperty("yuleteTimeout", 1);
         eim.schedule("yuleteAction", 10 * 1000);

--- a/gms-server/scripts-zh-CN/event/MagatiaPQ_Z.js
+++ b/gms-server/scripts-zh-CN/event/MagatiaPQ_Z.js
@@ -299,6 +299,61 @@ function playerLeft(eim, player) {
     }
 }
 
+function skipBeakerStage(eim) {
+    if (eim.getIntProperty("statusStg3") >= 3) {
+        return;
+    }
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    eim.setIntProperty("statusStg3", 3);
+    eim.showClearEffect();
+    eim.giveEventPlayersStageReward(3);
+
+    var map = eim.getMapInstance(926100100);
+    map.killAllMonsters();
+    var door = map.getReactorByName("rnj2_door");
+    if (door != null) {
+        door.forceHitReactor(1);
+    }
+}
+
+function skipDualLabStage(eim) {
+    if (eim.getIntProperty("statusStg4") >= 1) {
+        return;
+    }
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    eim.setIntProperty("statusStg4", 1);
+    eim.showClearEffect();
+    eim.giveEventPlayersStageReward(4);
+
+    var map = eim.getMapInstance(926100200);
+    map.killAllMonsters();
+    var door = map.getReactorByName("rnj3_out3");
+    if (door != null) {
+        door.forceHitReactor(1);
+    }
+}
+
+function skipMazeStage(eim, player) {
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    if (eim.getIntProperty("statusStg6") == 0) {
+        eim.setIntProperty("statusStg6", 1);
+        eim.showClearEffect();
+        eim.giveEventPlayersStageReward(6);
+    }
+
+    var next = eim.getMapInstance(926100400);
+    player.changeMap(next, next.getPortal(0));
+}
+
 function changedMap(eim, player, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
         if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
@@ -308,6 +363,12 @@ function changedMap(eim, player, mapid) {
             eim.unregisterPlayer(player);
         }
 
+    } else if (mapid == 926100100) {
+        skipBeakerStage(eim);
+    } else if (mapid == 926100200) {
+        skipDualLabStage(eim);
+    } else if (mapid == 926100300 || (mapid >= 926100301 && mapid <= 926100304)) {
+        skipMazeStage(eim, player);
     } else if (mapid == 926100203 && eim.getIntProperty("yuleteTimeout") == 0) {
         eim.setIntProperty("yuleteTimeout", 1);
         eim.schedule("yuleteAction", 10 * 1000);

--- a/gms-server/scripts-zh-CN/portal/jnr2_out.js
+++ b/gms-server/scripts-zh-CN/portal/jnr2_out.js
@@ -1,10 +1,32 @@
 function enter(pi) {
-    if (pi.getEventInstance().getIntProperty("statusStg3") == 3) {
+    var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim.getIntProperty("statusStg3") != 3
+            && GameConfig.getServerBoolean("use_enable_stage_skip")
+            && eim.getPlayerCount() == 1) {
+        eim.setIntProperty("statusStg3", 3);
+        try {
+            eim.showClearEffect();
+            eim.giveEventPlayersStageReward(3);
+            pi.getMap().killAllMonsters();
+            var door = pi.getMap().getReactorByName("jnr2_door");
+            if (door != null) {
+                door.forceHitReactor(1);
+            }
+        } catch (err) {
+        }
+    }
+
+    if (eim.getIntProperty("statusStg3") == 3) {
         pi.playPortalSound();
         pi.warp(926110200, 0); //next
         return true;
-    } else {
-        pi.playerMessage(5, "传送门尚未开启。");
-        return false;
     }
+
+    pi.playerMessage(5, "传送门尚未开启。");
+    return false;
 }

--- a/gms-server/scripts-zh-CN/portal/jnr3_out.js
+++ b/gms-server/scripts-zh-CN/portal/jnr3_out.js
@@ -1,10 +1,38 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg4") < 1) {
+            eim.setIntProperty("statusStg4", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(4);
+                pi.getMap().killAllMonsters();
+            } catch (err) {
+            }
+        }
+        try {
+            var door = pi.getMap().getReactorByName("jnr3_out3");
+            if (door != null) {
+                door.forceHitReactor(1);
+            }
+        } catch (err) {
+        }
+        pi.playPortalSound();
+        pi.warp(926110203, 0);
+        return true;
+    }
+
     if (pi.getMap().getReactorByName("jnr3_out3").getState() == 1) {
         pi.playPortalSound();
         pi.warp(926110203, 0); //next
         return true;
-    } else {
-        pi.playerMessage(5, "传送门尚未开启。");
-        return false;
     }
+
+    pi.playerMessage(5, "传送门尚未开启。");
+    return false;
 }

--- a/gms-server/scripts-zh-CN/portal/jnr4_r1.js
+++ b/gms-server/scripts-zh-CN/portal/jnr4_r1.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926110400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 0;
 

--- a/gms-server/scripts-zh-CN/portal/jnr4_r2.js
+++ b/gms-server/scripts-zh-CN/portal/jnr4_r2.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926110400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 1;
 

--- a/gms-server/scripts-zh-CN/portal/jnr4_r3.js
+++ b/gms-server/scripts-zh-CN/portal/jnr4_r3.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926110400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 2;
 

--- a/gms-server/scripts-zh-CN/portal/jnr4_r4.js
+++ b/gms-server/scripts-zh-CN/portal/jnr4_r4.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926110400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 3;
 

--- a/gms-server/scripts-zh-CN/portal/rnj2_out.js
+++ b/gms-server/scripts-zh-CN/portal/rnj2_out.js
@@ -1,10 +1,32 @@
 function enter(pi) {
-    if (pi.getEventInstance().getIntProperty("statusStg3") == 3) {
+    var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim.getIntProperty("statusStg3") != 3
+            && GameConfig.getServerBoolean("use_enable_stage_skip")
+            && eim.getPlayerCount() == 1) {
+        eim.setIntProperty("statusStg3", 3);
+        try {
+            eim.showClearEffect();
+            eim.giveEventPlayersStageReward(3);
+            pi.getMap().killAllMonsters();
+            var door = pi.getMap().getReactorByName("rnj2_door");
+            if (door != null) {
+                door.forceHitReactor(1);
+            }
+        } catch (err) {
+        }
+    }
+
+    if (eim.getIntProperty("statusStg3") == 3) {
         pi.playPortalSound();
         pi.warp(926100200, 0); //next
         return true;
-    } else {
-        pi.playerMessage(5, "传送门尚未开启。");
-        return false;
     }
+
+    pi.playerMessage(5, "传送门尚未开启。");
+    return false;
 }

--- a/gms-server/scripts-zh-CN/portal/rnj3_out.js
+++ b/gms-server/scripts-zh-CN/portal/rnj3_out.js
@@ -1,10 +1,38 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg4") < 1) {
+            eim.setIntProperty("statusStg4", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(4);
+                pi.getMap().killAllMonsters();
+            } catch (err) {
+            }
+        }
+        try {
+            var door = pi.getMap().getReactorByName("rnj3_out3");
+            if (door != null) {
+                door.forceHitReactor(1);
+            }
+        } catch (err) {
+        }
+        pi.playPortalSound();
+        pi.warp(926100203, 0);
+        return true;
+    }
+
     if (pi.getMap().getReactorByName("rnj3_out3").getState() == 1) {
         pi.playPortalSound();
         pi.warp(926100203, 0); //next
         return true;
-    } else {
-        pi.playerMessage(5, "传送门尚未开启。");
-        return false;
     }
+
+    pi.playerMessage(5, "传送门尚未开启。");
+    return false;
 }

--- a/gms-server/scripts-zh-CN/portal/rnj4_r1.js
+++ b/gms-server/scripts-zh-CN/portal/rnj4_r1.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926100400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 0;
 

--- a/gms-server/scripts-zh-CN/portal/rnj4_r2.js
+++ b/gms-server/scripts-zh-CN/portal/rnj4_r2.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926100400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 1;
 

--- a/gms-server/scripts-zh-CN/portal/rnj4_r3.js
+++ b/gms-server/scripts-zh-CN/portal/rnj4_r3.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926100400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 2;
 

--- a/gms-server/scripts-zh-CN/portal/rnj4_r4.js
+++ b/gms-server/scripts-zh-CN/portal/rnj4_r4.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926100400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 3;
 

--- a/gms-server/scripts/event/MagatiaPQ_A.js
+++ b/gms-server/scripts/event/MagatiaPQ_A.js
@@ -38,6 +38,12 @@ var eventTime = 45;     // 45 minutes
 
 const maxLobbies = 1;
 
+const GameConfig = Java.type('org.gms.config.GameConfig');
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;
+if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+    minLevel = 1, maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }
@@ -293,6 +299,61 @@ function playerLeft(eim, player) {
     }
 }
 
+function skipBeakerStage(eim) {
+    if (eim.getIntProperty("statusStg3") >= 3) {
+        return;
+    }
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    eim.setIntProperty("statusStg3", 3);
+    eim.showClearEffect();
+    eim.giveEventPlayersStageReward(3);
+
+    var map = eim.getMapInstance(926110100);
+    map.killAllMonsters();
+    var door = map.getReactorByName("jnr2_door");
+    if (door != null) {
+        door.forceHitReactor(1);
+    }
+}
+
+function skipDualLabStage(eim) {
+    if (eim.getIntProperty("statusStg4") >= 1) {
+        return;
+    }
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    eim.setIntProperty("statusStg4", 1);
+    eim.showClearEffect();
+    eim.giveEventPlayersStageReward(4);
+
+    var map = eim.getMapInstance(926110200);
+    map.killAllMonsters();
+    var door = map.getReactorByName("jnr3_out3");
+    if (door != null) {
+        door.forceHitReactor(1);
+    }
+}
+
+function skipMazeStage(eim, player) {
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    if (eim.getIntProperty("statusStg6") == 0) {
+        eim.setIntProperty("statusStg6", 1);
+        eim.showClearEffect();
+        eim.giveEventPlayersStageReward(6);
+    }
+
+    var next = eim.getMapInstance(926110400);
+    player.changeMap(next, next.getPortal(0));
+}
+
 function changedMap(eim, player, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
         if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
@@ -302,6 +363,12 @@ function changedMap(eim, player, mapid) {
             eim.unregisterPlayer(player);
         }
 
+    } else if (mapid == 926110100) {
+        skipBeakerStage(eim);
+    } else if (mapid == 926110200) {
+        skipDualLabStage(eim);
+    } else if (mapid == 926110300 || (mapid >= 926110301 && mapid <= 926110304)) {
+        skipMazeStage(eim, player);
     } else if (mapid == 926110203 && eim.getIntProperty("yuleteTimeout") == 0) {
         eim.setIntProperty("yuleteTimeout", 1);
         eim.schedule("yuleteAction", 10 * 1000);

--- a/gms-server/scripts/event/MagatiaPQ_Z.js
+++ b/gms-server/scripts/event/MagatiaPQ_Z.js
@@ -38,6 +38,12 @@ var eventTime = 45;     // 45 minutes
 
 const maxLobbies = 1;
 
+const GameConfig = Java.type('org.gms.config.GameConfig');
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;
+if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+    minLevel = 1, maxLevel = 999;
+}
+
 function init() {
     setEventRequirements();
 }
@@ -293,6 +299,61 @@ function playerLeft(eim, player) {
     }
 }
 
+function skipBeakerStage(eim) {
+    if (eim.getIntProperty("statusStg3") >= 3) {
+        return;
+    }
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    eim.setIntProperty("statusStg3", 3);
+    eim.showClearEffect();
+    eim.giveEventPlayersStageReward(3);
+
+    var map = eim.getMapInstance(926100100);
+    map.killAllMonsters();
+    var door = map.getReactorByName("rnj2_door");
+    if (door != null) {
+        door.forceHitReactor(1);
+    }
+}
+
+function skipDualLabStage(eim) {
+    if (eim.getIntProperty("statusStg4") >= 1) {
+        return;
+    }
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    eim.setIntProperty("statusStg4", 1);
+    eim.showClearEffect();
+    eim.giveEventPlayersStageReward(4);
+
+    var map = eim.getMapInstance(926100200);
+    map.killAllMonsters();
+    var door = map.getReactorByName("rnj3_out3");
+    if (door != null) {
+        door.forceHitReactor(1);
+    }
+}
+
+function skipMazeStage(eim, player) {
+    if (!(GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1)) {
+        return;
+    }
+
+    if (eim.getIntProperty("statusStg6") == 0) {
+        eim.setIntProperty("statusStg6", 1);
+        eim.showClearEffect();
+        eim.giveEventPlayersStageReward(6);
+    }
+
+    var next = eim.getMapInstance(926100400);
+    player.changeMap(next, next.getPortal(0));
+}
+
 function changedMap(eim, player, mapid) {
     if (mapid < minMapId || mapid > maxMapId) {
         if (eim.isEventTeamLackingNow(true, minPlayers, player)) {
@@ -302,6 +363,12 @@ function changedMap(eim, player, mapid) {
             eim.unregisterPlayer(player);
         }
 
+    } else if (mapid == 926100100) {
+        skipBeakerStage(eim);
+    } else if (mapid == 926100200) {
+        skipDualLabStage(eim);
+    } else if (mapid == 926100300 || (mapid >= 926100301 && mapid <= 926100304)) {
+        skipMazeStage(eim, player);
     } else if (mapid == 926100203 && eim.getIntProperty("yuleteTimeout") == 0) {
         eim.setIntProperty("yuleteTimeout", 1);
         eim.schedule("yuleteAction", 10 * 1000);

--- a/gms-server/scripts/portal/jnr2_out.js
+++ b/gms-server/scripts/portal/jnr2_out.js
@@ -1,10 +1,32 @@
 function enter(pi) {
-    if (pi.getEventInstance().getIntProperty("statusStg3") == 3) {
+    var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim.getIntProperty("statusStg3") != 3
+            && GameConfig.getServerBoolean("use_enable_stage_skip")
+            && eim.getPlayerCount() == 1) {
+        eim.setIntProperty("statusStg3", 3);
+        try {
+            eim.showClearEffect();
+            eim.giveEventPlayersStageReward(3);
+            pi.getMap().killAllMonsters();
+            var door = pi.getMap().getReactorByName("jnr2_door");
+            if (door != null) {
+                door.forceHitReactor(1);
+            }
+        } catch (err) {
+        }
+    }
+
+    if (eim.getIntProperty("statusStg3") == 3) {
         pi.playPortalSound();
         pi.warp(926110200, 0); //next
         return true;
-    } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
-        return false;
     }
+
+    pi.playerMessage(5, "The portal is not opened yet.");
+    return false;
 }

--- a/gms-server/scripts/portal/jnr3_out.js
+++ b/gms-server/scripts/portal/jnr3_out.js
@@ -1,10 +1,38 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg4") < 1) {
+            eim.setIntProperty("statusStg4", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(4);
+                pi.getMap().killAllMonsters();
+            } catch (err) {
+            }
+        }
+        try {
+            var door = pi.getMap().getReactorByName("jnr3_out3");
+            if (door != null) {
+                door.forceHitReactor(1);
+            }
+        } catch (err) {
+        }
+        pi.playPortalSound();
+        pi.warp(926110203, 0);
+        return true;
+    }
+
     if (pi.getMap().getReactorByName("jnr3_out3").getState() == 1) {
         pi.playPortalSound();
         pi.warp(926110203, 0); //next
         return true;
-    } else {
-        pi.playerMessage(5, "The door is not opened yet.");
-        return false;
     }
+
+    pi.playerMessage(5, "The door is not opened yet.");
+    return false;
 }

--- a/gms-server/scripts/portal/jnr4_r1.js
+++ b/gms-server/scripts/portal/jnr4_r1.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926110400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 0;
 

--- a/gms-server/scripts/portal/jnr4_r2.js
+++ b/gms-server/scripts/portal/jnr4_r2.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926110400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 1;
 

--- a/gms-server/scripts/portal/jnr4_r3.js
+++ b/gms-server/scripts/portal/jnr4_r3.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926110400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 2;
 

--- a/gms-server/scripts/portal/jnr4_r4.js
+++ b/gms-server/scripts/portal/jnr4_r4.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926110400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 3;
 

--- a/gms-server/scripts/portal/rnj2_out.js
+++ b/gms-server/scripts/portal/rnj2_out.js
@@ -1,10 +1,32 @@
 function enter(pi) {
-    if (pi.getEventInstance().getIntProperty("statusStg3") == 3) {
+    var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim.getIntProperty("statusStg3") != 3
+            && GameConfig.getServerBoolean("use_enable_stage_skip")
+            && eim.getPlayerCount() == 1) {
+        eim.setIntProperty("statusStg3", 3);
+        try {
+            eim.showClearEffect();
+            eim.giveEventPlayersStageReward(3);
+            pi.getMap().killAllMonsters();
+            var door = pi.getMap().getReactorByName("rnj2_door");
+            if (door != null) {
+                door.forceHitReactor(1);
+            }
+        } catch (err) {
+        }
+    }
+
+    if (eim.getIntProperty("statusStg3") == 3) {
         pi.playPortalSound();
         pi.warp(926100200, 0); //next
         return true;
-    } else {
-        pi.playerMessage(5, "The portal is not opened yet.");
-        return false;
     }
+
+    pi.playerMessage(5, "The portal is not opened yet.");
+    return false;
 }

--- a/gms-server/scripts/portal/rnj3_out.js
+++ b/gms-server/scripts/portal/rnj3_out.js
@@ -1,10 +1,38 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg4") < 1) {
+            eim.setIntProperty("statusStg4", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(4);
+                pi.getMap().killAllMonsters();
+            } catch (err) {
+            }
+        }
+        try {
+            var door = pi.getMap().getReactorByName("rnj3_out3");
+            if (door != null) {
+                door.forceHitReactor(1);
+            }
+        } catch (err) {
+        }
+        pi.playPortalSound();
+        pi.warp(926100203, 0);
+        return true;
+    }
+
     if (pi.getMap().getReactorByName("rnj3_out3").getState() == 1) {
         pi.playPortalSound();
         pi.warp(926100203, 0); //next
         return true;
-    } else {
-        pi.playerMessage(5, "The door is not opened yet.");
-        return false;
     }
+
+    pi.playerMessage(5, "The door is not opened yet.");
+    return false;
 }

--- a/gms-server/scripts/portal/rnj4_r1.js
+++ b/gms-server/scripts/portal/rnj4_r1.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926100400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 0;
 

--- a/gms-server/scripts/portal/rnj4_r2.js
+++ b/gms-server/scripts/portal/rnj4_r2.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926100400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 1;
 

--- a/gms-server/scripts/portal/rnj4_r3.js
+++ b/gms-server/scripts/portal/rnj4_r3.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926100400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 2;
 

--- a/gms-server/scripts/portal/rnj4_r4.js
+++ b/gms-server/scripts/portal/rnj4_r4.js
@@ -1,5 +1,24 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
+    if (eim == null) {
+        return false;
+    }
+
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("statusStg6") == 0) {
+            eim.setIntProperty("statusStg6", 1);
+            try {
+                eim.showClearEffect();
+                eim.giveEventPlayersStageReward(6);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(926100400, 0);
+        return true;
+    }
+
     var area = eim.getIntProperty("statusStg5");
     var reg = 3;
 


### PR DESCRIPTION
## Summary
- 开启 `use_enable_stage_skip` 且仅 1 人时，自动跳过玛加提亚 PQ（罗密欧/朱丽叶线）中需多人配合的关卡（烧杯/双实验室等）
- 便于单人推进 MagatiaPQ

## Test plan
- [ ] 开启 `use_enable_stage_skip`，单人进入玛加提亚组队并确认多人关卡可跳过
- [ ] 多人队伍时行为与原版一致，不误跳关
- [ ] 关闭开关后仍按原逻辑要求多人配合

Made with [Cursor](https://cursor.com)