### PR TITLE
补全昭和村相关任务 QuestInfo 中文说明

### DIFF
--- a/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
+++ b/gms-server/wz-zh-CN/Quest.wz/QuestInfo.img.xml
@@ -17745,7 +17745,7 @@
         <string name="1" value="能听懂波斯猫的话… 听说要想从#b波斯猫#k那里要回 #b雨珠子#k，还要满足它的要求。"/>
         <string name="2" value="要正确回答波斯猫所提的全部问题!为了挑战问题还要带来 #b炸鸡 300个#k。"/>
         <int name="area" value="30"/>
-        <string name="0" value="Now I must try to talk with the Boss Kitty to propose a deal for that Orange Marble..."/>
+        <string name="0" value="现在得去和波斯猫谈谈，商量拿回雨珠子的交易……"/>
     </imgdir>
     <imgdir name="8012">
         <string name="name" value="美代子，猫和雨珠子"/>
@@ -17754,13 +17754,13 @@
         <string name="1" value=" 收集#b炸鸡 300个#k， 正确回答全部的波斯猫所提的问题就可以得到雨珠子。 马上还给美代子。"/>
         <string name="2" value="将雨珠子安全地送给美代子。"/>
         <int name="area" value="30"/>
-        <string name="0" value="Hmm, I could understand what he is saying. Well, time to make that trade proposal into action."/>
+        <string name="0" value="嗯，我听得懂它在说什么。那就开始谈这笔交易吧。"/>
     </imgdir>
     <imgdir name="8013">
-        <string name="name" value="Upgrading Zakum Armor"/>
-        <string name="0" value="Tsuri, the gregarious fish merchant, claims to have knowledge of the way to awaken the Zakum Armor&apos;s dormant power. I can&apos;t imagine this armor at its full strength. Such power!"/>
-        <string name="1" value="According to Tsuri, in order to reawaken the dormant power, I&apos;ll have to eliminate #b20 Maladies#k and #b20 Wild Kargo&apos;s#k within the time limit. nnNo. of Maladies Left: #r#a80131##knNo. of Wild Kargos Left : #r#a80132##k"/>
-        <string name="2" value="I tried on the Zakum Armor that has been reawaken by Tsuri. I can literally feel the armor&apos;s strength, coursing through my veins...as if the fearsome power of Zakum is mine to wield and control...I feel invincible wearing this. This is awesome!"/>
+        <string name="name" value="唤醒神炎战装"/>
+        <string name="0" value="健谈的鱼贩勇助声称，自己知道如何唤醒神炎战装沉睡的力量。完全觉醒后的盔甲会有多强呢？真令人期待！"/>
+        <string name="1" value="据勇助说，要重新唤醒那股力量，必须在时限内打倒#b20只巫婆#k和#b20只怪猫#k。\n\n剩余巫婆数量：#r#a80131##k\n剩余怪猫数量：#r#a80132##k"/>
+        <string name="2" value="穿上勇助唤醒后的神炎战装，能真切感受到力量在体内流淌……仿佛扎昆那令人畏惧的力量已为我所用。穿上它简直所向披靡，太厉害了！"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8018">
@@ -17998,73 +17998,73 @@
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="7778">
-        <string name="name" value="Konpei&apos;s Gambit"/>
-        <string name="0" value="Konpei is thinking on a way to take down the threat that so long has been endangering the region of Showa. Let&apos;s listen to what he has to say."/>
-        <string name="1" value="Konpei said that to finish this problem our only solution is to seize the evil from it&apos;s root. That said, it is advisable to #rparty up with other maplers#k to take down the Elite 3 of the Showa gang. As proof of the progress, he requested the drop of these 3 guys. The reward of this one better make up for it!\n \n#t04000139#  #b#c04000139##k/1 \n#t04000140#  #b#c04000140##k/1 \n#t04000141#  #b#c04000141##k/1"/>
-        <string name="2" value="After an intense battle, the dominance of the Showa gang came to an end. As their chief has been taken down, the mob that long plagued the region started to dissipate. Wothy to mention the reward he gave to me was very, very welcome!"/>
+        <string name="name" value="铃木的计策"/>
+        <string name="0" value="铃木正在想办法消灭长期威胁昭和村的势力。先听听他怎么说吧。"/>
+        <string name="1" value="铃木说，要彻底解决这个问题，只能#b从根源上铲除邪恶#k。最好#r和其他冒险家组队#k，打倒昭和黑帮的三名精英。作为进度证明，他还要求带回这三人掉落的证物。希望报酬别太寒酸！\n \n#t04000139#  #b#c04000139##k/1 \n#t04000140#  #b#c04000140##k/1 \n#t04000141#  #b#c04000141##k/1"/>
+        <string name="2" value="一场激战后，昭和黑帮的气焰终于被压下去了。头目倒台后，长期困扰这一带的帮派势力开始瓦解。至于铃木给的报酬……真是太及时了！"/>
         <int name="area" value="48"/>
     </imgdir>
     <imgdir name="8053">
