### PR TITLE
新增任务捷径：补齐杀怪与非任务物品收集进度

### DIFF
--- a/gms-server/scripts-zh-CN/BeiDouSpecial/任务捷径.js
+++ b/gms-server/scripts-zh-CN/BeiDouSpecial/任务捷径.js
@@ -1,0 +1,98 @@
+/**
+ * 任务捷径：对进行中的「杀怪 / 非任务物品收集」任务补齐进度。
+ * 费用写死 10 万冒险币；进度已齐不收费。
+ */
+var COST = 100000;
+var status = -1;
+var eligible = [];
+var selectedQuestId = -1;
+
+function start() {
+    status = -1;
+    action(1, 0, 0);
+}
+
+function action(mode, type, selection) {
+    if (mode === -1 || (mode === 0 && status <= 0)) {
+        cm.dispose();
+        return;
+    }
+    if (mode === 1) {
+        status++;
+    } else {
+        status--;
+    }
+
+    if (status === 0) {
+        eligible = toJsArray(cm.getQuestShortcutEligibleIds());
+        if (eligible.length === 0) {
+            cm.sendOk("哟，看你一脸轻松……目前没有我能插手的任务啊。\r\n#b我只管杀怪计数、以及收集普通掉落物的任务#k，那些要交任务专属道具、走剧情脚本的，可帮不了你。");
+            cm.dispose();
+            return;
+        }
+
+        var text = "是有任务搞不定了吗？我可以帮你，但你懂的，需要意思意思……\r\n";
+        text += "#r每次 #e" + COST + "#n 冒险币#k，帮你把杀怪进度拉满、缺的普通材料补齐。\r\n";
+        text += "#b进度本来就够的，我分文不取——你自己去交任务就行。#k\r\n\r\n";
+        text += "来，挑一个让你头疼的：\r\n";
+        for (var i = 0; i < eligible.length; i++) {
+            var qid = eligible[i];
+            var name = cm.getQuestName(qid);
+            if (!name) {
+                name = "未命名任务";
+            }
+            text += "#L" + i + "##b[" + qid + "] " + name + "#k#l\r\n";
+        }
+        cm.sendSimple(text);
+    } else if (status === 1) {
+        if (selection < 0 || selection >= eligible.length) {
+            cm.sendOk("嗯？你点到空气了。再来一次吧。");
+            cm.dispose();
+            return;
+        }
+        selectedQuestId = eligible[selection];
+        var qName = cm.getQuestName(selectedQuestId);
+        if (!qName) {
+            qName = "任务#" + selectedQuestId;
+        }
+
+        if (cm.isQuestShortcutProgressSatisfied(selectedQuestId)) {
+            cm.sendOk("《" + qName + "》的进度我瞅了一眼——#b你其实已经够格交任务了#k。\r\n省下那 " + COST + " 冒险币，去找对应 NPC 交差吧，别在我这儿浪费表情。");
+            cm.dispose();
+            return;
+        }
+
+        cm.sendYesNo("《" + qName + "》是吧？\r\n\r\n一手交钱，一手交货：\r\n#r扣除 " + COST + " 冒险币#k\r\n#b杀怪计数拉满 + 缺的普通材料补齐#k\r\n\r\n交任务还得你自己跑一趟，我又不是你腿。同意就点是？");
+    } else if (status === 2) {
+        var qName = cm.getQuestName(selectedQuestId);
+        if (!qName) {
+            qName = "任务#" + selectedQuestId;
+        }
+        var result = cm.applyQuestShortcut(selectedQuestId, COST);
+        if (result === 0) {
+            cm.sendOk("成交！《" + qName + "》的脏活累活我替你干完了。\r\n#b记得去找任务 NPC 交任务#k——钱我收了，脸我可替你丢不了。");
+        } else if (result === 2) {
+            cm.sendOk("意思意思也得有本钱啊……你这钱包比任务进度还干瘪，先攒够 #r" + COST + "#k 冒险币再来。");
+        } else if (result === 3) {
+            cm.sendOk("背包塞得比仓鼠颊帮还满，我往哪儿塞材料？#b腾出点空位#k再来找我。");
+        } else if (result === 4) {
+            cm.sendOk("等等，你这进度刚才不知怎么已经齐了？那我就不收钱了，直接去交任务吧。");
+        } else {
+            cm.sendOk("这单我接不了——任务状态不对，或者不在我的业务范围内。换个别的试试？");
+        }
+        cm.dispose();
+    } else {
+        cm.dispose();
+    }
+}
+
+function toJsArray(javaList) {
+    var arr = [];
+    if (javaList == null) {
+        return arr;
+    }
+    for (var i = 0; i < javaList.size(); i++) {
+        arr.push(javaList.get(i));
+    }
+    return arr;
+}

