### PR TITLE
开放通用服务端扩展 SPI 与 Host Hook 能力

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,10 +49,13 @@ gms-server/*.log.bak.*
 gms-server/BotLog.txt
 gms-server/heap.hprof
 
-# Optional FS overrides for SoloMapling resources (normally inside plugin jar)
-gms-server/src/main/java/soloMapling/**/movementDataPackets/
-gms-server/src/main/java/soloMapling/**/*.yaml
-gms-server/src/main/java/soloMapling/**/*.yml
-gms-server/src/main/java/soloMapling/**/*.bin
-gms-server/src/main/java/soloMapling/**/*.csv
-gms-server/src/main/java/soloMapling/**/*.txt
+# Local launch overrides next to BeiDou-boot.jar (keep src/main/resources/application.yml tracked)
+gms-server/application.yml
+gms-server/EnvironmentPopulation.yaml
+
+# SoloMapling runtime + optional static overlays (plugin jar is source of truth for static assets)
+gms-server/data/solomapling/
+gms-server/logs/BotLog.txt
+
+# Do not keep a soloMapling source mirror under gms-server
+gms-server/src/main/java/soloMapling/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,25 @@ main/resources/static/
 src/main/resources/static/
 .claude/settings.local.json
 CLAUDE.local.md
+
+# SoloMapling / extension plugins (keep directory, ignore jars)
+gms-server/plugins/*.jar
+!gms-server/plugins/.gitkeep
+
+# Maven module build outputs
+**/target/
+
+# Local runtime noise (do not commit)
+gms-server/cache/
+gms-server/*.log
+gms-server/*.log.bak.*
+gms-server/BotLog.txt
+gms-server/heap.hprof
+
+# Optional FS overrides for SoloMapling resources (normally inside plugin jar)
+gms-server/src/main/java/soloMapling/**/movementDataPackets/
+gms-server/src/main/java/soloMapling/**/*.yaml
+gms-server/src/main/java/soloMapling/**/*.yml
+gms-server/src/main/java/soloMapling/**/*.bin
+gms-server/src/main/java/soloMapling/**/*.csv
+gms-server/src/main/java/soloMapling/**/*.txt

