### PR TITLE
玩具城组队任务单人时可跳过站位组合关

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2040043.js
+++ b/gms-server/scripts-zh-CN/npc/2040043.js
@@ -110,6 +110,14 @@ function action(mode, type, selection) {
                         return;
                     }
 
+                    const GameConfig = Java.type('org.gms.config.GameConfig');
+                    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+                        eim.setProperty("statusStg" + stage, 1);
+                        clearStage(stage, eim, curMap);
+                        cm.dispose();
+                        return;
+                    }
+
                     objset = [0, 0, 0, 0, 0, 0, 0, 0, 0];
                     var playersOnCombo = 0;
                     var map = cm.getPlayer().getMap();

--- a/gms-server/scripts/npc/2040043.js
+++ b/gms-server/scripts/npc/2040043.js
@@ -110,6 +110,14 @@ function action(mode, type, selection) {
                         return;
                     }
 
+                    const GameConfig = Java.type('org.gms.config.GameConfig');
+                    if (GameConfig.getServerBoolean("use_enable_stage_skip") && eim.getPlayerCount() == 1) {
+                        eim.setProperty("statusStg" + stage, 1);
+                        clearStage(stage, eim, curMap);
+                        cm.dispose();
+                        return;
+                    }
+
                     objset = [0, 0, 0, 0, 0, 0, 0, 0, 0];
                     var playersOnCombo = 0;
                     var map = cm.getPlayer().getMap();


### PR DESCRIPTION
## Summary
- 开启 `use_enable_stage_skip` 且仅 1 人时，玩具城组队清怪后可直接过关，无需多人站位 combo

## Test plan
- [ ] 开启开关后单人完成玩具城组队站位关
- [ ] 多人时仍需站位组合
- [ ] 关闭开关后行为不变

Made with [Cursor](https://cursor.com)