-        <string name="name" value="Traveling Around Maple 1"/>
-        <string name="parent" value="Traveling Around Maple"/>
+        <string name="name" value="环游冒险岛 1"/>
+        <string name="parent" value="环游冒险岛"/>
         <int name="order" value="1"/>
-        <string name="0" value="Olaf of Lith Harbor offered to take me to numerous famous spots in the Maple World."/>
-        <string name="1" value="According to Olaf, Riel will take me to the next stop. Where must that be?"/>
-        <string name="2" value="I was able to meet up with Riel. Where will I go next?"/>
+        <string name="0" value="明珠港的坤提出，可以带我去枫之世界的许多著名景点。"/>
+        <string name="1" value="据坤说，下一站会由丽尔带我前往。会是哪里呢？"/>
+        <string name="2" value="我见到了丽尔。接下来要去哪里呢？"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8054">
-        <string name="name" value="Traveling Around Maple 2"/>
-        <string name="parent" value="Traveling Around Maple"/>
+        <string name="name" value="环游冒险岛 2"/>
+        <string name="parent" value="环游冒险岛"/>
         <int name="order" value="2"/>
-        <string name="0" value="After soaking up the sun at Florina Beach, I should start up a conversation with Riel."/>
-        <string name="1" value="Riel offered to take me to Showa Town. Once I get there, she advised me to look for Skye..."/>
-        <string name="2" value="I was able to meet up with Skye. Where will I go next?"/>
+        <string name="0" value="在黄金海滩晒够了太阳，该去找丽尔聊聊了。"/>
+        <string name="1" value="丽尔提议送我去昭和村。到了那里之后，她让我去找绘里香……"/>
+        <string name="2" value="我见到了绘里香。接下来要去哪里呢？"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8055">
-        <string name="name" value="Traveling Around Maple 3"/>
-        <string name="parent" value="Traveling Around Maple"/>
+        <string name="name" value="环游冒险岛 3"/>
+        <string name="parent" value="环游冒险岛"/>
         <int name="order" value="3"/>
-        <string name="0" value=" After taking a stroll around Showa Town, I should start up a conversation with Skye."/>
-        <string name="1" value="Skye offered to take me to Orbis. Once I get there, she advised me to look for Elma..."/>
-        <string name="2" value="I was able to meet up with Elma. Where will I go next?"/>
+        <string name="0" value="在昭和村逛了一圈后，该去找绘里香聊聊了。"/>
+        <string name="1" value="绘里香提议送我去天空之城。到了那里之后，她让我去找保姆珥玛……"/>
+        <string name="2" value="我见到了保姆珥玛。接下来要去哪里呢？"/>
         <int name="area" value="40"/>
     </imgdir>
     <imgdir name="8056">
-        <string name="name" value="Traveling Around Maple 4"/>
-        <string name="parent" value="Traveling Around Maple"/>
+        <string name="name" value="环游冒险岛 4"/>
+        <string name="parent" value="环游冒险岛"/>
         <int name="order" value="4"/>