--- a/gms-server/scripts-zh-CN/npc/9900001.js
+++ b/gms-server/scripts-zh-CN/npc/9900001.js
@@ -50,6 +50,7 @@ function action(mode, type, selection) {
 		text += "#L3#传送自由#l \t #L69#快速转职#l \t #L70#学习技能#l\r\n";
 		text += "#L71#超级传送#l \t #L4#爆率一览#l \t #L2#在线奖励#l\r\n";
         text += "#L0#新人福利#l \t #L1#每日签到#l  \t #L72#转世重生#l\r\n";
+        text += "#L73#任务捷径#l\r\n";
 		// text += "#L999#测试脚本>>>未上线#l \t \r\n";
         if (cm.getPlayer().isGM()) {
             text += "\r\n\r\n";
@@ -83,6 +84,9 @@ function doSelect(selection) {
             break;
         case 72:
             openNpc("转世重生");
+            break;
+        case 73:
+            openNpc("任务捷径");
             break;
         case 0:
             openNpc("新人福利");

--- a/gms-server/src/main/java/org/gms/scripting/AbstractPlayerInteraction.java
+++ b/gms-server/src/main/java/org/gms/scripting/AbstractPlayerInteraction.java
@@ -468,6 +468,104 @@ public class AbstractPlayerInteraction {
         }
     }
 
+    /**
+     * 返回当前进行中、且可通过「任务捷径」补齐进度的任务 ID 列表。
+     */
+    public List<Integer> getQuestShortcutEligibleIds() {
+        List<Integer> ids = new ArrayList<>();
+        for (QuestStatus qs : getPlayer().getStartedQuests()) {
+            if (qs.getQuest().isCompleteShortcutEligible()) {
+                ids.add((int) qs.getQuestID());
+            }
+        }
+        return ids;
+    }
+
+    public String getQuestName(int questId) {
+        return Quest.getInstance(questId).getName();
+    }
+
+    /**
+     * 杀怪/物品收集进度是否已满足（不含交任务 NPC 校验）。
+     */
+    public boolean isQuestShortcutProgressSatisfied(int questId) {
+        if (!isQuestStarted(questId)) {
+            return false;
+        }
+        Quest quest = Quest.getInstance(questId);
+        if (!quest.isCompleteShortcutEligible()) {
+            return false;
+        }
+        Character chr = getPlayer();
+        for (Map.Entry<Integer, Integer> entry : quest.getCompleteMobRequirements().entrySet()) {
+            int progress;
+            try {
+                progress = Integer.parseInt(chr.getQuest(quest).getProgress(entry.getKey()));
+            } catch (NumberFormatException e) {
+                return false;
+            }
+            if (progress < entry.getValue()) {
+                return false;
+            }
+        }
+        for (Map.Entry<Integer, Integer> entry : quest.getCompleteItemRequirements().entrySet()) {
+            if (chr.getItemQuantity(entry.getKey(), false) < entry.getValue()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * 任务捷径：扣费并补齐杀怪计数与缺失的非任务物品。
+     *
+     * @return 0 成功；1 任务不可用；2 冒险币不足；3 背包空间不足；4 进度已齐（不扣费）
+     */
+    public int applyQuestShortcut(int questId, int mesoCost) {
+        if (!isQuestStarted(questId)) {
+            return 1;
+        }
+        Quest quest = Quest.getInstance(questId);
+        if (!quest.isCompleteShortcutEligible()) {
+            return 1;
+        }
+        if (isQuestShortcutProgressSatisfied(questId)) {
+            return 4;
+        }
+
+        Character chr = getPlayer();
+        if (chr.getMeso() < mesoCost) {
+            return 2;
+        }
+
+        List<Integer> giveItemIds = new ArrayList<>();
+        List<Integer> giveQuantities = new ArrayList<>();
+        for (Map.Entry<Integer, Integer> entry : quest.getCompleteItemRequirements().entrySet()) {
+            int itemId = entry.getKey();
+            int needed = entry.getValue();
+            int have = chr.getItemQuantity(itemId, false);
+            if (have < needed) {
+                giveItemIds.add(itemId);
+                giveQuantities.add(needed - have);
+            }
+        }
+        if (!giveItemIds.isEmpty() && !canHoldAll(giveItemIds, giveQuantities, true)) {
+            return 3;
+        }
+
+        chr.gainMeso(-mesoCost);
+
+        for (Map.Entry<Integer, Integer> entry : quest.getCompleteMobRequirements().entrySet()) {
+            String progress = StringUtil.getLeftPaddedStr(Integer.toString(entry.getValue()), '0', 3);
+            setQuestProgress(questId, entry.getKey(), progress);
+        }
+        for (int i = 0; i < giveItemIds.size(); i++) {
+            gainItem(giveItemIds.get(i), giveQuantities.get(i).shortValue());
+        }
+        chr.flushDelayedUpdateQuests();
+        return 0;
+    }
+
     public boolean forceStartQuest(int id) {
         return forceStartQuest(id, NpcId.MAPLE_ADMINISTRATOR);
     }

--- a/gms-server/src/main/java/org/gms/server/quest/Quest.java
+++ b/gms-server/src/main/java/org/gms/server/quest/Quest.java
@@ -33,6 +33,7 @@ import org.gms.provider.DataProvider;
 import org.gms.provider.DataProviderFactory;
 import org.gms.provider.DataTool;
 import org.gms.provider.wz.WZFiles;
+import org.gms.server.ItemInformationProvider;
 import org.gms.server.quest.actions.AbstractQuestAction;
 import org.gms.server.quest.actions.BuffAction;
 import org.gms.server.quest.actions.ExpAction;
@@ -71,6 +72,7 @@ import org.gms.util.PacketCreator;
 import org.gms.util.StringUtil;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -664,6 +666,59 @@ public class Quest {
         } else {
             return false;
         }
+    }
+
+    /**
+     * 任务捷径：完成条件仅允许 NPC + 杀怪 + 非任务物品收集。
+     */
+    public boolean isCompleteShortcutEligible() {
+        boolean hasMobOrItem = false;
+        for (QuestRequirementType type : completeReqs.keySet()) {
+            if (type == QuestRequirementType.NPC) {
+                continue;
+            }
+            if (type == QuestRequirementType.MOB || type == QuestRequirementType.ITEM) {
+                hasMobOrItem = true;
+                continue;
+            }
+            return false;
+        }
+        if (!hasMobOrItem) {
+            return false;
+        }
+
+        ItemInformationProvider ii = ItemInformationProvider.getInstance();
+        for (Map.Entry<Integer, Integer> entry : getCompleteItemRequirements().entrySet()) {
+            if (entry.getValue() <= 0) {
+                return false;
+            }
+            int itemId = entry.getKey();
+            if (ii.isQuestItem(itemId) || ii.isPartyQuestItem(itemId)) {
+                return false;
+            }
+        }
+        for (Map.Entry<Integer, Integer> entry : getCompleteMobRequirements().entrySet()) {
+            if (entry.getValue() <= 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public Map<Integer, Integer> getCompleteItemRequirements() {
+        AbstractQuestRequirement req = completeReqs.get(QuestRequirementType.ITEM);
+        if (req == null) {
+            return Collections.emptyMap();
+        }
+        return ((ItemRequirement) req).getAllItemRequirements();
+    }
+
+    public Map<Integer, Integer> getCompleteMobRequirements() {
+        AbstractQuestRequirement req = completeReqs.get(QuestRequirementType.MOB);
+        if (req == null) {
+            return Collections.emptyMap();
+        }
+        return ((MobRequirement) req).getAllMobRequirements();
     }
 
     public boolean hasNextQuestAction() {

--- a/gms-server/src/main/java/org/gms/server/quest/requirements/ItemRequirement.java
+++ b/gms-server/src/main/java/org/gms/server/quest/requirements/ItemRequirement.java
@@ -31,6 +31,7 @@ import org.gms.server.ItemInformationProvider;
 import org.gms.server.quest.Quest;
 import org.gms.server.quest.QuestRequirementType;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -102,5 +103,9 @@ public class ItemRequirement extends AbstractQuestRequirement {
         } else {
             return complete ? Integer.MAX_VALUE : Integer.MIN_VALUE;
         }
+    }
+
+    public Map<Integer, Integer> getAllItemRequirements() {
+        return Collections.unmodifiableMap(items);
     }
 }

--- a/gms-server/src/main/java/org/gms/server/quest/requirements/MobRequirement.java
+++ b/gms-server/src/main/java/org/gms/server/quest/requirements/MobRequirement.java
@@ -30,6 +30,7 @@ import org.gms.provider.DataTool;
 import org.gms.server.quest.Quest;
 import org.gms.server.quest.QuestRequirementType;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -86,5 +87,9 @@ public class MobRequirement extends AbstractQuestRequirement {
             return mobs.get(mobid);
         }
         return 0;
+    }
+
+    public Map<Integer, Integer> getAllMobRequirements() {
+        return Collections.unmodifiableMap(mobs);
     }
 }


### PR DESCRIPTION
## Summary
- 北斗 NPC 菜单支持付费补齐进行中任务的杀怪计数与缺失普通材料

## Test plan
- [ ] 进行中任务可通过捷径补齐杀怪进度
- [ ] 缺失的非任务收集物品可被补齐（付费路径）
- [ ] 已完成/未接任务不会被误改