### PR TITLE
绯红远征队支持单人跳过多人站位关卡

### DIFF
--- a/gms-server/scripts-zh-CN/event/CWKPQ.js
+++ b/gms-server/scripts-zh-CN/event/CWKPQ.js
@@ -44,6 +44,54 @@ if(GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {  //如果
     minLevel = 1 , maxLevel = 999;
 }
 
+function canSoloSkip(eim) {
+    return GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1;
+}
+
+function skipStage2(eim) {
+    if (eim.getIntProperty("glpq2") >= 5) {
+        return;
+    }
+    eim.setIntProperty("glpq2", 5);
+    eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
+    eim.showClearEffect(610030200, "2pt", 2);
+    eim.giveEventPlayersStageReward(2);
+}
+
+function skipStage3(eim) {
+    if (eim.getIntProperty("glpq3") >= 5 && eim.getIntProperty("glpq3_p") >= 5) {
+        return;
+    }
+    eim.setIntProperty("glpq3", 5);
+    eim.setIntProperty("glpq3_p", 5);
+    eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
+    eim.showClearEffect(610030300, "3pt", 2);
+    eim.giveEventPlayersStageReward(3);
+}
+
+function skipStage4(eim) {
+    if (eim.getIntProperty("glpq4") >= 5) {
+        return;
+    }
+    eim.setIntProperty("glpq4", 5);
+    eim.setIntProperty("glpq_s", 777);
+    var map = eim.getMapInstance(610030400);
+    map.killAllMonsters();
+    eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
+    eim.showClearEffect(610030400, "4pt", 2);
+    eim.giveEventPlayersStageReward(4);
+}
+
+function skipStage5(eim) {
+    if (eim.getIntProperty("glpq5") >= 5) {
+        return;
+    }
+    eim.setIntProperty("glpq5", 5);
+    eim.dropMessage(6, "安特利昂已为你开启下一传送门！前进吧！");
+    eim.showClearEffect(610030500, "5pt", 2);
+    eim.giveEventPlayersStageReward(5);
+}
+
 function init() {
     setEventRequirements();
 }
@@ -263,11 +311,17 @@ function changedMap(eim, player, mapid) {
                     eim.restartEventTimer(600000); //10 mins
                     eim.setIntProperty("current_instance", 1);
                 }
+                if (canSoloSkip(eim)) {
+                    skipStage2(eim);
+                }
                 break;
             case 610030300:
                 if (eim.getIntProperty("current_instance") == 1) {
                     eim.restartEventTimer(600000); //10 mins
                     eim.setIntProperty("current_instance", 2);
+                }
+                if (canSoloSkip(eim)) {
+                    skipStage3(eim);
                 }
                 break;
             case 610030400:
@@ -275,11 +329,17 @@ function changedMap(eim, player, mapid) {
                     eim.restartEventTimer(600000); //10 mins
                     eim.setIntProperty("current_instance", 3);
                 }
+                if (canSoloSkip(eim)) {
+                    skipStage4(eim);
+                }
                 break;
             case 610030500:
                 if (eim.getIntProperty("current_instance") == 3) {
                     eim.restartEventTimer(1200000); //20 mins
                     eim.setIntProperty("current_instance", 4);
+                }
+                if (canSoloSkip(eim)) {
+                    skipStage5(eim);
                 }
                 break;
             case 610030600:

--- a/gms-server/scripts-zh-CN/portal/glpqPortal00.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal00.js
@@ -1,10 +1,18 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim != null && GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        pi.playPortalSound();
+        pi.warp(610030510, 0);
+        return true;
+    }
+
     if (pi.getPlayer().getJob().getJobNiche() == 1) {
         pi.playPortalSound();
         pi.warp(610030510, 0);
         return true;
-    } else {
-        pi.playerMessage(5, "※ 仅限战士职业进入该传送门！");
-        return false;
     }
+
+    pi.playerMessage(5, "※ 仅限战士职业进入该传送门！");
+    return false;
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal01.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal01.js
@@ -1,10 +1,18 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim != null && GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        pi.playPortalSound();
+        pi.warp(610030540, 0);
+        return true;
+    }
+
     if (pi.getPlayer().getJob().getJobNiche() == 3) {
         pi.playPortalSound();
         pi.warp(610030540, 0);
         return true;
-    } else {
-        pi.playerMessage(5, "只有弓箭手才能进入此传送门。");
-        return false;
     }
