### PR TITLE
内拉金字塔支持单人入场并跟随等级限制解除开关

### DIFF
--- a/gms-server/scripts-zh-CN/npc/2103013.js
+++ b/gms-server/scripts-zh-CN/npc/2103013.js
@@ -136,22 +136,27 @@ function action(mode, type, selection) {
                         cm.dispose();
                         return;
                     }
-                    if (cm.partyMembersInMap() < 2) {
-                        cm.sendOk("请确认当前地图中有 2 名或更多队员。 ");
+                    const GameConfig = Java.type('org.gms.config.GameConfig');
+                    var minParty = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : 2;
+                    if (cm.partyMembersInMap() < minParty) {
+                        cm.sendOk("请确认当前地图中有 " + minParty + " 名或更多队员。 ");
                         cm.dispose();
                         return;
                     }
                 }
 
-                if (cm.getPlayer().getLevel() < 40) {
-                    cm.sendOk("你必须达到 40 级以上才能进入这个组队任务。 ");
-                    cm.dispose();
-                    return;
-                }
-                if (selection < 3 && cm.getPlayer().getLevel() > 60) {
-                    cm.sendOk("等级超过 60 级的玩家只能进入地狱模式。 ");
-                    cm.dispose();
-                    return;
+                const GameConfigLvl = Java.type('org.gms.config.GameConfig');
+                if (!GameConfigLvl.getServerBoolean("use_enable_party_level_limit_lift")) {
+                    if (cm.getPlayer().getLevel() < 40) {
+                        cm.sendOk("你必须达到 40 级以上才能进入这个组队任务。 ");
+                        cm.dispose();
+                        return;
+                    }
+                    if (selection < 3 && cm.getPlayer().getLevel() > 60) {
+                        cm.sendOk("等级超过 60 级的玩家只能进入地狱模式。 ");
+                        cm.dispose();
+                        return;
+                    }
                 }
                 if (selection == 1) {
                     mode = "NORMAL";

--- a/gms-server/scripts/npc/2103013.js
+++ b/gms-server/scripts/npc/2103013.js
@@ -136,8 +136,10 @@ function action(mode, type, selection) {
                         cm.dispose();
                         return;
                     }
-                    if (cm.partyMembersInMap() < 2) {
-                        cm.sendOk("Make sure that 2 or more party members are in your map.");
+                    const GameConfig = Java.type('org.gms.config.GameConfig');
+                    var minParty = GameConfig.getServerBoolean("use_enable_solo_expeditions") ? 1 : 2;
+                    if (cm.partyMembersInMap() < minParty) {
+                        cm.sendOk("Make sure that " + minParty + " or more party members are in your map.");
                         cm.dispose();
                         return;
                     }


### PR DESCRIPTION
## Summary
- 开启 `use_enable_solo_expeditions` 时允许 1 人进入内拉金字塔
- 开启 `use_enable_party_level_limit_lift` 时跳过 40+/非地狱≤60 的硬性等级检查

## Test plan
- [ ] 单人开关开启时 1 人可进场
- [ ] 等级解除开关开启时跳过原硬性等级检查
- [ ] 两开关关闭时保持原版人数与等级限制

Made with [Cursor](https://cursor.com)