--- a/README.md
+++ b/README.md
@@ -71,3 +71,39 @@ web中所有的图片均需要联网获取，感谢 https://maplestory.io 提供
 # Wiki
 发现很多同学的问题基本在Wiki中都有答案，欢迎大家去看看。另外如果发现Wiki中没有的问题，欢迎提issue，或直接补充。已将Wiki开放为所有人都可以编辑。  
 [Wiki地址](https://github.com/BeiDouMS/BeiDou-Server/wiki)
+
+# 扩展运行时 / SoloMapling
+
+北斗通过 **薄 SPI** 从 `gms-server/plugins/*.jar` 加载外部扩展。SoloMapling 框架在独立仓库 **solomapling-plugin**；本仓库只保留通用宿主能力（**不** `import soloMapling.*`）：
+
+| 组件 | 作用 |
+|------|------|
+| `extension-api` | `ServerExtension` / `HostRuntime` / `ArtificialCharacters` / `TradeParticipantHook` / 生命周期事件 |
+| `org.gms.extension.runtime` | `ExtensionLoader`、`HostHooks` |
+| `org.gms.extension.event` | `CharacterMapEnteredEvent`、`CharacterChatEvent`、`PartyInviteEvent`、`TradeInviteEvent`… |
+| 仿真 API | `BotClient`、`BotTier`、`moveBot` 等 |
+| `gms-server/plugins/` | 放置 `solomapling-plugin-*.jar` |
+
+插件在 `onLoad` 注册 `CharacterClassifier` 与可选的 `TradeParticipantHook`；宿主用 `HostHooks.isArtificial` / `HostHooks.trade*` 做超时/脚本/商店/交易分支，并用 `HostHooks.publish` 发游戏事件。详见 `gms-server/src/main/java/org/gms/extension/README.md`。
+
+```bash
+# 1) 安装宿主（供插件 compile provided）
+mvn -pl extension-api,gms-server -am install -DskipTests
+
+# 2) 在 solomapling-plugin 仓库打包，并拷入 plugins/
+cp /path/to/solomapling-plugin/target/solomapling-plugin-*-SNAPSHOT.jar gms-server/plugins/
+
+# 3) 工作目录必须是 gms-server
+cd gms-server
+java -Xmx4g -Dspring.config.location=src/main/resources/application.yml \
+  -jar target/BeiDou-boot.jar
+```
+
+`application.yml`：
+
+```yaml
+solomapling:
+  plugins-enabled: true
+  plugins-dir: plugins
+  spawn-bots-on-startup: true
+```

--- a/extension-api/pom.xml
+++ b/extension-api/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.gms</groupId>
+        <artifactId>BeiDou</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>extension-api</artifactId>
+    <packaging>jar</packaging>
+    <name>BeiDou Extension API</name>
+    <description>Host/plugin SPI shared by BeiDou runtime and SoloMapling plugin</description>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/extension-api/src/main/java/org/gms/extension/api/ArtificialCharacters.java
+++ b/extension-api/src/main/java/org/gms/extension/api/ArtificialCharacters.java
@@ -1,0 +1,47 @@
+package org.gms.extension.api;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Host-side registry of {@link CharacterClassifier}s. Engine hooks must call
+ * {@link #isArtificial(int)} instead of importing any plugin package.
+ *
+ * <p>Plugins register classifiers in {@code ServerExtension#onLoad}; the host clears
+ * them on unload.
+ */
+public final class ArtificialCharacters {
+
+    private static final CopyOnWriteArrayList<CharacterClassifier> CLASSIFIERS = new CopyOnWriteArrayList<>();
+
+    private ArtificialCharacters() {
+    }
+
+    public static void register(CharacterClassifier classifier) {
+        if (classifier != null) {
+            CLASSIFIERS.addIfAbsent(classifier);
+        }
+    }
+
+    public static void unregister(CharacterClassifier classifier) {
+        CLASSIFIERS.remove(classifier);
+    }
+
+    public static void clear() {
+        CLASSIFIERS.clear();
+    }
+
+    /** Snapshot for tests / diagnostics. */
+    public static List<CharacterClassifier> classifiers() {
+        return List.copyOf(CLASSIFIERS);
+    }
+
+    public static boolean isArtificial(int characterId) {
+        for (CharacterClassifier classifier : CLASSIFIERS) {
+            if (classifier.isArtificial(characterId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/extension-api/src/main/java/org/gms/extension/api/CharacterClassifier.java
+++ b/extension-api/src/main/java/org/gms/extension/api/CharacterClassifier.java
@@ -1,0 +1,11 @@
+package org.gms.extension.api;
+
+/**
+ * Decides whether a character id is owned by a plugin (bots, NPCs-as-characters, etc.).
+ * Registered by plugins via {@link ArtificialCharacters#register(CharacterClassifier)}.
+ */
+@FunctionalInterface
+public interface CharacterClassifier {
+
+    boolean isArtificial(int characterId);
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostCharacterProvisionRequest.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostCharacterProvisionRequest.java
@@ -1,0 +1,35 @@
+package org.gms.extension.api;
+
+import java.util.Objects;
+
+/**
+ * Host-neutral input for creating a dedicated account and a native beginner
+ * character. The credential is only valid for the duration of the synchronous
+ * provisioning call and must never be retained or logged.
+ */
+public record HostCharacterProvisionRequest(
+        String accountName,
+        char[] credential,
+        String characterName,
+        int worldId
+) {
+    public HostCharacterProvisionRequest {
+        accountName = requireText(accountName, "accountName");
+        characterName = requireText(characterName, "characterName");
+        Objects.requireNonNull(credential, "credential");
+        if (credential.length == 0) {
+            throw new IllegalArgumentException("credential must not be empty");
+        }
+        if (worldId < 0) {
+            throw new IllegalArgumentException("worldId must not be negative");
+        }
+    }
+
+    private static String requireText(String value, String name) {
+        Objects.requireNonNull(value, name);
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostCharacterProvisionResult.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostCharacterProvisionResult.java
@@ -1,0 +1,13 @@
+package org.gms.extension.api;
+
+/** Committed native identity returned by a host provisioner. */
+public record HostCharacterProvisionResult(int characterId, int accountId, String characterName) {
+    public HostCharacterProvisionResult {
+        if (characterId <= 0 || accountId <= 0) {
+            throw new IllegalArgumentException("provisioned ids must be positive");
+        }
+        if (characterName == null || characterName.isBlank()) {
+            throw new IllegalArgumentException("characterName must not be blank");
+        }
+    }
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostCharacterProvisioner.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostCharacterProvisioner.java
@@ -1,0 +1,8 @@
+package org.gms.extension.api;
+
+/** Atomic host-owned creation of an account and a native character. */
+@FunctionalInterface
+public interface HostCharacterProvisioner {
+
+    HostCharacterProvisionResult provision(HostCharacterProvisionRequest request) throws Exception;
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostCommandHandler.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostCommandHandler.java
@@ -1,0 +1,10 @@
+package org.gms.extension.api;
+
+/**
+ * Command callback. Character identity is passed as id to avoid leaking engine types into the API jar.
+ */
+@FunctionalInterface
+public interface HostCommandHandler {
+
+    void handle(int characterId, String[] args);
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostCommandRegistry.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostCommandRegistry.java
@@ -1,0 +1,16 @@
+package org.gms.extension.api;
+
+/**
+ * Registers in-game commands. BeiDou persists via command_info when possible;
+ * Cosmic registers into CommandsExecutor.
+ */
+public interface HostCommandRegistry {
+
+    /**
+     * @param syntax      command name without bang (e.g. {@code bot})
+     * @param level       required GM level
+     * @param description help text
+     * @param handler     invocation callback
+     */
+    void register(String syntax, int level, String description, HostCommandHandler handler);
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostConfig.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostConfig.java
@@ -1,0 +1,14 @@
+package org.gms.extension.api;
+
+/**
+ * Typed config bridge. BeiDou maps GameConfig / application properties;
+ * Cosmic maps YamlConfig.
+ */
+public interface HostConfig {
+
+    boolean getBool(String key, boolean defaultValue);
+
+    int getInt(String key, int defaultValue);
+
+    String getString(String key, String defaultValue);
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostEvent.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostEvent.java
@@ -1,0 +1,5 @@
+package org.gms.extension.api;
+
+/** Marker for host→plugin events. */
+public interface HostEvent {
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostEventBus.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostEventBus.java
@@ -1,0 +1,15 @@
+package org.gms.extension.api;
+
+import java.util.function.Consumer;
+
+/**
+ * Decoupled pub/sub between host engine hooks and plugins.
+ */
+public interface HostEventBus {
+
+    <T extends HostEvent> void publish(T event);
+
+    <T extends HostEvent> void subscribe(Class<T> type, Consumer<T> listener);
+
+    <T extends HostEvent> void unsubscribe(Class<T> type, Consumer<T> listener);
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostItemActions.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostItemActions.java
@@ -1,0 +1,48 @@
+package org.gms.extension.api;
+
+/**
+ * Authoritative host operations for map loot and inventory-backed player drops.
+ * Character and map-item ids are used so plugins do not depend on engine types.
+ */
+public interface HostItemActions {
+
+    PickupResult pickup(int characterId, int mapItemObjectId);
+
+    /**
+     * Drops an item from a positive backpack slot to a character on the same map.
+     * Inventory type uses the host protocol values: equip=1, use=2, setup=3, etc=4.
+     */
+    DropResult dropToCharacter(
+            int sourceCharacterId,
+            int targetCharacterId,
+            int inventoryType,
+            int slot,
+            int quantity
+    );
+
+    record PickupResult(boolean success, String code, int itemId, int quantity) {
+        public static PickupResult succeeded(int itemId, int quantity) {
+            return new PickupResult(true, "OK", itemId, quantity);
+        }
+
+        public static PickupResult failed(String code) {
+            return new PickupResult(false, code, 0, 0);
+        }
+    }
+
+    record DropResult(
+            boolean success,
+            String code,
+            int itemId,
+            int quantity,
+            int mapItemObjectId
+    ) {
+        public static DropResult succeeded(int itemId, int quantity, int mapItemObjectId) {
+            return new DropResult(true, "OK", itemId, quantity, mapItemObjectId);
+        }
+
+        public static DropResult failed(String code) {
+            return new DropResult(false, code, 0, 0, 0);
+        }
+    }
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostMonsterDrops.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostMonsterDrops.java
@@ -1,0 +1,12 @@
+package org.gms.extension.api;
+
+import java.util.List;
+
+/** Read-only, bounded lookup of monsters that have a real drop_data row for an item. */
+public interface HostMonsterDrops {
+
+    List<DropSource> findSources(int itemId, int limit);
+
+    record DropSource(int dropperId, int chance) {
+    }
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostRuntime.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostRuntime.java
@@ -1,0 +1,17 @@
+package org.gms.extension.api;
+
+/**
+ * Facade exposed to plugins. Implementations live in host runtimes
+ * (e.g. beidou-extension-runtime); plugins must not depend on engine types.
+ */
+public interface HostRuntime {
+
+    HostConfig config();
+
+    HostEventBus events();
+
+    HostCommandRegistry commands();
+
+    /** Host identifier: {@code beidou}, {@code cosmic}, … */
+    String hostId();
+}

--- a/extension-api/src/main/java/org/gms/extension/api/HostRuntime.java
+++ b/extension-api/src/main/java/org/gms/extension/api/HostRuntime.java
@@ -1,5 +1,7 @@
 package org.gms.extension.api;
 
+import java.util.Optional;
+
 /**
  * Facade exposed to plugins. Implementations live in host runtimes
  * (e.g. beidou-extension-runtime); plugins must not depend on engine types.
@@ -11,6 +13,22 @@ public interface HostRuntime {
     HostEventBus events();
 
     HostCommandRegistry commands();
+
+    /**
+     * Optional atomic native-character provisioning capability. The default
+     * keeps existing host implementations binary/source compatible.
+     */
+    default Optional<HostCharacterProvisioner> characterProvisioner() {
+        return Optional.empty();
+    }
+
+    default Optional<HostItemActions> itemActions() {
+        return Optional.empty();
+    }
+
+    default Optional<HostMonsterDrops> monsterDrops() {
+        return Optional.empty();
+    }
 
     /** Host identifier: {@code beidou}, {@code cosmic}, … */
     String hostId();

--- a/extension-api/src/main/java/org/gms/extension/api/ServerExtension.java
+++ b/extension-api/src/main/java/org/gms/extension/api/ServerExtension.java
@@ -1,0 +1,32 @@
+package org.gms.extension.api;
+
+/**
+ * Plugin entry discovered via {@link java.util.ServiceLoader} /
+ * {@code META-INF/services/org.gms.extension.api.ServerExtension}.
+ */
+public interface ServerExtension {
+
+    String id();
+
+    default String version() {
+        return "0.0.0";
+    }
+
+    /**
+     * Called once after the host runtime is constructed. Plugins should retain
+     * {@code runtime}, register commands, and subscribe to events here.
+     */
+    void onLoad(HostRuntime runtime);
+
+    /**
+     * Called when the game server has finished {@code Server.init()} and channels are online.
+     */
+    default void onServerReady() {
+    }
+
+    /**
+     * Called on host shutdown. Release schedulers, shops, and tick wheels.
+     */
+    default void onUnload() {
+    }
+}

--- a/extension-api/src/main/java/org/gms/extension/api/TradeParticipantHook.java
+++ b/extension-api/src/main/java/org/gms/extension/api/TradeParticipantHook.java
@@ -1,0 +1,40 @@
+package org.gms.extension.api;
+
+/**
+ * Plugin-registered trade participation rules for headless / artificial characters.
+ * Host {@code Trade} must consult this instead of hard-coding bot semantics.
+ */
+public interface TradeParticipantHook {
+
+    /**
+     * When {@code visitTrade(visitor, partner)} runs, should the visit proceed even if
+     * InviteCoordinator did not return {@code ACCEPTED}? Typical: partner (or visitor) is
+     * plugin-owned and has no client to answer the invite packet.
+     */
+    default boolean autoAcceptVisit(int visitorId, int partnerId) {
+        return false;
+    }
+
+    /**
+     * Skip inventory ownership / slot checks for this participant (bots often hold virtual stock).
+     */
+    default boolean relaxInventoryChecks(int characterId) {
+        return false;
+    }
+
+    /**
+     * If true, host skips sending trade UI packets to this character (no real client).
+     */
+    default boolean suppressTradePackets(int characterId) {
+        return false;
+    }
+
+    /**
+     * Called instead of the normal {@code completeTrade()} item/meso delivery path when the
+     * exchange succeeds for this participant. Return {@code true} if this hook handled the
+     * character (host must not also run {@code completeTrade()}).
+     */
+    default boolean onExchangeSuccess(int characterId) {
+        return false;
+    }
+}

--- a/extension-api/src/main/java/org/gms/extension/api/TradeParticipants.java
+++ b/extension-api/src/main/java/org/gms/extension/api/TradeParticipants.java
@@ -1,0 +1,74 @@
+package org.gms.extension.api;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Registry of {@link TradeParticipantHook}s. Engine trade code must use this (via HostHooks)
+ * instead of importing plugin packages.
+ */
+public final class TradeParticipants {
+
+    private static final CopyOnWriteArrayList<TradeParticipantHook> HOOKS = new CopyOnWriteArrayList<>();
+
+    private TradeParticipants() {
+    }
+
+    public static void register(TradeParticipantHook hook) {
+        if (hook != null) {
+            HOOKS.addIfAbsent(hook);
+        }
+    }
+
+    public static void unregister(TradeParticipantHook hook) {
+        HOOKS.remove(hook);
+    }
+
+    public static void clear() {
+        HOOKS.clear();
+    }
+
+    public static List<TradeParticipantHook> hooks() {
+        return List.copyOf(HOOKS);
+    }
+
+    public static boolean autoAcceptVisit(int visitorId, int partnerId) {
+        for (TradeParticipantHook hook : HOOKS) {
+            if (hook.autoAcceptVisit(visitorId, partnerId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean relaxInventoryChecks(int characterId) {
+        for (TradeParticipantHook hook : HOOKS) {
+            if (hook.relaxInventoryChecks(characterId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean suppressTradePackets(int characterId) {
+        for (TradeParticipantHook hook : HOOKS) {
+            if (hook.suppressTradePackets(characterId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return true if a hook claimed exchange completion for this character
+     */
+    public static boolean onExchangeSuccess(int characterId) {
+        boolean claimed = false;
+        for (TradeParticipantHook hook : HOOKS) {
+            if (hook.onExchangeSuccess(characterId)) {
+                claimed = true;
+            }
+        }
+        return claimed;
+    }
+}

--- a/extension-api/src/main/java/org/gms/extension/api/event/ServerReadyEvent.java
+++ b/extension-api/src/main/java/org/gms/extension/api/event/ServerReadyEvent.java
@@ -1,0 +1,6 @@
+package org.gms.extension.api.event;
+
+import org.gms.extension.api.HostEvent;
+
+public record ServerReadyEvent(long readyAtEpochMs) implements HostEvent {
+}

--- a/extension-api/src/main/java/org/gms/extension/api/event/ServerShutdownEvent.java
+++ b/extension-api/src/main/java/org/gms/extension/api/event/ServerShutdownEvent.java
@@ -1,0 +1,6 @@
+package org.gms.extension.api.event;
+
+import org.gms.extension.api.HostEvent;
+
+public record ServerShutdownEvent(long shutdownAtEpochMs) implements HostEvent {
+}

--- a/gms-server/launch.bat
+++ b/gms-server/launch.bat
@@ -2,5 +2,5 @@
 @title BeiDou
 chcp 65001
 
-.\jdk-21.0.11+10-jre\bin\java.exe  -Dspring.config.location=application.yml -jar BeiDou.jar
+.\jdk-21.0.11+10-jre\bin\java.exe  -Dspring.config.location=application.yml -jar BeiDou-boot.jar
 pause

--- a/gms-server/launch.sh
+++ b/gms-server/launch.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # cover write
-./jdk-21.0.11+10-jre/bin/java -Dspring.config.location=application.yml -jar BeiDou.jar &
+./jdk-21.0.11+10-jre/bin/java -Dspring.config.location=application.yml -jar BeiDou-boot.jar &

--- a/gms-server/pom.xml
+++ b/gms-server/pom.xml
@@ -65,6 +65,12 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>org.gms</groupId>
+            <artifactId>extension-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- springboot -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -237,6 +243,8 @@
                             <goal>repackage</goal>
                         </goals>
                         <configuration>
+                            <!-- Fat/runnable jar: BeiDou-boot.jar; main artifact stays thin for plugin compile -->
+                            <classifier>boot</classifier>
                             <mainClass>${mainClass}</mainClass>
                         </configuration>
                     </execution>

--- a/gms-server/src/main/java/org/gms/client/BotClient.java
+++ b/gms-server/src/main/java/org/gms/client/BotClient.java
@@ -1,0 +1,72 @@
+/*
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.gms.client;
+
+import io.netty.handler.timeout.IdleStateEvent;
+import org.gms.net.packet.Packet;
+
+/**
+ * Shared headless Client for SoloMapling bots (no Netty socket).
+ * Credits to NutNNut for the headless client pattern (c) 2026.
+ */
+public class BotClient extends Client {
+
+    public BotClient(int world, int channel) {
+        // Type/session/processor unused for bots; world+channel drive routing.
+        super(Type.CHANNEL, -1, "bot", null, world, channel);
+    }
+
+    @Override
+    public void sendPacket(Packet packet) {
+        // no socket
+    }
+
+    @Override
+    public boolean isLoggedIn() {
+        return true;
+    }
+
+    @Override
+    public void updateLoginState(int newState) {
+        // headless: no account row, no session registration
+    }
+
+    @Override
+    public void disconnectSession() {
+        // no socket
+    }
+
+    @Override
+    public void closeSession() {
+        // no socket
+    }
+
+    @Override
+    public void checkIfIdle(final IdleStateEvent event) {
+        // never reap the shared bot client
+    }
+
+    @Override
+    public long getLastPacket() {
+        return System.currentTimeMillis();
+    }
+}

--- a/gms-server/src/main/java/org/gms/client/BotTier.java
+++ b/gms-server/src/main/java/org/gms/client/BotTier.java
@@ -1,0 +1,212 @@
+package org.gms.client;
+
+/**
+ * Represents bot performance tiers with ordering and utility methods.
+ * Tiers are ordered from highest (S) to lowest (D).
+ */
+public enum BotTier {
+    S(5, "Elite"),      // Top tier, exceptional performance
+    A(4, "High"),       // High tier, very good performance
+    B(3, "Above Average"), // Above average tier
+    C(2, "Average"),    // Average tier
+    D(1, "Below Average"); // Below average tier
+
+    private final int value;
+    private final String description;
+
+    BotTier(int value, String description) {
+        this.value = value;
+        this.description = description;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+
+
+    /**
+     * Checks if this tier is at least as good as the specified minimum tier.
+     * @param minimumTier the minimum tier to compare against
+     * @return true if this tier is >= minimumTier
+     */
+    public boolean isAtLeast(BotTier minimumTier) {
+        return this.value >= minimumTier.value;
+    }
+
+    /**
+     * Checks if this tier is better than the specified tier.
+     * @param otherTier the tier to compare against
+     * @return true if this tier is better than otherTier
+     */
+    public boolean isBetterThan(BotTier otherTier) {
+        return this.value > otherTier.value;
+    }
+
+    /**
+     * Checks if this tier is worse than the specified tier.
+     * @param otherTier the tier to compare against
+     * @return true if this tier is worse than otherTier
+     */
+    public boolean isWorseThan(BotTier otherTier) {
+        return this.value < otherTier.value;
+    }
+
+    /**
+     * Returns a default tier if this tier is below the minimum threshold.
+     * @param minimumTier the minimum acceptable tier
+     * @param defaultTier the tier to return if below minimum
+     * @return this tier if >= minimum, otherwise the default tier
+     */
+    public BotTier orDefault(BotTier minimumTier, BotTier defaultTier) {
+        return this.isAtLeast(minimumTier) ? this : defaultTier;
+    }
+
+    /**
+     * Returns a boosted tier if this tier is below the threshold.
+     * Common use case: boost D tier to B tier.
+     * @param threshold the tier threshold to check against
+     * @param boostTo the tier to boost to if below threshold
+     * @return this tier if >= threshold, otherwise the boosted tier
+     */
+    public BotTier boostIfBelow(BotTier threshold, BotTier boostTo) {
+        return this.isAtLeast(threshold) ? this : boostTo;
+    }
+
+    /**
+     * Gets the next higher tier, or returns the same tier if already at maximum.
+     * @return the next higher tier
+     */
+    public BotTier getNextHigherTier() {
+        switch (this) {
+            case D: return C;
+            case C: return B;
+            case B: return A;
+            case A: return S;
+            case S: return S; // Already at top
+            default: return this;
+        }
+    }
+
+    /**
+     * Gets the next lower tier, or returns the same tier if already at minimum.
+     * @return the next lower tier
+     */
+    public BotTier getNextLowerTier() {
+        switch (this) {
+            case S: return A;
+            case A: return B;
+            case B: return C;
+            case C: return D;
+            case D: return D; // Already at bottom
+            default: return this;
+        }
+    }
+
+    /**
+     * Calculates the tier difference between this and another tier.
+     * Positive values mean this tier is higher, negative means lower.
+     * @param otherTier the tier to compare against
+     * @return the difference in tier values
+     */
+    public int getTierDifference(BotTier otherTier) {
+        return this.value - otherTier.value;
+    }
+
+    /**
+     * Creates a BotTier from a string representation.
+     * @param tierString the string representation ("S", "A", "B", "C", "D")
+     * @return the corresponding BotTier, or null if invalid
+     */
+    public static BotTier fromString(String tierString) {
+        try {
+            return BotTier.valueOf(tierString.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Gets the default tier for new characters.
+     * @return the default tier (C - Average)
+     */
+    public static BotTier getDefaultTier() {
+        return S;
+    }
+
+    @Override
+    public String toString() {
+        return name() + " (" + description + ")";
+    }
+
+    /**
+     * Utility class for managing BotTier operations on characters.
+     * Use this to avoid modifying existing Character.java code extensively.
+     */
+    public static class TierManager {
+
+        /**
+         * Safely sets a tier, using default if null is provided.
+         * @param currentTier the current tier value
+         * @param newTier the new tier to set
+         * @return the tier to set (newTier or default if null)
+         */
+        public static BotTier safeTierSet(BotTier currentTier, BotTier newTier) {
+            return newTier != null ? newTier : getDefaultTier();
+        }
+
+        /**
+         * Gets the effective tier with boost applied.
+         * @param currentTier the current tier
+         * @return boosted tier if below threshold, otherwise current tier
+         */
+        public static BotTier getEffectiveTier(BotTier currentTier) {
+            if (currentTier == null) return getDefaultTier();
+            // Boost D tier to B tier for better gameplay experience
+            return currentTier.boostIfBelow(BotTier.C, BotTier.B);
+        }
+
+        /**
+         * Checks if a character can perform an action based on tier requirement.
+         * @param currentTier the character's current tier
+         * @param requiredTier the minimum tier required
+         * @return true if character's tier meets the requirement
+         */
+        public static boolean canPerformAction(BotTier currentTier, BotTier requiredTier) {
+            if (currentTier == null || requiredTier == null) return false;
+            return currentTier.isAtLeast(requiredTier);
+        }
+
+        /**
+         * Upgrades a tier by one level.
+         * @param currentTier the current tier
+         * @return the upgraded tier
+         */
+        public static BotTier upgradeTier(BotTier currentTier) {
+            return currentTier != null ? currentTier.getNextHigherTier() : getDefaultTier();
+        }
+
+        /**
+         * Downgrades a tier by one level.
+         * @param currentTier the current tier
+         * @return the downgraded tier
+         */
+        public static BotTier downgradeTier(BotTier currentTier) {
+            return currentTier != null ? currentTier.getNextLowerTier() : getDefaultTier();
+        }
+
+        /**
+         * Gets a safe tier value, returning default if null.
+         * @param tier the tier to check
+         * @return the tier or default if null
+         */
+        public static BotTier getSafeTier(BotTier tier) {
+            return tier != null ? tier : getDefaultTier();
+        }
+    }
+
+}

--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -486,6 +486,7 @@ public class Character extends AbstractCharacterObject {
     @Setter
     @Getter
     private boolean chasing = false;
+    private BotTier botTier = BotTier.getDefaultTier(); // artificial-character performance tier (default C)
     private float mobExpRate = -1;
 
     @Getter
@@ -529,7 +530,7 @@ public class Character extends AbstractCharacterObject {
     }
 
 
-    private Character() {
+    public Character() {
         super.setListener(new CharacterListener(this));
         useCS = false;
         setStance(0);
@@ -625,6 +626,11 @@ public class Character extends AbstractCharacterObject {
         if (canRecvPartySearchInvite) {
             this.getWorldServer().getPartySearchCoordinator().attachPlayer(this);
         }
+    }
+
+    /** Headless / artificial characters: clear awayFromWorld without PartySearch side effects. */
+    public void markPresentInWorld() {
+        awayFromWorld.set(false);
     }
 
     public void setAwayFromChannelWorld() {
@@ -4639,7 +4645,7 @@ public class Character extends AbstractCharacterObject {
         int quickLv = GameConfig.getWorldInt(getWorld(), "quick_level");
         if (level >= quickLv) return 1;
 
-        return 1f + (quickLv - level) * GameConfig.getWorldFloat(getWorld(), "quick_level_exp_rate");
+        return 1f + (quickLv - level) * GameConfig.getWorldFloat(getWorld(), "quick_level_rate");
     }
 
     public void updateMobExpRate() {
@@ -4902,6 +4908,35 @@ public class Character extends AbstractCharacterObject {
 
     public int getTotalStr() {
         return localstr;
+    }
+
+    // GCMoveSystem: base 100 + equip bonuses + buff → BotMovementProfile bucket
+    public int getTotalMoveSpeedStat() {
+        int total = 100;
+        for (Item item : getInventory(InventoryType.EQUIPPED)) {
+            if (item instanceof Equip equip) {
+                total += equip.getSpeed();
+            }
+        }
+        Integer speedBuff = getBuffedValue(BuffStat.SPEED);
+        if (speedBuff != null) {
+            total += speedBuff;
+        }
+        return Math.max(1, total);
+    }
+
+    public int getTotalJumpStat() {
+        int total = 100;
+        for (Item item : getInventory(InventoryType.EQUIPPED)) {
+            if (item instanceof Equip equip) {
+                total += equip.getJump();
+            }
+        }
+        Integer jumpBuff = getBuffedValue(BuffStat.JUMP);
+        if (jumpBuff != null) {
+            total += jumpBuff;
+        }
+        return Math.max(1, total);
     }
 
     public int getTotalDex() {
@@ -6836,7 +6871,7 @@ public class Character extends AbstractCharacterObject {
         enableActions();
     }
 
-    private void unsitChairInternal() {
+    public void unsitChairInternal() {
         int chairid = chair.get();
         if (chairid >= 0) {
             if (ItemConstants.isFishingChair(chairid)) {
@@ -6876,7 +6911,7 @@ public class Character extends AbstractCharacterObject {
         }
     }
 
-    private void setChair(int chair) {
+    public void setChair(int chair) {
         this.chair.set(chair);
     }
 
@@ -10148,5 +10183,13 @@ public class Character extends AbstractCharacterObject {
     /** 更新全局攻击时间戳，只被正常主动技能调用 */
     public void updateGlobalTime(long now) {
         globalAttackTime = now;
+    }
+
+    public void setTier(BotTier newTier) {
+        this.botTier = BotTier.TierManager.safeTierSet(this.botTier, newTier);
+    }
+
+    public BotTier getTier() {
+        return BotTier.TierManager.getSafeTier(botTier);
     }
 }

--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -7411,7 +7411,41 @@ public class Character extends AbstractCharacterObject {
         savedLocations[SavedLocationType.fromString(type).ordinal()] = new SavedLocation(getMapId(), closest != null ? closest.getId() : 0);
     }
 
+    /**
+     * Creates a character in its own transaction, preserving the historical
+     * public method contract.
+     */
     public final boolean insertNewChar(CharacterFactoryRecipe recipe) {
+        try (Connection con = DatabaseConnection.getConnection()) {
+            con.setAutoCommit(false);
+            con.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
+            try {
+                if (!insertNewChar(recipe, con)) {
+                    con.rollback();
+                    return false;
+                }
+                con.commit();
+                return true;
+            } catch (Exception e) {
+                con.rollback();
+                throw e;
+            } finally {
+                con.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+                con.setAutoCommit(true);
+            }
+        } catch (Throwable t) {
+            log.error("Error creating chr {}, level: {}, job: {}", name, level, job.getId(), t);
+            return false;
+        }
+    }
+
+    /**
+     * Creates the character and all native child rows on the caller's
+     * connection. This method never commits, rolls back, closes, or changes
+     * transaction settings on that connection.
+     */
+    public final boolean insertNewChar(CharacterFactoryRecipe recipe, Connection con) throws SQLException {
+        Objects.requireNonNull(con, "con");
         attrStr = recipe.getStr();
         attrDex = recipe.getDex();
         attrInt = recipe.getInt();
@@ -7440,12 +7474,7 @@ public class Character extends AbstractCharacterObject {
         this.events.put("rescueGaga", new RescueGaga(0));
 
 
-        try (Connection con = DatabaseConnection.getConnection()) {
-            con.setAutoCommit(false);
-            con.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
-
-            try {
-                // Character info
+        // Character info
                 try (PreparedStatement ps = con.prepareStatement("INSERT INTO characters (str, dex, luk, `int`, gm, skincolor, gender, job, hair, face, map, meso, spawnpoint, accountid, name, world, hp, mp, maxhp, maxmp, level, ap, sp) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", Statement.RETURN_GENERATED_KEYS)) {
                     ps.setInt(1, attrStr);
                     ps.setInt(2, attrDex);
@@ -7558,20 +7587,7 @@ public class Character extends AbstractCharacterObject {
                     }
                 }
 
-                con.commit();
-                return true;
-            } catch (Exception e) {
-                con.rollback();
-                throw e;
-            } finally {
-                con.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
-                con.setAutoCommit(true);
-            }
-        } catch (Throwable t) {
-            log.error("Error creating chr {}, level: {}, job: {}", name, level, job.getId(), t);
-        }
-
-        return false;
+        return true;
     }
 
     public void saveCharToDB() {
@@ -9055,7 +9071,11 @@ public class Character extends AbstractCharacterObject {
 
     @Override
     public void sendSpawnData(Client client) {
-        if (!this.isHidden() || client.getPlayer().gmLevel() > 1) {
+        Character viewer = client == null ? null : client.getPlayer();
+        if (viewer == null) {
+            return;
+        }
+        if (!this.isHidden() || viewer.gmLevel() > 1) {
             client.sendPacket(PacketCreator.spawnPlayerMapObject(client, this, false));
 
             if (buffEffects.containsKey(getJobMapChair(job))) { // mustn't effLock, chrLock sendSpawnData

--- a/gms-server/src/main/java/org/gms/client/Client.java
+++ b/gms-server/src/main/java/org/gms/client/Client.java
@@ -1463,6 +1463,10 @@ public class Client extends ChannelInboundHandlerAdapter {
     }
 
     public synchronized void announceBossHpBar(Monster mm, final int mobHash, Packet packet) {
+        // Shared BotClient has no Character; bots never show a boss HP bar UI.
+        if (player == null) {
+            return;
+        }
         long timeNow = System.currentTimeMillis();
         int targetHash = player.getTargetHpBarHash();
 

--- a/gms-server/src/main/java/org/gms/client/Job.java
+++ b/gms-server/src/main/java/org/gms/client/Job.java
@@ -126,6 +126,21 @@ public enum Job {
         */
     }
 
+    public int getJobTier() {
+        if (id == 0) {
+            return 0;
+        }
+
+        int lastTwoDigits = id % 100;
+        return switch (lastTwoDigits) {
+            case 0 -> 1;
+            case 10, 20, 30 -> 2;
+            case 11, 21, 31 -> 3;
+            case 12, 22, 32 -> 4;
+            default -> 0;
+        };
+    }
+
     public static Job getJobStyleInternal(int jobid, byte opt) {
         int jobtype = jobid / 100;
 

--- a/gms-server/src/main/java/org/gms/client/SkillFactory.java
+++ b/gms-server/src/main/java/org/gms/client/SkillFactory.java
@@ -82,7 +82,9 @@ import org.gms.provider.wz.WZFiles;
 import org.gms.server.StatEffect;
 import org.gms.server.life.Element;
 
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class SkillFactory {
@@ -91,6 +93,13 @@ public class SkillFactory {
 
     public static Skill getSkill(int id) {
         return skills.get(id);
+    }
+
+    public static List<Skill> getSkillsForJob(int jobId) {
+        return skills.values().stream()
+                .filter(skill -> skill.getId() / 10000 == jobId)
+                .sorted(Comparator.comparingInt(Skill::getId))
+                .toList();
     }
 
     public static void loadAllSkills() {

--- a/gms-server/src/main/java/org/gms/client/command/CommandsExecutor.java
+++ b/gms-server/src/main/java/org/gms/client/command/CommandsExecutor.java
@@ -34,6 +34,9 @@ import org.gms.client.command.commands.gm5.*;
 import org.gms.client.command.commands.gm6.*;
 import org.gms.config.GameConfig;
 import org.gms.constants.id.MapId;
+import org.gms.extension.api.HostRuntime;
+import org.gms.extension.runtime.BeiDouHostCommandRegistry;
+import org.gms.extension.runtime.ExtensionLoader;
 import org.gms.manager.ServerManager;
 import org.gms.service.CommandService;
 import org.gms.util.I18nUtil;
@@ -118,6 +121,9 @@ public class CommandsExecutor {
 
         final Command command = registeredCommands.get(commandName);
         if (command == null) {
+            if (tryExtensionCommand(client, commandName, lowercaseParams)) {
+                return;
+            }
             client.getPlayer().yellowMessage(I18nUtil.getMessage("CommandsExecutor.handleInternal.message2", commandName));
             return;
         }
@@ -134,6 +140,30 @@ public class CommandsExecutor {
 
         command.execute(client, params);
         log.info(I18nUtil.getLogMessage("CommandsExecutor.handleInternal.info1"), client.getPlayer().getName(), command.getClass().getSimpleName());
+    }
+
+    private boolean tryExtensionCommand(Client client, String commandName, String[] params) {
+        HostRuntime runtime = ExtensionLoader.getInstance().getRuntime();
+        if (runtime == null || !(runtime.commands() instanceof BeiDouHostCommandRegistry registry)) {
+            return false;
+        }
+        BeiDouHostCommandRegistry.RegisteredCommand registered = registry.get(commandName);
+        if (registered == null) {
+            return false;
+        }
+        if (client.getPlayer().gmLevel() < registered.level()) {
+            client.getPlayer().yellowMessage(I18nUtil.getMessage("CommandsExecutor.handleInternal.message3"));
+            return true;
+        }
+        String[] args;
+        if (params.length > 0 && !params[0].isEmpty()) {
+            args = Arrays.copyOfRange(params, 0, params.length);
+        } else {
+            args = new String[]{};
+        }
+        registered.handler().handle(client.getPlayer().getId(), args);
+        log.info(I18nUtil.getLogMessage("CommandsExecutor.handleInternal.info1"), client.getPlayer().getName(), "ext:" + commandName);
+        return true;
     }
 
     private void addCommandInfo(String name, Class<? extends Command> commandClass) {

--- a/gms-server/src/main/java/org/gms/client/creator/CharacterFactory.java
+++ b/gms-server/src/main/java/org/gms/client/creator/CharacterFactory.java
@@ -48,6 +48,36 @@ public abstract class CharacterFactory {
             return -1;
         }
 
+        Character newCharacter = prepareNewCharacter(c, name, face, hair, skin, gender, recipe);
+        if (newCharacter == null) {
+            return -2;
+        }
+
+        if (!newCharacter.insertNewChar(recipe)) {
+            return -2;
+        }
+        c.sendPacket(PacketCreator.addNewCharEntry(newCharacter));
+
+        Server.getInstance().createCharacterEntry(newCharacter);
+        Server.getInstance().broadcastGMMessage(c.getWorld(), PacketCreator.sendYellowTip("[New Char]: " + c.getAccountName() + I18nUtil.getMessage("CharacterFactory.message1") + name));
+        log.info("账号 {} 创建了角色 {}", c.getAccountName(), name);
+
+        return 0;
+    }
+
+    /**
+     * Builds the exact native character state consumed by insertNewChar,
+     * without touching the database or server character-entry cache.
+     */
+    protected static Character prepareNewCharacter(
+            Client c,
+            String name,
+            int face,
+            int hair,
+            int skin,
+            int gender,
+            CharacterFactoryRecipe recipe
+    ) {
         Character newCharacter = Character.getDefault(c);
         newCharacter.setWorld(c.getWorld());
         newCharacter.setSkinColor(SkinColor.getById(skin));
@@ -91,18 +121,9 @@ public abstract class CharacterFactory {
 
         if (!MakeCharInfoValidator.isNewCharacterValid(newCharacter)) {
             log.warn("Owner from account {} tried to packet edit in character creation", c.getAccountName());
-            return -2;
+            return null;
         }
 
-        if (!newCharacter.insertNewChar(recipe)) {
-            return -2;
-        }
-        c.sendPacket(PacketCreator.addNewCharEntry(newCharacter));
-
-        Server.getInstance().createCharacterEntry(newCharacter);
-        Server.getInstance().broadcastGMMessage(c.getWorld(), PacketCreator.sendYellowTip("[New Char]: " + c.getAccountName() + I18nUtil.getMessage("CharacterFactory.message1") + name));
-        log.info("账号 {} 创建了角色 {}", c.getAccountName(), name);
-
-        return 0;
+        return newCharacter;
     }
 }

--- a/gms-server/src/main/java/org/gms/client/creator/novice/BeginnerCreator.java
+++ b/gms-server/src/main/java/org/gms/client/creator/novice/BeginnerCreator.java
@@ -19,6 +19,7 @@
 */
 package org.gms.client.creator.novice;
 
+import org.gms.client.Character;
 import org.gms.client.Client;
 import org.gms.client.Job;
 import org.gms.client.creator.CharacterFactory;
@@ -33,6 +34,15 @@ import org.gms.constants.id.MapId;
  */
 public class BeginnerCreator extends CharacterFactory {
 
+    public static final int DEFAULT_GENDER = 0;
+    public static final int DEFAULT_FACE = 20000;
+    public static final int DEFAULT_HAIR = 30000;
+    public static final int DEFAULT_SKIN = 0;
+    public static final int DEFAULT_TOP = 1040002;
+    public static final int DEFAULT_BOTTOM = 1060002;
+    public static final int DEFAULT_SHOES = 1072001;
+    public static final int DEFAULT_WEAPON = 1302000;
+
     private static CharacterFactoryRecipe createRecipe(Job job, int level, int map, int top, int bottom, int shoes, int weapon) {
         CharacterFactoryRecipe recipe = new CharacterFactoryRecipe(job, level, map, top, bottom, shoes, weapon);
         giveItem(recipe, ItemId.BEGINNERS_GUIDE, 1, InventoryType.ETC);
@@ -44,13 +54,27 @@ public class BeginnerCreator extends CharacterFactory {
     }
 
     public static int createCharacter(Client c, String name, int face, int hair, int skin, int top, int bottom, int shoes, int weapon, int gender) {
+        return createNewCharacter(c, name, face, hair, skin, gender,
+                createRecipe(Job.BEGINNER, 1, beginnerMap(), top, bottom, shoes, weapon));
+    }
 
-        int iMapID = MapId.MUSHROOM_TOWN;
-        if (GameConfig.getServerBoolean("use_beidou_beginner_map"))
-        {
-            iMapID = MapId.BEIDOU_BEGINNER;
-        }
+    public static CharacterFactoryRecipe createDefaultRecipe() {
+        return createRecipe(Job.BEGINNER, 1, beginnerMap(),
+                DEFAULT_TOP, DEFAULT_BOTTOM, DEFAULT_SHOES, DEFAULT_WEAPON);
+    }
 
-        return createNewCharacter(c, name, face, hair, skin, gender, createRecipe(Job.BEGINNER, 1, iMapID, top, bottom, shoes, weapon));
+    public static Character prepareProvisionedCharacter(int accountId, int worldId, String name) {
+        Client client = Client.createMock();
+        client.setAccID(accountId);
+        client.setWorld(worldId);
+        client.setAccountName("<provisioning>");
+        return prepareNewCharacter(client, name, DEFAULT_FACE, DEFAULT_HAIR,
+                DEFAULT_SKIN, DEFAULT_GENDER, createDefaultRecipe());
+    }
+
+    private static int beginnerMap() {
+        return GameConfig.getServerBoolean("use_beidou_beginner_map")
+                ? MapId.BEIDOU_BEGINNER
+                : MapId.MUSHROOM_TOWN;
     }
 }

--- a/gms-server/src/main/java/org/gms/client/inventory/BodyPart.java
+++ b/gms-server/src/main/java/org/gms/client/inventory/BodyPart.java
@@ -1,0 +1,130 @@
+/*
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.gms.client.inventory;
+
+public enum BodyPart {
+    EQUIPPED_BASE(0),
+    HAIR(0),
+    CAP(1),
+    FACE_ACCESSORY(2),
+    EYE_ACCESSORY(3),
+    EAR_ACCESSORY(4),
+    COAT(5),
+    LONGCOAT(5), // Shared BodyPart for top / overall
+    PANTS(6),
+    SHOES(7),
+    GLOVE(8),
+    CAPE(9),
+    SHIELD(10),
+    WEAPON(11),
+
+    RING_1(12),
+    RING_2(13),
+    PET_EQUIP_1(14),
+    RING_3(15),
+    RING_4(16),
+    PENDANT(17),
+    TAMING_MOB(18),
+    SADDLE(19),
+    MOB_EQUIP(20),
+
+    PET_LABEL_RING_1(21),
+    PET_ITEM_POUCH_1(22),
+    PET_MESO_MAGNET_1(23),
+    PET_AUTO_HP_POUCH(24),
+    PET_AUTO_MP_POUCH(25),
+    PET_WING_BOOTS_1(26),
+    PET_BINOCULAR_1(27),
+    PET_MAGIC_SCALES_1(28),
+    PET_QUOTE_RING_1(29),
+
+    PET_EQUIP_2(30),
+    PET_LABEL_RING_2(31),
+    PET_QUOTE_RING_2(32),
+    PET_ITEM_POUCH_2(33),
+    PET_MESO_MAGNET_2(34),
+    PET_WING_BOOTS_2(35),
+    PET_BINOCULAR_2(36),
+    PET_MAGIC_SCALES_2(37),
+
+    PET_EQUIP_3(38),
+    PET_LABEL_RING_3(39),
+    PET_QUOTE_RING_3(40),
+    PET_ITEM_POUCH_3(41),
+    PET_MESO_MAGNET_3(42),
+    PET_WING_BOOTS_3(43),
+    PET_BINOCULAR_3(44),
+    PET_MAGIC_SCALES_3(45),
+
+    PET_ITEM_IGNORE_1(46),
+    PET_ITEM_IGNORE_2(47),
+    PET_ITEM_IGNORE_3(48),
+
+    MEDAL(49),
+    BELT(50),
+    SHOULDER(51),
+    BADGE(56),
+    PENDANT_EXT(61),
+    EQUIPPED_END(60),
+
+    CASH_BASE(100), // -100 when encoding
+    CASH_WEAPON(111),
+    CASH_END(160),
+
+    DRAGON_BASE(1000),
+    DRAGON_MASK(1000),
+    DRAGON_PENDANT(1001),
+    DRAGON_WING(1002),
+    DRAGON_TAIL(1003),
+    DRAGON_END(1100),
+
+    MECHANIC_BASE(1100),
+    MECHANIC_ENGINE(1100),
+    MECHANIC_ARM(1101),
+    MECHANIC_LEG(1102),
+    MECHANIC_FRAME(1103),
+    MECHANIC_TRANSISTOR(1104),
+    MECHANIC_END(1200);
+
+    private final int value;
+
+    BodyPart(int value) {
+        this.value = value;
+    }
+
+    public final int getValue() {
+        return value;
+    }
+
+    public static BodyPart getBySelectedAL(int i) {
+        if (i == 4) {
+            return COAT;
+        } else if (i == 5) {
+            return PANTS;
+        } else if (i == 6) {
+            return SHOES;
+        } else if (i == 7) {
+            return WEAPON;
+        }
+        throw new IllegalArgumentException();
+    }
+}

--- a/gms-server/src/main/java/org/gms/constants/game/CharacterStance.java
+++ b/gms-server/src/main/java/org/gms/constants/game/CharacterStance.java
@@ -1,0 +1,95 @@
+/*
+This file is part of the OdinMS Maple Story Server
+Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
+Matthias Butz <matze@odinms.de>
+Jan Christian Meyer <vimes@odinms.de>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation version 3 as published by
+the Free Software Foundation. You may not use, modify or distribute
+this program under any other version of the GNU Affero General Public
+License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.gms.constants.game;
+
+/**
+ * MapleStory v83 character animation stance constants, used by the GCMoveSystem
+ * dynamic movement engine to map physics state -> wire stance bytes.
+ */
+public final class CharacterStance {
+    public static final int WALK_RIGHT_STANCE = 2;
+    public static final int WALK_LEFT_STANCE = 3;
+    public static final int STAND_RIGHT_STANCE = 4;
+    public static final int STAND_LEFT_STANCE = 5;
+    public static final int JUMP_RIGHT_STANCE = 6;
+    public static final int JUMP_LEFT_STANCE = 7;
+    public static final int ALERT_RIGHT_STANCE = 8;
+    public static final int ALERT_LEFT_STANCE = 9;
+    public static final int PRONE_RIGHT_STANCE = 10;
+    public static final int PRONE_LEFT_STANCE = 11;
+    public static final int PRONE_STANCE = PRONE_RIGHT_STANCE;
+    public static final int SWIM_RIGHT_STANCE = 12;
+    public static final int SWIM_LEFT_STANCE = 13;
+    public static final int LADDER_RIGHT_STANCE = 14;
+    public static final int LADDER_LEFT_STANCE = 15;
+    public static final int LADDER_STANCE = LADDER_RIGHT_STANCE;
+    public static final int ROPE_RIGHT_STANCE = 16;
+    public static final int ROPE_LEFT_STANCE = 17;
+    public static final int ROPE_STANCE = ROPE_RIGHT_STANCE;
+    public static final int DEAD_RIGHT_STANCE = 18;
+    public static final int DEAD_LEFT_STANCE = 19;
+
+    private CharacterStance() {
+    }
+
+    public static boolean isFacingLeft(int stance) {
+        return stance == WALK_LEFT_STANCE
+                || stance == STAND_LEFT_STANCE
+                || stance == JUMP_LEFT_STANCE
+                || stance == PRONE_LEFT_STANCE
+                || stance == SWIM_LEFT_STANCE
+                || stance == LADDER_LEFT_STANCE
+                || stance == ROPE_LEFT_STANCE
+                || stance == DEAD_LEFT_STANCE;
+    }
+
+    public static boolean isSwimming(int stance) {
+        return stance == SWIM_RIGHT_STANCE || stance == SWIM_LEFT_STANCE;
+    }
+
+    public static boolean isStanding(int stance) {
+        return stance == STAND_RIGHT_STANCE || stance == STAND_LEFT_STANCE;
+    }
+
+    public static boolean isWalking(int stance) {
+        return stance == WALK_RIGHT_STANCE || stance == WALK_LEFT_STANCE;
+    }
+
+    public static boolean isJumping(int stance) {
+        return stance == JUMP_RIGHT_STANCE || stance == JUMP_LEFT_STANCE;
+    }
+
+    public static boolean isProne(int stance) {
+        return stance == PRONE_RIGHT_STANCE || stance == PRONE_LEFT_STANCE;
+    }
+
+    public static boolean isClimbing(int stance) {
+        return stance == ROPE_RIGHT_STANCE
+                || stance == ROPE_LEFT_STANCE
+                || stance == LADDER_RIGHT_STANCE
+                || stance == LADDER_LEFT_STANCE;
+    }
+
+    public static boolean isDead(int stance) {
+        return stance == DEAD_RIGHT_STANCE || stance == DEAD_LEFT_STANCE;
+    }
+}

--- a/gms-server/src/main/java/org/gms/constants/id/MapId.java
+++ b/gms-server/src/main/java/org/gms/constants/id/MapId.java
@@ -188,6 +188,9 @@ public class MapId {
     public static final int ANT_TUNNEL_2 = 105050100;
     public static final int CAVE_OF_MUSHROOMS_BASE = 105050101;
     public static final int SLEEPY_DUNGEON_4 = 105040304;
+    public static final int ANT_TUNNEL_PARK = 105070001;
+    public static final int PATH_OF_TIME_HUB = 220050300;
+    public static final int SHARP_CLIFF_I = 211040300;
     public static final int GOLEMS_CASTLE_RUINS_BASE = 105040320;
     public static final int SAHEL_2 = 260020600;
     public static final int HILL_OF_SANDSTORMS_BASE = 260020630;

--- a/gms-server/src/main/java/org/gms/constants/inventory/EquipType.java
+++ b/gms-server/src/main/java/org/gms/constants/inventory/EquipType.java
@@ -29,6 +29,7 @@ public enum EquipType {
     UNDEFINED(-1),
     ACCESSORY(0),
     CAP(100),
+    EARRING(103),
     CAPE(110),
     COAT(104),
     FACE(2),

--- a/gms-server/src/main/java/org/gms/constants/inventory/ItemConstants.java
+++ b/gms-server/src/main/java/org/gms/constants/inventory/ItemConstants.java
@@ -21,6 +21,7 @@
 */
 package org.gms.constants.inventory;
 
+import org.gms.client.inventory.BodyPart;
 import org.gms.client.inventory.InventoryType;
 import org.gms.config.GameConfig;
 import org.gms.constants.id.ItemId;
@@ -241,6 +242,38 @@ public final class ItemConstants {
     public static boolean isHair(int itemId) {
         int itemType = itemId / 10000;
         return itemType == 3 || itemType == 4 || itemType == 6;
+    }
+
+    public static int getItemPrefix(int itemId) {
+        return itemId / 10000;
+    }
+
+    public static int getEquipSlotType(int itemId) {
+        int itemPrefix = getItemPrefix(itemId);
+        if (isWeapon(itemId)) {
+            return BodyPart.WEAPON.getValue();
+        }
+
+        return switch (itemPrefix) {
+            case 100 -> BodyPart.CAP.getValue();
+            case 101 -> BodyPart.FACE_ACCESSORY.getValue();
+            case 102 -> BodyPart.EYE_ACCESSORY.getValue();
+            case 103 -> BodyPart.EAR_ACCESSORY.getValue();
+            case 104 -> BodyPart.COAT.getValue();
+            case 105 -> BodyPart.LONGCOAT.getValue();
+            case 106 -> BodyPart.PANTS.getValue();
+            case 107 -> BodyPart.SHOES.getValue();
+            case 108 -> BodyPart.GLOVE.getValue();
+            case 109, 119, 134 -> BodyPart.SHIELD.getValue();
+            case 110 -> BodyPart.CAPE.getValue();
+            case 111 -> BodyPart.RING_1.getValue();
+            case 112 -> BodyPart.PENDANT.getValue();
+            case 113 -> BodyPart.BELT.getValue();
+            case 114 -> BodyPart.MEDAL.getValue();
+            case 115 -> BodyPart.SHOULDER.getValue();
+            case 118 -> BodyPart.BADGE.getValue();
+            default -> 0;
+        };
     }
 
     public static boolean isNewCharDefaultFace(int job, int gender, int faceId) {

--- a/gms-server/src/main/java/org/gms/constants/skills/Warrior.java
+++ b/gms-server/src/main/java/org/gms/constants/skills/Warrior.java
@@ -12,6 +12,6 @@ public class Warrior {
     public static final int IMPROVED_MAXHP = 1000001;
     public static final int ENDURE = 1000002;
     public static final int IRON_BODY = 1000003;
-    public static final int POWER_STRIKE = 1000004;
-    public static final int SLASH_BLAST = 1000005;
+    public static final int POWER_STRIKE = 1001004;
+    public static final int SLASH_BLAST = 1001005;
 }

--- a/gms-server/src/main/java/org/gms/extension/README.md
+++ b/gms-server/src/main/java/org/gms/extension/README.md
@@ -1,0 +1,52 @@
+# BeiDou Extension Runtime
+
+## Modules
+
+| Module / package | Role |
+|------------------|------|
+| `extension-api` | Shared SPI: `ServerExtension`, `HostRuntime`, `ArtificialCharacters`, `TradeParticipantHook` / `TradeParticipants`, lifecycle events |
+| `org.gms.extension.runtime` | `ExtensionLoader`, `BeiDouHostRuntime`, `HostHooks` |
+| `org.gms.extension.event` | Host gameplay events (`CharacterMapEnteredEvent`, `CharacterChatEvent`, `PartyInviteEvent`, `TradeInviteEvent`, …) |
+| `gms-server/plugins/*.jar` | Drop zone for external plugins |
+| **solomapling-plugin** (external repo) | Artificial-player framework jar |
+
+SoloMapling sources are **not** a Maven module of this repository.
+
+## Host capabilities (no plugin package imports)
+
+Engine code must not `import soloMapling.*`. Use:
+
+| Capability | API |
+|------------|-----|
+| Is this character plugin-owned? | `HostHooks.isArtificial(chr)` / `ArtificialCharacters.isArtificial(id)` |
+| Trade participant rules | `TradeParticipants` / `HostHooks.trade*` + `TradeInviteEvent` |
+| Publish gameplay events | `HostHooks.publish(new CharacterMapEnteredEvent(...))` etc. |
+| Bot performance tier on `Character` | `org.gms.client.BotTier` |
+| Headless session | `org.gms.client.BotClient` |
+| Plugin lifecycle | `ServerExtension` + `ExtensionLoader` |
+
+Plugins register a `CharacterClassifier` and optionally a `TradeParticipantHook` in `onLoad`.
+
+## Load order
+
+1. Spring Boot starts
+2. `ServerManager` builds `BeiDouHostRuntime` and `ExtensionLoader.load(plugins/)` → each extension `onLoad` (classifiers + trade hooks + command registration)
+3. `Server.init()`
+4. `notifyServerReady()` → `onServerReady` → optional SoloMapling world population
+5. On shutdown: `onUnload` → `ArtificialCharacters.clear()` / `TradeParticipants.clear()`
+
+## Config
+
+```yaml
+solomapling:
+  plugins-enabled: true
+  plugins-dir: plugins
+  spawn-bots-on-startup: true
+```
+
+## Build
+
+```bash
+mvn -pl extension-api,gms-server -am install -DskipTests
+# then build solomapling-plugin and copy jar into gms-server/plugins/
+```

--- a/gms-server/src/main/java/org/gms/extension/event/CharacterChatEvent.java
+++ b/gms-server/src/main/java/org/gms/extension/event/CharacterChatEvent.java
@@ -1,0 +1,10 @@
+package org.gms.extension.event;
+
+import org.gms.client.Character;
+import org.gms.extension.api.HostEvent;
+
+/**
+ * A non-artificial character sent a general (map) chat message.
+ */
+public record CharacterChatEvent(Character character, String message) implements HostEvent {
+}

--- a/gms-server/src/main/java/org/gms/extension/event/CharacterMapEnteredEvent.java
+++ b/gms-server/src/main/java/org/gms/extension/event/CharacterMapEnteredEvent.java
@@ -1,0 +1,11 @@
+package org.gms.extension.event;
+
+import org.gms.client.Character;
+import org.gms.extension.api.HostEvent;
+
+/**
+ * A non-artificial character entered a map. Plugins that simulate ambient bots
+ * can react (greetings, LOD wake-ups) without the host importing plugin types.
+ */
+public record CharacterMapEnteredEvent(Character character, int mapId) implements HostEvent {
+}

--- a/gms-server/src/main/java/org/gms/extension/event/PartyInviteEvent.java
+++ b/gms-server/src/main/java/org/gms/extension/event/PartyInviteEvent.java
@@ -1,0 +1,12 @@
+package org.gms.extension.event;
+
+import org.gms.client.Character;
+import org.gms.extension.api.HostEvent;
+
+/**
+ * A party invite was created and delivered to {@code invited}. Published for every invite so a
+ * plugin owning the invited character (a bot has no real client to answer the invite packet) can
+ * answer it on the character's behalf.
+ */
+public record PartyInviteEvent(Character invited, Character inviter, int partyId) implements HostEvent {
+}

--- a/gms-server/src/main/java/org/gms/extension/event/TradeInviteEvent.java
+++ b/gms-server/src/main/java/org/gms/extension/event/TradeInviteEvent.java
@@ -1,0 +1,11 @@
+package org.gms.extension.event;
+
+import org.gms.client.Character;
+import org.gms.extension.api.HostEvent;
+
+/**
+ * A trade invite was created targeting {@code invited}. Plugins owning headless invitees
+ * (no client to accept the packet) subscribe and drive accept/decline themselves.
+ */
+public record TradeInviteEvent(Character invited, Character inviter) implements HostEvent {
+}

--- a/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostCharacterProvisioner.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostCharacterProvisioner.java
@@ -1,0 +1,150 @@
+package org.gms.extension.runtime;
+
+import org.gms.client.Character;
+import org.gms.client.creator.CharacterFactoryRecipe;
+import org.gms.client.creator.novice.BeginnerCreator;
+import org.gms.extension.api.HostCharacterProvisionRequest;
+import org.gms.extension.api.HostCharacterProvisionResult;
+import org.gms.extension.api.HostCharacterProvisioner;
+import org.gms.net.server.Server;
+import org.gms.service.AccountService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.util.Objects;
+
+/**
+ * BeiDou's native atomic account/character provisioning implementation.
+ */
+public final class BeiDouHostCharacterProvisioner implements HostCharacterProvisioner {
+
+    private static final Logger log =
+            LoggerFactory.getLogger(BeiDouHostCharacterProvisioner.class);
+
+    private final AccountService accounts;
+    private final JdbcTransactionCoordinator transactions;
+
+    public BeiDouHostCharacterProvisioner(AccountService accounts) {
+        this(accounts, new JdbcTransactionCoordinator());
+    }
+
+    BeiDouHostCharacterProvisioner(
+            AccountService accounts,
+            JdbcTransactionCoordinator transactions
+    ) {
+        this.accounts = Objects.requireNonNull(accounts, "accounts");
+        this.transactions = Objects.requireNonNull(transactions, "transactions");
+    }
+
+    @Override
+    public HostCharacterProvisionResult provision(HostCharacterProvisionRequest request) throws Exception {
+        Objects.requireNonNull(request, "request");
+        validateLengths(request);
+
+        String encodedPassword = accounts.encryptPassword(request.credential());
+        Provisioned provisioned = transactions.execute(connection -> {
+            ensureAvailable(connection, "accounts", "name", request.accountName());
+            ensureAvailable(connection, "characters", "name", request.characterName());
+
+            int accountId = insertAccount(connection, request.accountName(), encodedPassword);
+            Character character = BeginnerCreator.prepareProvisionedCharacter(
+                    accountId, request.worldId(), request.characterName());
+            if (character == null) {
+                throw new IllegalArgumentException("host rejected default beginner character");
+            }
+
+            CharacterFactoryRecipe recipe = BeginnerCreator.createDefaultRecipe();
+            if (!character.insertNewChar(recipe, connection)) {
+                throw new IllegalStateException("native character insertion failed");
+            }
+
+            return new Provisioned(character, new HostCharacterProvisionResult(
+                    character.getId(), accountId, request.characterName()));
+        });
+
+        // The login-server view must never expose an uncommitted character.
+        // This is deliberately best-effort after commit: a cache publication
+        // failure must not turn a durable provisioning success into a false
+        // failure response that encourages the caller to create a duplicate.
+        publishPostCommit(
+                provisioned.character().getId(),
+                provisioned.character().getName(),
+                () -> Server.getInstance().createCharacterEntry(provisioned.character()));
+        return provisioned.result();
+    }
+
+    static boolean publishPostCommit(
+            int characterId,
+            String characterName,
+            Runnable publisher
+    ) {
+        Objects.requireNonNull(characterName, "characterName");
+        Objects.requireNonNull(publisher, "publisher");
+        try {
+            publisher.run();
+            return true;
+        } catch (RuntimeException failure) {
+            log.warn(
+                    "Provisioned character {} ({}) committed, but login cache publication failed; "
+                            + "the next server restart will rebuild the cache",
+                    characterName, characterId, failure);
+            return false;
+        }
+    }
+
+    private static int insertAccount(Connection connection, String accountName, String encodedPassword)
+            throws Exception {
+        String sql = "INSERT INTO accounts (name, password, birthday, tempban) VALUES (?, ?, ?, ?)";
+        try (PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            statement.setString(1, accountName);
+            statement.setString(2, encodedPassword);
+            statement.setDate(3, Date.valueOf(LocalDate.of(2005, 5, 11)));
+            statement.setTimestamp(4, Timestamp.valueOf("2005-05-11 00:00:00"));
+            if (statement.executeUpdate() != 1) {
+                throw new IllegalStateException("native account insertion failed");
+            }
+            try (ResultSet keys = statement.getGeneratedKeys()) {
+                if (!keys.next()) {
+                    throw new IllegalStateException("native account id was not generated");
+                }
+                return keys.getInt(1);
+            }
+        }
+    }
+
+    private static void ensureAvailable(
+            Connection connection,
+            String table,
+            String column,
+            String value
+    ) throws Exception {
+        try (PreparedStatement statement =
+                     connection.prepareStatement("SELECT 1 FROM " + table + " WHERE " + column + " = ?")) {
+            statement.setString(1, value);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    throw new IllegalArgumentException(column + " is already in use");
+                }
+            }
+        }
+    }
+
+    private static void validateLengths(HostCharacterProvisionRequest request) {
+        if (request.accountName().length() > 13) {
+            throw new IllegalArgumentException("accountName exceeds host limit");
+        }
+        if (request.characterName().length() > 13) {
+            throw new IllegalArgumentException("characterName exceeds host limit");
+        }
+    }
+
+    private record Provisioned(Character character, HostCharacterProvisionResult result) {
+    }
+}

--- a/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostCommandRegistry.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostCommandRegistry.java
@@ -1,0 +1,38 @@
+package org.gms.extension.runtime;
+
+import org.gms.extension.api.HostCommandHandler;
+import org.gms.extension.api.HostCommandRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory command table for plugin-registered commands.
+ * Full command_info DB wiring can be added later; for now GM dispatch can consult this map.
+ */
+public final class BeiDouHostCommandRegistry implements HostCommandRegistry {
+
+    private static final Logger log = LoggerFactory.getLogger(BeiDouHostCommandRegistry.class);
+
+    public record RegisteredCommand(String syntax, int level, String description, HostCommandHandler handler) {
+    }
+
+    private final Map<String, RegisteredCommand> commands = new ConcurrentHashMap<>();
+
+    @Override
+    public void register(String syntax, int level, String description, HostCommandHandler handler) {
+        String key = syntax.toLowerCase();
+        commands.put(key, new RegisteredCommand(key, level, description, handler));
+        log.info("Registered extension command '!{}' (gm level {})", key, level);
+    }
+
+    public RegisteredCommand get(String syntax) {
+        return commands.get(syntax.toLowerCase());
+    }
+
+    public Map<String, RegisteredCommand> snapshot() {
+        return Map.copyOf(commands);
+    }
+}

--- a/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostConfig.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostConfig.java
@@ -1,0 +1,38 @@
+package org.gms.extension.runtime;
+
+import org.gms.extension.api.HostConfig;
+import org.springframework.core.env.Environment;
+
+/**
+ * Reads SoloMapling / extension keys from Spring Environment ({@code application.yml}).
+ */
+public final class BeiDouHostConfig implements HostConfig {
+
+    public static final String SPAWN_BOTS_ON_STARTUP = "solomapling.spawn-bots-on-startup";
+    public static final String PLUGINS_DIR = "solomapling.plugins-dir";
+    public static final String PLUGINS_ENABLED = "solomapling.plugins-enabled";
+
+    private final Environment environment;
+
+    public BeiDouHostConfig(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public boolean getBool(String key, boolean defaultValue) {
+        Boolean value = environment.getProperty(key, Boolean.class);
+        return value != null ? value : defaultValue;
+    }
+
+    @Override
+    public int getInt(String key, int defaultValue) {
+        Integer value = environment.getProperty(key, Integer.class);
+        return value != null ? value : defaultValue;
+    }
+
+    @Override
+    public String getString(String key, String defaultValue) {
+        String value = environment.getProperty(key);
+        return value != null && !value.isBlank() ? value : defaultValue;
+    }
+}

--- a/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostItemActions.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostItemActions.java
@@ -1,0 +1,207 @@
+package org.gms.extension.runtime;
+
+import org.gms.client.Character;
+import org.gms.client.inventory.Inventory;
+import org.gms.client.inventory.InventoryType;
+import org.gms.client.inventory.Item;
+import org.gms.client.inventory.ModifyInventory;
+import org.gms.constants.inventory.ItemConstants;
+import org.gms.extension.api.HostItemActions;
+import org.gms.net.server.Server;
+import org.gms.server.ItemInformationProvider;
+import org.gms.server.maps.MapItem;
+import org.gms.server.maps.MapObject;
+import org.gms.server.maps.MapleMap;
+import org.gms.server.maps.FieldLimit;
+import org.gms.util.PacketCreator;
+
+import java.util.Collections;
+import java.util.function.IntFunction;
+
+public final class BeiDouHostItemActions implements HostItemActions {
+    private static final short FORBIDDEN_FLAGS = ItemConstants.LOCK
+            | ItemConstants.UNTRADEABLE
+            | ItemConstants.ACCOUNT_SHARING
+            | ItemConstants.MERGE_UNTRADEABLE;
+
+    private final IntFunction<Character> characterResolver;
+
+    public BeiDouHostItemActions() {
+        this(BeiDouHostItemActions::findOnlineCharacter);
+    }
+
+    BeiDouHostItemActions(IntFunction<Character> characterResolver) {
+        this.characterResolver = characterResolver;
+    }
+
+    @Override
+    public PickupResult pickup(int characterId, int mapItemObjectId) {
+        Character character = characterResolver.apply(characterId);
+        if (character == null || character.getMap() == null) {
+            return PickupResult.failed("CHARACTER_NOT_FOUND");
+        }
+
+        MapObject object = character.getMap().getMapObject(mapItemObjectId);
+        if (!(object instanceof MapItem mapItem)) {
+            return PickupResult.failed("MAP_ITEM_NOT_FOUND");
+        }
+
+        int itemId;
+        int quantity;
+        mapItem.lockItem();
+        try {
+            if (mapItem.isPickedUp()) {
+                return PickupResult.failed("ALREADY_PICKED_UP");
+            }
+            if (System.currentTimeMillis() - mapItem.getDropTime() < 400) {
+                return PickupResult.failed("DROP_NOT_READY");
+            }
+            itemId = mapItem.getItemId();
+            quantity = mapItem.getMeso() > 0 ? mapItem.getMeso() : mapItem.getItem().getQuantity();
+        } finally {
+            mapItem.unlockItem();
+        }
+
+        // This is the engine's normal authoritative path. It performs ownership,
+        // quest and inventory checks and calls InventoryManipulator.addFromDrop.
+        character.pickupItem(mapItem);
+
+        mapItem.lockItem();
+        try {
+            return mapItem.isPickedUp()
+                    ? PickupResult.succeeded(itemId, quantity)
+                    : PickupResult.failed("PICKUP_REJECTED");
+        } finally {
+            mapItem.unlockItem();
+        }
+    }
+
+    @Override
+    public DropResult dropToCharacter(
+            int sourceCharacterId,
+            int targetCharacterId,
+            int inventoryType,
+            int slot,
+            int quantity
+    ) {
+        Character source = characterResolver.apply(sourceCharacterId);
+        Character target = characterResolver.apply(targetCharacterId);
+        if (source == null) {
+            return DropResult.failed("SOURCE_NOT_FOUND");
+        }
+        if (target == null) {
+            return DropResult.failed("TARGET_NOT_FOUND");
+        }
+        MapleMap map = source.getMap();
+        if (map == null || target.getMap() != map) {
+            return DropResult.failed("NOT_ON_SAME_MAP");
+        }
+        if (FieldLimit.DROP_LIMIT.check(map.getFieldLimit())) {
+            return DropResult.failed("MAP_DISALLOWS_DROPS");
+        }
+        if (quantity <= 0 || slot <= 0 || slot > Short.MAX_VALUE) {
+            return DropResult.failed("INVALID_QUANTITY_OR_SLOT");
+        }
+
+        InventoryType type = InventoryType.getByType((byte) inventoryType);
+        if (type == InventoryType.UNDEFINED
+                || type == InventoryType.EQUIPPED
+                || type == InventoryType.CASH
+                || type == InventoryType.CANHOLD) {
+            return DropResult.failed("INVALID_INVENTORY");
+        }
+
+        Inventory inventory = source.getInventory(type);
+        inventory.lockInventory();
+        try {
+            Item sourceItem = inventory.getItem((short) slot);
+            if (sourceItem == null) {
+                return DropResult.failed("SLOT_EMPTY");
+            }
+            String restriction = dropRestriction(sourceItem);
+            if (restriction != null) {
+                return DropResult.failed(restriction);
+            }
+            if (sourceItem.getQuantity() < quantity
+                    || (sourceItem.getItemType() == 1 && quantity != 1)) {
+                return DropResult.failed("INVALID_QUANTITY");
+            }
+
+            short originalQuantity = sourceItem.getQuantity();
+            boolean wholeStack = quantity == originalQuantity;
+            Item droppedItem = wholeStack ? sourceItem : sourceItem.copy();
+            droppedItem.setQuantity((short) quantity);
+
+            if (wholeStack) {
+                inventory.removeSlot((short) slot);
+            } else {
+                sourceItem.setQuantity((short) (originalQuantity - quantity));
+            }
+
+            MapItem mapItem;
+            try {
+                mapItem = map.spawnOwnerOnlyItemDrop(source, target, droppedItem, target.getPosition());
+            } catch (RuntimeException e) {
+                // A thrown map-spawn may have partially registered the object; restoring
+                // here could duplicate the item, so fail closed and leave it removed.
+                return DropResult.failed("DROP_SPAWN_FAILED");
+            }
+            if (mapItem == null) {
+                if (wholeStack) {
+                    sourceItem.setPosition((short) slot);
+                    inventory.addItemFromDB(sourceItem);
+                } else {
+                    sourceItem.setQuantity(originalQuantity);
+                }
+                return DropResult.failed("DROP_SPAWN_FAILED");
+            }
+
+            source.getClient().sendPacket(PacketCreator.modifyInventory(
+                    true,
+                    Collections.singletonList(new ModifyInventory(wholeStack ? 3 : 1, sourceItem))));
+            return DropResult.succeeded(droppedItem.getItemId(), quantity, mapItem.getObjectId());
+        } finally {
+            inventory.unlockInventory();
+        }
+    }
+
+    static String dropRestriction(Item item) {
+        ItemInformationProvider ii = ItemInformationProvider.getInstance();
+        return dropRestriction(
+                ii.isCash(item.getItemId()),
+                ii.isQuestItem(item.getItemId()) || ii.isDropRestricted(item.getItemId()),
+                item.getPetId() >= 0,
+                item.isUntradeable(),
+                item.getFlag());
+    }
+
+    static String dropRestriction(
+            boolean cash,
+            boolean questOrDropRestricted,
+            boolean pet,
+            boolean untradeable,
+            short flags
+    ) {
+        if (cash) {
+            return "CASH_ITEM";
+        }
+        if (questOrDropRestricted) {
+            return "DROP_RESTRICTED";
+        }
+        if (pet) {
+            return "PET_ITEM";
+        }
+        if (untradeable || (flags & FORBIDDEN_FLAGS) != 0) {
+            return "BOUND_ITEM";
+        }
+        return null;
+    }
+
+    private static Character findOnlineCharacter(int characterId) {
+        return Server.getInstance().getWorlds().stream()
+                .map(world -> world.getPlayerStorage().getCharacterById(characterId))
+                .filter(character -> character != null)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostMonsterDrops.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostMonsterDrops.java
@@ -1,0 +1,16 @@
+package org.gms.extension.runtime;
+
+import org.gms.extension.api.HostMonsterDrops;
+import org.gms.server.life.MonsterInformationProvider;
+
+import java.util.List;
+
+public final class BeiDouHostMonsterDrops implements HostMonsterDrops {
+
+    @Override
+    public List<DropSource> findSources(int itemId, int limit) {
+        return MonsterInformationProvider.getInstance().retrieveDropSources(itemId, limit).stream()
+                .map(source -> new DropSource(source.dropperId(), source.chance()))
+                .toList();
+    }
+}

--- a/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostRuntime.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostRuntime.java
@@ -1,0 +1,42 @@
+package org.gms.extension.runtime;
+
+import org.gms.extension.api.HostCommandRegistry;
+import org.gms.extension.api.HostConfig;
+import org.gms.extension.api.HostEventBus;
+import org.gms.extension.api.HostRuntime;
+
+/**
+ * BeiDou implementation of {@link HostRuntime}. Constructed once per server process.
+ */
+public final class BeiDouHostRuntime implements HostRuntime {
+
+    private final HostConfig config;
+    private final HostEventBus events;
+    private final HostCommandRegistry commands;
+
+    public BeiDouHostRuntime(HostConfig config, HostEventBus events, HostCommandRegistry commands) {
+        this.config = config;
+        this.events = events;
+        this.commands = commands;
+    }
+
+    @Override
+    public HostConfig config() {
+        return config;
+    }
+
+    @Override
+    public HostEventBus events() {
+        return events;
+    }
+
+    @Override
+    public HostCommandRegistry commands() {
+        return commands;
+    }
+
+    @Override
+    public String hostId() {
+        return "beidou";
+    }
+}

--- a/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostRuntime.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/BeiDouHostRuntime.java
@@ -1,9 +1,14 @@
 package org.gms.extension.runtime;
 
 import org.gms.extension.api.HostCommandRegistry;
+import org.gms.extension.api.HostCharacterProvisioner;
 import org.gms.extension.api.HostConfig;
 import org.gms.extension.api.HostEventBus;
+import org.gms.extension.api.HostItemActions;
+import org.gms.extension.api.HostMonsterDrops;
 import org.gms.extension.api.HostRuntime;
+
+import java.util.Optional;
 
 /**
  * BeiDou implementation of {@link HostRuntime}. Constructed once per server process.
@@ -13,11 +18,37 @@ public final class BeiDouHostRuntime implements HostRuntime {
     private final HostConfig config;
     private final HostEventBus events;
     private final HostCommandRegistry commands;
+    private final HostCharacterProvisioner characterProvisioner;
+    private final HostItemActions itemActions;
+    private final HostMonsterDrops monsterDrops;
 
     public BeiDouHostRuntime(HostConfig config, HostEventBus events, HostCommandRegistry commands) {
+        this(config, events, commands, null);
+    }
+
+    public BeiDouHostRuntime(
+            HostConfig config,
+            HostEventBus events,
+            HostCommandRegistry commands,
+            HostCharacterProvisioner characterProvisioner
+    ) {
+        this(config, events, commands, characterProvisioner, null, null);
+    }
+
+    public BeiDouHostRuntime(
+            HostConfig config,
+            HostEventBus events,
+            HostCommandRegistry commands,
+            HostCharacterProvisioner characterProvisioner,
+            HostItemActions itemActions,
+            HostMonsterDrops monsterDrops
+    ) {
         this.config = config;
         this.events = events;
         this.commands = commands;
+        this.characterProvisioner = characterProvisioner;
+        this.itemActions = itemActions;
+        this.monsterDrops = monsterDrops;
     }
 
     @Override
@@ -33,6 +64,21 @@ public final class BeiDouHostRuntime implements HostRuntime {
     @Override
     public HostCommandRegistry commands() {
         return commands;
+    }
+
+    @Override
+    public Optional<HostCharacterProvisioner> characterProvisioner() {
+        return Optional.ofNullable(characterProvisioner);
+    }
+
+    @Override
+    public Optional<HostItemActions> itemActions() {
+        return Optional.ofNullable(itemActions);
+    }
+
+    @Override
+    public Optional<HostMonsterDrops> monsterDrops() {
+        return Optional.ofNullable(monsterDrops);
     }
 
     @Override

--- a/gms-server/src/main/java/org/gms/extension/runtime/ExtensionLoader.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/ExtensionLoader.java
@@ -1,0 +1,160 @@
+package org.gms.extension.runtime;
+
+import org.gms.extension.api.ArtificialCharacters;
+import org.gms.extension.api.HostRuntime;
+import org.gms.extension.api.ServerExtension;
+import org.gms.extension.api.TradeParticipants;
+import org.gms.extension.api.event.ServerReadyEvent;
+import org.gms.extension.api.event.ServerShutdownEvent;
+import org.gms.util.I18nUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Discovers {@link ServerExtension} implementations from the application classpath
+ * and from {@code plugins/*.jar}, then drives their lifecycle.
+ */
+public final class ExtensionLoader {
+
+    private static final Logger log = LoggerFactory.getLogger(ExtensionLoader.class);
+
+    private static final ExtensionLoader INSTANCE = new ExtensionLoader();
+
+    private final List<ServerExtension> extensions = new ArrayList<>();
+    private final List<URLClassLoader> pluginLoaders = new ArrayList<>();
+    private final AtomicBoolean loaded = new AtomicBoolean(false);
+
+    private HostRuntime runtime;
+
+    private ExtensionLoader() {
+    }
+
+    public static ExtensionLoader getInstance() {
+        return INSTANCE;
+    }
+
+    public HostRuntime getRuntime() {
+        return runtime;
+    }
+
+    public synchronized void load(HostRuntime runtime, Path pluginsDir) {
+        if (!loaded.compareAndSet(false, true)) {
+            log.warn(I18nUtil.getLogMessage("ExtensionLoader.load.warn.alreadyLoaded"));
+            return;
+        }
+        this.runtime = runtime;
+
+        List<ServerExtension> discovered = new ArrayList<>();
+        discovered.addAll(loadFromClassLoader(ServerExtension.class.getClassLoader(), "classpath"));
+        discovered.addAll(loadFromPluginDirectory(pluginsDir));
+
+        for (ServerExtension ext : discovered) {
+            try {
+                log.info(I18nUtil.getLogMessage("ExtensionLoader.load.info.loading"), ext.id(), ext.version());
+                ext.onLoad(runtime);
+                extensions.add(ext);
+                log.info(I18nUtil.getLogMessage("ExtensionLoader.load.info.loaded"), ext.id());
+            } catch (Exception e) {
+                log.error(I18nUtil.getLogMessage("ExtensionLoader.load.error.onLoad"), ext.id(), e);
+            }
+        }
+
+        log.info(I18nUtil.getLogMessage("ExtensionLoader.load.info.summary"), extensions.size());
+    }
+
+    public synchronized void notifyServerReady() {
+        if (runtime != null) {
+            runtime.events().publish(new ServerReadyEvent(System.currentTimeMillis()));
+        }
+        for (ServerExtension ext : extensions) {
+            try {
+                ext.onServerReady();
+                log.info(I18nUtil.getLogMessage("ExtensionLoader.ready.info"), ext.id());
+            } catch (Exception e) {
+                log.error(I18nUtil.getLogMessage("ExtensionLoader.ready.error"), ext.id(), e);
+            }
+        }
+    }
+
+    public synchronized void unloadAll() {
+        if (runtime != null) {
+            runtime.events().publish(new ServerShutdownEvent(System.currentTimeMillis()));
+        }
+        for (ServerExtension ext : List.copyOf(extensions)) {
+            try {
+                ext.onUnload();
+            } catch (Exception e) {
+                log.error(I18nUtil.getLogMessage("ExtensionLoader.unload.error"), ext.id(), e);
+            }
+        }
+        extensions.clear();
+        for (URLClassLoader loader : pluginLoaders) {
+            try {
+                loader.close();
+            } catch (IOException e) {
+                log.warn("Failed to close plugin classloader", e);
+            }
+        }
+        pluginLoaders.clear();
+        ArtificialCharacters.clear();
+        TradeParticipants.clear();
+        loaded.set(false);
+        runtime = null;
+    }
+
+    private List<ServerExtension> loadFromClassLoader(ClassLoader classLoader, String source) {
+        List<ServerExtension> result = new ArrayList<>();
+        try {
+            ServiceLoader<ServerExtension> loader = ServiceLoader.load(ServerExtension.class, classLoader);
+            for (ServerExtension ext : loader) {
+                log.info(I18nUtil.getLogMessage("ExtensionLoader.discover.info"), ext.id(), source);
+                result.add(ext);
+            }
+        } catch (Exception e) {
+            log.error(I18nUtil.getLogMessage("ExtensionLoader.discover.error"), source, e);
+        }
+        return result;
+    }
+
+    private List<ServerExtension> loadFromPluginDirectory(Path pluginsDir) {
+        List<ServerExtension> result = new ArrayList<>();
+        if (pluginsDir == null) {
+            return result;
+        }
+        try {
+            Files.createDirectories(pluginsDir);
+        } catch (IOException e) {
+            log.error(I18nUtil.getLogMessage("ExtensionLoader.plugins.error.mkdir"), pluginsDir, e);
+            return result;
+        }
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(pluginsDir, "*.jar")) {
+            for (Path jar : stream) {
+                try {
+                    URLClassLoader pluginCl = new URLClassLoader(
+                            new URL[]{jar.toUri().toURL()},
+                            ServerExtension.class.getClassLoader());
+                    pluginLoaders.add(pluginCl);
+                    log.info(I18nUtil.getLogMessage("ExtensionLoader.plugins.info.jar"), jar.getFileName());
+                    result.addAll(loadFromClassLoader(pluginCl, jar.getFileName().toString()));
+                } catch (Exception e) {
+                    log.error(I18nUtil.getLogMessage("ExtensionLoader.plugins.error.jar"), jar, e);
+                }
+            }
+        } catch (IOException e) {
+            log.error(I18nUtil.getLogMessage("ExtensionLoader.plugins.error.scan"), pluginsDir, e);
+        }
+        return result;
+    }
+}

--- a/gms-server/src/main/java/org/gms/extension/runtime/HostHooks.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/HostHooks.java
@@ -1,0 +1,52 @@
+package org.gms.extension.runtime;
+
+import org.gms.client.Character;
+import org.gms.extension.api.ArtificialCharacters;
+import org.gms.extension.api.HostEvent;
+import org.gms.extension.api.HostRuntime;
+import org.gms.extension.api.TradeParticipants;
+
+/**
+ * Convenience accessors for engine code: artificial-character checks, trade hooks, and host events.
+ * Keeps {@code org.gms} free of plugin package imports.
+ */
+public final class HostHooks {
+
+    private HostHooks() {
+    }
+
+    public static boolean isArtificial(Character character) {
+        return character != null && ArtificialCharacters.isArtificial(character.getId());
+    }
+
+    public static boolean isArtificial(int characterId) {
+        return ArtificialCharacters.isArtificial(characterId);
+    }
+
+    public static boolean tradeAutoAcceptVisit(int visitorId, int partnerId) {
+        return TradeParticipants.autoAcceptVisit(visitorId, partnerId);
+    }
+
+    public static boolean tradeRelaxInventoryChecks(int characterId) {
+        return TradeParticipants.relaxInventoryChecks(characterId);
+    }
+
+    public static boolean tradeSuppressPackets(int characterId) {
+        return TradeParticipants.suppressTradePackets(characterId);
+    }
+
+    /** @return true if a plugin hook claimed exchange completion for this character */
+    public static boolean tradeOnExchangeSuccess(int characterId) {
+        return TradeParticipants.onExchangeSuccess(characterId);
+    }
+
+    public static void publish(HostEvent event) {
+        if (event == null) {
+            return;
+        }
+        HostRuntime runtime = ExtensionLoader.getInstance().getRuntime();
+        if (runtime != null) {
+            runtime.events().publish(event);
+        }
+    }
+}

--- a/gms-server/src/main/java/org/gms/extension/runtime/InMemoryHostEventBus.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/InMemoryHostEventBus.java
@@ -1,0 +1,51 @@
+package org.gms.extension.runtime;
+
+import org.gms.extension.api.HostEvent;
+import org.gms.extension.api.HostEventBus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+public final class InMemoryHostEventBus implements HostEventBus {
+
+    private static final Logger log = LoggerFactory.getLogger(InMemoryHostEventBus.class);
+
+    private final Map<Class<? extends HostEvent>, List<Consumer>> listeners = new ConcurrentHashMap<>();
+
+    @Override
+    public <T extends HostEvent> void publish(T event) {
+        if (event == null) {
+            return;
+        }
+        List<Consumer> consumers = listeners.get(event.getClass());
+        if (consumers == null || consumers.isEmpty()) {
+            return;
+        }
+        for (Consumer consumer : consumers) {
+            try {
+                consumer.accept(event);
+            } catch (Exception e) {
+                log.warn("HostEventBus listener failed for {}", event.getClass().getSimpleName(), e);
+            }
+        }
+    }
+
+    @Override
+    public <T extends HostEvent> void subscribe(Class<T> type, Consumer<T> listener) {
+        listeners.computeIfAbsent(type, t -> new CopyOnWriteArrayList<>()).add(listener);
+    }
+
+    @Override
+    public <T extends HostEvent> void unsubscribe(Class<T> type, Consumer<T> listener) {
+        List<Consumer> consumers = listeners.get(type);
+        if (consumers != null) {
+            consumers.remove(listener);
+        }
+    }
+}

--- a/gms-server/src/main/java/org/gms/extension/runtime/JdbcTransactionCoordinator.java
+++ b/gms-server/src/main/java/org/gms/extension/runtime/JdbcTransactionCoordinator.java
@@ -1,0 +1,53 @@
+package org.gms.extension.runtime;
+
+import org.gms.util.DatabaseConnection;
+
+import java.sql.Connection;
+
+/** Small injectable transaction boundary used by host extension capabilities. */
+public final class JdbcTransactionCoordinator {
+
+    @FunctionalInterface
+    public interface ConnectionProvider {
+        Connection open() throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface Work<T> {
+        T execute(Connection connection) throws Exception;
+    }
+
+    private final ConnectionProvider connections;
+
+    public JdbcTransactionCoordinator() {
+        this(DatabaseConnection::getConnection);
+    }
+
+    public JdbcTransactionCoordinator(ConnectionProvider connections) {
+        this.connections = connections;
+    }
+
+    public <T> T execute(Work<T> work) throws Exception {
+        try (Connection connection = connections.open()) {
+            boolean originalAutoCommit = connection.getAutoCommit();
+            int originalIsolation = connection.getTransactionIsolation();
+            connection.setAutoCommit(false);
+            connection.setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
+            try {
+                T result = work.execute(connection);
+                connection.commit();
+                return result;
+            } catch (Exception | Error failure) {
+                try {
+                    connection.rollback();
+                } catch (Exception rollbackFailure) {
+                    failure.addSuppressed(rollbackFailure);
+                }
+                throw failure;
+            } finally {
+                connection.setTransactionIsolation(originalIsolation);
+                connection.setAutoCommit(originalAutoCommit);
+            }
+        }
+    }
+}

--- a/gms-server/src/main/java/org/gms/manager/ServerManager.java
+++ b/gms-server/src/main/java/org/gms/manager/ServerManager.java
@@ -8,10 +8,14 @@ import org.gms.constants.net.ServerConstants;
 import org.gms.extension.api.HostRuntime;
 import org.gms.extension.runtime.BeiDouHostCommandRegistry;
 import org.gms.extension.runtime.BeiDouHostConfig;
+import org.gms.extension.runtime.BeiDouHostCharacterProvisioner;
+import org.gms.extension.runtime.BeiDouHostItemActions;
+import org.gms.extension.runtime.BeiDouHostMonsterDrops;
 import org.gms.extension.runtime.BeiDouHostRuntime;
 import org.gms.extension.runtime.ExtensionLoader;
 import org.gms.extension.runtime.InMemoryHostEventBus;
 import org.gms.net.server.Server;
+import org.gms.service.AccountService;
 import org.gms.util.I18nUtil;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
@@ -47,7 +51,10 @@ public class ServerManager implements ApplicationContextAware, ApplicationRunner
             HostRuntime runtime = new BeiDouHostRuntime(
                     new BeiDouHostConfig(environment),
                     new InMemoryHostEventBus(),
-                    new BeiDouHostCommandRegistry());
+                    new BeiDouHostCommandRegistry(),
+                    new BeiDouHostCharacterProvisioner(applicationContext.getBean(AccountService.class)),
+                    new BeiDouHostItemActions(),
+                    new BeiDouHostMonsterDrops());
             Path pluginsDir = Path.of(environment.getProperty(BeiDouHostConfig.PLUGINS_DIR, "plugins"));
             ExtensionLoader.getInstance().load(runtime, pluginsDir);
         }

--- a/gms-server/src/main/java/org/gms/manager/ServerManager.java
+++ b/gms-server/src/main/java/org/gms/manager/ServerManager.java
@@ -5,6 +5,12 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.gms.ServerApplication;
 import org.gms.constants.net.ServerConstants;
+import org.gms.extension.api.HostRuntime;
+import org.gms.extension.runtime.BeiDouHostCommandRegistry;
+import org.gms.extension.runtime.BeiDouHostConfig;
+import org.gms.extension.runtime.BeiDouHostRuntime;
+import org.gms.extension.runtime.ExtensionLoader;
+import org.gms.extension.runtime.InMemoryHostEventBus;
 import org.gms.net.server.Server;
 import org.gms.util.I18nUtil;
 import org.springdoc.core.properties.SpringDocConfigProperties;
@@ -20,6 +26,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.InputStream;
 import java.net.InetAddress;
+import java.nio.file.Path;
 
 @Component
 @Slf4j
@@ -34,17 +41,31 @@ public class ServerManager implements ApplicationContextAware, ApplicationRunner
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
+        Environment environment = applicationContext.getBean(Environment.class);
+        boolean pluginsEnabled = environment.getProperty(BeiDouHostConfig.PLUGINS_ENABLED, Boolean.class, true);
+        if (pluginsEnabled) {
+            HostRuntime runtime = new BeiDouHostRuntime(
+                    new BeiDouHostConfig(environment),
+                    new InMemoryHostEventBus(),
+                    new BeiDouHostCommandRegistry());
+            Path pluginsDir = Path.of(environment.getProperty(BeiDouHostConfig.PLUGINS_DIR, "plugins"));
+            ExtensionLoader.getInstance().load(runtime, pluginsDir);
+        }
+
         Server.getInstance().init();
+
+        if (pluginsEnabled) {
+            ExtensionLoader.getInstance().notifyServerReady();
+        }
 
         SpringDocConfigProperties springDocConfigProperties = applicationContext.getBean(SpringDocConfigProperties.class);
         SwaggerUiConfigProperties swaggerUiConfigProperties = applicationContext.getBean(SwaggerUiConfigProperties.class);
-        Environment environment = applicationContext.getBean(Environment.class);
         log.info(I18nUtil.getLogMessage("ServerManager.run.info3"), ServerConstants.BEI_DOU_VERSION, ServerConstants.BEI_DOU_BUILD_TIME);
         if (springDocConfigProperties.getApiDocs().isEnabled() && swaggerUiConfigProperties.isEnabled()) {
             log.info(I18nUtil.getLogMessage("ServerManager.run.info1"), InetAddress.getLocalHost().getHostAddress(), environment.getProperty("server.port"));
         }
         // 判断是否集成前端，集成则提示前端地址
-        try(InputStream resource = ServerApplication.class.getClassLoader().getResourceAsStream("static/index.html")) {
+        try (InputStream resource = ServerApplication.class.getClassLoader().getResourceAsStream("static/index.html")) {
             if (resource != null) {
                 log.info(I18nUtil.getLogMessage("ServerManager.run.info2"), InetAddress.getLocalHost().getHostAddress(), environment.getProperty("server.port"));
             }
@@ -53,6 +74,7 @@ public class ServerManager implements ApplicationContextAware, ApplicationRunner
 
     @Override
     public void destroy() throws Exception {
+        ExtensionLoader.getInstance().unloadAll();
         Server.getInstance().shutdownInternal(false);
     }
 }

--- a/gms-server/src/main/java/org/gms/net/packet/ByteBufInPacket.java
+++ b/gms-server/src/main/java/org/gms/net/packet/ByteBufInPacket.java
@@ -106,4 +106,9 @@ public class ByteBufInPacket implements InPacket {
         sb.insert(2 * index, '_');
         return sb.toString();
     }
+
+    @Override
+    public InPacket copy() {
+        return new ByteBufInPacket(byteBuf.copy());
+    }
 }

--- a/gms-server/src/main/java/org/gms/net/packet/InPacket.java
+++ b/gms-server/src/main/java/org/gms/net/packet/InPacket.java
@@ -15,4 +15,5 @@ public interface InPacket extends Packet {
     int available();
     void seek(int byteOffset);
     int getPosition();
+    InPacket copy();
 }

--- a/gms-server/src/main/java/org/gms/net/server/Server.java
+++ b/gms-server/src/main/java/org/gms/net/server/Server.java
@@ -1223,9 +1223,9 @@ public class Server {
 
         lgnWLock.lock();
         try {
-            accountCharacterCount.put(accountid, (short) (accountCharacterCount.get(accountid) + 1));
+            accountCharacterCount.merge(accountid, (short) 1, (current, one) -> (short) (current + one));
 
-            Set<Integer> accChars = accountChars.get(accountid);
+            Set<Integer> accChars = accountChars.computeIfAbsent(accountid, ignored -> new HashSet<>());
             accChars.add(chrid);
 
             worldChars.put(chrid, world);

--- a/gms-server/src/main/java/org/gms/net/server/channel/Channel.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/Channel.java
@@ -196,8 +196,10 @@ public final class Channel {
             disconnectAwayPlayers();
             players.disconnectAll();
 
-            eventSM.dispose();
-            eventSM = null;
+            if (eventSM != null) {
+                eventSM.dispose();
+                eventSM = null;
+            }
 
             mapManager.dispose();
             mapManager = null;
@@ -234,7 +236,7 @@ public final class Channel {
         closeChannelServices();
     }
 
-    private void closeAllMerchants() {
+    public void closeAllMerchants() {
         List<HiredMerchant> merchs;
 
         merchWlock.lock();

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractMovementPacketHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/AbstractMovementPacketHandler.java
@@ -259,6 +259,69 @@ public abstract class AbstractMovementPacketHandler extends AbstractPacketHandle
         }
     }
 
+    public static void updatePositionBot(InPacket p, AnimatedMapObject target, int yOffset) throws EmptyMovementException {
+        byte numCommands = p.readByte();
+        if (numCommands < 1) {
+            throw new EmptyMovementException(p);
+        }
+        for (byte i = 0; i < numCommands; i++) {
+            byte command = p.readByte();
+            switch (command) {
+                case 0:
+                case 5:
+                case 17: {
+                    short xpos = p.readShort();
+                    short ypos = p.readShort();
+                    target.setPosition(new Point(xpos, ypos + yOffset));
+                    p.skip(6);
+                    target.setStance(p.readByte());
+                    p.readShort();
+                    break;
+                }
+                case 1:
+                case 2:
+                case 6:
+                case 12:
+                case 13:
+                case 16:
+                case 18:
+                case 19:
+                case 20:
+                case 22:
+                    p.skip(4);
+                    target.setStance(p.readByte());
+                    p.readShort();
+                    break;
+                case 3:
+                case 4:
+                case 7:
+                case 8:
+                case 9:
+                case 11:
+                    p.skip(8);
+                    target.setStance(p.readByte());
+                    break;
+                case 14:
+                    p.skip(9);
+                    break;
+                case 10:
+                    p.readByte();
+                    break;
+                case 15:
+                    p.skip(12);
+                    target.setStance(p.readByte());
+                    p.readShort();
+                    break;
+                case 21:
+                    p.skip(3);
+                    break;
+                default:
+                    log.warn("Unhandled Case: {}", command);
+                    throw new EmptyMovementException(p);
+            }
+        }
+    }
+
     /**
      * 处理瞬移动作（3/4）：同步坐标并在玩家对象上记录传送前后坐标。
      */

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/GeneralChatHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/GeneralChatHandler.java
@@ -31,6 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.gms.server.ChatLogger;
 import org.gms.util.PacketCreator;
+import org.gms.extension.event.CharacterChatEvent;
+import org.gms.extension.runtime.HostHooks;
 
 public final class GeneralChatHandler extends AbstractPacketHandler {
     private static final Logger log = LoggerFactory.getLogger(GeneralChatHandler.class);
@@ -62,6 +64,9 @@ public final class GeneralChatHandler extends AbstractPacketHandler {
             if (!chr.isHidden()) {
                 chr.getMap().broadcastMessage(PacketCreator.getChatText(chr.getId(), s, chr.getWhiteChat(), show));
                 ChatLogger.log(c, "General", s);
+                if (!HostHooks.isArtificial(chr)) {
+                    HostHooks.publish(new CharacterChatEvent(chr, s));
+                }
             } else {
                 chr.getMap().broadcastGMMessage(PacketCreator.getChatText(chr.getId(), s, chr.getWhiteChat(), show));
                 ChatLogger.log(c, "GM General", s);

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/GeneralChatHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/GeneralChatHandler.java
@@ -64,12 +64,12 @@ public final class GeneralChatHandler extends AbstractPacketHandler {
             if (!chr.isHidden()) {
                 chr.getMap().broadcastMessage(PacketCreator.getChatText(chr.getId(), s, chr.getWhiteChat(), show));
                 ChatLogger.log(c, "General", s);
-                if (!HostHooks.isArtificial(chr)) {
-                    HostHooks.publish(new CharacterChatEvent(chr, s));
-                }
             } else {
                 chr.getMap().broadcastGMMessage(PacketCreator.getChatText(chr.getId(), s, chr.getWhiteChat(), show));
                 ChatLogger.log(c, "GM General", s);
+            }
+            if (!HostHooks.isArtificial(chr)) {
+                HostHooks.publish(new CharacterChatEvent(chr, s));
             }
 
             chr.getAutoBanManager().spam(7);

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/MoveLifeHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/MoveLifeHandler.java
@@ -165,7 +165,8 @@ public final class MoveLifeHandler extends AbstractMovementPacketHandler {
                         useSkillLevel, nextMovementCouldBeSkill, mobMp);
             }
 
-            map.broadcastMessage(player, PacketCreator.moveMonster(objectid, nextMovementCouldBeSkill, rawActivity, useSkillId, useSkillLevel, pOption, startPos, p, movementDataLength), serverStartPos);
+            map.broadcastMessage(player, PacketCreator.moveMonster(objectid, nextMovementCouldBeSkill,
+                    rawActivity, useSkillId, useSkillLevel, pOption, startPos, p, movementDataLength), serverStartPos);
             //updatePosition(res, monster, -2); //does this need to be done after the packet is broadcast?
             map.moveMonster(monster, monster.getPosition());
         } catch (EmptyMovementException e) {

--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/PartyOperationHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/PartyOperationHandler.java
@@ -24,6 +24,9 @@ package org.gms.net.server.channel.handlers;
 import org.gms.client.Character;
 import org.gms.client.Client;
 import org.gms.config.GameConfig;
+import org.gms.extension.api.HostRuntime;
+import org.gms.extension.event.PartyInviteEvent;
+import org.gms.extension.runtime.ExtensionLoader;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
 import org.gms.net.server.coordinator.world.InviteCoordinator;
@@ -97,6 +100,7 @@ public final class PartyOperationHandler extends AbstractPacketHandler {
                         if (party.getMembers().size() < 6) {
                             if (InviteCoordinator.createInvite(InviteType.PARTY, player, party.getId(), invited.getId())) {
                                 invited.sendPacket(PacketCreator.partyInvite(player));
+                                publishInvite(invited, player, party.getId());
                             } else {
                                 c.sendPacket(PacketCreator.partyStatusMessage(22, invited.getName()));
                             }
@@ -123,5 +127,15 @@ public final class PartyOperationHandler extends AbstractPacketHandler {
                 break;
             }
         }
+    }
+
+    // The invite packet only reaches a real client. Extensions that own a character without one
+    // (SoloMapling bots) answer through this event instead.
+    private static void publishInvite(Character invited, Character inviter, int partyId) {
+        HostRuntime runtime = ExtensionLoader.getInstance().getRuntime();
+        if (runtime == null) {
+            return;
+        }
+        runtime.events().publish(new PartyInviteEvent(invited, inviter, partyId));
     }
 }

--- a/gms-server/src/main/java/org/gms/net/server/task/TimeoutTask.java
+++ b/gms-server/src/main/java/org/gms/net/server/task/TimeoutTask.java
@@ -5,6 +5,7 @@ import org.gms.config.GameConfig;
 import org.gms.net.server.world.World;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.gms.extension.runtime.HostHooks;
 
 import java.util.Collection;
 
@@ -19,7 +20,7 @@ public class TimeoutTask extends BaseTask implements Runnable {
         long time = System.currentTimeMillis();
         Collection<Character> chars = wserv.getPlayerStorage().getAllCharacters();
         for (Character chr : chars) {
-            if (time - chr.getClient().getLastPacket() > GameConfig.getServerLong("timeout_duration")) {
+            if (!HostHooks.isArtificial(chr) && time - chr.getClient().getLastPacket() > GameConfig.getServerLong("timeout_duration")) {
                 log.info("Chr {} auto-disconnected due to inactivity", chr.getName());
                 // 默认1h还没有发过任何包，那就是异常连接，直接断开
                 chr.getClient().timeoutDisconnect();

--- a/gms-server/src/main/java/org/gms/net/server/world/World.java
+++ b/gms-server/src/main/java/org/gms/net/server/world/World.java
@@ -452,7 +452,8 @@ public class World {
     public void registerAccountCharacterView(Integer accountId, Character chr) {
         accountCharsLock.lock();
         try {
-            accountChars.get(accountId).put(chr.getId(), chr);
+            accountChars.computeIfAbsent(accountId, ignored -> new TreeMap<>())
+                    .put(chr.getId(), chr);
         } finally {
             accountCharsLock.unlock();
         }
@@ -461,7 +462,10 @@ public class World {
     public void unregisterAccountCharacterView(Integer accountId, Integer chrId) {
         accountCharsLock.lock();
         try {
-            accountChars.get(accountId).remove(chrId);
+            SortedMap<Integer, Character> chars = accountChars.get(accountId);
+            if (chars != null) {
+                chars.remove(chrId);
+            }
         } finally {
             accountCharsLock.unlock();
         }

--- a/gms-server/src/main/java/org/gms/server/Shop.java
+++ b/gms-server/src/main/java/org/gms/server/Shop.java
@@ -106,12 +106,20 @@ public class Shop {
                 if (c.getPlayer().getMeso() >= amount) {
                     if (InventoryManipulator.checkSpace(c, itemId, quantity, "")) {
                         if (!ItemConstants.isRechargeable(itemId)) { //Pets can't be bought from shops
-                            InventoryManipulator.addById(c, itemId, quantity, "", -1);
-                            c.getPlayer().gainMeso(-amount, false);
+                            if (InventoryManipulator.addById(c, itemId, quantity, "", -1)) {
+                                c.getPlayer().gainMeso(-amount, false);
+                            } else {
+                                c.sendPacket(PacketCreator.shopTransaction((byte) 3));
+                                return;
+                            }
                         } else {
                             quantity = ii.getSlotMax(c, item.getItemId());
-                            InventoryManipulator.addById(c, itemId, quantity, "", -1);
-                            c.getPlayer().gainMeso(-item.getPrice(), false);
+                            if (InventoryManipulator.addById(c, itemId, quantity, "", -1)) {
+                                c.getPlayer().gainMeso(-item.getPrice(), false);
+                            } else {
+                                c.sendPacket(PacketCreator.shopTransaction((byte) 3));
+                                return;
+                            }
                         }
                         c.sendPacket(PacketCreator.shopTransaction((byte) 0));
                     } else {
@@ -262,6 +270,17 @@ public class Shop {
 
     private ShopItem findBySlot(short slot) {
         return items.get(slot);
+    }
+
+    /**
+     * Immutable catalog view for trusted server-side automation.
+     *
+     * <p>Slots in the returned list are the same zero-based slots accepted by
+     * {@link #buy(Client, short, int, short)}. Returning a copy prevents an
+     * extension from mutating the live shop catalog.</p>
+     */
+    public List<ShopItem> getItems() {
+        return List.copyOf(items);
     }
 
     public static Shop createFromDB(int id, boolean isShopId) {

--- a/gms-server/src/main/java/org/gms/server/StatEffect.java
+++ b/gms-server/src/main/java/org/gms/server/StatEffect.java
@@ -922,6 +922,14 @@ public class StatEffect {
         return applyTo(chr, chr, true, pos, false, 1);
     }
 
+    /**
+     * Applies this effect to a target as if it were cast by {@code caster}.
+     * The target receives the effect without paying the caster's primary cost.
+     */
+    public boolean applyToTarget(Character caster, Character target) {
+        return applyTo(caster, target, false, null, false, 1);
+    }
+
     // primary: the player caster of the buff
     private boolean applyTo(Character applyfrom, Character applyto, boolean primary, Point pos, boolean useMaxRange, int affectedPlayers) {
         if (skill && (sourceid == GM.HIDE || sourceid == SuperGM.HIDE)) {
@@ -1213,6 +1221,13 @@ public class StatEffect {
      */
     public boolean hasBoundingBox() {
         return lt != null && rb != null;
+    }
+
+    public Rectangle getAttackBox(Point from, boolean facingLeft) {
+        if (!hasBoundingBox()) {
+            return null;
+        }
+        return calculateBoundingBox(from, facingLeft);
     }
 
     /**
@@ -1560,7 +1575,7 @@ public class StatEffect {
         return false;
     }
 
-    private boolean isPartyBuff() {
+    public boolean isPartyBuff() {
         if (lt == null || rb == null) {
             return false;
         }

--- a/gms-server/src/main/java/org/gms/server/Trade.java
+++ b/gms-server/src/main/java/org/gms/server/Trade.java
@@ -38,6 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.gms.util.PacketCreator;
 import org.gms.util.Pair;
+import org.gms.extension.event.TradeInviteEvent;
+import org.gms.extension.runtime.HostHooks;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -126,7 +128,9 @@ public class Trade {
 
         for (Item item : exchangeItems) {
             KarmaManipulator.toggleKarmaFlagToUntradeable(item);
-            InventoryManipulator.addFromDrop(chr.getClient(), item, show);
+            if (!HostHooks.tradeRelaxInventoryChecks(chr.getId())) {
+                InventoryManipulator.addFromDrop(chr.getClient(), item, show);
+            }
         }
 
         if (exchangeMeso > 0) {//此处对金币交易进行扣税处理
@@ -186,11 +190,11 @@ public class Trade {
         chr.sendPacket(PacketCreator.getTradeResult(number, result));
     }
 
-    private boolean isLocked() {
+    public boolean isLocked() {
         return locked.get();
     }
 
-    private int getMeso() {
+    public int getMeso() {
         return meso;
     }
 
@@ -214,6 +218,14 @@ public class Trade {
         }
     }
 
+    public void setMesoBot(int meso) {
+        this.meso = meso;
+        chr.sendPacket(PacketCreator.getTradeMesoSet((byte) 0, this.meso));
+        if (partner != null) {
+            partner.getChr().sendPacket(PacketCreator.getTradeMesoSet((byte) 1, this.meso));
+        }
+    }
+
     public boolean addItem(Item item) {
         synchronized (items) {
             if (items.size() > 9) {
@@ -228,6 +240,17 @@ public class Trade {
             items.add(item);
         }
 
+        return true;
+    }
+
+    public boolean swapItem(Item item) {
+        synchronized (items) {
+            if (items.size() > 9) {
+                return false;
+            }
+            items.removeIf(existingItem -> existingItem.getPosition() == item.getPosition());
+            items.add(item);
+        }
         return true;
     }
 
@@ -271,7 +294,8 @@ public class Trade {
             tradeItems.add(new Pair<>(item, item.getInventoryType()));
         }
 
-        return Inventory.checkSpotsAndOwnership(chr, tradeItems);
+        return HostHooks.tradeRelaxInventoryChecks(chr.getId())
+                || Inventory.checkSpotsAndOwnership(chr, tradeItems);
     }
 
     private boolean fitsUniquesInInventory() {
@@ -394,8 +418,8 @@ public class Trade {
             }
 
             logTrade(local, partner);
-            local.completeTrade();
-            partner.completeTrade();
+            completeExchangeFor(local);
+            completeExchangeFor(partner);
 
             partner.getChr().setTrade(null);
             chr.setTrade(null);
@@ -526,6 +550,7 @@ public class Trade {
 
                 c1.sendPacket(PacketCreator.getTradeStart(c1.getClient(), c1.getTrade(), (byte) 0));
                 c2.sendPacket(PacketCreator.tradeInvite(c1));
+                HostHooks.publish(new TradeInviteEvent(c2, c1));
             } else {
                 c1.message(I18nUtil.getMessage("Trade.inviteTrade.createInvite.msg1"));
                 cancelTrade(c1, TradeResult.NO_RESPONSE);
@@ -541,10 +566,13 @@ public class Trade {
         InviteResult inviteRes = InviteCoordinator.answerInvite(InviteType.TRADE, c1.getId(), c2.getId(), true);
 
         InviteResultType res = inviteRes.result;
-        if (res == InviteResultType.ACCEPTED) {
+        if (res == InviteResultType.ACCEPTED
+                || HostHooks.tradeAutoAcceptVisit(c1.getId(), c2.getId())) {
             if (c1.getTrade() != null && c1.getTrade().getPartner() == c2.getTrade() && c2.getTrade() != null && c2.getTrade().getPartner() == c1.getTrade()) {
                 c2.sendPacket(PacketCreator.getTradePartnerAdd(c1));
-                c1.sendPacket(PacketCreator.getTradeStart(c1.getClient(), c1.getTrade(), (byte) 1));
+                if (!HostHooks.tradeSuppressPackets(c1.getId())) {
+                    c1.sendPacket(PacketCreator.getTradeStart(c1.getClient(), c1.getTrade(), (byte) 1));
+                }
                 c1.getTrade().setFullTrade(true);
                 c2.getTrade().setFullTrade(true);
             } else {
@@ -615,5 +643,30 @@ public class Trade {
             sj.add(I18nUtil.getLogMessage("Trade.info.inviteTrade.logTrade.msg3" , item.getQuantity(), itemName, item.getItemId()) + "\n");
         }
         return sj.toString();
+    }
+
+    public interface TradeResultCallback {
+        void onTradeResult(TradeResult result);
+    }
+
+    private TradeResultCallback callback;
+
+    public void setTradeResultCallback(TradeResultCallback callback) {
+        this.callback = callback;
+    }
+
+    private void setCallbackSuccessfulTrade() {
+        if (callback != null) {
+            callback.onTradeResult(TradeResult.SUCCESSFUL);
+        }
+    }
+
+    private static void completeExchangeFor(Trade side) {
+        Character participant = side.getChr();
+        if (HostHooks.tradeOnExchangeSuccess(participant.getId())) {
+            side.setCallbackSuccessfulTrade();
+            return;
+        }
+        side.completeTrade();
     }
 }

--- a/gms-server/src/main/java/org/gms/server/life/Monster.java
+++ b/gms-server/src/main/java/org/gms/server/life/Monster.java
@@ -42,6 +42,7 @@ import org.gms.constants.skills.NightWalker;
 import org.gms.constants.skills.Priest;
 import org.gms.constants.skills.Shadower;
 import org.gms.constants.skills.WhiteKnight;
+import org.gms.extension.runtime.HostHooks;
 import org.gms.net.packet.Packet;
 import org.gms.net.server.channel.Channel;
 import org.gms.net.server.coordinator.world.MonsterAggroCoordinator;
@@ -592,6 +593,15 @@ public class Monster extends AbstractLoadedLife {
 
         int membersSize = expMembers.size();
         float participationExp = partyDamage * expPerDmg;
+        Party participantParty = partyParticipation.keySet().iterator().next().getParty();
+        if (hasArtificialMember(participantParty)) {
+            log.info("Artificial-party EXP diagnostic map={} mobId={} mobLevel={} mobExp={} partyDamage={} participationExp={} "
+                            + "participants={} partyMembers={} eligible={} totalPartyLevel={}",
+                    getMap().getId(), getId(), getLevel(), getExp(), partyDamage, participationExp,
+                    describeCharacters(partyParticipation.keySet()),
+                    describePartyMembers(participantParty),
+                    describeCharacters(expMembers), totalPartyLevel);
+        }
 
         // thanks Crypter for reporting an insufficiency on party exp bonuses
         boolean hasPartySharers = membersSize > 1;
@@ -601,6 +611,41 @@ public class Monster extends AbstractLoadedLife {
             distributePlayerExperience(mc, participationExp, partyBonusMod, totalPartyLevel, mc == participationMvp, isWhiteExpGain(mc, personalRatio, sdevRatio), hasPartySharers);
             giveFamilyRep(mc.getFamilyEntry());
         }
+    }
+
+    private static boolean hasArtificialMember(Party party) {
+        if (party == null) {
+            return false;
+        }
+        for (PartyCharacter member : party.getMembers()) {
+            if (member.getPlayer() != null && HostHooks.isArtificial(member.getPlayer())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String describePartyMembers(Party party) {
+        List<String> members = new ArrayList<>();
+        if (party != null) {
+            for (PartyCharacter member : party.getMembers()) {
+                Character player = member.getPlayer();
+                members.add(member.getId() + ":player=" + (player != null)
+                        + ":map=" + (player == null || player.getMap() == null ? -1 : player.getMapId())
+                        + ":logged=" + (player != null && player.isLoggedInWorld())
+                        + ":artificial=" + (player != null && HostHooks.isArtificial(player)));
+            }
+        }
+        return members.toString();
+    }
+
+    private static String describeCharacters(Collection<Character> characters) {
+        List<String> members = new ArrayList<>();
+        for (Character character : characters) {
+            members.add(character.getId() + ":level=" + character.getLevel()
+                    + ":exp=" + character.getExp());
+        }
+        return members.toString();
     }
 
     private void distributeExperience(int killerId) {
@@ -1855,10 +1900,30 @@ public class Monster extends AbstractLoadedLife {
         Character newControllerDead = null;
 
         Character newControllerWithPuppet = null;
+        int minHiddenControlled = Integer.MAX_VALUE;
+        Character hiddenController = null;
+        int minHiddenControlledDead = Integer.MAX_VALUE;
+        Character hiddenControllerDead = null;
 
         for (Character chr : getMap().getAllPlayers()) {
-            if (!chr.isHidden() && chr.isLoggedInWorld()) {   // 过滤已断线/awayFromWorld 的幽灵玩家，避免被选为 controller 候选
+            if (!HostHooks.isArtificial(chr) && chr.isLoggedInWorld()) {
                 int ctrlMonsSize = chr.getNumControlledMonsters();
+
+                // Prefer visible players, preserving normal controller distribution. A hidden GM
+                // remains a valid fallback: its real client can drive mob movement without revealing
+                // the GM. Headless bots must never be selected because they cannot emit MOVE_LIFE.
+                if (chr.isHidden()) {
+                    if (chr.isAlive()) {
+                        if (ctrlMonsSize < minHiddenControlled) {
+                            minHiddenControlled = ctrlMonsSize;
+                            hiddenController = chr;
+                        }
+                    } else if (ctrlMonsSize < minHiddenControlledDead) {
+                        minHiddenControlledDead = ctrlMonsSize;
+                        hiddenControllerDead = chr;
+                    }
+                    continue;
+                }
 
                 if (isCharacterPuppetInVicinity(chr)) {
                     newControllerWithPuppet = chr;
@@ -1881,8 +1946,12 @@ public class Monster extends AbstractLoadedLife {
             return newControllerWithPuppet;
         } else if (newController != null) {
             return newController;
-        } else {
+        } else if (newControllerDead != null) {
             return newControllerDead;
+        } else if (hiddenController != null) {
+            return hiddenController;
+        } else {
+            return hiddenControllerDead;
         }
     }
 
@@ -1920,6 +1989,9 @@ public class Monster extends AbstractLoadedLife {
      * player controller.
      */
     public void aggroSwitchController(Character newController, boolean immediateAggro) {
+        if (newController != null && HostHooks.isArtificial(newController)) {
+            newController = getNextControllerCandidate();
+        }
         if (aggroUpdateLock.tryLock()) {
             try {
                 Character prevController = getController();

--- a/gms-server/src/main/java/org/gms/server/life/MonsterInformationProvider.java
+++ b/gms-server/src/main/java/org/gms/server/life/MonsterInformationProvider.java
@@ -39,21 +39,26 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MonsterInformationProvider {
     private static final Logger log = LoggerFactory.getLogger(MonsterInformationProvider.class);
+    public static final int MAX_DROP_SOURCE_RESULTS = 100;
     // Author : LightPepsi
 
-    private static final MonsterInformationProvider instance = new MonsterInformationProvider();
-
     public static MonsterInformationProvider getInstance() {
-        return instance;
+        return InstanceHolder.INSTANCE;
+    }
+
+    private static class InstanceHolder {
+        private static final MonsterInformationProvider INSTANCE = new MonsterInformationProvider();
     }
 
     private final Map<Integer, List<MonsterDropEntry>> drops = new HashMap<>();
@@ -71,9 +76,16 @@ public class MonsterInformationProvider {
 
     private final Map<Integer, Boolean> mobBossCache = new HashMap<>();
     private final Map<Integer, String> mobNameCache = new HashMap<>();
+    private final Map<Integer, List<DropSource>> dropSourcesByItem = new ConcurrentHashMap<>();
 
     protected MonsterInformationProvider() {
-        retrieveGlobal();
+        this(true);
+    }
+
+    protected MonsterInformationProvider(boolean loadGlobalDrops) {
+        if (loadGlobalDrops) {
+            retrieveGlobal();
+        }
     }
 
     public final List<MonsterGlobalDropEntry> getRelevantGlobalDrops(int mapid) {
@@ -178,6 +190,43 @@ public class MonsterInformationProvider {
 
         drops.put(monsterId, ret);
         return ret;
+    }
+
+    /**
+     * Returns monsters backed by real {@code drop_data} rows for {@code itemId}.
+     * Results are cached per item and every request is capped to prevent unbounded
+     * plugin queries or SQL work in a bot tick loop.
+     */
+    public final List<DropSource> retrieveDropSources(final int itemId, final int limit) {
+        if (itemId <= 0 || limit <= 0) {
+            return List.of();
+        }
+
+        List<DropSource> sources = dropSourcesByItem.computeIfAbsent(itemId, this::loadDropSources);
+        return sources.subList(0, Math.min(sources.size(), Math.min(limit, MAX_DROP_SOURCE_RESULTS)));
+    }
+
+    protected List<DropSource> loadDropSources(final int itemId) {
+        List<DropSource> result = new ArrayList<>();
+        try (Connection con = DatabaseConnection.getConnection();
+             PreparedStatement ps = con.prepareStatement(
+                     "SELECT dropperid, chance FROM drop_data "
+                             + "WHERE itemid = ? AND chance > 0 "
+                             + "ORDER BY chance DESC, dropperid ASC LIMIT ?")) {
+            ps.setInt(1, itemId);
+            ps.setInt(2, MAX_DROP_SOURCE_RESULTS);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    result.add(new DropSource(rs.getInt("dropperid"), rs.getInt("chance")));
+                }
+            }
+        } catch (SQLException e) {
+            log.error("Error retrieving drop sources for item {}", itemId, e);
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    public record DropSource(int dropperId, int chance) {
     }
 
     public final List<Integer> retrieveDropPool(final int monsterId) {  // ignores Quest and Party Quest items
@@ -294,6 +343,7 @@ public class MonsterInformationProvider {
         dropsChancePool.clear();
         globaldrops.clear();
         continentdrops.clear();
+        dropSourcesByItem.clear();
         retrieveGlobal();
     }
 }

--- a/gms-server/src/main/java/org/gms/server/maps/Foothold.java
+++ b/gms-server/src/main/java/org/gms/server/maps/Foothold.java
@@ -22,6 +22,7 @@
 package org.gms.server.maps;
 
 import java.awt.*;
+import java.util.Map;
 
 /**
  * @author Matze
@@ -31,6 +32,7 @@ public class Foothold implements Comparable<Foothold> {
     private final Point p2;
     private final int id;
     private int next, prev;
+    private boolean forbidFallDown;
 
     public Foothold(Point p1, Point p2, int id) {
         this.p1 = p1;
@@ -98,5 +100,62 @@ public class Foothold implements Comparable<Foothold> {
 
     public void setPrev(int prev) {
         this.prev = prev;
+    }
+
+    public double slope() {
+        if (isWall()) {
+            return 0.0;
+        }
+        return (double) (p2.y - p1.y) / (p2.x - p1.x);
+    }
+
+    public boolean isForbidFallDown() {
+        return forbidFallDown;
+    }
+
+    public void setForbidFallDown(boolean forbidFallDown) {
+        this.forbidFallDown = forbidFallDown;
+    }
+
+    public static boolean isCollidableWall(Foothold wall, Map<Integer, Foothold> footholdsById) {
+        if (wall == null || !wall.isWall()) {
+            return false;
+        }
+        Point lowerEndpoint = wall.getY1() >= wall.getY2() ? wall.p1 : wall.p2;
+        return linkedChainReachesGroundAtEndpoint(wall, wall.prev, false, lowerEndpoint, footholdsById)
+                || linkedChainReachesGroundAtEndpoint(wall, wall.next, true, lowerEndpoint, footholdsById);
+    }
+
+    private static boolean linkedChainReachesGroundAtEndpoint(Foothold wall, int linkedId, boolean followNext, Point endpoint, Map<Integer, Foothold> footholdsById) {
+        if (linkedId == 0) {
+            return false;
+        }
+        Foothold linked = footholdsById.get(linkedId);
+        if (linked == null || !touchesPoint(linked, endpoint)) {
+            return false;
+        }
+        return chainReachesGround(wall, followNext, footholdsById);
+    }
+
+    private static boolean chainReachesGround(Foothold start, boolean followNext, Map<Integer, Foothold> footholdsById) {
+        int id = followNext ? start.next : start.prev;
+        int depth = 0;
+        while (id != 0 && depth < 10) {
+            Foothold foothold = footholdsById.get(id);
+            if (foothold == null) {
+                return false;
+            }
+            if (!foothold.isWall()) {
+                return true;
+            }
+            id = followNext ? foothold.next : foothold.prev;
+            depth++;
+        }
+        return false;
+    }
+
+    private static boolean touchesPoint(Foothold foothold, Point point) {
+        return (foothold.getX1() == point.x && foothold.getY1() == point.y)
+                || (foothold.getX2() == point.x && foothold.getY2() == point.y);
     }
 }

--- a/gms-server/src/main/java/org/gms/server/maps/FootholdTree.java
+++ b/gms-server/src/main/java/org/gms/server/maps/FootholdTree.java
@@ -216,4 +216,20 @@ public class FootholdTree {
     public int getMinDropX() {
         return minDropX;
     }
+
+    public List<Foothold> getAllFootholds() {
+        List<Foothold> all = new LinkedList<>();
+        collectAll(all);
+        return all;
+    }
+
+    private void collectAll(List<Foothold> out) {
+        out.addAll(footholds);
+        if (nw != null) {
+            nw.collectAll(out);
+            ne.collectAll(out);
+            sw.collectAll(out);
+            se.collectAll(out);
+        }
+    }
 }

--- a/gms-server/src/main/java/org/gms/server/maps/HiredMerchant.java
+++ b/gms-server/src/main/java/org/gms/server/maps/HiredMerchant.java
@@ -38,10 +38,12 @@ import org.gms.net.server.world.World;
 import org.gms.server.ItemInformationProvider;
 import org.gms.server.Trade;
 import org.gms.util.DatabaseConnection;
+import org.gms.util.I18nUtil;
 import org.gms.util.PacketCreator;
 import org.gms.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.gms.extension.runtime.HostHooks;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -68,7 +70,7 @@ public class HiredMerchant extends AbstractMapObject {
     private static final int VISITOR_HISTORY_LIMIT = 10;
     private static final int BLACKLIST_LIMIT = 20;
 
-    private final int ownerId;
+    private int ownerId;
     private final int itemId;
     private final int mesos = 0;
     private final int channel;
@@ -102,6 +104,14 @@ public class HiredMerchant extends AbstractMapObject {
         this.ownerName = owner.getName();
         this.description = desc;
         this.map = owner.getMap();
+    }
+
+    public void setOwnerId(int ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    public void setOwnerName(String ownerName) {
+        this.ownerName = ownerName;
     }
 
     public void broadcastToVisitorsThreadsafe(Packet packet) {
@@ -797,6 +807,59 @@ public class HiredMerchant extends AbstractMapObject {
 
     public Set<String> getBlacklist() {
         return Collections.unmodifiableSet(blacklist);
+    }
+
+    public void botBuy(Character bot, PlayerShopItem shopItem, short quantity) {
+        synchronized (items) {
+            Item item = shopItem.getItem().copy();
+            int price = (int) Math.min((float) shopItem.getPrice() * quantity, Integer.MAX_VALUE);
+            price -= Trade.getFee(price);
+
+            synchronized (sold) {
+                sold.add(new SoldItem(bot.getName(), shopItem.getItem().getItemId(), quantity, price));
+            }
+
+            shopItem.setBundles((short) (shopItem.getBundles() - quantity));
+            if (shopItem.getBundles() < 1) {
+                shopItem.setDoesExist(false);
+            }
+
+            if (GameConfig.getServerBoolean("use_announce_shopitemsold")) {
+                announceItemSold(item, price, getQuantityLeft(shopItem.getItem().getItemId()));
+            }
+
+            Character owner = Server.getInstance().getWorld(world).getPlayerStorage().getCharacterByName(ownerName);
+            if (owner != null && !HostHooks.isArtificial(owner)) {
+                owner.addMerchantMesos(price);
+            } else {
+                try (Connection con = DatabaseConnection.getConnection()) {
+                    long merchantMesos = 0;
+                    try (PreparedStatement ps = con.prepareStatement("SELECT MerchantMesos FROM characters WHERE id = ?")) {
+                        ps.setInt(1, ownerId);
+                        try (ResultSet rs = ps.executeQuery()) {
+                            if (rs.next()) {
+                                merchantMesos = rs.getInt(1);
+                            }
+                        }
+                    }
+                    merchantMesos += price;
+                    try (PreparedStatement ps = con.prepareStatement(
+                            "UPDATE characters SET MerchantMesos = ? WHERE id = ?")) {
+                        ps.setInt(1, (int) Math.min(merchantMesos, Integer.MAX_VALUE));
+                        ps.setInt(2, ownerId);
+                        ps.executeUpdate();
+                    }
+                } catch (SQLException e) {
+                    log.error(I18nUtil.getLogMessage("HiredMerchant.botBuy.error1", ownerName), e);
+                }
+            }
+
+            try {
+                saveItems(false);
+            } catch (SQLException e) {
+                log.error(I18nUtil.getLogMessage("HiredMerchant.botBuy.error1", ownerName), e);
+            }
+        }
     }
 
     private boolean isBlacklisted(String chrName) {

--- a/gms-server/src/main/java/org/gms/server/maps/MapFactory.java
+++ b/gms-server/src/main/java/org/gms/server/maps/MapFactory.java
@@ -168,6 +168,11 @@ public class MapFactory {
 
         map.setFieldLimit(DataTool.getInt(infoData.getChildByPath("fieldLimit"), 0));
         map.setMobInterval((short) DataTool.getInt(infoData.getChildByPath("createMobInterval"), 5000));
+        map.setSwim(DataTool.getInt(infoData.getChildByPath("swim"), 0) != 0);
+        Data footholdSpeedData = infoData.getChildByPath("fs");
+        if (footholdSpeedData != null) {
+            map.setFootholdSpeed(DataTool.getFloat(footholdSpeedData));
+        }
         PortalFactory portalFactory = new PortalFactory();
         for (Data portal : mapData.getChildByPath("portal")) {
             map.addPortal(portalFactory.makePortal(DataTool.getInt(portal.getChildByPath("pt")), portal));
@@ -214,6 +219,7 @@ public class MapFactory {
                     Foothold fh = new Foothold(new Point(x1, y1), new Point(x2, y2), Integer.parseInt(footHold.getName()));
                     fh.setPrev(DataTool.getInt(footHold.getChildByPath("prev")));
                     fh.setNext(DataTool.getInt(footHold.getChildByPath("next")));
+                    fh.setForbidFallDown(DataTool.getInt(footHold.getChildByPath("forbidFallDown"), 0) != 0);
                     if (fh.getX1() < lBound.x) {
                         lBound.x = fh.getX1();
                     }
@@ -235,6 +241,16 @@ public class MapFactory {
             fTree.insert(fh);
         }
         map.setFootholds(fTree);
+        Data ropeData = mapData.getChildByPath("ladderRope");
+        if (ropeData != null) {
+            for (Data rope : ropeData) {
+                int x = DataTool.getInt(rope.getChildByPath("x"));
+                int y1 = DataTool.getInt(rope.getChildByPath("y1"));
+                int y2 = DataTool.getInt(rope.getChildByPath("y2"));
+                boolean ladder = DataTool.getInt(rope.getChildByPath("l"), 0) == 1;
+                map.addRope(new Rope(x, y1, y2, ladder));
+            }
+        }
         if (mapData.getChildByPath("area") != null) {
             for (Data area : mapData.getChildByPath("area")) {
                 int x1 = DataTool.getInt(area.getChildByPath("x1"));

--- a/gms-server/src/main/java/org/gms/server/maps/MapItem.java
+++ b/gms-server/src/main/java/org/gms/server/maps/MapItem.java
@@ -37,7 +37,7 @@ public class MapItem extends AbstractMapObject {
     protected MapObject dropper;
     protected int character_ownerid, party_ownerid, meso, questid = -1;
     protected byte type;
-    protected boolean pickedUp = false, playerDrop, partyDrop;
+    protected boolean pickedUp = false, playerDrop, partyDrop, permanentOwner;
     protected long dropTime;
     private final Lock itemLock = new ReentrantLock();
 
@@ -154,11 +154,12 @@ public class MapItem extends AbstractMapObject {
     }
 
     public final boolean hasClientsideOwnership(Character player) {
-        return this.character_ownerid == player.getId() || this.party_ownerid == player.getPartyId() || hasExpiredOwnershipTime();
+        return this.character_ownerid == player.getId() || this.party_ownerid == player.getPartyId()
+                || (!permanentOwner && hasExpiredOwnershipTime());
     }
 
     public final boolean isFFADrop() {
-        return type == 2 || type == 3 || hasExpiredOwnershipTime();
+        return !permanentOwner && (type == 2 || type == 3 || hasExpiredOwnershipTime());
     }
 
     public final boolean hasExpiredOwnershipTime() {
@@ -195,7 +196,11 @@ public class MapItem extends AbstractMapObject {
             }
         }
 
-        return hasExpiredOwnershipTime();
+        return !permanentOwner && hasExpiredOwnershipTime();
+    }
+
+    public void setPermanentOwner(boolean permanentOwner) {
+        this.permanentOwner = permanentOwner;
     }
 
     public final Client getOwnerClient() {

--- a/gms-server/src/main/java/org/gms/server/maps/MapleMap.java
+++ b/gms-server/src/main/java/org/gms/server/maps/MapleMap.java
@@ -74,6 +74,8 @@ import org.gms.server.partyquest.GuardianSpawnPoint;
 import org.gms.util.PacketCreator;
 import org.gms.util.Pair;
 import org.gms.util.Randomizer;
+import org.gms.extension.event.CharacterMapEnteredEvent;
+import org.gms.extension.runtime.HostHooks;
 
 import java.awt.*;
 import java.lang.ref.WeakReference;
@@ -125,7 +127,10 @@ public class MapleMap {
     private final Map<MobLootEntry, Long> mobLootEntries = new HashMap(20);
     private final List<Runnable> statUpdateRunnables = new ArrayList(50);
     private final List<Rectangle> areas = new ArrayList<>();
+    private final List<Rope> ropes = new ArrayList<>();
     private FootholdTree footholds = null;
+    private float footholdSpeed = 1.0f;
+    private boolean swim;
     private Pair<Integer, Integer> xLimits;  // caches the min and max x's with available footholds
     private final Rectangle mapArea = new Rectangle();
     private final int mapid;
@@ -428,8 +433,10 @@ public class MapleMap {
             for (Character chr : characters) {
                 if (condition == null || condition.canSpawn(chr)) {
                     if (chr.getPosition().distanceSq(mapobject.getPosition()) <= getRangedDistance()) {
-                        inRangeCharacters.add(chr);
-                        chr.addVisibleMapObject(mapobject);
+                        if (!HostHooks.isArtificial(chr)) {
+                            inRangeCharacters.add(chr);
+                            chr.addVisibleMapObject(mapobject);
+                        }
                     }
                 }
             }
@@ -794,6 +801,11 @@ public class MapleMap {
         spawnDrop(drop, this.calcDropPos(dropPos, reactor.getPosition()), reactor, chr, (byte) (chr.getParty() != null ? 1 : 0), questid);
     }
 
+    public void dropFromReactor(final Character chr, final Reactor reactor, Item drop, Point dropPos, short questid,
+                                short delay) {
+        dropFromReactor(chr, reactor, drop, dropPos, questid);
+    }
+
     private void stopItemMonitor() {
         itemMonitor.cancel(false);
         itemMonitor = null;
@@ -926,8 +938,38 @@ public class MapleMap {
         droppedItemCount.incrementAndGet();
     }
 
+    private void instantiateItemDropNoExpire(MapItem mdrop) {
+        if (droppedItemCount.get() >= GameConfig.getServerInt("item_limit_on_map")) {
+            MapObject mapobj;
+            do {
+                mapobj = null;
+                objectWLock.lock();
+                try {
+                    while (mapobj == null && !registeredDrops.isEmpty()) {
+                        mapobj = registeredDrops.remove(0).get();
+                    }
+                } finally {
+                    objectWLock.unlock();
+                }
+            } while (!makeDisappearItemFromMap(mapobj));
+        }
+
+        objectWLock.lock();
+        try {
+            registerItemDropNoExpire(mdrop);
+            registeredDrops.add(new WeakReference<>(mdrop));
+        } finally {
+            objectWLock.unlock();
+        }
+        droppedItemCount.incrementAndGet();
+    }
+
     private void registerItemDrop(MapItem mdrop) {
         droppedItems.put(mdrop, !everlast ? Server.getInstance().getCurrentTime() + GameConfig.getServerLong("item_expire_time") : Long.MAX_VALUE);
+    }
+
+    private void registerItemDropNoExpire(MapItem mdrop) {
+        droppedItems.put(mdrop, Long.MAX_VALUE);
     }
 
     private void unregisterItemDrop(MapItem mdrop) {
@@ -1177,6 +1219,14 @@ public class MapleMap {
         instantiateItemDrop(mdrop);
     }
 
+    /**
+     * Compatibility overload for delayed drop sources. Meso drops are instantiated
+     * immediately by the map's existing drop lifecycle, so the delay is packet-only.
+     */
+    public final void spawnMesoDrop(final int meso, final Point position, final MapObject dropper, final Character owner, final boolean playerDrop, final byte droptype, short delay) {
+        spawnMesoDrop(meso, position, dropper, owner, playerDrop, droptype);
+    }
+
     public final void disappearingItemDrop(final MapObject dropper, final Character owner, final Item item, final Point pos) {
         final Point droppos = calcDropPos(pos, pos);
         final MapItem mdrop = new MapItem(item, droppos, dropper, owner, owner.getClient(), (byte) 1, false);
@@ -1246,6 +1296,30 @@ public class MapleMap {
 
     public final List<MapObject> getMonsters() {
         return getMapObjectsInRange(new Point(0, 0), Double.POSITIVE_INFINITY, Arrays.asList(MapObjectType.MONSTER));
+    }
+
+    public final List<MapObject> getHiredMerchants() {
+        return getMapObjectsInRange(new Point(0, 0), Double.POSITIVE_INFINITY, Arrays.asList(MapObjectType.HIRED_MERCHANT));
+    }
+
+    public final List<MapObject> getPlayerStores() {
+        return getMapObjectsInRange(new Point(0, 0), Double.POSITIVE_INFINITY, Arrays.asList(MapObjectType.SHOP));
+    }
+
+    public final List<PlayerShop> getAllPlayerShops() {
+        List<PlayerShop> list = new LinkedList<>();
+        for (MapObject mmo : getPlayerStores()) {
+            list.add((PlayerShop) mmo);
+        }
+        return list;
+    }
+
+    public final List<HiredMerchant> getAllHiredMerchants() {
+        List<HiredMerchant> list = new LinkedList<>();
+        for (MapObject mmo : getHiredMerchants()) {
+            list.add((HiredMerchant) mmo);
+        }
+        return list;
     }
 
     public final List<Reactor> getAllReactors() {
@@ -1965,6 +2039,17 @@ public class MapleMap {
         }
     }
 
+    public List<Point> getMonsterSpawnPositions() {
+        List<Point> positions = new ArrayList<>();
+        for (SpawnPoint spawnPoint : getAllMonsterSpawn()) {
+            Point position = spawnPoint.getPosition();
+            if (position != null) {
+                positions.add(new Point(position));
+            }
+        }
+        return positions;
+    }
+
     public void spawnAllMonsterIdFromMapSpawnList(int id) {
         spawnAllMonsterIdFromMapSpawnList(id, 1, false);
     }
@@ -2210,6 +2295,40 @@ public class MapleMap {
         activateItemReactors(mdrop, owner.getClient());
     }
 
+    public final MapItem spawnItemDropNoExpire(final MapObject dropper, final Character owner, final Item item, Point pos,
+                                               final boolean ffaDrop, final boolean playerDrop) {
+        if (FieldLimit.DROP_LIMIT.check(this.getFieldLimit())) {
+            this.disappearingItemDrop(dropper, owner, item, pos);
+            return null;
+        }
+
+        final Point droppos = calcDropPos(pos, pos);
+        final MapItem mdrop = new MapItem(item, droppos, dropper, owner, owner.getClient(),
+                (byte) (ffaDrop ? 2 : 0), playerDrop);
+        mdrop.setDropTime(Server.getInstance().getCurrentTime());
+
+        spawnAndAddRangedMapObject(mdrop, c -> {
+            mdrop.lockItem();
+            try {
+                c.sendPacket(PacketCreator.dropItemFromMapObject(c.getPlayer(), mdrop, dropper.getPosition(), droppos,
+                        (byte) 1));
+            } finally {
+                mdrop.unlockItem();
+            }
+        }, null);
+
+        mdrop.lockItem();
+        try {
+            broadcastItemDropMessage(mdrop, dropper.getPosition(), droppos, (byte) 0);
+        } finally {
+            mdrop.unlockItem();
+        }
+
+        instantiateItemDropNoExpire(mdrop);
+        activateItemReactors(mdrop, owner.getClient());
+        return mdrop;
+    }
+
     public final void spawnItemDropList(List<Integer> list, final MapObject dropper, final Character owner, Point pos) {
         spawnItemDropList(list, 1, 1, dropper, owner, pos, true, false);
     }
@@ -2424,6 +2543,10 @@ public class MapleMap {
         chr.setMapId(mapid);
         chr.updateActiveEffects();
 
+        if (!HostHooks.isArtificial(chr)) {
+            HostHooks.publish(new CharacterMapEnteredEvent(chr, mapid));
+        }
+
         if (this.getHPDec() > 0) {
             getWorldServer().addPlayerHpDecrease(chr);
         } else {
@@ -2437,11 +2560,11 @@ public class MapleMap {
                 aggroMonitor.startAggroCoordinator();
             }
 
-            if (onFirstUserEnter.length() != 0) {
+            if (onFirstUserEnter.length() != 0 && !HostHooks.isArtificial(chr)) {
                 msm.runMapScript(chr.getClient(), "onFirstUserEnter/" + onFirstUserEnter, true);
             }
         }
-        if (onUserEnter.length() != 0) {
+        if (onUserEnter.length() != 0 && !HostHooks.isArtificial(chr)) {
             if (onUserEnter.equals("cygnusTest") && !MapId.isCygnusIntro(mapid)) {
                 chr.saveLocation("INTRO");
             }
@@ -2791,7 +2914,9 @@ public class MapleMap {
         chrRLock.lock();
         try {
             for (Character c : characters) {
-                if (c != null && c.isAwayFromWorld()) {
+                // SoloMapling bots stay on maps with awayFromWorld=true until marked entered;
+                // never treat them as disconnect ghosts.
+                if (c != null && c.isAwayFromWorld() && !HostHooks.isArtificial(c)) {
                     ghosts.add(c);
                 }
             }
@@ -2905,7 +3030,7 @@ public class MapleMap {
                 if (chrDisconnected(iterator, chr)) {
                     continue;
                 }
-                if (chr != source) {
+                if (chr != source && !HostHooks.isArtificial(chr)) {
                     if (rangeSq < Double.POSITIVE_INFINITY) {
                         if (rangedFrom.distanceSq(chr.getPosition()) <= rangeSq) {
                             chr.sendPacket(packet);
@@ -2956,7 +3081,7 @@ public class MapleMap {
         chrRLock.lock();
         try {
             for (Character chr : characters) {
-                if (chr != source) {
+                if (chr != source && !HostHooks.isArtificial(chr)) {
                     if (rangeSq < Double.POSITIVE_INFINITY) {
                         if (rangedFrom.distanceSq(chr.getPosition()) <= rangeSq) {
                             chr.getClient().announceBossHpBar(mm, bossHash, packet);
@@ -3186,6 +3311,10 @@ public class MapleMap {
         return portals.get(portalid);
     }
 
+    public Collection<Portal> getPortals() {
+        return Collections.unmodifiableCollection(portals.values());
+    }
+
     public void addMapleArea(Rectangle rec) {
         areas.add(rec);
     }
@@ -3204,6 +3333,30 @@ public class MapleMap {
 
     public FootholdTree getFootholds() {
         return footholds;
+    }
+
+    public void addRope(Rope rope) {
+        ropes.add(rope);
+    }
+
+    public List<Rope> getRopes() {
+        return Collections.unmodifiableList(ropes);
+    }
+
+    public float getFootholdSpeed() {
+        return footholdSpeed;
+    }
+
+    public void setFootholdSpeed(float footholdSpeed) {
+        this.footholdSpeed = footholdSpeed;
+    }
+
+    public boolean isSwim() {
+        return swim;
+    }
+
+    public void setSwim(boolean swim) {
+        this.swim = swim;
     }
 
     public void setMapPointBoundings(int px, int py, int h, int w) {
@@ -3386,6 +3539,10 @@ public class MapleMap {
                 player.addVisibleMapObject(mo);
             }
         }
+    }
+
+    public void moveBot(Character player, Point newPosition) {
+        player.setPosition(newPosition);
     }
 
     public final void toggleEnvironment(final String ms) {

--- a/gms-server/src/main/java/org/gms/server/maps/MapleMap.java
+++ b/gms-server/src/main/java/org/gms/server/maps/MapleMap.java
@@ -2295,6 +2295,71 @@ public class MapleMap {
         activateItemReactors(mdrop, owner.getClient());
     }
 
+    /**
+     * Spawns a normal-expiry player drop that only {@code owner} can pick up.
+     * Used by host-directed transfers after the exact inventory item is removed.
+     */
+    public final MapItem spawnOwnerOnlyItemDrop(
+            final MapObject dropper,
+            final Character owner,
+            final Item item,
+            Point pos
+    ) {
+        if (FieldLimit.DROP_LIMIT.check(this.getFieldLimit())) {
+            return null;
+        }
+
+        final Point droppos = calcDropPos(pos, pos);
+        final MapItem mdrop = new MapItem(item, droppos, dropper, owner, owner.getClient(), (byte) 0, true);
+        mdrop.setDropTime(Server.getInstance().getCurrentTime());
+        mdrop.lockItem();
+        try {
+            mdrop.setPartyOwnerIdLocked(-1);
+            mdrop.setPermanentOwner(true);
+        } finally {
+            mdrop.unlockItem();
+        }
+
+        try {
+            spawnAndAddRangedMapObject(mdrop, c -> {
+                mdrop.lockItem();
+                try {
+                    c.sendPacket(PacketCreator.dropItemFromMapObject(
+                            c.getPlayer(), mdrop, dropper.getPosition(), droppos, (byte) 1));
+                } finally {
+                    mdrop.unlockItem();
+                }
+            }, null);
+        } catch (RuntimeException e) {
+            if (getMapObject(mdrop.getObjectId()) != mdrop) {
+                return null;
+            }
+            log.warn("Owner-only item {} spawned but one viewer notification failed",
+                    item.getItemId(), e);
+        }
+
+        mdrop.lockItem();
+        try {
+            try {
+                broadcastItemDropMessage(mdrop, dropper.getPosition(), droppos, (byte) 0);
+            } catch (RuntimeException e) {
+                log.warn("Owner-only item {} spawned but drop broadcast failed",
+                        item.getItemId(), e);
+            }
+        } finally {
+            mdrop.unlockItem();
+        }
+
+        instantiateItemDrop(mdrop);
+        try {
+            activateItemReactors(mdrop, owner.getClient());
+        } catch (RuntimeException e) {
+            log.warn("Owner-only item {} spawned but reactor activation failed",
+                    item.getItemId(), e);
+        }
+        return mdrop;
+    }
+
     public final MapItem spawnItemDropNoExpire(final MapObject dropper, final Character owner, final Item item, Point pos,
                                                final boolean ffaDrop, final boolean playerDrop) {
         if (FieldLimit.DROP_LIMIT.check(this.getFieldLimit())) {
@@ -2682,7 +2747,12 @@ public class MapleMap {
             broadcastSpawnPlayerMapObjectMessage(chr, chr, true);
         }
 
-        sendObjectPlacement(chr.getClient());
+        // Artificial players have a headless client with no viewer Character.
+        // They must be visible to real players, but there is no socket/viewer
+        // that needs the map's existing objects sent back to them.
+        if (!HostHooks.isArtificial(chr)) {
+            sendObjectPlacement(chr.getClient());
+        }
 
         if (isStartingEventMap() && !eventStarted()) {
             chr.getMap().getPortal("join00").setPortalStatus(false);

--- a/gms-server/src/main/java/org/gms/server/maps/PlayerShop.java
+++ b/gms-server/src/main/java/org/gms/server/maps/PlayerShop.java
@@ -32,6 +32,7 @@ import org.gms.net.packet.Packet;
 import org.gms.server.Trade;
 import org.gms.util.PacketCreator;
 import org.gms.util.Pair;
+import org.gms.extension.runtime.HostHooks;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -126,7 +127,7 @@ public class PlayerShop extends AbstractMapObject {
         for (int i = 0; i < 3; i++) {
             if (visitors[i] == null) {
                 visitors[i] = visitor;
-                visitor.setSlot(i);
+                visitor.setSlot(i + 1);
 
                 this.broadcast(PacketCreator.getPlayerShopNewVisitor(visitor, i + 1));
                 owner.getMap().broadcastMessage(PacketCreator.updatePlayerShopBox(this));
@@ -339,7 +340,7 @@ public class PlayerShop extends AbstractMapObject {
         visitorLock.lock();
         try {
             for (int i = 0; i < 3; i++) {
-                if (visitors[i] != null) {
+                if (visitors[i] != null && !HostHooks.isArtificial(visitors[i])) {
                     visitors[i].sendPacket(packet);
                 }
             }
@@ -421,17 +422,20 @@ public class PlayerShop extends AbstractMapObject {
     }
 
     public void chat(Client c, String chat) {
-        byte s = getVisitorSlot(c.getPlayer());
+        chat(c.getPlayer(), chat);
+    }
 
+    public void chat(Character player, String chat) {
+        byte s = getVisitorSlot(player);
         synchronized (chatLog) {
-            chatLog.add(new Pair<>(c.getPlayer(), chat));
+            chatLog.add(new Pair<>(player, chat));
             if (chatLog.size() > 25) {
                 chatLog.remove(0);
             }
-            chatSlot.put(c.getPlayer().getId(), s);
+            chatSlot.put(player.getId(), s);
         }
 
-        broadcast(PacketCreator.getPlayerShopChat(c.getPlayer(), chat, s));
+        broadcast(PacketCreator.getPlayerShopChat(player, chat, s));
     }
 
     private void recoverChatLog() {
@@ -490,6 +494,12 @@ public class PlayerShop extends AbstractMapObject {
         }
     }
 
+    public void setItems(List<PlayerShopItem> premadeShop) {
+        synchronized (items) {
+            items.addAll(premadeShop);
+        }
+    }
+
     public boolean hasItem(int itemid) {
         for (PlayerShopItem mpsi : getItems()) {
             if (mpsi.getItem().getItemId() == itemid && mpsi.isExist() && mpsi.getBundles() > 0) {
@@ -536,6 +546,46 @@ public class PlayerShop extends AbstractMapObject {
         return bannedList.contains(name);
     }
 
+    public boolean botBuy(Character bot, PlayerShopItem shopItem, int itemPosition, short quantity) {
+        synchronized (items) {
+            if (!shopItem.isExist() || shopItem.getBundles() < quantity) {
+                return false;
+            }
+
+            visitorLock.lock();
+            try {
+                int price = (int) Math.min((float) shopItem.getPrice() * quantity, Integer.MAX_VALUE);
+                if (!owner.canHoldMeso(price)) {
+                    return false;
+                }
+
+                price -= Trade.getFee(price);
+                owner.gainMeso(price, true);
+
+                SoldItem soldItem = new SoldItem(bot.getName(), shopItem.getItem().getItemId(), quantity, price);
+                if (!HostHooks.isArtificial(owner)) {
+                    owner.sendPacket(PacketCreator.getPlayerShopOwnerUpdate(soldItem, itemPosition));
+                }
+                synchronized (sold) {
+                    sold.add(soldItem);
+                }
+
+                shopItem.setBundles((short) (shopItem.getBundles() - quantity));
+                if (shopItem.getBundles() < 1) {
+                    shopItem.setDoesExist(false);
+                    if (++boughtnumber == items.size()) {
+                        owner.setPlayerShop(null);
+                        setOpen(false);
+                        closeShop();
+                    }
+                }
+                return true;
+            } finally {
+                visitorLock.unlock();
+            }
+        }
+    }
+
     public synchronized boolean visitShop(Character chr) {
         if (this.isBanned(chr.getName())) {
             chr.dropMessage(1, "You have been banned from this store.");
@@ -552,7 +602,9 @@ public class PlayerShop extends AbstractMapObject {
             if (this.hasFreeSlot() && !this.isVisitor(chr)) {
                 this.addVisitor(chr);
                 chr.setPlayerShop(this);
-                this.sendShop(chr.getClient());
+                if (!HostHooks.isArtificial(chr)) {
+                    this.sendShop(chr.getClient());
+                }
 
                 return true;
             }

--- a/gms-server/src/main/java/org/gms/server/maps/PlayerShopItem.java
+++ b/gms-server/src/main/java/org/gms/server/maps/PlayerShopItem.java
@@ -29,7 +29,7 @@ import org.gms.client.inventory.Item;
 public class PlayerShopItem {
     private final Item item;
     private short bundles;
-    private final int price;
+    private int price;
     private boolean doesExist;
 
     public PlayerShopItem(Item item, short bundles, int price) {
@@ -57,6 +57,10 @@ public class PlayerShopItem {
 
     public int getPrice() {
         return price;
+    }
+
+    public void setPrice(int price) {
+        this.price = price;
     }
 
     public void setBundles(short bundles) {

--- a/gms-server/src/main/java/org/gms/server/maps/Rope.java
+++ b/gms-server/src/main/java/org/gms/server/maps/Rope.java
@@ -1,0 +1,14 @@
+package org.gms.server.maps;
+
+/**
+ * Represents a rope or ladder climbable object parsed from WZ ladderRope data.
+ * isLadder: true when the WZ {@code l} field is 1 (ladder), false for rope.
+ *
+ * Part of the GCMoveSystem terrain model (GreenCat dynamic movement).
+ */
+public record Rope(int x, int y1, int y2, boolean isLadder) {
+    /** Top of the rope (smaller y = higher on screen). */
+    public int topY() { return Math.min(y1, y2); }
+    /** Bottom of the rope (larger y = lower on screen). */
+    public int bottomY() { return Math.max(y1, y2); }
+}

--- a/gms-server/src/main/java/org/gms/service/AccountService.java
+++ b/gms-server/src/main/java/org/gms/service/AccountService.java
@@ -149,6 +149,14 @@ public class AccountService {
         return GameConfig.getServerBoolean("bcrypt_migration") ? BCrypt.hashpw(password, BCrypt.gensalt(12)) : BCrypt.hashpwSHA512(password);
     }
 
+    /**
+     * Password encoding entry point for ephemeral credentials supplied by
+     * extensions. Callers remain responsible for clearing the source array.
+     */
+    public String encryptPassword(char[] password) throws NoSuchAlgorithmException {
+        return encryptPassword(String.valueOf(password));
+    }
+
     public boolean checkPassword(String pwd, AccountsDO accountsDO) {
         String passHash = accountsDO.getPassword();
         if (passHash.charAt(0) == '$' && passHash.charAt(1) == '2' && BCrypt.checkpw(pwd, passHash)) {

--- a/gms-server/src/main/resources/application.yml
+++ b/gms-server/src/main/resources/application.yml
@@ -67,3 +67,12 @@ gms:
     localhost: 127.0.0.1
     # 客户端登录端口
     login-port: 8484
+
+# SoloMapling plugin SPI (beidou-runtime)
+solomapling:
+  plugins-enabled: true
+  plugins-dir: plugins
+  spawn-bots-on-startup: true
+  # Optional override path for EnvironmentPopulation.yaml (default: cwd-relative
+  # src/main/java/soloMapling/Environment/EnvironmentPopulation.yaml, then classpath).
+  # population-config: src/main/java/soloMapling/Environment/EnvironmentPopulation.yaml

--- a/gms-server/src/main/resources/db/migration/V1.9.3__solomapling_fmbot_data.sql
+++ b/gms-server/src/main/resources/db/migration/V1.9.3__solomapling_fmbot_data.sql
@@ -1,0 +1,21 @@
+-- SoloMapling: bot-only account + template character for bot cloning.
+-- Login: fmbot / password (bcrypt hash from SoloMapling 162-fmbot-data.sql)
+-- Do NOT force character id=2 (BeiDou DBs may already use that for a player).
+-- BotGeneration resolves the template by characters.name = 'fmbot'.
+
+INSERT IGNORE INTO accounts (`name`, password, pin, pic, birthday, nxCredit, maplePoint, nxPrepaid, characterslots,
+                             gender, tos)
+VALUES ('fmbot', '$2y$12$xS3xZTX5hSU8v0SvC4h1FewFeK4Lx0q6kXoqv/bFJu6Hr3Wuimr9q', '0000', '000000',
+        '2005-05-11', 0, 0, 0, 3, 0, 1);
+
+INSERT INTO characters (accountid, world, `name`, level, exp,
+                               str, dex, luk, `int`, hp, mp, maxhp, maxmp, meso, job, skincolor, gender,
+                               hair, face, ap, map, spawnpoint, gm, equipslots, useslots,
+                               setupslots, etcslots)
+SELECT a.id, 0, 'fmbot', 1, 0,
+        12, 5, 4, 4, 50, 5, 50, 5, 0, 0, 0, 0,
+        30030, 20000, 0, 10000, 0, 0, 96, 96,
+        96, 96
+FROM accounts a
+WHERE a.name = 'fmbot'
+  AND NOT EXISTS (SELECT 1 FROM characters c WHERE c.name = 'fmbot');

--- a/gms-server/src/main/resources/i18n/log_en_US.properties
+++ b/gms-server/src/main/resources/i18n/log_en_US.properties
@@ -231,3 +231,22 @@ Client.warn.map.message1 = [Client] Player {} returned abnormal information on m
 PlayerLoggedinHandler.error.message1 = Chr {}'s family doesn't have an entry for them. (familyId {})
 PlayerLoggedinHandler.error.message2 = Chr {} has an invalid family ID ({})
 ChangeMapHandler.warn.message1=Player {} got stuck while switching maps from map [{}] ({}), list of recently visited maps: {}
+
+##############################
+# ExtensionLoader
+##############################
+ExtensionLoader.load.warn.alreadyLoaded=Extensions already loaded; ignoring duplicate load
+ExtensionLoader.load.info.loading=Loading extension: {} (v{})
+ExtensionLoader.load.info.loaded=Extension loaded: {}
+ExtensionLoader.load.error.onLoad=Extension onLoad failed: {}
+ExtensionLoader.load.info.summary=Loaded {} extension(s)
+ExtensionLoader.ready.info=Extension onServerReady completed: {}
+ExtensionLoader.ready.error=Extension onServerReady failed: {}
+ExtensionLoader.unload.error=Extension onUnload failed: {}
+ExtensionLoader.discover.info=Discovered extension {} (source: {})
+ExtensionLoader.discover.error=Failed to discover extensions from {}
+ExtensionLoader.plugins.error.mkdir=Cannot create plugins directory: {}
+ExtensionLoader.plugins.info.jar=Scanning plugin jar: {}
+ExtensionLoader.plugins.error.jar=Failed to load plugin jar: {}
+ExtensionLoader.plugins.error.scan=Failed to scan plugins directory: {}
+HiredMerchant.botBuy.error1=Unable to complete bot purchase from {}'s hired merchant.

--- a/gms-server/src/main/resources/i18n/log_zh_CN.properties
+++ b/gms-server/src/main/resources/i18n/log_zh_CN.properties
@@ -242,3 +242,22 @@ ChangeMapHandler.warn.message1=玩家 {} 从地图 [{}]({}) 切换地图时卡�
 ##############################
 # ChangeMapHandler
 ##############################
+
+##############################
+# ExtensionLoader
+##############################
+ExtensionLoader.load.warn.alreadyLoaded=扩展已加载，忽略重复 load
+ExtensionLoader.load.info.loading=正在加载扩展：{} (v{})
+ExtensionLoader.load.info.loaded=扩展已加载：{}
+ExtensionLoader.load.error.onLoad=扩展 onLoad 失败：{}
+ExtensionLoader.load.info.summary=共加载 {} 个扩展
+ExtensionLoader.ready.info=扩展 onServerReady 完成：{}
+ExtensionLoader.ready.error=扩展 onServerReady 失败：{}
+ExtensionLoader.unload.error=扩展 onUnload 失败：{}
+ExtensionLoader.discover.info=发现扩展 {}（来源：{}）
+ExtensionLoader.discover.error=从 {} 发现扩展失败
+ExtensionLoader.plugins.error.mkdir=无法创建插件目录：{}
+ExtensionLoader.plugins.info.jar=扫描插件 jar：{}
+ExtensionLoader.plugins.error.jar=加载插件 jar 失败：{}
+ExtensionLoader.plugins.error.scan=扫描插件目录失败：{}
+HiredMerchant.botBuy.error1=无法完成从 {} 的雇佣商店购买的机器人交易。

--- a/gms-server/src/main/resources/log4j2.xml
+++ b/gms-server/src/main/resources/log4j2.xml
@@ -8,6 +8,8 @@
         <property name="every_file_size">10MB</property>
         <property name="rolling_fileName">${basePath}/out.log</property>
         <property name="rolling_filePattern">${basePath}/%d{yyyyMMdd}/out%i.log</property>
+        <property name="solomapling_fileName">${basePath}/BotLog.txt</property>
+        <property name="solomapling_filePattern">${basePath}/%d{yyyyMMdd}/BotLog%i.txt</property>
         <property name="rolling_max">10</property>
         <property name="rolling_timeInterval">1</property>
         <property name="rolling_timeModulate">true</property>
@@ -36,15 +38,70 @@
                 </Delete>
             </DefaultRolloverStrategy>
         </RollingFile>
+
+        <RollingFile name="SoloMaplingRollingFile"
+                     fileName="${solomapling_fileName}"
+                     filePattern="${solomapling_filePattern}">
+            <ThresholdFilter level="${file_print_level}" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="${log_pattern}"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="${rolling_timeInterval}" modulate="${rolling_timeModulate}"/>
+                <SizeBasedTriggeringPolicy size="${every_file_size}"/>
+            </Policies>
+            <DefaultRolloverStrategy max="${rolling_max}">
+                <Delete basePath="${basePath}" maxDepth="2">
+                    <IfFileName glob="*/BotLog*.txt"/>
+                    <IfLastModified age="1d"/>
+                    <IfAccumulatedFileSize exceeds="100MB"/>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingFile>
+
+        <RollingFile name="CompanionRollingFile"
+                     fileName="${basePath}/companion.log"
+                     filePattern="${basePath}/%d{yyyyMMdd}/companion%i.log">
+            <ThresholdFilter level="${file_print_level}" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="${log_pattern}"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="${rolling_timeInterval}" modulate="true"/>
+                <SizeBasedTriggeringPolicy size="${every_file_size}"/>
+            </Policies>
+            <DefaultRolloverStrategy max="${rolling_max}">
+                <Delete basePath="${basePath}" maxDepth="2">
+                    <IfFileName glob="*/companion*.log"/>
+                    <IfLastModified age="1d"/>
+                    <IfAccumulatedFileSize exceeds="100MB"/>
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingFile>
     </appenders>
 
     <loggers>
-        <!-- 降低 Druid 的日志级别 -->
+        <Logger name="soloMapling.BotLogger" level="INFO" additivity="false">
+            <AppenderRef ref="SoloMaplingRollingFile"/>
+        </Logger>
+
+        <Logger name="soloMapling.companion" level="DEBUG" additivity="false">
+            <AppenderRef ref="CompanionRollingFile"/>
+        </Logger>
+        <Logger name="soloMapling.command.CompanionCommand" level="INFO" additivity="false">
+            <AppenderRef ref="CompanionRollingFile"/>
+        </Logger>
+        <Logger name="soloMapling.ArtificialPlayer.BotTypes.CompanionBot"
+                level="DEBUG" additivity="false">
+            <AppenderRef ref="CompanionRollingFile"/>
+        </Logger>
+        <Logger name="org.gms.extension.runtime.BeiDouHostCharacterProvisioner"
+                level="INFO" additivity="false">
+            <AppenderRef ref="CompanionRollingFile"/>
+        </Logger>
+
+        <!-- Reduce Druid logging noise. -->
         <Logger name="com.alibaba.druid" level="ERROR">
             <AppenderRef ref="Console"/>
         </Logger>
 
-        <!-- 降低 flyway 的日志级别 -->
+        <!-- Reduce Flyway logging noise. -->
         <Logger name="org.flywaydb.core.internal.command.DbMigrate" level="INFO" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>

--- a/gms-server/src/test/java/org/gms/constants/skills/WarriorSkillConstantsTest.java
+++ b/gms-server/src/test/java/org/gms/constants/skills/WarriorSkillConstantsTest.java
@@ -1,0 +1,14 @@
+package org.gms.constants.skills;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WarriorSkillConstantsTest {
+
+    @Test
+    void activeFirstJobSkillsUseTheIdsPresentInV83Wz() {
+        assertEquals(1_001_004, Warrior.POWER_STRIKE);
+        assertEquals(1_001_005, Warrior.SLASH_BLAST);
+    }
+}

--- a/gms-server/src/test/java/org/gms/extension/runtime/BeiDouHostCharacterProvisionerTest.java
+++ b/gms-server/src/test/java/org/gms/extension/runtime/BeiDouHostCharacterProvisionerTest.java
@@ -1,0 +1,33 @@
+package org.gms.extension.runtime;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BeiDouHostCharacterProvisionerTest {
+
+    @Test
+    void postCommitCacheFailureDoesNotBecomeProvisioningFailure() {
+        boolean published = BeiDouHostCharacterProvisioner.publishPostCommit(
+                5,
+                "luna",
+                () -> {
+                    throw new IllegalStateException("synthetic cache failure");
+                });
+
+        assertFalse(published);
+    }
+
+    @Test
+    void successfulPostCommitCachePublicationIsReported() {
+        AtomicInteger publications = new AtomicInteger();
+
+        assertTrue(BeiDouHostCharacterProvisioner.publishPostCommit(
+                5, "luna", publications::incrementAndGet));
+        assertEquals(1, publications.get());
+    }
+}

--- a/gms-server/src/test/java/org/gms/extension/runtime/BeiDouHostItemActionsTest.java
+++ b/gms-server/src/test/java/org/gms/extension/runtime/BeiDouHostItemActionsTest.java
@@ -1,0 +1,26 @@
+package org.gms.extension.runtime;
+
+import org.gms.constants.inventory.ItemConstants;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BeiDouHostItemActionsTest {
+
+    @Test
+    void directedDropPolicyRejectsRestrictedAndBoundItems() {
+        assertEquals("CASH_ITEM",
+                BeiDouHostItemActions.dropRestriction(true, false, false, false, (short) 0));
+        assertEquals("DROP_RESTRICTED",
+                BeiDouHostItemActions.dropRestriction(false, true, false, false, (short) 0));
+        assertEquals("PET_ITEM",
+                BeiDouHostItemActions.dropRestriction(false, false, true, false, (short) 0));
+        assertEquals("BOUND_ITEM",
+                BeiDouHostItemActions.dropRestriction(false, false, false, true, (short) 0));
+        assertEquals("BOUND_ITEM",
+                BeiDouHostItemActions.dropRestriction(
+                        false, false, false, false, ItemConstants.ACCOUNT_SHARING));
+        assertEquals(null,
+                BeiDouHostItemActions.dropRestriction(false, false, false, false, (short) 0));
+    }
+}

--- a/gms-server/src/test/java/org/gms/extension/runtime/JdbcTransactionCoordinatorTest.java
+++ b/gms-server/src/test/java/org/gms/extension/runtime/JdbcTransactionCoordinatorTest.java
@@ -1,0 +1,54 @@
+package org.gms.extension.runtime;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JdbcTransactionCoordinatorTest {
+
+    @Test
+    void commitsOnlyAfterWorkCompletes() throws Exception {
+        Connection connection = connection();
+        JdbcTransactionCoordinator coordinator = new JdbcTransactionCoordinator(() -> connection);
+
+        assertEquals(Integer.valueOf(7), coordinator.execute(ignored -> 7));
+
+        var order = inOrder(connection);
+        order.verify(connection).setAutoCommit(false);
+        order.verify(connection).setTransactionIsolation(Connection.TRANSACTION_READ_UNCOMMITTED);
+        order.verify(connection).commit();
+        order.verify(connection).setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+        order.verify(connection).setAutoCommit(true);
+        order.verify(connection).close();
+    }
+
+    @Test
+    void metadataFailureRollsBackAndDoesNotCommit() throws Exception {
+        Connection connection = connection();
+        JdbcTransactionCoordinator coordinator = new JdbcTransactionCoordinator(() -> connection);
+
+        SQLException failure = assertThrows(SQLException.class,
+                () -> coordinator.execute(ignored -> {
+                    throw new SQLException("metadata failed");
+                }));
+
+        assertEquals("metadata failed", failure.getMessage());
+        verify(connection).rollback();
+        verify(connection, org.mockito.Mockito.never()).commit();
+    }
+
+    private static Connection connection() throws SQLException {
+        Connection connection = mock(Connection.class);
+        when(connection.getAutoCommit()).thenReturn(true);
+        when(connection.getTransactionIsolation()).thenReturn(Connection.TRANSACTION_REPEATABLE_READ);
+        return connection;
+    }
+}

--- a/gms-server/src/test/java/org/gms/server/life/MonsterInformationProviderDropSourceTest.java
+++ b/gms-server/src/test/java/org/gms/server/life/MonsterInformationProviderDropSourceTest.java
@@ -1,0 +1,53 @@
+package org.gms.server.life;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MonsterInformationProviderDropSourceTest {
+
+    @Test
+    void dropSourceLookupIsCachedBoundedAndReadOnly() {
+        AtomicInteger loads = new AtomicInteger();
+        MonsterInformationProvider provider = new MonsterInformationProvider(false) {
+            @Override
+            protected List<DropSource> loadDropSources(int itemId) {
+                loads.incrementAndGet();
+                List<DropSource> sources = new ArrayList<>();
+                for (int i = 0; i < MAX_DROP_SOURCE_RESULTS; i++) {
+                    sources.add(new DropSource(100_000 + i, 1_000 - i));
+                }
+                return List.copyOf(sources);
+            }
+        };
+
+        assertEquals(3, provider.retrieveDropSources(2000000, 3).size());
+        assertEquals(MonsterInformationProvider.MAX_DROP_SOURCE_RESULTS,
+                provider.retrieveDropSources(2000000, Integer.MAX_VALUE).size());
+        assertEquals(1, loads.get());
+        assertThrows(UnsupportedOperationException.class,
+                () -> provider.retrieveDropSources(2000000, 3)
+                        .add(new MonsterInformationProvider.DropSource(1, 1)));
+    }
+
+    @Test
+    void invalidLookupDoesNotLoad() {
+        AtomicInteger loads = new AtomicInteger();
+        MonsterInformationProvider provider = new MonsterInformationProvider(false) {
+            @Override
+            protected List<DropSource> loadDropSources(int itemId) {
+                loads.incrementAndGet();
+                return List.of();
+            }
+        };
+
+        assertEquals(List.of(), provider.retrieveDropSources(0, 10));
+        assertEquals(List.of(), provider.retrieveDropSources(2000000, 0));
+        assertEquals(0, loads.get());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,9 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>extension-api</module>
         <module>gms-server</module>
+        <!-- SoloMapling lives in the external solomapling-plugin repo; drop jar into gms-server/plugins/ -->
     </modules>
 
 


### PR DESCRIPTION
## 背景

为服务端扩展提供稳定、通用的开放边界，使 Host 无需在核心代码中依赖任何具体插件包。扩展通过薄 SPI 接入生命周期、配置、命令、事件和权威游戏操作；Host 继续负责引擎状态与规则校验，插件自行管理业务逻辑和持久化结构。

未安装任何插件时，服务端仍可独立启动和运行。

## 新增特性

- 新增独立 `extension-api` 模块，提供不依赖具体插件实现的公共 SPI。
- 新增 `ServerExtension` 生命周期：`onLoad`、`onServerReady`、`onUnload`。
- 新增 `ExtensionLoader`，从 `gms-server/plugins/*.jar` 自动发现并加载扩展。
- 新增 `HostRuntime` 统一入口，开放：
  - 类型化配置 `HostConfig`
  - 事件总线 `HostEventBus`
  - 命令注册 `HostCommandRegistry`
  - 原生账号与角色创建 `HostCharacterProvisioner`
  - 权威拾取、背包物品转移 `HostItemActions`
  - 有界怪物掉落来源查询 `HostMonsterDrops`
- 原生角色创建只返回 Host 身份信息，不向插件暴露 JDBC 连接或 Host 事务；插件持久化由插件自行负责。
- 开放稳定的职业技能枚举、只读商店目录，并保证购买失败时不会错误扣除金币。
- 增加人工角色与 headless client 支持，包括角色缓存、进图、可见性、怪物控制权、聊天和组队经验路径。
- 增加独立扩展日志与滚动策略，避免插件日志污染主日志。

## Host Hooks

- `ArtificialCharacters` / `CharacterClassifier`：注册人工角色判定规则。
- `HostHooks.isArtificial(...)`：核心引擎统一识别人工角色，不依赖具体插件类型。
- `HostHooks.publish(...)` + `HostEventBus`：向扩展发布服务端和游戏事件。
- `CharacterMapEnteredEvent`：真实角色进入地图。
- `CharacterChatEvent`：地图聊天输入。
- `PartyInviteEvent`：组队邀请。
- `TradeInviteEvent`：交易邀请。
- `ServerReadyEvent` / `ServerShutdownEvent`：服务生命周期通知。
- `TradeParticipantHook` / `TradeParticipants`：将交易参与者语义和处理策略放在可注册 Hook 后，保留玩家原生交易路径。
- `HostRuntime` 可选能力：由 Host 实现权威操作，扩展只使用稳定 DTO 和结果码，不直接操作引擎内部对象。

## 兼容性与安全边界

- Host 核心代码不导入具体插件包。
- 所有可选能力均有缺失能力处理，插件不存在或未注册 Hook 时保持原生行为。
- 拾取、物品转移、商店购买和角色创建继续走 Host 权威校验。
- 人工角色不会获得怪物控制权，避免 headless client 无法发送移动包造成地图异常。
- 扩展业务表、迁移和连接池不属于 Host SPI。

## Test plan

- [ ] `mvn -pl extension-api,gms-server -am test`
- [ ] 未放置插件 JAR 时服务端正常启动和关闭
- [ ] 插件可完成发现、加载、命令注册和生命周期回调
- [ ] Host 核心包不存在对具体插件包的 import
- [ ] 地图进入、聊天、组队邀请和交易邀请事件可正常投递
- [ ] 玩家原生交易、组队经验和怪物移动行为不受影响
- [ ] 原生角色创建、物品拾取/转移、商店购买和掉落查询通过权威校验
- [ ] 人工角色进图、聊天、组队和持久化重启路径正常