+
+    pi.playerMessage(5, "只有弓箭手才能进入此传送门。");
+    return false;
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal02.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal02.js
@@ -1,10 +1,18 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim != null && GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        pi.playPortalSound();
+        pi.warp(610030521, 0);
+        return true;
+    }
+
     if (pi.getPlayer().getJob().getJobNiche() == 2) {
         pi.playPortalSound();
         pi.warp(610030521, 0);
         return true;
-    } else {
-        pi.playerMessage(5, "※ 仅限魔法师职业进入该传送门！");
-        return false;
     }
+
+    pi.playerMessage(5, "※ 仅限魔法师职业进入该传送门！");
+    return false;
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal03.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal03.js
@@ -1,10 +1,18 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim != null && GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        pi.playPortalSound();
+        pi.warp(610030530, 0);
+        return true;
+    }
+
     if (pi.getPlayer().getJob().getJobNiche() == 4) {
         pi.playPortalSound();
         pi.warp(610030530, 0);
         return true;
-    } else {
-        pi.playerMessage(5, "※ 仅限飞侠职业进入该传送门！");
-        return false;
     }
+
+    pi.playerMessage(5, "※ 仅限飞侠职业进入该传送门！");
+    return false;
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal04.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal04.js
@@ -1,10 +1,18 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim != null && GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        pi.playPortalSound();
+        pi.warp(610030550, 0);
+        return true;
+    }
+
     if (pi.getPlayer().getJob().getJobNiche() == 5) {
         pi.playPortalSound();
         pi.warp(610030550, 0);
         return true;
-    } else {
-        pi.playerMessage(5, "※ 仅限海盗职业进入该传送门！")
-        return false;
     }
