### PR TITLE
修复：medalQuest

### DIFF
--- a/gms-server/scripts-zh-CN/quest/29002.js
+++ b/gms-server/scripts-zh-CN/quest/29002.js
@@ -45,7 +45,7 @@ function end(mode, type, selection) {
     }
 
     var questRecord = qm.getQuestRecord(qm.getQuest());
-    if (questRecord == null || System.currentTimeMillis() > questRecord.getCompletionTime() + challengeDurationMs) {
+    if (questRecord == null) {
         qm.sendOk("30 天挑战期限已经结束了。如果你还想挑战#b#t" + medalId + "##k，请先重新接取任务。");
         qm.dispose();
         return;

--- a/gms-server/scripts/quest/29002.js
+++ b/gms-server/scripts/quest/29002.js
@@ -45,7 +45,7 @@ function end(mode, type, selection) {
     }
 
     var questRecord = qm.getQuestRecord(qm.getQuest());
-    if (questRecord == null || System.currentTimeMillis() > questRecord.getCompletionTime() + challengeDurationMs) {
+    if (questRecord == null) {
         qm.sendOk("The 30-day challenge period has expired. Please restart the challenge if you want to try for the #b#t" + medalId + "##k again.");
         qm.dispose();
         return;

--- a/gms-server/src/main/java/org/gms/client/Character.java
+++ b/gms-server/src/main/java/org/gms/client/Character.java
@@ -8911,7 +8911,10 @@ public class Character extends AbstractCharacterObject {
         evtLock.lock();
         try {
             for (Quest quest : questExpirations.keySet()) {
-                quest.forfeit(this);
+                if (quest.getTimeLimit() > 0) {
+                    // timeLimit2 是medalQuest的长期任务，不能在进入商城时被取消
+                    quest.forfeit(this);
+                }
             }
 
             questExpirations.clear();


### PR DESCRIPTION
1. 29002 移除不正常的引用：System.currentTimeMillis， 任务本身存在过期属性，不需要在完成时再次判断是否过期
2. timeLimit2的任务在进入商城时被错误的取消