### PR TITLE
fix: 修复玩家无法成功创建家族问题

### DIFF
--- a/gms-server/src/main/java/org/gms/net/server/channel/handlers/GuildOperationHandler.java
+++ b/gms-server/src/main/java/org/gms/net/server/channel/handlers/GuildOperationHandler.java
@@ -29,20 +29,15 @@ import org.gms.constants.id.MapId;
 import org.gms.net.AbstractPacketHandler;
 import org.gms.net.packet.InPacket;
 import org.gms.net.server.Server;
-import org.gms.net.server.coordinator.matchchecker.MatchCheckerListenerFactory.MatchCheckerType;
 import org.gms.net.server.guild.Alliance;
 import org.gms.net.server.guild.Guild;
 import org.gms.net.server.guild.GuildPackets;
 import org.gms.net.server.guild.GuildResponse;
-import org.gms.net.server.world.Party;
-import org.gms.net.server.world.World;
 import org.gms.util.I18nUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.gms.util.PacketCreator;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 public final class GuildOperationHandler extends AbstractPacketHandler {
@@ -72,7 +67,6 @@ public final class GuildOperationHandler extends AbstractPacketHandler {
                 }
                 if (mc.getMeso() < GameConfig.getServerInt("create_guild_cost")) {
                     mc.dropMessage(1, I18nUtil.getMessage("GuildOperationHandler.handlePacket.message2"));
-                    //mc.dropMessage(1, "You do not have " + GameConstants.numberWithCommas(GameConfig.getServerInt("create_guild_cost")) + " mesos to create a Guild.");
                     return;
                 }
                 String guildName = p.readString();
@@ -81,30 +75,29 @@ public final class GuildOperationHandler extends AbstractPacketHandler {
                     return;
                 }
 
-                Set<Character> eligibleMembers = new HashSet<>(Guild.getEligiblePlayersForGuild(mc));
-                if (eligibleMembers.size() < GameConfig.getServerInt("create_guild_min_partners")) {
-                    if (mc.getMap().getAllPlayers().size() < GameConfig.getServerInt("create_guild_min_partners")) {
-                        // thanks NovaStory for noticing message in need of smoother info
-                        mc.dropMessage(1, I18nUtil.getMessage("GuildOperationHandler.handlePacket.message4"));
-                    } else {
-                        // players may be unaware of not belonging on a party in order to become eligible, thanks Hair (Legalize) for pointing this out
-                        mc.dropMessage(1, I18nUtil.getMessage("GuildOperationHandler.handlePacket.message5"));
-                    }
-
+                // 必须在队伍中且为队长才能创建公会
+                if (mc.getParty() == null || !mc.isPartyLeader()) {
+                    mc.dropMessage(1, I18nUtil.getMessage("GuildOperationHandler.handlePacket.message9"));
                     return;
                 }
 
-                if (!Party.createParty(mc, true)) {
-                    mc.dropMessage(1, I18nUtil.getMessage("GuildOperationHandler.handlePacket.message6"));
+                // 直接创建公会：校验通过后立即创建，无需同屏确认
+                int guildId = Server.getInstance().createGuild(mc.getId(), guildName);
+                if (guildId == 0) {
+                    mc.sendPacket(GuildPackets.genericGuildMessage((byte) 0x23));
                     return;
                 }
+                mc.gainMeso(-GameConfig.getServerInt("create_guild_cost"), true, false, true);
 
-                Set<Integer> eligibleCids = new HashSet<>();
-                for (Character chr : eligibleMembers) {
-                    eligibleCids.add(chr.getId());
-                }
+                mc.getMGC().setGuildId(guildId);
+                Server.getInstance().getGuild(guildId, mc.getWorld(), mc);  // 初始化并缓存公会结构
+                Server.getInstance().changeRank(guildId, mc.getId(), 1);     // 设为会长(rank 1)，同时落库 characters
 
-                c.getWorldServer().getMatchCheckerCoordinator().createMatchConfirmation(MatchCheckerType.GUILD_CREATION, c.getWorld(), mc.getId(), eligibleCids, guildName);
+                mc.sendPacket(GuildPackets.showGuildInfo(mc));
+                mc.dropMessage(1, I18nUtil.getMessage("GuildOperationHandler.handlePacket.message8"));
+
+                mc.getGuild().broadcastNameChanged();
+                mc.getGuild().broadcastEmblemChanged();
                 break;
             case 0x05:
                 if (mc.getGuildId() <= 0 || mc.getGuildRank() > 2) {
@@ -255,32 +248,6 @@ public final class GuildOperationHandler extends AbstractPacketHandler {
                     return;
                 }
                 Server.getInstance().setGuildNotice(mc.getGuildId(), notice);
-                break;
-            case 0x1E:
-                p.readInt();
-                World wserv = c.getWorldServer();
-
-                if (mc.getParty() != null) {
-                    wserv.getMatchCheckerCoordinator().dismissMatchConfirmation(mc.getId());
-                    return;
-                }
-
-                int leaderid = wserv.getMatchCheckerCoordinator().getMatchConfirmationLeaderid(mc.getId());
-                if (leaderid != -1) {
-                    boolean result = p.readByte() != 0;
-                    if (result && wserv.getMatchCheckerCoordinator().isMatchConfirmationActive(mc.getId())) {
-                        Character leader = wserv.getPlayerStorage().getCharacterById(leaderid);
-                        if (leader != null) {
-                            int partyid = leader.getPartyId();
-                            if (partyid != -1) {
-                                Party.joinParty(mc, partyid, true);    // GMS gimmick "party to form guild" recalled thanks to Vcoc
-                            }
-                        }
-                    }
-
-                    wserv.getMatchCheckerCoordinator().answerMatchConfirmation(mc.getId(), result);
-                }
-
                 break;
             default:
                 log.warn("Unhandled GUILD_OPERATION packet: {}", p);

--- a/gms-server/src/main/java/org/gms/net/server/coordinator/matchchecker/MatchCheckerListenerFactory.java
+++ b/gms-server/src/main/java/org/gms/net/server/coordinator/matchchecker/MatchCheckerListenerFactory.java
@@ -20,7 +20,6 @@
 package org.gms.net.server.coordinator.matchchecker;
 
 import org.gms.net.server.coordinator.matchchecker.listener.MatchCheckerCPQChallenge;
-import org.gms.net.server.coordinator.matchchecker.listener.MatchCheckerGuildCreation;
 
 /**
  * @author Ronan
@@ -29,7 +28,6 @@ public class MatchCheckerListenerFactory {
 
     public enum MatchCheckerType {
 
-        GUILD_CREATION(MatchCheckerGuildCreation.loadListener()),
         CPQ_CHALLENGE(MatchCheckerCPQChallenge.loadListener());
 
         private final AbstractMatchCheckerListener listener;

--- a/gms-server/src/main/java/org/gms/net/server/guild/Guild.java
+++ b/gms-server/src/main/java/org/gms/net/server/guild/Guild.java
@@ -28,7 +28,6 @@ import org.gms.net.packet.Packet;
 import org.gms.net.server.PlayerStorage;
 import org.gms.net.server.Server;
 import org.gms.net.server.channel.Channel;
-import org.gms.net.server.coordinator.matchchecker.MatchCheckerCoordinator;
 import org.gms.net.server.coordinator.world.InviteCoordinator;
 import org.gms.net.server.coordinator.world.InviteCoordinator.InviteResult;
 import org.gms.net.server.coordinator.world.InviteCoordinator.InviteType;
@@ -42,8 +41,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -441,20 +440,20 @@ public class Guild {
                 }
             }
 
-            try (PreparedStatement ps = con.prepareStatement("INSERT INTO guilds (`leader`, `name`, `signature`) VALUES (?, ?, ?)")) {
+            final int guildId;
+            try (PreparedStatement ps = con.prepareStatement(
+                    "INSERT INTO guilds (`leader`, `name`, `signature`) VALUES (?, ?, ?)"
+                    , Statement.RETURN_GENERATED_KEYS)) {
                 ps.setInt(1, leaderId);
                 ps.setString(2, name);
                 ps.setInt(3, (int) System.currentTimeMillis());
                 ps.executeUpdate();
-            }
 
-            final int guildId;
-            try (PreparedStatement ps = con.prepareStatement("SELECT guildid FROM guilds WHERE leader = ?")) {
-                ps.setInt(1, leaderId);
-
-                try (ResultSet rs = ps.executeQuery()) {
-                    rs.next();
-                    guildId = rs.getInt("guildid");
+                try (ResultSet rs = ps.getGeneratedKeys()) {
+                    if (!rs.next()) {
+                        return 0;
+                    }
+                    guildId = rs.getInt(1);
                 }
             }
 
@@ -742,20 +741,6 @@ public class Guild {
             sender.sendPacket(mgr.getPacket(targetName));
         }
         return false;
-    }
-
-    public static Set<Character> getEligiblePlayersForGuild(Character guildLeader) {
-        Set<Character> guildMembers = new HashSet<>();
-        guildMembers.add(guildLeader);
-
-        MatchCheckerCoordinator mmce = guildLeader.getWorldServer().getMatchCheckerCoordinator();
-        for (Character chr : guildLeader.getMap().getAllPlayers()) {
-            if (chr.getParty() == null && chr.getGuild() == null && mmce.getMatchConfirmationLeaderid(chr.getId()) == -1) {
-                guildMembers.add(chr);
-            }
-        }
-
-        return guildMembers;
     }
 
     public static void displayGuildRanks(Client c, int npcid) {

--- a/gms-server/src/main/java/org/gms/net/server/guild/GuildPackets.java
+++ b/gms-server/src/main/java/org/gms/net/server/guild/GuildPackets.java
@@ -80,15 +80,6 @@ public class GuildPackets {
         return p;
     }
 
-    public static Packet createGuildMessage(String masterName, String guildName) {
-        OutPacket p = OutPacket.create(SendOpcode.GUILD_OPERATION);
-        p.writeByte(0x3);
-        p.writeInt(0);
-        p.writeString(masterName);
-        p.writeString(guildName);
-        return p;
-    }
-
     /**
      * Gets a Heracle/guild message packet.
      * <p>

--- a/gms-server/src/main/java/org/gms/net/server/guild/GuildPackets.java
+++ b/gms-server/src/main/java/org/gms/net/server/guild/GuildPackets.java
@@ -80,6 +80,15 @@ public class GuildPackets {
         return p;
     }
 
+    public static Packet createGuildMessage(String masterName, String guildName) {
+        OutPacket p = OutPacket.create(SendOpcode.GUILD_OPERATION);
+        p.writeByte(0x3);
+        p.writeInt(0);
+        p.writeString(masterName);
+        p.writeString(guildName);
+        return p;
+    }
+
     /**
      * Gets a Heracle/guild message packet.
      * <p>

--- a/gms-server/src/main/java/org/gms/net/server/world/Party.java
+++ b/gms-server/src/main/java/org/gms/net/server/world/Party.java
@@ -26,8 +26,6 @@ import lombok.Setter;
 import org.gms.client.Character;
 import org.gms.client.Client;
 import org.gms.config.GameConfig;
-import org.gms.net.server.coordinator.matchchecker.MatchCheckerCoordinator;
-import org.gms.net.server.coordinator.matchchecker.MatchCheckerListenerFactory.MatchCheckerType;
 import org.gms.scripting.event.EventInstanceManager;
 import org.gms.server.maps.Door;
 import org.gms.server.maps.MapleMap;
@@ -414,11 +412,6 @@ public class Party {
             }
 
             player.setParty(null);
-
-            MatchCheckerCoordinator mmce = c.getWorldServer().getMatchCheckerCoordinator();
-            if (mmce.getMatchConfirmationLeaderid(player.getId()) == player.getId() && mmce.getMatchConfirmationType(player.getId()) == MatchCheckerType.GUILD_CREATION) {
-                mmce.dismissMatchConfirmation(player.getId());
-            }
         }
     }
 

--- a/gms-server/src/main/resources/i18n/message_en_US.properties
+++ b/gms-server/src/main/resources/i18n/message_en_US.properties
@@ -838,6 +838,8 @@ GuildOperationHandler.handlePacket.message4 = Your Guild doesn't have enough cof
 GuildOperationHandler.handlePacket.message5 = Please make sure everyone you are trying to invite is neither on a guild nor on a party.
 GuildOperationHandler.handlePacket.message6 = You cannot create a new Guild while in a party.
 GuildOperationHandler.handlePacket.message7 = The guild you are trying to join is already full.
+GuildOperationHandler.handlePacket.message8 = You have successfully created a Guild.
+GuildOperationHandler.handlePacket.message9 = You must be in a party and lead it to create a Guild.
 
 ##############################
 # InventoryManipulator

--- a/gms-server/src/main/resources/i18n/message_zh_CN.properties
+++ b/gms-server/src/main/resources/i18n/message_zh_CN.properties
@@ -839,6 +839,8 @@ GuildOperationHandler.handlePacket.message4 = 您的家族没有足够的创始�
 GuildOperationHandler.handlePacket.message5 = 请确保您要邀请的所有人都没有加入家族或者队伍。
 GuildOperationHandler.handlePacket.message6 = 您无法在组队状态时创建家族。
 GuildOperationHandler.handlePacket.message7 = 您申请加入的家族已经满员。
+GuildOperationHandler.handlePacket.message8 = 您已成功创建家族。
+GuildOperationHandler.handlePacket.message9 = 您需要加入队伍并担任队长后才能创建家族。
 
 ##############################
 # InventoryManipulator移动物品提示代码


### PR DESCRIPTION
原版逻辑点击创建家族只会创建组队，而不会真正创建家族。修复后能正确创建家族。
<img width="1602" height="933" alt="123123123" src="https://github.com/user-attachments/assets/4a2ac44c-9817-497f-bca0-30130ed25a4b" />