+
+    pi.playerMessage(5, "※ 仅限海盗职业进入该传送门！");
+    return false;
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal1.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal1.js
@@ -1,15 +1,30 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
-    if (eim != null) {
-        if (eim.getIntProperty("glpq2") == 5) {
-            pi.playPortalSound();
-            pi.warp(610030300, 0);
-            return true;
-        } else {
-            pi.playerMessage(5, "传送门尚未激活！");
-            return false;
-        }
+    if (eim == null) {
+        return false;
     }
 
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("glpq2") < 5) {
+            eim.setIntProperty("glpq2", 5);
+            try {
+                eim.showClearEffect(610030200, "2pt", 2);
+                eim.giveEventPlayersStageReward(2);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(610030300, 0);
+        return true;
+    }
+
+    if (eim.getIntProperty("glpq2") == 5) {
+        pi.playPortalSound();
+        pi.warp(610030300, 0);
+        return true;
+    }
+
+    pi.playerMessage(5, "传送门尚未激活！");
     return false;
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal3.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal3.js
@@ -1,15 +1,31 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
-    if (eim != null) {
-        if (eim.getIntProperty("glpq3") < 5 || eim.getIntProperty("glpq3_p") < 5) {
-            pi.playerMessage(5, "传送门尚未开启。");
-            return false;
-        } else {
-            pi.playPortalSound();
-            pi.warp(610030400, 0);
-            return true;
-        }
+    if (eim == null) {
+        return false;
     }
 
-    return false;
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("glpq3") < 5 || eim.getIntProperty("glpq3_p") < 5) {
+            eim.setIntProperty("glpq3", 5);
+            eim.setIntProperty("glpq3_p", 5);
+            try {
+                eim.showClearEffect(610030300, "3pt", 2);
+                eim.giveEventPlayersStageReward(3);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(610030400, 0);
+        return true;
+    }
+
+    if (eim.getIntProperty("glpq3") < 5 || eim.getIntProperty("glpq3_p") < 5) {
+        pi.playerMessage(5, "传送门尚未开启。");
+        return false;
+    }
+
+    pi.playPortalSound();
+    pi.warp(610030400, 0);
+    return true;
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal4.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal4.js
@@ -1,15 +1,32 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
-    if (eim != null) {
-        if (eim.getIntProperty("glpq4") < 5) {
-            pi.playerMessage(5, "传送门尚未开启。");
-            return false;
-        } else {
-            pi.playPortalSound();
-            pi.warp(610030500, 0);
-            return true;
-        }
+    if (eim == null) {
+        return false;
     }
 
-    return false;
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("glpq4") < 5) {
+            eim.setIntProperty("glpq4", 5);
+            eim.setIntProperty("glpq_s", 777);
+            try {
+                pi.getMap().killAllMonsters();
+                eim.showClearEffect(610030400, "4pt", 2);
+                eim.giveEventPlayersStageReward(4);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(610030500, 0);
+        return true;
+    }
+
+    if (eim.getIntProperty("glpq4") < 5) {
+        pi.playerMessage(5, "传送门尚未开启。");
+        return false;
+    }
+
+    pi.playPortalSound();
+    pi.warp(610030500, 0);
+    return true;
 }

--- a/gms-server/scripts-zh-CN/portal/glpqPortal5.js
+++ b/gms-server/scripts-zh-CN/portal/glpqPortal5.js
@@ -1,15 +1,30 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
-    if (eim != null) {
-        if (eim.getIntProperty("glpq5") < 5) {
-            pi.playerMessage(5, "传送门尚未开启。");
-            return false;
-        } else {
-            pi.playPortalSound();
-            pi.warp(610030600, 0);
-            return true;
-        }
+    if (eim == null) {
+        return false;
     }
 
-    return false;
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("glpq5") < 5) {
+            eim.setIntProperty("glpq5", 5);
+            try {
+                eim.showClearEffect(610030500, "5pt", 2);
+                eim.giveEventPlayersStageReward(5);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(610030600, 0);
+        return true;
+    }
+
+    if (eim.getIntProperty("glpq5") < 5) {
+        pi.playerMessage(5, "传送门尚未开启。");
+        return false;
+    }
+
+    pi.playPortalSound();
+    pi.warp(610030600, 0);
+    return true;
 }

--- a/gms-server/scripts/event/CWKPQ.js
+++ b/gms-server/scripts/event/CWKPQ.js
@@ -38,6 +38,60 @@ var eventTime = 2;     // 2 minutes for first stg
 
 const maxLobbies = 1;
 
+const GameConfig = Java.type('org.gms.config.GameConfig');
+minPlayers = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : minPlayers;
+if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+    minLevel = 1, maxLevel = 999;
+}
+
+function canSoloSkip(eim) {
+    return GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1;
+}
+
+function skipStage2(eim) {
+    if (eim.getIntProperty("glpq2") >= 5) {
+        return;
+    }
+    eim.setIntProperty("glpq2", 5);
+    eim.dropMessage(6, "The Antellion grants you the next portal! Proceed!");
+    eim.showClearEffect(610030200, "2pt", 2);
+    eim.giveEventPlayersStageReward(2);
+}
+
+function skipStage3(eim) {
+    if (eim.getIntProperty("glpq3") >= 5 && eim.getIntProperty("glpq3_p") >= 5) {
+        return;
+    }
+    eim.setIntProperty("glpq3", 5);
+    eim.setIntProperty("glpq3_p", 5);
+    eim.dropMessage(6, "The Antellion grants you the next portal! Proceed!");
+    eim.showClearEffect(610030300, "3pt", 2);
+    eim.giveEventPlayersStageReward(3);
+}
+
+function skipStage4(eim) {
+    if (eim.getIntProperty("glpq4") >= 5) {
+        return;
+    }
+    eim.setIntProperty("glpq4", 5);
+    eim.setIntProperty("glpq_s", 777);
+    var map = eim.getMapInstance(610030400);
+    map.killAllMonsters();
+    eim.dropMessage(6, "The Antellion grants you the next portal! Proceed!");
+    eim.showClearEffect(610030400, "4pt", 2);
+    eim.giveEventPlayersStageReward(4);
+}
+
+function skipStage5(eim) {
+    if (eim.getIntProperty("glpq5") >= 5) {
+        return;
+    }
+    eim.setIntProperty("glpq5", 5);
+    eim.dropMessage(6, "The Antellion grants you the next portal! Proceed!");
+    eim.showClearEffect(610030500, "5pt", 2);
+    eim.giveEventPlayersStageReward(5);
+}
+
 function init() {
     setEventRequirements();
 }
@@ -264,11 +318,17 @@ function changedMap(eim, player, mapid) {
                     eim.restartEventTimer(600000); //10 mins
                     eim.setIntProperty("current_instance", 1);
                 }
+                if (canSoloSkip(eim)) {
+                    skipStage2(eim);
+                }
                 break;
             case 610030300:
                 if (eim.getIntProperty("current_instance") == 1) {
                     eim.restartEventTimer(600000); //10 mins
                     eim.setIntProperty("current_instance", 2);
+                }
+                if (canSoloSkip(eim)) {
+                    skipStage3(eim);
                 }
                 break;
             case 610030400:
@@ -276,11 +336,17 @@ function changedMap(eim, player, mapid) {
                     eim.restartEventTimer(600000); //10 mins
                     eim.setIntProperty("current_instance", 3);
                 }
+                if (canSoloSkip(eim)) {
+                    skipStage4(eim);
+                }
                 break;
             case 610030500:
                 if (eim.getIntProperty("current_instance") == 3) {
                     eim.restartEventTimer(1200000); //20 mins
                     eim.setIntProperty("current_instance", 4);
+                }
+                if (canSoloSkip(eim)) {
+                    skipStage5(eim);
                 }
                 break;
             case 610030600:

--- a/gms-server/scripts/portal/glpqPortal00.js
+++ b/gms-server/scripts/portal/glpqPortal00.js
@@ -1,10 +1,18 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim != null && GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        pi.playPortalSound();
+        pi.warp(610030510, 0);
+        return true;
+    }
+
     if (pi.getPlayer().getJob().getJobNiche() == 1) {
         pi.playPortalSound();
         pi.warp(610030510, 0);
         return true;
-    } else {
-        pi.playerMessage(5, "Only warriors may enter this portal.");
-        return false;
     }
