### PR TITLE
阿里安特竞技场入场跟随等级限制解除开关

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2101014.js
+++ b/gms-server/scripts-zh-CN/npc/2101014.js
@@ -35,8 +35,8 @@ function action(mode, type, selection) {
             status--;
         }
         if (cm.getPlayer().getMapId() == 980010000) {
-            if (cm.getLevel() > 30) {
-                cm.sendOk("你已经超过了#r等级30#k，因此你不能再参与这个副本了。");
+            if (cm.getLevel() > exped.getMaxLevel()) {
+                cm.sendOk("你已经超过了#r等级" + exped.getMaxLevel() + "#k，因此你不能再参与这个副本了。");
                 cm.dispose();
                 return;
             }

--- a/gms-server/scripts-zh-CN/npc/2101018.js
+++ b/gms-server/scripts-zh-CN/npc/2101018.js
@@ -30,7 +30,10 @@
 status = -1;
 
 function start() {
-    if ((cm.getPlayer().getLevel() < 19 || cm.getPlayer().getLevel() > 30) && !cm.getPlayer().isGM()) {
+    const GameConfig = Java.type('org.gms.config.GameConfig');
+    if (!GameConfig.getServerBoolean("use_enable_party_level_limit_lift")
+            && (cm.getPlayer().getLevel() < 19 || cm.getPlayer().getLevel() > 30)
+            && !cm.getPlayer().isGM()) {
         cm.sendNext("你的等级不在20级到30级之间。抱歉，你不能参加。");
         cm.dispose();
         return;


### PR DESCRIPTION
## Summary
- 开启 `use_enable_party_level_limit_lift` 后，放宽/对齐阿里安特竞技场等级校验
- 避免仍按写死 19–30 级拦截

## Test plan
- [ ] 开启开关后，超出原等级范围的角色可入场
- [ ] 关闭开关后仍按原范围限制
- [ ] 检查 2101014 / 2101018 入场逻辑

Made with [Cursor](https://cursor.com)