### PR TITLE
远征等级范围跟随 use_enable_party_level_limit_lift 开关

### DIFF
--- a/gms-server/src/main/java/org/gms/server/expeditions/ExpeditionType.java
+++ b/gms-server/src/main/java/org/gms/server/expeditions/ExpeditionType.java
@@ -66,11 +66,11 @@ public enum ExpeditionType {
     }
 
     public int getMinLevel() {
-        return minLevel;
+        return !GameConfig.getServerBoolean("use_enable_party_level_limit_lift") ? minLevel : 1;
     }
 
     public int getMaxLevel() {
-        return maxLevel;
+        return !GameConfig.getServerBoolean("use_enable_party_level_limit_lift") ? maxLevel : 999;
     }
 
     public int getRegistrationMinutes() {


### PR DESCRIPTION
## Summary
- `ExpeditionType.getMinLevel/getMaxLevel` 在开启 `use_enable_party_level_limit_lift` 后放宽为 1–999
- 与脚本侧等级解除行为对齐，避免远征入场仍被 Java 侧等级卡住

## Test plan
- [ ] 开启开关后，低等级/高等级角色可创建或加入远征（如扎昆/龙王/品克缤入口）
- [ ] 关闭开关后恢复各远征原等级范围
- [ ] 确认不影响 `getMinSize` 等人数逻辑

Made with [Cursor](https://cursor.com)