+
+    pi.playerMessage(5, "Only Warriors may enter this portal!");
+    return false;
 }

--- a/gms-server/scripts/portal/glpqPortal01.js
+++ b/gms-server/scripts/portal/glpqPortal01.js
@@ -1,10 +1,18 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim != null && GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        pi.playPortalSound();
+        pi.warp(610030540, 0);
+        return true;
+    }
+
     if (pi.getPlayer().getJob().getJobNiche() == 3) {
         pi.playPortalSound();
         pi.warp(610030540, 0);
         return true;
-    } else {
-        pi.playerMessage(5, "Only bowmen may enter this portal.");
-        return false;
     }
+
+    pi.playerMessage(5, "Only Bowmen may enter this portal.");
+    return false;
 }

--- a/gms-server/scripts/portal/glpqPortal02.js
+++ b/gms-server/scripts/portal/glpqPortal02.js
@@ -1,10 +1,18 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim != null && GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        pi.playPortalSound();
+        pi.warp(610030521, 0);
+        return true;
+    }
+
     if (pi.getPlayer().getJob().getJobNiche() == 2) {
         pi.playPortalSound();
         pi.warp(610030521, 0);
         return true;
-    } else {
-        pi.playerMessage(5, "Only mages may enter this portal.");
-        return false;
     }
+
+    pi.playerMessage(5, "Only Magicians may enter this portal!");
+    return false;
 }

--- a/gms-server/scripts/portal/glpqPortal03.js
+++ b/gms-server/scripts/portal/glpqPortal03.js
@@ -1,10 +1,18 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim != null && GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        pi.playPortalSound();
+        pi.warp(610030530, 0);
+        return true;
+    }
+
     if (pi.getPlayer().getJob().getJobNiche() == 4) {
         pi.playPortalSound();
         pi.warp(610030530, 0);
         return true;
-    } else {
-        pi.playerMessage(5, "Only thieves may enter this portal.");
-        return false;
     }
+
+    pi.playerMessage(5, "Only Thieves may enter this portal!");
+    return false;
 }

--- a/gms-server/scripts/portal/glpqPortal04.js
+++ b/gms-server/scripts/portal/glpqPortal04.js
@@ -1,10 +1,18 @@
 function enter(pi) {
+    var eim = pi.getEventInstance();
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (eim != null && GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        pi.playPortalSound();
+        pi.warp(610030550, 0);
+        return true;
+    }
+
     if (pi.getPlayer().getJob().getJobNiche() == 5) {
         pi.playPortalSound();
         pi.warp(610030550, 0);
         return true;
-    } else {
-        pi.playerMessage(5, "Only pirates may enter this portal.");
-        return false;
     }
+
+    pi.playerMessage(5, "Only Pirates may enter this portal!");
+    return false;
 }

--- a/gms-server/scripts/portal/glpqPortal1.js
+++ b/gms-server/scripts/portal/glpqPortal1.js
@@ -1,15 +1,30 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
-    if (eim != null) {
-        if (eim.getIntProperty("glpq2") == 5) {
-            pi.playPortalSound();
-            pi.warp(610030300, 0);
-            return true;
-        } else {
-            pi.playerMessage(5, "The portal has not been activated yet!");
-            return false;
-        }
+    if (eim == null) {
+        return false;
     }
 
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("glpq2") < 5) {
+            eim.setIntProperty("glpq2", 5);
+            try {
+                eim.showClearEffect(610030200, "2pt", 2);
+                eim.giveEventPlayersStageReward(2);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(610030300, 0);
+        return true;
+    }
+
+    if (eim.getIntProperty("glpq2") == 5) {
+        pi.playPortalSound();
+        pi.warp(610030300, 0);
+        return true;
+    }
+
+    pi.playerMessage(5, "The portal is not activated yet!");
     return false;
 }