-        <string name="0" value="After observing the stunning scenery of Orbis, I should start up a conversation with Elma."/>
-        <string name="1" value="Elma offered to take me to Ludibrium. Once I get there, she advised me to look for Marcel..."/>
-        <string name="2" value="I was able to meet up with Marcel. Where will I go next?"/>
+        <string name="0" value="欣赏完天空之城的美景后，该去找保姆珥玛聊聊了。"/>
+        <string name="1" value="保姆珥玛提议送我去玩具城。到了那里之后，她让我去找马勒萨里……"/>
+        <string name="2" value="我见到了马勒萨里。接下来要去哪里呢？"/>
         <int name="area" value="40"/>
     </imgdir>
     <imgdir name="8057">
-        <string name="name" value="Traveling Around Maple 5"/>
-        <string name="parent" value="Traveling Around Maple"/>
+        <string name="name" value="环游冒险岛 5"/>
+        <string name="parent" value="环游冒险岛"/>
         <int name="order" value="5"/>
-        <string name="0" value=" After I get done touring around Ludibrium, I should start up a conversation with Marcel"/>
-        <string name="1" value="Marcel offered to take me to El Nath. Once I get there, he advised me to look for Scadur..."/>
-        <string name="2" value="I was able to meet up with Scadur. Where will I go next?"/>
+        <string name="0" value="在玩具城游览结束后，该去找马勒萨里聊聊了。"/>
+        <string name="1" value="马勒萨里提议送我去冰峰雪域。到了那里之后，他让我去找斯卡德……"/>
+        <string name="2" value="我见到了斯卡德。接下来要去哪里呢？"/>
         <int name="area" value="40"/>
     </imgdir>
     <imgdir name="8058">
-        <string name="name" value="Traveling Around Maple 6"/>
-        <string name="parent" value="Traveling Around Maple"/>
+        <string name="name" value="环游冒险岛 6"/>
+        <string name="parent" value="环游冒险岛"/>
         <int name="order" value="6"/>
-        <string name="0" value=" After observing the magnificent view of El Nath, I should start up a conversation with Scadur"/>
-        <string name="1" value="Scadur offered to take me to Omega Sector. Once I get there, he advised me to look for Jr. Officer Medin..."/>
-        <string name="2" value="I was able to meet up with Jr. Officer Medin. Where will I go next?"/>
+        <string name="0" value="欣赏完冰峰雪域的壮丽景色后，该去找斯卡德聊聊了。"/>
+        <string name="1" value="斯卡德提议送我去地球防御本部。到了那里之后，他让我去找参谋美得恩……"/>
+        <string name="2" value="我见到了参谋美得恩。接下来要去哪里呢？"/>
         <int name="area" value="40"/>
     </imgdir>
     <imgdir name="8059">
-        <string name="name" value="Traveling Around Maple 7"/>
-        <string name="parent" value="Traveling Around Maple"/>
+        <string name="name" value="环游冒险岛 7"/>
+        <string name="parent" value="环游冒险岛"/>
         <int name="order" value="7"/>
-        <string name="0" value="After carefully observing Omega Sector, I should start up a conversation with Jr. Officer Medin."/>
-        <string name="1" value="Scadur offered to take me back to Lith Harbor. Once I get there, I better get back to Olaf..."/>
-        <string name="2" value="I met up with Olaf again. What&apos;s this creepy scroll for...?"/>
+        <string name="0" value="仔细参观完地球防御本部后，该去找参谋美得恩聊聊了。"/>
+        <string name="1" value="参谋美得恩提议送我回明珠港。到了那里之后，最好再去找坤……"/>
+        <string name="2" value="我又见到了坤。这卷看起来怪怪的卷轴是什么……？"/>
         <int name="area" value="30"/>
     </imgdir>
     <imgdir name="8060">


### PR DESCRIPTION
## Summary
- 补全昭和村相关任务在 `QuestInfo` 中的中文说明文案

## Test plan
- [ ] 相关昭和村任务在任务窗口显示完整中文说明
- [ ] 抽查若干任务 ID，确认无残留乱码/英文占位

Made with [Cursor](https://cursor.com)