### PR TITLE
怪物嘉年华入场跟随等级限制解除开关

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2042000.js
+++ b/gms-server/scripts-zh-CN/npc/2042000.js
@@ -20,6 +20,13 @@ var cpqMinLvl = 30;
 var cpqMaxLvl = 50;
 var cpqMinAmt = 2;
 var cpqMaxAmt = 6;
+(function () {
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+        cpqMinLvl = 1;
+        cpqMaxLvl = 999;
+    }
+})();
 
 // Ronan's custom ore refiner NPC
 var refineRocks = true;     // enables moon rock, star rock
@@ -245,17 +252,17 @@ function action(mode, type, selection) {
                 cm.sendSimple(talk);
             } else if (status == 1) {
                 if (selection == 0) {
-                    if ((cm.getLevel() > 29 && cm.getLevel() < 51) || cm.getPlayer().isGM()) {
+                    if ((cm.getLevel() >= cpqMinLvl && cm.getLevel() <= cpqMaxLvl) || cm.getPlayer().isGM()) {
                         cm.getChar().saveLocation("MONSTER_CARNIVAL");
                         cm.warp(980000000, 0);
                         cm.dispose();
 
-                    } else if (cm.getLevel() < 30) {
-                        cm.sendOk("你必须至少达到30级才能参加怪物嘉年华。当你足够强大时，和我交谈。");
+                    } else if (cm.getLevel() < cpqMinLvl) {
+                        cm.sendOk("你必须至少达到" + cpqMinLvl + "级才能参加怪物嘉年华。当你足够强大时，和我交谈。");
                         cm.dispose();
 
                     } else {
-                        cm.sendOk("很抱歉，只有等级在30到50级之间的玩家才能参加怪物嘉年华活动。");
+                        cm.sendOk("很抱歉，只有等级在" + cpqMinLvl + "到" + cpqMaxLvl + "级之间的玩家才能参加怪物嘉年华活动。");
                         cm.dispose();
 
                     }

--- a/gms-server/scripts-zh-CN/npc/2042001.js
+++ b/gms-server/scripts-zh-CN/npc/2042001.js
@@ -19,6 +19,13 @@ var cpqMinLvl = 30;
 var cpqMaxLvl = 50;
 var cpqMinAmt = 2;
 var cpqMaxAmt = 6;
+(function () {
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+        cpqMinLvl = 1;
+        cpqMaxLvl = 999;
+    }
+})();
 
 // Ronan's custom ore refiner NPC
 var refineRocks = true;     // enables moon rock, star rock
@@ -244,17 +251,17 @@ function action(mode, type, selection) {
                 cm.sendSimple(talk);
             } else if (status == 1) {
                 if (selection == 0) {
-                    if ((cm.getLevel() > 29 && cm.getLevel() < 51) || cm.getPlayer().isGM()) {
+                    if ((cm.getLevel() >= cpqMinLvl && cm.getLevel() <= cpqMaxLvl) || cm.getPlayer().isGM()) {
                         cm.getChar().saveLocation("MONSTER_CARNIVAL");
                         cm.warp(980000000, 0);
                         cm.dispose();
 
-                    } else if (cm.getLevel() < 30) {
-                        cm.sendOk("你必须至少达到30级才能参加怪物嘉年华。当你足够强大时，和我交谈。");
+                    } else if (cm.getLevel() < cpqMinLvl) {
+                        cm.sendOk("你必须至少达到" + cpqMinLvl + "级才能参加怪物嘉年华。当你足够强大时，和我交谈。");
                         cm.dispose();
 
                     } else {
-                        cm.sendOk("很抱歉，只有等级在30到50级之间的玩家才能参加怪物嘉年华活动。");
+                        cm.sendOk("很抱歉，只有等级在" + cpqMinLvl + "到" + cpqMaxLvl + "级之间的玩家才能参加怪物嘉年华活动。");
                         cm.dispose();
 
                     }

--- a/gms-server/scripts-zh-CN/npc/2042002.js
+++ b/gms-server/scripts-zh-CN/npc/2042002.js
@@ -19,6 +19,13 @@ var cpqMinLvl = 30;
 var cpqMaxLvl = 50;
 var cpqMinAmt = 2;
 var cpqMaxAmt = 6;
+(function () {
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+        cpqMinLvl = 1;
+        cpqMaxLvl = 999;
+    }
+})();
 
 // Ronan's custom ore refiner NPC
 var refineRocks = true;     // enables moon rock, star rock
@@ -245,17 +252,17 @@ function action(mode, type, selection) {
                 cm.sendSimple(talk);
             } else if (status == 1) {
                 if (selection == 0) {
-                    if ((cm.getLevel() > 29 && cm.getLevel() < 51) || cm.getPlayer().isGM()) {
+                    if ((cm.getLevel() >= cpqMinLvl && cm.getLevel() <= cpqMaxLvl) || cm.getPlayer().isGM()) {
                         cm.getChar().saveLocation("MONSTER_CARNIVAL");
                         cm.warp(980000000, 0);
                         cm.dispose();
 
-                    } else if (cm.getLevel() < 30) {
-                        cm.sendOk("你必须至少达到30级才能参加怪物嘉年华。当你足够强大时，和我交谈。");
+                    } else if (cm.getLevel() < cpqMinLvl) {
+                        cm.sendOk("你必须至少达到" + cpqMinLvl + "级才能参加怪物嘉年华。当你足够强大时，和我交谈。");
                         cm.dispose();
 
                     } else {
-                        cm.sendOk("很抱歉，只有等级在30到50级之间的玩家才能参加怪物嘉年华活动。");
+                        cm.sendOk("很抱歉，只有等级在" + cpqMinLvl + "到" + cpqMaxLvl + "级之间的玩家才能参加怪物嘉年华活动。");
                         cm.dispose();
 
                     }

--- a/gms-server/scripts-zh-CN/npc/2042005.js
+++ b/gms-server/scripts-zh-CN/npc/2042005.js
@@ -9,6 +9,13 @@ var cpqMinLvl = 51;
 var cpqMaxLvl = 70;
 var cpqMinAmt = 2;
 var cpqMaxAmt = 6;
+(function () {
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+        cpqMinLvl = 1;
+        cpqMaxLvl = 999;
+    }
+})();
 
 function start() {
     status = -1;

--- a/gms-server/scripts/npc/2042000.js
+++ b/gms-server/scripts/npc/2042000.js
@@ -20,6 +20,13 @@ var cpqMinLvl = 30;
 var cpqMaxLvl = 50;
 var cpqMinAmt = 2;
 var cpqMaxAmt = 6;
+(function () {
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+        cpqMinLvl = 1;
+        cpqMaxLvl = 999;
+    }
+})();
 
 // Ronan's custom ore refiner NPC
 var refineRocks = true;     // enables moon rock, star rock

--- a/gms-server/scripts/npc/2042001.js
+++ b/gms-server/scripts/npc/2042001.js
@@ -19,6 +19,13 @@ var cpqMinLvl = 30;
 var cpqMaxLvl = 50;
 var cpqMinAmt = 2;
 var cpqMaxAmt = 6;
+(function () {
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+        cpqMinLvl = 1;
+        cpqMaxLvl = 999;
+    }
+})();
 
 // Ronan's custom ore refiner NPC
 var refineRocks = true;     // enables moon rock, star rock

--- a/gms-server/scripts/npc/2042002.js
+++ b/gms-server/scripts/npc/2042002.js
@@ -19,6 +19,13 @@ var cpqMinLvl = 30;
 var cpqMaxLvl = 50;
 var cpqMinAmt = 2;
 var cpqMaxAmt = 6;
+(function () {
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+        cpqMinLvl = 1;
+        cpqMaxLvl = 999;
+    }
+})();
 
 // Ronan's custom ore refiner NPC
 var refineRocks = true;     // enables moon rock, star rock

--- a/gms-server/scripts/npc/2042005.js
+++ b/gms-server/scripts/npc/2042005.js
@@ -9,6 +9,13 @@ var cpqMinLvl = 51;
 var cpqMaxLvl = 70;
 var cpqMinAmt = 2;
 var cpqMaxAmt = 6;
+(function () {
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (GameConfig.getServerBoolean("use_enable_party_level_limit_lift")) {
+        cpqMinLvl = 1;
+        cpqMaxLvl = 999;
+    }
+})();
 
 function start() {
     status = -1;


### PR DESCRIPTION
## Summary
- 开启 `use_enable_party_level_limit_lift` 后，怪物嘉年华入场不再硬卡 30–50 级
- 任意等级可进入（仍受其它既有校验约束）

## Test plan
- [ ] 开启开关后，等级不在 30–50 的角色可进入怪物嘉年华
- [ ] 关闭开关后仍按原等级范围拦截
- [ ] 覆盖相关入口 NPC（2042000/2042001/2042002/2042005）

Made with [Cursor](https://cursor.com)