--- a/gms-server/scripts/portal/glpqPortal3.js
+++ b/gms-server/scripts/portal/glpqPortal3.js
@@ -1,15 +1,31 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
-    if (eim != null) {
-        if (eim.getIntProperty("glpq3") < 5 || eim.getIntProperty("glpq3_p") < 5) {
-            pi.playerMessage(5, "The portal is not opened yet.");
-            return false;
-        } else {
-            pi.playPortalSound();
-            pi.warp(610030400, 0);
-            return true;
-        }
+    if (eim == null) {
+        return false;
     }
 
-    return false;
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("glpq3") < 5 || eim.getIntProperty("glpq3_p") < 5) {
+            eim.setIntProperty("glpq3", 5);
+            eim.setIntProperty("glpq3_p", 5);
+            try {
+                eim.showClearEffect(610030300, "3pt", 2);
+                eim.giveEventPlayersStageReward(3);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(610030400, 0);
+        return true;
+    }
+
+    if (eim.getIntProperty("glpq3") < 5 || eim.getIntProperty("glpq3_p") < 5) {
+        pi.playerMessage(5, "The portal is not opened yet.");
+        return false;
+    }
+
+    pi.playPortalSound();
+    pi.warp(610030400, 0);
+    return true;
 }

--- a/gms-server/scripts/portal/glpqPortal4.js
+++ b/gms-server/scripts/portal/glpqPortal4.js
@@ -1,15 +1,32 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
-    if (eim != null) {
-        if (eim.getIntProperty("glpq4") < 5) {
-            pi.playerMessage(5, "The portal is not opened yet.");
-            return false;
-        } else {
-            pi.playPortalSound();
-            pi.warp(610030500, 0);
-            return true;
-        }
+    if (eim == null) {
+        return false;
     }
 
-    return false;
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("glpq4") < 5) {
+            eim.setIntProperty("glpq4", 5);
+            eim.setIntProperty("glpq_s", 777);
+            try {
+                pi.getMap().killAllMonsters();
+                eim.showClearEffect(610030400, "4pt", 2);
+                eim.giveEventPlayersStageReward(4);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(610030500, 0);
+        return true;
+    }
+
+    if (eim.getIntProperty("glpq4") < 5) {
+        pi.playerMessage(5, "The portal is not opened yet.");
+        return false;
+    }
+
+    pi.playPortalSound();
+    pi.warp(610030500, 0);
+    return true;
 }

--- a/gms-server/scripts/portal/glpqPortal5.js
+++ b/gms-server/scripts/portal/glpqPortal5.js
@@ -1,15 +1,30 @@
 function enter(pi) {
     var eim = pi.getEventInstance();
-    if (eim != null) {
-        if (eim.getIntProperty("glpq5") < 5) {
-            pi.playerMessage(5, "The portal is not opened yet.");
-            return false;
-        } else {
-            pi.playPortalSound();
-            pi.warp(610030600, 0);
-            return true;
-        }
+    if (eim == null) {
+        return false;
     }
 
-    return false;
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+        if (eim.getIntProperty("glpq5") < 5) {
+            eim.setIntProperty("glpq5", 5);
+            try {
+                eim.showClearEffect(610030500, "5pt", 2);
+                eim.giveEventPlayersStageReward(5);
+            } catch (err) {
+            }
+        }
+        pi.playPortalSound();
+        pi.warp(610030600, 0);
+        return true;
+    }
+
+    if (eim.getIntProperty("glpq5") < 5) {
+        pi.playerMessage(5, "The portal is not opened yet.");
+        return false;
+    }
+
+    pi.playPortalSound();
+    pi.warp(610030600, 0);
+    return true;
 }


### PR DESCRIPTION
## Summary
- 开启 `use_enable_stage_skip` 且仅 1 人时，跳过 CWKPQ 中需多职业/多人站位的关卡
- 便于单人推进绯红远征队

## Test plan
- [ ] 开启 `use_enable_stage_skip`，单人进入绯红远征并确认站位关可跳过
- [ ] 多人队伍时站位/职业校验仍生效
- [ ] 关闭开关后恢复原版多人站位要求

Made with [Cursor](https://cursor.com)